### PR TITLE
feat: make mqb CLI compile one TU incrementally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # 忽略测试目录
 .worktrees/
 .cache/
+.mqb/
 test_compile_out/
 test_out/
 test_out2/

--- a/cpp/apps/mqb/CMakeLists.txt
+++ b/cpp/apps/mqb/CMakeLists.txt
@@ -1,12 +1,42 @@
+if(NOT WIN32)
+    message(STATUS "mqb executable is currently available on Windows only")
+    return()
+endif()
+
+add_library(mqb_cli STATIC
+    Cli.cpp
+)
+
+target_include_directories(mqb_cli
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_link_libraries(mqb_cli
+    PUBLIC
+        mqb_core
+        mqb_msvc
+)
+
+target_compile_features(mqb_cli PUBLIC cxx_std_23)
+
 add_executable(mqb
     main.cpp
 )
 
-target_link_libraries(mqb PRIVATE mqb_core)
+target_link_libraries(mqb
+    PRIVATE
+        mqb_cli
+        mqb_orchestration
+        mqb_platform_windows
+)
+
 target_compile_features(mqb PRIVATE cxx_std_23)
 
-if(MSVC)
-    target_compile_options(mqb PRIVATE /W4 /permissive-)
-else()
-    target_compile_options(mqb PRIVATE -Wall -Wextra -Wpedantic)
-endif()
+foreach(target IN ITEMS mqb_cli mqb)
+    if(MSVC)
+        target_compile_options(${target} PRIVATE /W4 /permissive-)
+    else()
+        target_compile_options(${target} PRIVATE -Wall -Wextra -Wpedantic)
+    endif()
+endforeach()

--- a/cpp/apps/mqb/Cli.cpp
+++ b/cpp/apps/mqb/Cli.cpp
@@ -1,0 +1,204 @@
+#include "Cli.hpp"
+
+#include <expected>
+#include <filesystem>
+#include <span>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace mqb::cli {
+namespace {
+
+[[nodiscard]] Error error(std::string message) {
+    return Error{.message = std::move(message)};
+}
+
+[[nodiscard]] std::expected<std::string_view, Error>
+require_value(
+    const std::span<const std::string_view> arguments,
+    std::size_t& index,
+    const std::string_view option) {
+    if (index + 1 >= arguments.size()) {
+        return std::unexpected(error("missing value for " + std::string{option}));
+    }
+    ++index;
+    if (arguments[index].empty()) {
+        return std::unexpected(error("empty value for " + std::string{option}));
+    }
+    return arguments[index];
+}
+
+[[nodiscard]] std::expected<CppStandard, Error>
+parse_standard(const std::string_view value) {
+    if (value == "20" || value == "c++20") {
+        return CppStandard::cpp20;
+    }
+    if (value == "23" || value == "c++23") {
+        return CppStandard::cpp23;
+    }
+    if (value == "latest" || value == "c++latest") {
+        return CppStandard::latest;
+    }
+    return std::unexpected(error(
+        "unsupported C++ standard '" + std::string{value}
+        + "' (expected 20, 23, or latest)"));
+}
+
+[[nodiscard]] std::expected<msvc::ToolchainPreference, Error>
+parse_toolchain_preference(const std::string_view value) {
+    if (value == "auto") {
+        return msvc::ToolchainPreference::automatic;
+    }
+    if (value == "vs") {
+        return msvc::ToolchainPreference::visual_studio;
+    }
+    if (value == "portable") {
+        return msvc::ToolchainPreference::portable;
+    }
+    return std::unexpected(error(
+        "unsupported toolchain preference '" + std::string{value}
+        + "' (expected auto, vs, or portable)"));
+}
+
+[[nodiscard]] std::expected<std::string_view, Error>
+attached_or_next(
+    const std::span<const std::string_view> arguments,
+    std::size_t& index,
+    const std::string_view argument,
+    const std::string_view option) {
+    if (argument.size() > option.size()) {
+        return argument.substr(option.size());
+    }
+    return require_value(arguments, index, option);
+}
+
+} // namespace
+
+std::expected<Options, Error>
+parse_arguments(const std::span<const std::string_view> arguments) {
+    Options options;
+    bool saw_source = false;
+
+    for (std::size_t index = 0; index < arguments.size(); ++index) {
+        const std::string_view argument = arguments[index];
+
+        if (argument == "-h" || argument == "--help") {
+            options.show_help = true;
+            continue;
+        }
+        if (argument == "--verbose" || argument == "-v") {
+            options.verbose = true;
+            continue;
+        }
+        if (argument == "--debug") {
+            options.build.configuration = BuildConfiguration::debug;
+            continue;
+        }
+        if (argument == "--release") {
+            options.build.configuration = BuildConfiguration::release;
+            continue;
+        }
+        if (argument == "--x86") {
+            options.build.architecture = Architecture::x86;
+            continue;
+        }
+        if (argument == "--x64") {
+            options.build.architecture = Architecture::x64;
+            continue;
+        }
+        if (argument == "--std") {
+            auto value = require_value(arguments, index, argument);
+            if (!value) {
+                return std::unexpected(value.error());
+            }
+            auto standard = parse_standard(*value);
+            if (!standard) {
+                return std::unexpected(standard.error());
+            }
+            options.build.standard = *standard;
+            continue;
+        }
+        if (argument == "--env") {
+            auto value = require_value(arguments, index, argument);
+            if (!value) {
+                return std::unexpected(value.error());
+            }
+            auto preference = parse_toolchain_preference(*value);
+            if (!preference) {
+                return std::unexpected(preference.error());
+            }
+            options.toolchain_preference = *preference;
+            continue;
+        }
+        if (argument == "--portable-root") {
+            auto value = require_value(arguments, index, argument);
+            if (!value) {
+                return std::unexpected(value.error());
+            }
+            options.portable_roots.emplace_back(std::string{*value});
+            continue;
+        }
+        if (argument == "-I" || argument.starts_with("-I")) {
+            auto value = attached_or_next(arguments, index, argument, "-I");
+            if (!value) {
+                return std::unexpected(value.error());
+            }
+            if (value->empty()) {
+                return std::unexpected(error("empty include directory"));
+            }
+            options.include_directories.emplace_back(std::string{*value});
+            continue;
+        }
+        if (argument == "-D" || argument.starts_with("-D")) {
+            auto value = attached_or_next(arguments, index, argument, "-D");
+            if (!value) {
+                return std::unexpected(value.error());
+            }
+            if (value->empty()) {
+                return std::unexpected(error("empty preprocessor define"));
+            }
+            options.defines.emplace_back(*value);
+            continue;
+        }
+        if (!argument.empty() && argument.front() == '-') {
+            return std::unexpected(error("unknown option '" + std::string{argument} + "'"));
+        }
+        if (saw_source) {
+            return std::unexpected(error("only one source file is supported in this milestone"));
+        }
+
+        options.build.entry = std::filesystem::path{std::string{argument}};
+        saw_source = true;
+    }
+
+    if (!options.show_help && !saw_source) {
+        return std::unexpected(error("missing source file"));
+    }
+    return options;
+}
+
+std::string_view usage() noexcept {
+    return R"(MQB - MSVC Quick Build (C++ V2)
+
+Usage:
+  mqb <source.cpp> [options]
+
+Current milestone:
+  Incremental compilation of one C++ translation unit to .mqb/obj/.
+
+Options:
+  --debug                 Debug compiler preset (default)
+  --release               Release compiler preset
+  --std <20|23|latest>    C++ language standard (default: 23)
+  --x86 | --x64           Target architecture (default: x64)
+  -I <dir>, -I<dir>       Add an include directory
+  -D <value>, -D<value>   Add a preprocessor definition
+  --env <auto|vs|portable> Toolchain selection (default: auto)
+  --portable-root <dir>   Add a portable_msvc root candidate
+  -v, --verbose           Show toolchain and artifact details
+  -h, --help              Show this help
+)";
+}
+
+} // namespace mqb::cli

--- a/cpp/apps/mqb/Cli.hpp
+++ b/cpp/apps/mqb/Cli.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <expected>
+#include <filesystem>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "mqb/core/BuildRequest.hpp"
+#include "mqb/msvc/MsvcToolchainLocator.hpp"
+
+namespace mqb::cli {
+
+struct Options {
+    BuildRequest build;
+    std::vector<std::string> defines;
+    std::vector<std::filesystem::path> include_directories;
+    msvc::ToolchainPreference toolchain_preference{msvc::ToolchainPreference::automatic};
+    std::vector<std::filesystem::path> portable_roots;
+    bool verbose{false};
+    bool show_help{false};
+};
+
+struct Error {
+    std::string message;
+};
+
+[[nodiscard]] std::expected<Options, Error>
+parse_arguments(std::span<const std::string_view> arguments);
+
+[[nodiscard]] std::string_view usage() noexcept;
+
+} // namespace mqb::cli

--- a/cpp/apps/mqb/main.cpp
+++ b/cpp/apps/mqb/main.cpp
@@ -1,23 +1,267 @@
+#include <algorithm>
+#include <cctype>
+#include <expected>
 #include <filesystem>
 #include <iostream>
+#include <span>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <utility>
+#include <vector>
 
-#include "mqb/core/BuildRequest.hpp"
+#include "Cli.hpp"
+#include "mqb/core/Artifact.hpp"
 #include "mqb/core/BuildTypes.hpp"
+#include "mqb/core/CompilerOptions.hpp"
+#include "mqb/core/TranslationUnit.hpp"
+#include "mqb/msvc/MsvcCompileExecutor.hpp"
+#include "mqb/msvc/MsvcToolchainLocator.hpp"
+#include "mqb/orchestration/MsvcIncrementalCompileCoordinator.hpp"
+#include "mqb/platform/windows/WindowsProcessRunner.hpp"
+#include "mqb/process/Process.hpp"
+
+namespace {
+
+namespace fs = std::filesystem;
+
+[[nodiscard]] std::string path_text(const fs::path& path) {
+    const auto bytes = path.generic_u8string();
+    return std::string{
+        reinterpret_cast<const char*>(bytes.data()),
+        bytes.size()};
+}
+
+[[nodiscard]] std::expected<fs::path, std::string>
+absolute_path(const fs::path& path, const std::string_view description) {
+    std::error_code error_code;
+    fs::path absolute = fs::absolute(path, error_code);
+    if (error_code) {
+        return std::unexpected(
+            "failed to resolve " + std::string{description} + ": " + error_code.message());
+    }
+    return absolute.lexically_normal();
+}
+
+[[nodiscard]] bool supported_source(const fs::path& source) {
+    std::string extension = source.extension().string();
+    std::transform(
+        extension.begin(),
+        extension.end(),
+        extension.begin(),
+        [](const unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+    return extension == ".cpp" || extension == ".cc" || extension == ".cxx";
+}
+
+void add_portable_root_if_missing(
+    std::vector<fs::path>& roots,
+    const fs::path& candidate) {
+    if (candidate.empty()) {
+        return;
+    }
+    const fs::path normalized = candidate.lexically_normal();
+    if (std::find(roots.begin(), roots.end(), normalized) == roots.end()) {
+        roots.push_back(normalized);
+    }
+}
+
+void print_process_output(const mqb::process::ProcessResult& process) {
+    if (!process.stdout_text.empty()) {
+        std::cout << process.stdout_text;
+        if (process.stdout_text.back() != '\n') {
+            std::cout << '\n';
+        }
+    }
+    if (!process.stderr_text.empty()) {
+        std::cerr << process.stderr_text;
+        if (process.stderr_text.back() != '\n') {
+            std::cerr << '\n';
+        }
+    }
+}
+
+void print_compile_failure(const mqb::orchestration::IncrementalCompileError& error) {
+    std::cerr << "error: " << error.message << '\n';
+    if (!error.compile_error) {
+        return;
+    }
+
+    const auto& compile_error = *error.compile_error;
+    std::cerr << "  " << compile_error.message << '\n';
+    if (compile_error.compiler_error) {
+        const auto& compiler_error = *compile_error.compiler_error;
+        std::cerr << "  " << compiler_error.message << '\n';
+        if (compiler_error.process_result) {
+            print_process_output(*compiler_error.process_result);
+        }
+    }
+    if (compile_error.dependency_error) {
+        std::cerr << "  " << compile_error.dependency_error->message << '\n';
+    }
+}
+
+[[nodiscard]] fs::path with_suffix(fs::path path, const std::string_view suffix) {
+    path += std::string{suffix};
+    return path;
+}
+
+} // namespace
 
 int main(const int argc, char* argv[]) {
-    if (argc < 2) {
-        std::cerr << "usage: mqb <source-file>\n";
+    std::vector<std::string_view> arguments;
+    arguments.reserve(argc > 1 ? static_cast<std::size_t>(argc - 1) : 0u);
+    for (int index = 1; index < argc; ++index) {
+        arguments.emplace_back(argv[index]);
+    }
+
+    auto parsed = mqb::cli::parse_arguments(
+        std::span<const std::string_view>{arguments});
+    if (!parsed) {
+        std::cerr << "error: " << parsed.error().message << "\n\n"
+                  << mqb::cli::usage();
+        return 2;
+    }
+    auto options = std::move(*parsed);
+    if (options.show_help) {
+        std::cout << mqb::cli::usage();
+        return 0;
+    }
+
+    auto source = absolute_path(options.build.entry, "source file");
+    if (!source) {
+        std::cerr << "error: " << source.error() << '\n';
         return 2;
     }
 
-    mqb::BuildRequest request;
-    request.entry = std::filesystem::path{argv[1]};
+    std::error_code error_code;
+    if (!fs::is_regular_file(*source, error_code) || error_code) {
+        std::cerr << "error: source file does not exist: " << path_text(*source) << '\n';
+        return 2;
+    }
+    if (!supported_source(*source)) {
+        std::cerr << "error: this milestone supports .cpp, .cc, and .cxx files only\n";
+        return 2;
+    }
+    options.build.entry = *source;
 
-    std::cout << "MQB C++ v2 scaffold\n"
-              << "entry: " << request.entry.string() << '\n'
-              << "config: " << mqb::to_string(request.configuration) << '\n'
-              << "arch: " << mqb::to_string(request.architecture) << '\n'
-              << "std: " << mqb::to_string(request.standard) << '\n';
+    for (auto& include_directory : options.include_directories) {
+        auto resolved = absolute_path(include_directory, "include directory");
+        if (!resolved) {
+            std::cerr << "error: " << resolved.error() << '\n';
+            return 2;
+        }
+        include_directory = std::move(*resolved);
+    }
+    for (auto& portable_root : options.portable_roots) {
+        auto resolved = absolute_path(portable_root, "portable toolchain root");
+        if (!resolved) {
+            std::cerr << "error: " << resolved.error() << '\n';
+            return 2;
+        }
+        portable_root = std::move(*resolved);
+    }
 
+    const fs::path source_directory = source->parent_path();
+    const fs::path artifact_root = source_directory / ".mqb";
+
+    fs::path object_name = source->stem();
+    object_name += ".obj";
+    const fs::path object_file = artifact_root / "obj" / object_name;
+    const fs::path dependency_file = artifact_root / "deps" / with_suffix(source->filename(), ".json");
+    const fs::path cache_file = artifact_root / "cache" / with_suffix(source->filename(), ".mqbcache");
+
+    add_portable_root_if_missing(options.portable_roots, source_directory / "portable_msvc");
+    const fs::path current_directory = fs::current_path(error_code);
+    if (!error_code) {
+        add_portable_root_if_missing(options.portable_roots, current_directory / "portable_msvc");
+    }
+
+    mqb::platform::windows::WindowsProcessRunner runner;
+    mqb::msvc::MsvcToolchainLocator locator{runner};
+    mqb::msvc::DiscoveryOptions discovery;
+    discovery.target_architecture = options.build.architecture;
+    discovery.host_architecture = mqb::Architecture::x64;
+    discovery.preference = options.toolchain_preference;
+    discovery.portable_roots = options.portable_roots;
+
+    auto toolchain = locator.discover(discovery);
+    if (!toolchain) {
+        std::cerr << "error: " << toolchain.error().message;
+        if (!toolchain.error().path.empty()) {
+            std::cerr << ": " << path_text(toolchain.error().path);
+        }
+        std::cerr << '\n';
+        return 3;
+    }
+
+    mqb::CompilerOptions compiler_options;
+    compiler_options.configuration = options.build.configuration;
+    compiler_options.architecture = options.build.architecture;
+    compiler_options.standard = options.build.standard;
+    compiler_options.defines = std::move(options.defines);
+    compiler_options.include_directories = std::move(options.include_directories);
+
+    mqb::TranslationUnit unit;
+    unit.source = *source;
+    unit.kind = mqb::TranslationUnitKind::source;
+    unit.outputs.push_back(mqb::Artifact{
+        .path = object_file,
+        .kind = mqb::ArtifactKind::object,
+    });
+
+    if (options.verbose) {
+        std::cout << "[toolchain] MSVC " << toolchain->identity.version
+                  << " (" << mqb::to_string(options.build.architecture) << ")\n"
+                  << "  cl:    " << path_text(toolchain->identity.compiler) << '\n'
+                  << "  obj:   " << path_text(object_file) << '\n'
+                  << "  deps:  " << path_text(dependency_file) << '\n'
+                  << "  cache: " << path_text(cache_file) << '\n';
+    }
+
+    mqb::msvc::MsvcCompileExecutor executor{*toolchain, runner};
+    mqb::orchestration::MsvcIncrementalCompileCoordinator coordinator{*toolchain, executor};
+    mqb::orchestration::IncrementalCompileRequest request{
+        .unit = std::move(unit),
+        .options = std::move(compiler_options),
+        .cache_file = cache_file,
+        .source_dependencies_file = dependency_file,
+        .working_directory = source_directory,
+    };
+
+    auto result = coordinator.run(request);
+    if (!result) {
+        print_compile_failure(result.error());
+        return 4;
+    }
+
+    for (const auto& warning : result->warnings) {
+        std::cerr << "warning: " << warning.message;
+        if (!warning.path.empty()) {
+            std::cerr << ": " << path_text(warning.path);
+        }
+        std::cerr << '\n';
+    }
+
+    if (result->compiled) {
+        std::cout << "[compile] " << path_text(source->filename());
+        if (!result->validation.reasons.empty()) {
+            std::cout << " [";
+            for (std::size_t index = 0; index < result->validation.reasons.size(); ++index) {
+                if (index != 0) {
+                    std::cout << ", ";
+                }
+                std::cout << mqb::to_string(result->validation.reasons[index]);
+            }
+            std::cout << ']';
+        }
+        std::cout << '\n';
+        if (result->process) {
+            print_process_output(*result->process);
+        }
+    } else {
+        std::cout << "[up-to-date] " << path_text(source->filename()) << '\n';
+    }
+
+    std::cout << "object: " << path_text(object_file) << '\n';
     return 0;
 }

--- a/cpp/apps/mqb/main.cpp
+++ b/cpp/apps/mqb/main.cpp
@@ -164,7 +164,9 @@ int main(const int argc, char* argv[]) {
     const fs::path source_directory = source->parent_path();
     const fs::path artifact_root = source_directory / ".mqb";
 
-    fs::path object_name = source->stem();
+    // Keep the source extension in internal artifact names so sibling files
+    // such as foo.cpp and foo.cxx cannot alias the same cached object.
+    fs::path object_name = source->filename();
     object_name += ".obj";
     const fs::path object_file = artifact_root / "obj" / object_name;
     const fs::path dependency_file = artifact_root / "deps" / with_suffix(source->filename(), ".json");

--- a/cpp/backends/msvc/src/MsvcCompiler.cpp
+++ b/cpp/backends/msvc/src/MsvcCompiler.cpp
@@ -31,11 +31,11 @@ namespace fs = std::filesystem;
     case CppStandard::cpp20:
         return "/std:c++20";
     case CppStandard::cpp23:
-        return "/std:c++23";
+        return "/std:c++23preview";
     case CppStandard::latest:
         return "/std:c++latest";
     }
-    return "/std:c++23";
+    return "/std:c++23preview";
 }
 
 void append_configuration_arguments(

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -69,6 +69,10 @@ if(WIN32)
     target_link_libraries(mqb_msvc_source_dependencies_tests PRIVATE mqb_msvc)
     target_compile_features(mqb_msvc_source_dependencies_tests PRIVATE cxx_std_23)
 
+    add_executable(mqb_cli_argument_tests cli_argument_tests.cpp)
+    target_link_libraries(mqb_cli_argument_tests PRIVATE mqb_cli)
+    target_compile_features(mqb_cli_argument_tests PRIVATE cxx_std_23)
+
     list(APPEND MQB_TEST_TARGETS
         mqb_windows_command_line_tests
         mqb_process_echo_helper
@@ -77,6 +81,7 @@ if(WIN32)
         mqb_msvc_compiler_arguments_tests
         mqb_msvc_compile_executor_tests
         mqb_msvc_source_dependencies_tests
+        mqb_cli_argument_tests
     )
 
     if(MQB_ENABLE_INSTALLED_MSVC_TESTS)
@@ -92,10 +97,15 @@ if(WIN32)
         target_link_libraries(mqb_msvc_incremental_loop_tests PRIVATE mqb_core mqb_msvc mqb_platform_windows)
         target_compile_features(mqb_msvc_incremental_loop_tests PRIVATE cxx_std_23)
 
+        add_executable(mqb_cli_e2e_tests mqb_cli_e2e_tests.cpp)
+        target_link_libraries(mqb_cli_e2e_tests PRIVATE mqb_platform_windows)
+        target_compile_features(mqb_cli_e2e_tests PRIVATE cxx_std_23)
+
         list(APPEND MQB_TEST_TARGETS
             mqb_msvc_visual_studio_tests
             mqb_msvc_compile_integration_tests
             mqb_msvc_incremental_loop_tests
+            mqb_cli_e2e_tests
         )
     endif()
 endif()
@@ -127,10 +137,15 @@ if(WIN32)
     add_test(NAME mqb.msvc.compiler_arguments COMMAND mqb_msvc_compiler_arguments_tests)
     add_test(NAME mqb.msvc.compile_executor COMMAND mqb_msvc_compile_executor_tests)
     add_test(NAME mqb.msvc.source_dependencies COMMAND mqb_msvc_source_dependencies_tests)
+    add_test(NAME mqb.cli.arguments COMMAND mqb_cli_argument_tests)
 
     if(MQB_ENABLE_INSTALLED_MSVC_TESTS)
         add_test(NAME mqb.msvc.visual_studio COMMAND mqb_msvc_visual_studio_tests)
         add_test(NAME mqb.msvc.compile_integration COMMAND mqb_msvc_compile_integration_tests)
         add_test(NAME mqb.msvc.incremental_loop COMMAND mqb_msvc_incremental_loop_tests)
+        add_test(
+            NAME mqb.cli.single_tu_e2e
+            COMMAND mqb_cli_e2e_tests $<TARGET_FILE:mqb>
+        )
     endif()
 endif()

--- a/cpp/tests/cli_argument_tests.cpp
+++ b/cpp/tests/cli_argument_tests.cpp
@@ -1,0 +1,111 @@
+#include <iostream>
+#include <string_view>
+#include <vector>
+
+#include "Cli.hpp"
+#include "mqb/core/BuildTypes.hpp"
+#include "mqb/msvc/MsvcToolchainLocator.hpp"
+
+namespace {
+
+int failures = 0;
+
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+} // namespace
+
+int main() {
+    using namespace std::string_view_literals;
+
+    {
+        const std::vector<std::string_view> arguments{};
+        auto parsed = mqb::cli::parse_arguments(arguments);
+        expect(!parsed, "missing source should be rejected");
+    }
+
+    {
+        const std::vector arguments{"main.cpp"sv};
+        auto parsed = mqb::cli::parse_arguments(arguments);
+        expect(parsed.has_value(), "single source should parse");
+        if (parsed) {
+            expect(parsed->build.entry == "main.cpp", "source path should be preserved");
+            expect(parsed->build.configuration == mqb::BuildConfiguration::debug,
+                   "default configuration should be debug");
+            expect(parsed->build.architecture == mqb::Architecture::x64,
+                   "default architecture should be x64");
+            expect(parsed->build.standard == mqb::CppStandard::cpp23,
+                   "default standard should be C++23");
+            expect(parsed->toolchain_preference == mqb::msvc::ToolchainPreference::automatic,
+                   "default toolchain preference should be automatic");
+        }
+    }
+
+    {
+        const std::vector arguments{
+            "source.cpp"sv,
+            "--release"sv,
+            "--std"sv,
+            "latest"sv,
+            "--x86"sv,
+            "--env"sv,
+            "portable"sv,
+            "--portable-root"sv,
+            "tool chain"sv,
+            "-Iinclude dir"sv,
+            "-D"sv,
+            "VALUE=42"sv,
+            "--verbose"sv,
+        };
+        auto parsed = mqb::cli::parse_arguments(arguments);
+        expect(parsed.has_value(), "full option set should parse");
+        if (parsed) {
+            expect(parsed->build.configuration == mqb::BuildConfiguration::release,
+                   "release flag should override default");
+            expect(parsed->build.architecture == mqb::Architecture::x86,
+                   "x86 flag should be parsed");
+            expect(parsed->build.standard == mqb::CppStandard::latest,
+                   "latest standard should be parsed");
+            expect(parsed->toolchain_preference == mqb::msvc::ToolchainPreference::portable,
+                   "portable toolchain preference should be parsed");
+            expect(parsed->portable_roots.size() == 1,
+                   "portable root should be collected");
+            expect(parsed->include_directories.size() == 1,
+                   "attached include directory should be collected");
+            expect(parsed->defines.size() == 1 && parsed->defines.front() == "VALUE=42",
+                   "separate define value should be collected");
+            expect(parsed->verbose, "verbose flag should be parsed");
+        }
+    }
+
+    {
+        const std::vector arguments{"--help"sv};
+        auto parsed = mqb::cli::parse_arguments(arguments);
+        expect(parsed.has_value() && parsed->show_help,
+               "help should not require a source file");
+    }
+
+    {
+        const std::vector arguments{"main.cpp"sv, "--wat"sv};
+        auto parsed = mqb::cli::parse_arguments(arguments);
+        expect(!parsed, "unknown options should be rejected");
+    }
+
+    {
+        const std::vector arguments{"a.cpp"sv, "b.cpp"sv};
+        auto parsed = mqb::cli::parse_arguments(arguments);
+        expect(!parsed, "multiple sources should be rejected until multi-TU milestone");
+    }
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+
+    std::cout << "mqb_cli_argument_tests passed\n";
+    return 0;
+}

--- a/cpp/tests/mqb_cli_e2e_tests.cpp
+++ b/cpp/tests/mqb_cli_e2e_tests.cpp
@@ -100,7 +100,7 @@ int main(const int argc, char* argv[]) {
         "#endif\n"
         "int value() { return sample_value + MQB_CLI_TEST; }\n");
 
-    const fs::path object = tree.root / ".mqb" / "obj" / "sample.obj";
+    const fs::path object = tree.root / ".mqb" / "obj" / "sample.cpp.obj";
     const fs::path cache = tree.root / ".mqb" / "cache" / "sample.cpp.mqbcache";
     const fs::path dependencies = tree.root / ".mqb" / "deps" / "sample.cpp.json";
 
@@ -116,7 +116,7 @@ int main(const int argc, char* argv[]) {
         expect(cold->stdout_text.find("[compile]") != std::string::npos,
                "cold build should report a compile action");
     }
-    expect(fs::is_regular_file(object), "cold build should create object artifact");
+    expect(fs::is_regular_file(object), "cold build should create collision-free object artifact");
     expect(fs::is_regular_file(cache), "cold build should persist compile cache");
     expect(fs::is_regular_file(dependencies), "cold build should create sourceDependencies metadata");
 

--- a/cpp/tests/mqb_cli_e2e_tests.cpp
+++ b/cpp/tests/mqb_cli_e2e_tests.cpp
@@ -1,0 +1,200 @@
+#include <chrono>
+#include <expected>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+#include "mqb/platform/windows/WindowsProcessRunner.hpp"
+#include "mqb/process/Process.hpp"
+
+namespace {
+
+namespace fs = std::filesystem;
+int failures = 0;
+
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+[[nodiscard]] std::string path_text(const fs::path& path) {
+    const auto bytes = path.generic_u8string();
+    return std::string{
+        reinterpret_cast<const char*>(bytes.data()),
+        bytes.size()};
+}
+
+void write_text(const fs::path& path, const std::string_view text) {
+    std::ofstream stream{path, std::ios::binary | std::ios::trunc};
+    stream << text;
+}
+
+struct TempTree {
+    fs::path root;
+
+    ~TempTree() {
+        std::error_code ignored;
+        fs::remove_all(root, ignored);
+    }
+};
+
+[[nodiscard]] std::expected<mqb::process::ProcessResult, std::string>
+run_mqb(
+    mqb::platform::windows::WindowsProcessRunner& runner,
+    const fs::path& executable,
+    const fs::path& working_directory,
+    const fs::path& source,
+    const std::vector<std::string>& extra_arguments = {}) {
+    mqb::process::ProcessSpec spec;
+    spec.executable = executable;
+    spec.arguments = {path_text(source), "--env", "vs", "-DMQB_CLI_TEST=1"};
+    spec.arguments.insert(spec.arguments.end(), extra_arguments.begin(), extra_arguments.end());
+    spec.working_directory = working_directory;
+    spec.capture_stdout = true;
+    spec.capture_stderr = true;
+
+    auto result = runner.run(spec);
+    if (!result) {
+        return std::unexpected(
+            "failed to launch mqb: " + result.error().message);
+    }
+    return std::move(*result);
+}
+
+void dump_failure(const mqb::process::ProcessResult& result) {
+    std::cerr << "exit: " << result.exit_code << '\n'
+              << "stdout:\n" << result.stdout_text << '\n'
+              << "stderr:\n" << result.stderr_text << '\n';
+}
+
+} // namespace
+
+int main(const int argc, char* argv[]) {
+    if (argc != 2) {
+        std::cerr << "usage: mqb_cli_e2e_tests <mqb-executable>\n";
+        return 2;
+    }
+
+    const fs::path mqb_executable{argv[1]};
+    const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
+    TempTree tree{
+        .root = fs::temp_directory_path() / ("mqb_cli_e2e_" + std::to_string(unique)),
+    };
+    fs::create_directories(tree.root);
+
+    const fs::path header = tree.root / "sample.hpp";
+    const fs::path source = tree.root / "sample.cpp";
+    write_text(header, "#pragma once\ninline constexpr int sample_value = 41;\n");
+    write_text(
+        source,
+        "#include \"sample.hpp\"\n"
+        "#ifndef MQB_CLI_TEST\n"
+        "#error MQB_CLI_TEST must be defined\n"
+        "#endif\n"
+        "int value() { return sample_value + MQB_CLI_TEST; }\n");
+
+    const fs::path object = tree.root / ".mqb" / "obj" / "sample.obj";
+    const fs::path cache = tree.root / ".mqb" / "cache" / "sample.cpp.mqbcache";
+    const fs::path dependencies = tree.root / ".mqb" / "deps" / "sample.cpp.json";
+
+    mqb::platform::windows::WindowsProcessRunner runner;
+
+    auto cold = run_mqb(runner, mqb_executable, tree.root, source);
+    expect(cold.has_value(), "cold invocation should launch");
+    if (cold) {
+        if (cold->exit_code != 0) {
+            dump_failure(*cold);
+        }
+        expect(cold->exit_code == 0, "cold build should succeed");
+        expect(cold->stdout_text.find("[compile]") != std::string::npos,
+               "cold build should report a compile action");
+    }
+    expect(fs::is_regular_file(object), "cold build should create object artifact");
+    expect(fs::is_regular_file(cache), "cold build should persist compile cache");
+    expect(fs::is_regular_file(dependencies), "cold build should create sourceDependencies metadata");
+
+    auto warm = run_mqb(runner, mqb_executable, tree.root, source);
+    expect(warm.has_value(), "warm invocation should launch");
+    if (warm) {
+        if (warm->exit_code != 0) {
+            dump_failure(*warm);
+        }
+        expect(warm->exit_code == 0, "warm build should succeed");
+        expect(warm->stdout_text.find("[up-to-date]") != std::string::npos,
+               "warm build should reuse the cached object");
+    }
+
+    std::error_code error_code;
+    const auto first_object_time = fs::last_write_time(object, error_code);
+    expect(!error_code, "object timestamp should be readable");
+    if (!error_code) {
+        write_text(header, "#pragma once\ninline constexpr int sample_value = 42;\n");
+        fs::last_write_time(header, first_object_time + std::chrono::seconds{2}, error_code);
+        expect(!error_code, "header timestamp should be adjustable for deterministic invalidation");
+    }
+
+    auto header_changed = run_mqb(runner, mqb_executable, tree.root, source);
+    expect(header_changed.has_value(), "header-change invocation should launch");
+    if (header_changed) {
+        if (header_changed->exit_code != 0) {
+            dump_failure(*header_changed);
+        }
+        expect(header_changed->exit_code == 0, "header-change build should succeed");
+        expect(header_changed->stdout_text.find("[compile]") != std::string::npos,
+               "header change should trigger compilation");
+        expect(header_changed->stdout_text.find("dependency_changed") != std::string::npos,
+               "header change should be explained as dependency_changed");
+    }
+
+    error_code.clear();
+    const auto rebuilt_object_time = fs::last_write_time(object, error_code);
+    expect(!error_code, "rebuilt object timestamp should be readable");
+    if (!error_code) {
+        fs::last_write_time(header, rebuilt_object_time - std::chrono::seconds{2}, error_code);
+        expect(!error_code, "header timestamp should be normalized after rebuild");
+    }
+
+    auto warm_again = run_mqb(runner, mqb_executable, tree.root, source);
+    expect(warm_again.has_value(), "second warm invocation should launch");
+    if (warm_again) {
+        if (warm_again->exit_code != 0) {
+            dump_failure(*warm_again);
+        }
+        expect(warm_again->exit_code == 0, "second warm build should succeed");
+        expect(warm_again->stdout_text.find("[up-to-date]") != std::string::npos,
+               "rebuilt object should become reusable again");
+    }
+
+    auto release = run_mqb(
+        runner,
+        mqb_executable,
+        tree.root,
+        source,
+        {"--release"});
+    expect(release.has_value(), "release invocation should launch");
+    if (release) {
+        if (release->exit_code != 0) {
+            dump_failure(*release);
+        }
+        expect(release->exit_code == 0, "release build should succeed");
+        expect(release->stdout_text.find("[compile]") != std::string::npos,
+               "Debug to Release should trigger compilation without source edits");
+        expect(release->stdout_text.find("compiler_options_changed") != std::string::npos,
+               "configuration invalidation should be explained as compiler_options_changed");
+    }
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+
+    std::cout << "mqb_cli_e2e_tests passed\n";
+    return 0;
+}

--- a/cpp/tests/mqb_cli_e2e_tests.cpp
+++ b/cpp/tests/mqb_cli_e2e_tests.cpp
@@ -149,8 +149,8 @@ int main(const int argc, char* argv[]) {
         expect(header_changed->exit_code == 0, "header-change build should succeed");
         expect(header_changed->stdout_text.find("[compile]") != std::string::npos,
                "header change should trigger compilation");
-        expect(header_changed->stdout_text.find("dependency_changed") != std::string::npos,
-               "header change should be explained as dependency_changed");
+        expect(header_changed->stdout_text.find("dependency changed") != std::string::npos,
+               "header change should be explained as dependency changed");
     }
 
     error_code.clear();
@@ -186,8 +186,8 @@ int main(const int argc, char* argv[]) {
         expect(release->exit_code == 0, "release build should succeed");
         expect(release->stdout_text.find("[compile]") != std::string::npos,
                "Debug to Release should trigger compilation without source edits");
-        expect(release->stdout_text.find("compiler_options_changed") != std::string::npos,
-               "configuration invalidation should be explained as compiler_options_changed");
+        expect(release->stdout_text.find("compiler options changed") != std::string::npos,
+               "configuration invalidation should be explained as compiler options changed");
     }
 
     if (failures != 0) {

--- a/cpp/tests/msvc_compiler_arguments_tests.cpp
+++ b/cpp/tests/msvc_compiler_arguments_tests.cpp
@@ -51,7 +51,10 @@ int main() {
         expect(contains(*result, "/Od"), "debug configuration should disable optimization");
         expect(contains(*result, "/MDd"), "debug configuration should select debug DLL CRT");
         expect(contains(*result, "/D_DEBUG"), "debug configuration should define _DEBUG");
-        expect(contains(*result, "/std:c++23"), "C++23 should map to the MSVC standard switch");
+        expect(contains(*result, "/std:c++23preview"),
+               "C++23 should map to MSVC's current C++23 preview switch");
+        expect(!contains(*result, "/std:c++23"),
+               "unsupported /std:c++23 must not be emitted before MSVC implements it");
         expect(contains(*result, "/DUNICODE"), "explicit defines should become /D argv elements");
         expect(contains(*result, "/DFEATURE=7"), "define values should be preserved");
         expect(contains(*result, "/Iinclude"), "include path should become one /I argv element");
@@ -70,6 +73,15 @@ int main() {
         const auto structured_fo = std::find(result->begin(), result->end(), "/Fobuild/my file.obj");
         expect(raw_fo != result->end() && structured_fo != result->end() && raw_fo < structured_fo,
                "structured object routing should win by appearing after a raw /Fo");
+    }
+
+    auto cpp20 = invocation;
+    cpp20.options.standard = mqb::CppStandard::cpp20;
+    cpp20.options.additional_arguments.clear();
+    const auto cpp20_result = mqb::msvc::MsvcCompiler::build_arguments(cpp20);
+    expect(cpp20_result.has_value(), "C++20 compile invocation should be supported");
+    if (cpp20_result) {
+        expect(contains(*cpp20_result, "/std:c++20"), "C++20 should map correctly");
     }
 
     auto release = invocation;


### PR DESCRIPTION
Milestone 2A for the C++ V2 migration.

- replaces the scaffold CLI with a real single-TU incremental compile path
- keeps planning/cache policy in the existing core/orchestration layers
- writes generated state under `.mqb/{obj,deps,cache}` instead of the source directory
- supports Debug/Release, C++20/23/latest, x86/x64, `-I`, `-D`, and toolchain selection
- adds CLI argument tests and a real VS/MSVC end-to-end test covering cold build, warm cache, header invalidation, and Debug→Release invalidation

This milestone intentionally stops at object compilation. Link state/executable production is the next isolated milestone.