### PR TITLE
refactor: add first-class incremental link state

### DIFF
--- a/cpp/apps/mqb/Cli.cpp
+++ b/cpp/apps/mqb/Cli.cpp
@@ -185,19 +185,25 @@ Usage:
   mqb <source.cpp> [options]
 
 Current milestone:
-  Incremental compilation of one C++ translation unit to .mqb/obj/.
+  Incrementally compile and link one C++ translation unit into .mqb/bin/.
 
 Options:
-  --debug                 Debug compiler preset (default)
-  --release               Release compiler preset
-  --std <20|23|latest>    C++ language standard (default: 23)
-  --x86 | --x64           Target architecture (default: x64)
-  -I <dir>, -I<dir>       Add an include directory
-  -D <value>, -D<value>   Add a preprocessor definition
+  --debug                  Debug compile/link preset (default)
+  --release                Release compile/link preset
+  --std <20|23|latest>     C++ language standard (default: 23)
+  --x86 | --x64            Target architecture (default: x64)
+  -I <dir>, -I<dir>        Add an include directory
+  -D <value>, -D<value>    Add a preprocessor definition
   --env <auto|vs|portable> Toolchain selection (default: auto)
-  --portable-root <dir>   Add a portable_msvc root candidate
-  -v, --verbose           Show toolchain and artifact details
-  -h, --help              Show this help
+  --portable-root <dir>    Add a portable_msvc root candidate
+  -v, --verbose            Show toolchain and artifact details
+  -h, --help               Show this help
+
+Generated state:
+  .mqb/obj/    object files
+  .mqb/deps/   compiler dependency metadata
+  .mqb/cache/  compile and link cache metadata
+  .mqb/bin/    linked executables
 )";
 }
 

--- a/cpp/apps/mqb/main.cpp
+++ b/cpp/apps/mqb/main.cpp
@@ -14,10 +14,13 @@
 #include "mqb/core/Artifact.hpp"
 #include "mqb/core/BuildTypes.hpp"
 #include "mqb/core/CompilerOptions.hpp"
+#include "mqb/core/LinkOptions.hpp"
 #include "mqb/core/TranslationUnit.hpp"
 #include "mqb/msvc/MsvcCompileExecutor.hpp"
+#include "mqb/msvc/MsvcLinker.hpp"
 #include "mqb/msvc/MsvcToolchainLocator.hpp"
 #include "mqb/orchestration/MsvcIncrementalCompileCoordinator.hpp"
+#include "mqb/orchestration/MsvcIncrementalLinkCoordinator.hpp"
 #include "mqb/platform/windows/WindowsProcessRunner.hpp"
 #include "mqb/process/Process.hpp"
 
@@ -80,6 +83,20 @@ void print_process_output(const mqb::process::ProcessResult& process) {
     }
 }
 
+void print_reasons(const std::vector<mqb::BuildReason>& reasons) {
+    if (reasons.empty()) {
+        return;
+    }
+    std::cout << " [";
+    for (std::size_t index = 0; index < reasons.size(); ++index) {
+        if (index != 0) {
+            std::cout << ", ";
+        }
+        std::cout << mqb::to_string(reasons[index]);
+    }
+    std::cout << ']';
+}
+
 void print_compile_failure(const mqb::orchestration::IncrementalCompileError& error) {
     std::cerr << "error: " << error.message << '\n';
     if (!error.compile_error) {
@@ -97,6 +114,22 @@ void print_compile_failure(const mqb::orchestration::IncrementalCompileError& er
     }
     if (compile_error.dependency_error) {
         std::cerr << "  " << compile_error.dependency_error->message << '\n';
+    }
+}
+
+void print_link_failure(const mqb::orchestration::IncrementalLinkError& error) {
+    std::cerr << "error: " << error.message << '\n';
+    if (!error.linker_error) {
+        return;
+    }
+
+    const auto& linker_error = *error.linker_error;
+    std::cerr << "  " << linker_error.message << '\n';
+    if (linker_error.process_result) {
+        print_process_output(*linker_error.process_result);
+    }
+    if (linker_error.process_error) {
+        std::cerr << "  " << linker_error.process_error->message << '\n';
     }
 }
 
@@ -165,12 +198,17 @@ int main(const int argc, char* argv[]) {
     const fs::path artifact_root = source_directory / ".mqb";
 
     // Keep the source extension in internal artifact names so sibling files
-    // such as foo.cpp and foo.cxx cannot alias the same cached object.
+    // such as foo.cpp and foo.cxx cannot alias one another.
     fs::path object_name = source->filename();
     object_name += ".obj";
+    fs::path executable_name = source->filename();
+    executable_name += ".exe";
+
     const fs::path object_file = artifact_root / "obj" / object_name;
     const fs::path dependency_file = artifact_root / "deps" / with_suffix(source->filename(), ".json");
-    const fs::path cache_file = artifact_root / "cache" / with_suffix(source->filename(), ".mqbcache");
+    const fs::path compile_cache_file = artifact_root / "cache" / with_suffix(source->filename(), ".mqbcache");
+    const fs::path link_cache_file = artifact_root / "cache" / with_suffix(source->filename(), ".linkcache");
+    const fs::path executable_file = artifact_root / "bin" / executable_name;
 
     add_portable_root_if_missing(options.portable_roots, source_directory / "portable_msvc");
     const fs::path current_directory = fs::current_path(error_code);
@@ -214,29 +252,34 @@ int main(const int argc, char* argv[]) {
     if (options.verbose) {
         std::cout << "[toolchain] MSVC " << toolchain->identity.version
                   << " (" << mqb::to_string(options.build.architecture) << ")\n"
-                  << "  cl:    " << path_text(toolchain->identity.compiler) << '\n'
-                  << "  obj:   " << path_text(object_file) << '\n'
-                  << "  deps:  " << path_text(dependency_file) << '\n'
-                  << "  cache: " << path_text(cache_file) << '\n';
+                  << "  cl:         " << path_text(toolchain->identity.compiler) << '\n'
+                  << "  link:       " << path_text(toolchain->linker) << '\n'
+                  << "  obj:        " << path_text(object_file) << '\n'
+                  << "  deps:       " << path_text(dependency_file) << '\n'
+                  << "  cc-cache:   " << path_text(compile_cache_file) << '\n'
+                  << "  link-cache: " << path_text(link_cache_file) << '\n'
+                  << "  exe:        " << path_text(executable_file) << '\n';
     }
 
-    mqb::msvc::MsvcCompileExecutor executor{*toolchain, runner};
-    mqb::orchestration::MsvcIncrementalCompileCoordinator coordinator{*toolchain, executor};
-    mqb::orchestration::IncrementalCompileRequest request{
+    mqb::msvc::MsvcCompileExecutor compile_executor{*toolchain, runner};
+    mqb::orchestration::MsvcIncrementalCompileCoordinator compile_coordinator{
+        *toolchain,
+        compile_executor};
+    mqb::orchestration::IncrementalCompileRequest compile_request{
         .unit = std::move(unit),
         .options = std::move(compiler_options),
-        .cache_file = cache_file,
+        .cache_file = compile_cache_file,
         .source_dependencies_file = dependency_file,
         .working_directory = source_directory,
     };
 
-    auto result = coordinator.run(request);
-    if (!result) {
-        print_compile_failure(result.error());
+    auto compile_result = compile_coordinator.run(compile_request);
+    if (!compile_result) {
+        print_compile_failure(compile_result.error());
         return 4;
     }
 
-    for (const auto& warning : result->warnings) {
+    for (const auto& warning : compile_result->warnings) {
         std::cerr << "warning: " << warning.message;
         if (!warning.path.empty()) {
             std::cerr << ": " << path_text(warning.path);
@@ -244,26 +287,58 @@ int main(const int argc, char* argv[]) {
         std::cerr << '\n';
     }
 
-    if (result->compiled) {
+    if (compile_result->compiled) {
         std::cout << "[compile] " << path_text(source->filename());
-        if (!result->validation.reasons.empty()) {
-            std::cout << " [";
-            for (std::size_t index = 0; index < result->validation.reasons.size(); ++index) {
-                if (index != 0) {
-                    std::cout << ", ";
-                }
-                std::cout << mqb::to_string(result->validation.reasons[index]);
-            }
-            std::cout << ']';
-        }
+        print_reasons(compile_result->validation.reasons);
         std::cout << '\n';
-        if (result->process) {
-            print_process_output(*result->process);
+        if (compile_result->process) {
+            print_process_output(*compile_result->process);
         }
     } else {
         std::cout << "[up-to-date] " << path_text(source->filename()) << '\n';
     }
 
-    std::cout << "object: " << path_text(object_file) << '\n';
+    mqb::LinkOptions link_options;
+    link_options.configuration = options.build.configuration;
+    link_options.architecture = options.build.architecture;
+    link_options.subsystem = mqb::LinkSubsystem::console;
+
+    mqb::msvc::MsvcLinker linker{*toolchain, runner};
+    mqb::orchestration::MsvcIncrementalLinkCoordinator link_coordinator{*toolchain, linker};
+    mqb::orchestration::IncrementalLinkRequest link_request{
+        .objects = {object_file},
+        .output = executable_file,
+        .options = std::move(link_options),
+        .cache_file = link_cache_file,
+        .working_directory = source_directory,
+        .force_relink = compile_result->compiled,
+    };
+
+    auto link_result = link_coordinator.run(link_request);
+    if (!link_result) {
+        print_link_failure(link_result.error());
+        return 5;
+    }
+
+    for (const auto& warning : link_result->warnings) {
+        std::cerr << "warning: " << warning.message;
+        if (!warning.path.empty()) {
+            std::cerr << ": " << path_text(warning.path);
+        }
+        std::cerr << '\n';
+    }
+
+    if (link_result->linked) {
+        std::cout << "[link] " << path_text(executable_file.filename());
+        print_reasons(link_result->validation.reasons);
+        std::cout << '\n';
+        if (link_result->process) {
+            print_process_output(*link_result->process);
+        }
+    } else {
+        std::cout << "[up-to-date] " << path_text(executable_file.filename()) << '\n';
+    }
+
+    std::cout << "executable: " << path_text(executable_file) << '\n';
     return 0;
 }

--- a/cpp/backends/msvc/CMakeLists.txt
+++ b/cpp/backends/msvc/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(mqb_msvc STATIC
     src/MsvcCompileExecutor.cpp
     src/MsvcCompiler.cpp
+    src/MsvcLinker.cpp
     src/MsvcSourceDependenciesReader.cpp
     src/MsvcToolchainLocator.cpp
 )

--- a/cpp/backends/msvc/include/mqb/msvc/MsvcLinker.hpp
+++ b/cpp/backends/msvc/include/mqb/msvc/MsvcLinker.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <expected>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "mqb/core/LinkOptions.hpp"
+#include "mqb/core/LinkerIdentity.hpp"
+#include "mqb/msvc/MsvcToolchainLocator.hpp"
+#include "mqb/process/Process.hpp"
+
+namespace mqb::msvc {
+
+struct LinkInvocation {
+    std::vector<std::filesystem::path> objects;
+    std::filesystem::path output;
+    LinkOptions options;
+    std::filesystem::path working_directory;
+};
+
+enum class LinkerErrorCode {
+    invalid_request,
+    identity_failed,
+    output_prepare_failed,
+    process_failed,
+    link_failed,
+};
+
+struct LinkerError {
+    LinkerErrorCode code{LinkerErrorCode::invalid_request};
+    std::string message;
+    std::filesystem::path path;
+    std::optional<process::ProcessError> process_error;
+    std::optional<process::ProcessResult> process_result;
+};
+
+class MsvcLinker {
+public:
+    MsvcLinker(const MsvcToolchain& toolchain, process::ProcessRunner& runner)
+        : toolchain_(toolchain), runner_(runner) {}
+
+    [[nodiscard]] static std::expected<LinkerIdentity, LinkerError>
+    identity(const MsvcToolchain& toolchain);
+
+    [[nodiscard]] static std::expected<std::vector<std::string>, LinkerError>
+    build_arguments(const LinkInvocation& invocation);
+
+    [[nodiscard]] std::expected<process::ProcessResult, LinkerError>
+    link(const LinkInvocation& invocation) const;
+
+private:
+    const MsvcToolchain& toolchain_;
+    process::ProcessRunner& runner_;
+};
+
+} // namespace mqb::msvc

--- a/cpp/backends/msvc/src/MsvcLinker.cpp
+++ b/cpp/backends/msvc/src/MsvcLinker.cpp
@@ -1,0 +1,213 @@
+#include "mqb/msvc/MsvcLinker.hpp"
+
+#include <filesystem>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <utility>
+
+namespace mqb::msvc {
+namespace {
+
+namespace fs = std::filesystem;
+
+[[nodiscard]] LinkerError failure(
+    const LinkerErrorCode code,
+    std::string message,
+    fs::path path = {}) {
+    return LinkerError{
+        .code = code,
+        .message = std::move(message),
+        .path = std::move(path),
+    };
+}
+
+[[nodiscard]] std::string path_to_utf8(const fs::path& path) {
+    const auto bytes = path.generic_u8string();
+    return std::string{
+        reinterpret_cast<const char*>(bytes.data()),
+        bytes.size()};
+}
+
+[[nodiscard]] std::string architecture_argument(const Architecture architecture) {
+    return architecture == Architecture::x86 ? "/MACHINE:X86" : "/MACHINE:X64";
+}
+
+[[nodiscard]] std::string subsystem_argument(const LinkSubsystem subsystem) {
+    return subsystem == LinkSubsystem::windows ? "/SUBSYSTEM:WINDOWS" : "/SUBSYSTEM:CONSOLE";
+}
+
+[[nodiscard]] std::expected<void, LinkerError> prepare_output_parent(const fs::path& output) {
+    const fs::path parent = output.parent_path();
+    if (parent.empty()) {
+        return {};
+    }
+
+    std::error_code error_code;
+    fs::create_directories(parent, error_code);
+    if (error_code) {
+        return std::unexpected(failure(
+            LinkerErrorCode::output_prepare_failed,
+            "failed to prepare linker output directory",
+            parent));
+    }
+    return {};
+}
+
+} // namespace
+
+std::expected<LinkerIdentity, LinkerError>
+MsvcLinker::identity(const MsvcToolchain& toolchain) {
+    if (toolchain.linker.empty()) {
+        return std::unexpected(failure(
+            LinkerErrorCode::identity_failed,
+            "MSVC linker path is empty"));
+    }
+
+    std::error_code error_code;
+    if (!fs::is_regular_file(toolchain.linker, error_code) || error_code) {
+        return std::unexpected(failure(
+            LinkerErrorCode::identity_failed,
+            "MSVC linker executable does not exist",
+            toolchain.linker));
+    }
+
+    const auto size = fs::file_size(toolchain.linker, error_code);
+    if (error_code) {
+        return std::unexpected(failure(
+            LinkerErrorCode::identity_failed,
+            "cannot read MSVC linker size",
+            toolchain.linker));
+    }
+    const auto modified = fs::last_write_time(toolchain.linker, error_code);
+    if (error_code) {
+        return std::unexpected(failure(
+            LinkerErrorCode::identity_failed,
+            "cannot read MSVC linker timestamp",
+            toolchain.linker));
+    }
+
+    return LinkerIdentity{
+        .linker = toolchain.linker,
+        .version = toolchain.identity.version,
+        .binary_stamp = std::to_string(size) + ":"
+            + std::to_string(modified.time_since_epoch().count()),
+    };
+}
+
+std::expected<std::vector<std::string>, LinkerError>
+MsvcLinker::build_arguments(const LinkInvocation& invocation) {
+    if (invocation.objects.empty()) {
+        return std::unexpected(failure(
+            LinkerErrorCode::invalid_request,
+            "link invocation has no object inputs"));
+    }
+    for (const auto& object : invocation.objects) {
+        if (object.empty()) {
+            return std::unexpected(failure(
+                LinkerErrorCode::invalid_request,
+                "link invocation contains an empty object path"));
+        }
+    }
+    if (invocation.output.empty()) {
+        return std::unexpected(failure(
+            LinkerErrorCode::invalid_request,
+            "link output path is empty"));
+    }
+
+    std::vector<std::string> arguments;
+    arguments.reserve(
+        12
+        + invocation.objects.size()
+        + invocation.options.library_directories.size()
+        + invocation.options.libraries.size()
+        + invocation.options.additional_arguments.size());
+
+    arguments.emplace_back("/NOLOGO");
+    if (invocation.options.configuration == BuildConfiguration::debug) {
+        arguments.emplace_back("/DEBUG");
+        arguments.emplace_back("/INCREMENTAL");
+    } else {
+        arguments.emplace_back("/INCREMENTAL:NO");
+        arguments.emplace_back("/OPT:REF");
+        arguments.emplace_back("/OPT:ICF");
+    }
+
+    for (const auto& directory : invocation.options.library_directories) {
+        if (directory.empty()) {
+            return std::unexpected(failure(
+                LinkerErrorCode::invalid_request,
+                "library directory must not be empty"));
+        }
+        arguments.push_back("/LIBPATH:" + path_to_utf8(directory));
+    }
+    for (const auto& library : invocation.options.libraries) {
+        if (library.empty()) {
+            return std::unexpected(failure(
+                LinkerErrorCode::invalid_request,
+                "library name must not be empty"));
+        }
+        arguments.push_back(library);
+    }
+    for (const auto& argument : invocation.options.additional_arguments) {
+        if (argument.empty()) {
+            return std::unexpected(failure(
+                LinkerErrorCode::invalid_request,
+                "additional linker argument must not be empty"));
+        }
+        arguments.push_back(argument);
+    }
+
+    // Structured routing is emitted after raw flags so the BuildPlan owns the
+    // final target identity even if a user supplied a conflicting raw switch.
+    arguments.push_back(architecture_argument(invocation.options.architecture));
+    arguments.push_back(subsystem_argument(invocation.options.subsystem));
+    arguments.push_back("/OUT:" + path_to_utf8(invocation.output));
+    for (const auto& object : invocation.objects) {
+        arguments.push_back(path_to_utf8(object));
+    }
+    return arguments;
+}
+
+std::expected<process::ProcessResult, LinkerError>
+MsvcLinker::link(const LinkInvocation& invocation) const {
+    auto arguments = build_arguments(invocation);
+    if (!arguments) {
+        return std::unexpected(arguments.error());
+    }
+
+    auto prepared = prepare_output_parent(invocation.output);
+    if (!prepared) {
+        return std::unexpected(prepared.error());
+    }
+
+    process::ProcessSpec spec;
+    spec.executable = toolchain_.linker;
+    spec.arguments = std::move(*arguments);
+    spec.working_directory = invocation.working_directory;
+    spec.environment = toolchain_.environment;
+    spec.inherit_environment = true;
+    spec.capture_stdout = true;
+    spec.capture_stderr = true;
+
+    auto result = runner_.run(spec);
+    if (!result) {
+        return std::unexpected(LinkerError{
+            .code = LinkerErrorCode::process_failed,
+            .message = "failed to launch MSVC linker",
+            .path = toolchain_.linker,
+            .process_error = result.error(),
+        });
+    }
+    if (result->exit_code != 0) {
+        return std::unexpected(LinkerError{
+            .code = LinkerErrorCode::link_failed,
+            .message = "MSVC linker returned a non-zero exit code",
+            .path = toolchain_.linker,
+            .process_result = std::move(*result),
+        });
+    }
+    return std::move(*result);
+}
+
+} // namespace mqb::msvc

--- a/cpp/core/CMakeLists.txt
+++ b/cpp/core/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(mqb_core STATIC
     src/CompileCache.cpp
     src/CompileCacheFile.cpp
     src/DependencyGraph.cpp
+    src/LinkCache.cpp
 )
 
 target_include_directories(mqb_core

--- a/cpp/core/CMakeLists.txt
+++ b/cpp/core/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(mqb_core STATIC
     src/CompileCacheFile.cpp
     src/DependencyGraph.cpp
     src/LinkCache.cpp
+    src/LinkCacheFile.cpp
 )
 
 target_include_directories(mqb_core

--- a/cpp/core/include/mqb/core/BuildPlanner.hpp
+++ b/cpp/core/include/mqb/core/BuildPlanner.hpp
@@ -8,6 +8,7 @@
 
 #include "mqb/core/BuildPlan.hpp"
 #include "mqb/core/CompileCache.hpp"
+#include "mqb/core/LinkCache.hpp"
 #include "mqb/core/TranslationUnit.hpp"
 
 namespace mqb {
@@ -15,6 +16,8 @@ namespace mqb {
 enum class BuildPlannerErrorCode {
     missing_object_output,
     multiple_object_outputs,
+    missing_link_input,
+    missing_link_output,
 };
 
 struct BuildPlannerError {
@@ -28,10 +31,19 @@ struct CompilePlanItem {
     CompileCacheValidation cache_validation;
 };
 
+struct LinkPlanItem {
+    std::vector<std::filesystem::path> objects;
+    std::filesystem::path output;
+    LinkCacheValidation cache_validation;
+};
+
 class BuildPlanner {
 public:
     [[nodiscard]] static std::expected<BuildPlan, BuildPlannerError> plan_compile(
         std::span<const CompilePlanItem> items);
+
+    [[nodiscard]] static std::expected<BuildPlan, BuildPlannerError> plan_link(
+        const LinkPlanItem& item);
 };
 
 } // namespace mqb

--- a/cpp/core/include/mqb/core/BuildSignature.hpp
+++ b/cpp/core/include/mqb/core/BuildSignature.hpp
@@ -1,9 +1,13 @@
 #pragma once
 
 #include <cstdint>
+#include <filesystem>
+#include <span>
 #include <string>
 
 #include "mqb/core/CompilerOptions.hpp"
+#include "mqb/core/LinkOptions.hpp"
+#include "mqb/core/LinkerIdentity.hpp"
 #include "mqb/core/ToolchainIdentity.hpp"
 #include "mqb/core/TranslationUnit.hpp"
 
@@ -23,6 +27,12 @@ public:
         const TranslationUnit& unit,
         const ToolchainIdentity& toolchain,
         const CompilerOptions& options);
+
+    [[nodiscard]] static BuildSignature for_link(
+        std::span<const std::filesystem::path> objects,
+        const std::filesystem::path& output,
+        const LinkerIdentity& linker,
+        const LinkOptions& options);
 
     [[nodiscard]] static BuildSignature from_digest(const SignatureDigest digest) noexcept {
         return BuildSignature{digest};

--- a/cpp/core/include/mqb/core/BuildTypes.hpp
+++ b/cpp/core/include/mqb/core/BuildTypes.hpp
@@ -27,6 +27,7 @@ enum class BuildReason {
     dependency_changed,
     toolchain_changed,
     compiler_options_changed,
+    link_inputs_changed,
     linker_options_changed,
     explicit_rebuild,
 };

--- a/cpp/core/include/mqb/core/CompileCache.hpp
+++ b/cpp/core/include/mqb/core/CompileCache.hpp
@@ -9,16 +9,11 @@
 #include "mqb/core/BuildSignature.hpp"
 #include "mqb/core/BuildTypes.hpp"
 #include "mqb/core/CompilerOptions.hpp"
+#include "mqb/core/FileSnapshot.hpp"
 #include "mqb/core/ToolchainIdentity.hpp"
 #include "mqb/core/TranslationUnit.hpp"
 
 namespace mqb {
-
-struct FileSnapshot {
-    std::filesystem::path path;
-    bool exists{false};
-    std::filesystem::file_time_type modified{};
-};
 
 struct CompileCacheEntry {
     std::filesystem::path source;

--- a/cpp/core/include/mqb/core/FileSnapshot.hpp
+++ b/cpp/core/include/mqb/core/FileSnapshot.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <filesystem>
+
+namespace mqb {
+
+struct FileSnapshot {
+    std::filesystem::path path;
+    bool exists{false};
+    std::filesystem::file_time_type modified{};
+};
+
+} // namespace mqb

--- a/cpp/core/include/mqb/core/LinkCache.hpp
+++ b/cpp/core/include/mqb/core/LinkCache.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <filesystem>
+#include <optional>
+#include <span>
+#include <vector>
+
+#include "mqb/core/BuildSignature.hpp"
+#include "mqb/core/BuildTypes.hpp"
+#include "mqb/core/FileSnapshot.hpp"
+#include "mqb/core/LinkOptions.hpp"
+#include "mqb/core/LinkerIdentity.hpp"
+
+namespace mqb {
+
+struct LinkCacheEntry {
+    LinkerIdentity linker;
+    BuildSignature signature;
+    std::vector<std::filesystem::path> objects;
+    std::filesystem::path output;
+};
+
+struct LinkCacheValidation {
+    std::vector<BuildReason> reasons;
+
+    [[nodiscard]] bool reusable() const noexcept {
+        return reasons.empty();
+    }
+};
+
+class LinkCacheValidator {
+public:
+    [[nodiscard]] static LinkCacheValidation validate(
+        std::span<const std::filesystem::path> current_objects,
+        const std::filesystem::path& current_output,
+        const LinkerIdentity& current_linker,
+        const LinkOptions& current_options,
+        const std::optional<LinkCacheEntry>& cached_entry,
+        const FileSnapshot& output_snapshot,
+        std::span<const FileSnapshot> object_snapshots,
+        bool force_relink = false);
+};
+
+} // namespace mqb

--- a/cpp/core/include/mqb/core/LinkCacheFile.hpp
+++ b/cpp/core/include/mqb/core/LinkCacheFile.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <cstddef>
+#include <expected>
+#include <filesystem>
+#include <optional>
+#include <string>
+
+#include "mqb/core/LinkCache.hpp"
+
+namespace mqb {
+
+enum class LinkCacheFileErrorCode {
+    file_open_failed,
+    file_read_failed,
+    file_write_failed,
+    invalid_magic,
+    unsupported_version,
+    corrupt_data,
+    replace_failed,
+};
+
+struct LinkCacheFileError {
+    LinkCacheFileErrorCode code{LinkCacheFileErrorCode::corrupt_data};
+    std::filesystem::path file;
+    std::size_t offset{};
+    std::string message;
+};
+
+class LinkCacheFile {
+public:
+    [[nodiscard]] static std::expected<std::optional<LinkCacheEntry>, LinkCacheFileError>
+    load(const std::filesystem::path& file);
+
+    [[nodiscard]] static std::expected<void, LinkCacheFileError>
+    save(const std::filesystem::path& file, const LinkCacheEntry& entry);
+};
+
+} // namespace mqb

--- a/cpp/core/include/mqb/core/LinkOptions.hpp
+++ b/cpp/core/include/mqb/core/LinkOptions.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include "mqb/core/BuildTypes.hpp"
+
+namespace mqb {
+
+enum class LinkSubsystem {
+    console,
+    windows,
+};
+
+struct LinkOptions {
+    BuildConfiguration configuration{BuildConfiguration::debug};
+    Architecture architecture{Architecture::x64};
+    LinkSubsystem subsystem{LinkSubsystem::console};
+    std::vector<std::filesystem::path> library_directories;
+    std::vector<std::string> libraries;
+    std::vector<std::string> additional_arguments;
+};
+
+} // namespace mqb

--- a/cpp/core/include/mqb/core/LinkerIdentity.hpp
+++ b/cpp/core/include/mqb/core/LinkerIdentity.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+
+namespace mqb {
+
+// Core treats binary_stamp as opaque. The backend decides whether it is an
+// mtime, version-resource digest, or stronger content fingerprint.
+struct LinkerIdentity {
+    std::filesystem::path linker;
+    std::string version;
+    std::string binary_stamp;
+};
+
+} // namespace mqb

--- a/cpp/core/src/BuildPlanner.cpp
+++ b/cpp/core/src/BuildPlanner.cpp
@@ -55,4 +55,37 @@ std::expected<BuildPlan, BuildPlannerError> BuildPlanner::plan_compile(
     return plan;
 }
 
+std::expected<BuildPlan, BuildPlannerError> BuildPlanner::plan_link(
+    const LinkPlanItem& item) {
+    BuildPlan plan;
+    if (item.cache_validation.reusable()) {
+        return plan;
+    }
+
+    if (item.objects.empty()) {
+        return std::unexpected(BuildPlannerError{
+            .code = BuildPlannerErrorCode::missing_link_input,
+        });
+    }
+    for (const auto& object : item.objects) {
+        if (object.empty()) {
+            return std::unexpected(BuildPlannerError{
+                .code = BuildPlannerErrorCode::missing_link_input,
+            });
+        }
+    }
+    if (item.output.empty()) {
+        return std::unexpected(BuildPlannerError{
+            .code = BuildPlannerErrorCode::missing_link_output,
+        });
+    }
+
+    plan.actions.emplace_back(LinkAction{
+        .objects = item.objects,
+        .output = item.output,
+        .reasons = item.cache_validation.reasons,
+    });
+    return plan;
+}
+
 } // namespace mqb

--- a/cpp/core/src/BuildSignature.cpp
+++ b/cpp/core/src/BuildSignature.cpp
@@ -55,7 +55,7 @@ public:
         }
     }
 
-    void add_paths(const std::vector<std::filesystem::path>& values) noexcept {
+    void add_paths(const std::span<const std::filesystem::path> values) noexcept {
         add_u64(static_cast<std::uint64_t>(values.size()));
         for (const auto& value : values) {
             add_path(value);
@@ -105,9 +105,6 @@ BuildSignature BuildSignature::for_compile(
     const ToolchainIdentity& toolchain,
     const CompilerOptions& options) {
     StableHasher hasher;
-
-    // Version the schema explicitly. Adding/removing signature fields must bump
-    // this token so old cache entries cannot alias the new representation.
     hasher.add_string("mqb.compile.signature.v1");
 
     // Dependencies and output paths are deliberately excluded. Dependency
@@ -125,6 +122,34 @@ BuildSignature BuildSignature::for_compile(
     hasher.add_enum(options.standard);
     hasher.add_strings(options.defines);
     hasher.add_paths(options.include_directories);
+    hasher.add_strings(options.additional_arguments);
+
+    return BuildSignature{hasher.finish()};
+}
+
+BuildSignature BuildSignature::for_link(
+    const std::span<const std::filesystem::path> objects,
+    const std::filesystem::path& output,
+    const LinkerIdentity& linker,
+    const LinkOptions& options) {
+    StableHasher hasher;
+    hasher.add_string("mqb.link.signature.v1");
+
+    // Link input order is intentionally preserved. Although ordinary COFF
+    // objects are often order-insensitive, libraries and future link inputs are
+    // not universally so; signature identity should mirror the requested argv.
+    hasher.add_paths(objects);
+    hasher.add_path(output);
+
+    hasher.add_path(linker.linker);
+    hasher.add_string(linker.version);
+    hasher.add_string(linker.binary_stamp);
+
+    hasher.add_enum(options.configuration);
+    hasher.add_enum(options.architecture);
+    hasher.add_enum(options.subsystem);
+    hasher.add_paths(options.library_directories);
+    hasher.add_strings(options.libraries);
     hasher.add_strings(options.additional_arguments);
 
     return BuildSignature{hasher.finish()};

--- a/cpp/core/src/BuildTypes.cpp
+++ b/cpp/core/src/BuildTypes.cpp
@@ -48,6 +48,8 @@ std::string_view to_string(const BuildReason value) noexcept {
         return "toolchain changed";
     case BuildReason::compiler_options_changed:
         return "compiler options changed";
+    case BuildReason::link_inputs_changed:
+        return "link inputs changed";
     case BuildReason::linker_options_changed:
         return "linker options changed";
     case BuildReason::explicit_rebuild:

--- a/cpp/core/src/LinkCache.cpp
+++ b/cpp/core/src/LinkCache.cpp
@@ -1,0 +1,123 @@
+#include "mqb/core/LinkCache.hpp"
+
+#include <algorithm>
+#include <filesystem>
+#include <span>
+
+namespace mqb {
+namespace {
+
+[[nodiscard]] bool same_path(
+    const std::filesystem::path& left,
+    const std::filesystem::path& right) {
+    return left.lexically_normal() == right.lexically_normal();
+}
+
+[[nodiscard]] bool same_paths(
+    const std::span<const std::filesystem::path> left,
+    const std::span<const std::filesystem::path> right) {
+    if (left.size() != right.size()) {
+        return false;
+    }
+    for (std::size_t index = 0; index < left.size(); ++index) {
+        if (!same_path(left[index], right[index])) {
+            return false;
+        }
+    }
+    return true;
+}
+
+[[nodiscard]] bool same_linker(
+    const LinkerIdentity& left,
+    const LinkerIdentity& right) {
+    return same_path(left.linker, right.linker)
+        && left.version == right.version
+        && left.binary_stamp == right.binary_stamp;
+}
+
+void add_reason(std::vector<BuildReason>& reasons, const BuildReason reason) {
+    if (std::find(reasons.begin(), reasons.end(), reason) == reasons.end()) {
+        reasons.push_back(reason);
+    }
+}
+
+[[nodiscard]] const FileSnapshot* find_snapshot(
+    const std::span<const FileSnapshot> snapshots,
+    const std::filesystem::path& path) {
+    const auto it = std::find_if(
+        snapshots.begin(),
+        snapshots.end(),
+        [&path](const FileSnapshot& snapshot) {
+            return same_path(snapshot.path, path);
+        });
+    return it == snapshots.end() ? nullptr : &*it;
+}
+
+} // namespace
+
+LinkCacheValidation LinkCacheValidator::validate(
+    const std::span<const std::filesystem::path> current_objects,
+    const std::filesystem::path& current_output,
+    const LinkerIdentity& current_linker,
+    const LinkOptions& current_options,
+    const std::optional<LinkCacheEntry>& cached_entry,
+    const FileSnapshot& output_snapshot,
+    const std::span<const FileSnapshot> object_snapshots,
+    const bool force_relink) {
+    LinkCacheValidation result;
+
+    if (force_relink) {
+        add_reason(result.reasons, BuildReason::explicit_rebuild);
+    }
+
+    if (!cached_entry) {
+        add_reason(result.reasons, BuildReason::missing_cache_entry);
+        if (!output_snapshot.exists) {
+            add_reason(result.reasons, BuildReason::missing_output);
+        }
+        return result;
+    }
+
+    const auto& cached = *cached_entry;
+    const bool linker_matches = same_linker(cached.linker, current_linker);
+    if (!linker_matches) {
+        add_reason(result.reasons, BuildReason::toolchain_changed);
+    }
+
+    const bool inputs_match = same_paths(cached.objects, current_objects);
+    if (!inputs_match) {
+        add_reason(result.reasons, BuildReason::link_inputs_changed);
+    }
+
+    const auto current_signature = BuildSignature::for_link(
+        current_objects,
+        current_output,
+        current_linker,
+        current_options);
+    if (cached.signature != current_signature && linker_matches && inputs_match) {
+        add_reason(result.reasons, BuildReason::linker_options_changed);
+    }
+
+    if (!same_path(cached.output, current_output)) {
+        add_reason(result.reasons, BuildReason::linker_options_changed);
+    }
+
+    if (!output_snapshot.exists) {
+        add_reason(result.reasons, BuildReason::missing_output);
+    }
+
+    for (const auto& object : current_objects) {
+        const auto* snapshot = find_snapshot(object_snapshots, object);
+        if (snapshot == nullptr || !snapshot->exists) {
+            add_reason(result.reasons, BuildReason::link_inputs_changed);
+            continue;
+        }
+        if (output_snapshot.exists && snapshot->modified > output_snapshot.modified) {
+            add_reason(result.reasons, BuildReason::link_inputs_changed);
+        }
+    }
+
+    return result;
+}
+
+} // namespace mqb

--- a/cpp/core/src/LinkCacheFile.cpp
+++ b/cpp/core/src/LinkCacheFile.cpp
@@ -1,0 +1,430 @@
+#include "mqb/core/LinkCacheFile.hpp"
+
+#include <array>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <expected>
+#include <filesystem>
+#include <fstream>
+#include <limits>
+#include <span>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+#include "mqb/core/BuildSignature.hpp"
+#include "mqb/core/LinkerIdentity.hpp"
+
+namespace mqb {
+namespace {
+
+namespace fs = std::filesystem;
+
+constexpr std::array<std::uint8_t, 8> magic{
+    'M', 'Q', 'B', 'L', 'I', 'N', 'K', 'C'};
+constexpr std::uint32_t format_version = 1;
+constexpr std::size_t max_cache_file_size = 64u * 1024u * 1024u;
+constexpr std::uint32_t max_string_size = 4u * 1024u * 1024u;
+constexpr std::uint32_t max_object_count = 100000u;
+
+[[nodiscard]] LinkCacheFileError make_error(
+    const LinkCacheFileErrorCode code,
+    const fs::path& file,
+    const std::size_t offset,
+    std::string message) {
+    return LinkCacheFileError{
+        .code = code,
+        .file = file,
+        .offset = offset,
+        .message = std::move(message),
+    };
+}
+
+[[nodiscard]] std::string path_to_utf8(const fs::path& path) {
+    const auto bytes = path.lexically_normal().generic_u8string();
+    return std::string{
+        reinterpret_cast<const char*>(bytes.data()),
+        bytes.size()};
+}
+
+[[nodiscard]] fs::path path_from_utf8(const std::string_view value) {
+    std::u8string bytes;
+    bytes.assign(
+        reinterpret_cast<const char8_t*>(value.data()),
+        reinterpret_cast<const char8_t*>(value.data() + value.size()));
+    return fs::path{bytes}.lexically_normal();
+}
+
+class BinaryWriter {
+public:
+    void write_u8(const std::uint8_t value) {
+        bytes_.push_back(value);
+    }
+
+    void write_u32(const std::uint32_t value) {
+        for (std::uint32_t shift = 0; shift < 32u; shift += 8u) {
+            write_u8(static_cast<std::uint8_t>((value >> shift) & 0xffu));
+        }
+    }
+
+    void write_u64(const std::uint64_t value) {
+        for (std::uint32_t shift = 0; shift < 64u; shift += 8u) {
+            write_u8(static_cast<std::uint8_t>((value >> shift) & 0xffu));
+        }
+    }
+
+    void write_bytes(const std::span<const std::uint8_t> bytes) {
+        bytes_.insert(bytes_.end(), bytes.begin(), bytes.end());
+    }
+
+    [[nodiscard]] bool write_string(const std::string_view value) {
+        if (value.size() > max_string_size
+            || value.size() > std::numeric_limits<std::uint32_t>::max()) {
+            return false;
+        }
+        write_u32(static_cast<std::uint32_t>(value.size()));
+        bytes_.insert(bytes_.end(), value.begin(), value.end());
+        return true;
+    }
+
+    [[nodiscard]] bool write_path(const fs::path& path) {
+        return write_string(path_to_utf8(path));
+    }
+
+    [[nodiscard]] const std::vector<std::uint8_t>& bytes() const noexcept {
+        return bytes_;
+    }
+
+private:
+    std::vector<std::uint8_t> bytes_;
+};
+
+class BinaryReader {
+public:
+    BinaryReader(const fs::path& file, const std::span<const std::uint8_t> bytes)
+        : file_(file), bytes_(bytes) {}
+
+    [[nodiscard]] std::size_t offset() const noexcept { return offset_; }
+    [[nodiscard]] bool at_end() const noexcept { return offset_ == bytes_.size(); }
+
+    [[nodiscard]] std::expected<std::uint8_t, LinkCacheFileError> read_u8() {
+        if (offset_ >= bytes_.size()) {
+            return std::unexpected(corrupt("unexpected end of link cache file"));
+        }
+        return bytes_[offset_++];
+    }
+
+    [[nodiscard]] std::expected<std::uint32_t, LinkCacheFileError> read_u32() {
+        std::uint32_t value = 0;
+        for (std::uint32_t shift = 0; shift < 32u; shift += 8u) {
+            auto byte = read_u8();
+            if (!byte) return std::unexpected(byte.error());
+            value |= static_cast<std::uint32_t>(*byte) << shift;
+        }
+        return value;
+    }
+
+    [[nodiscard]] std::expected<std::uint64_t, LinkCacheFileError> read_u64() {
+        std::uint64_t value = 0;
+        for (std::uint32_t shift = 0; shift < 64u; shift += 8u) {
+            auto byte = read_u8();
+            if (!byte) return std::unexpected(byte.error());
+            value |= static_cast<std::uint64_t>(*byte) << shift;
+        }
+        return value;
+    }
+
+    [[nodiscard]] std::expected<std::string, LinkCacheFileError> read_string() {
+        auto length = read_u32();
+        if (!length) return std::unexpected(length.error());
+        if (*length > max_string_size) {
+            return std::unexpected(corrupt("link cache string exceeds safety limit"));
+        }
+        if (static_cast<std::size_t>(*length) > bytes_.size() - offset_) {
+            return std::unexpected(corrupt("link cache string extends past end of file"));
+        }
+        const char* begin = reinterpret_cast<const char*>(bytes_.data() + offset_);
+        std::string value{begin, begin + *length};
+        offset_ += *length;
+        return value;
+    }
+
+    [[nodiscard]] std::expected<fs::path, LinkCacheFileError> read_path() {
+        auto value = read_string();
+        if (!value) return std::unexpected(value.error());
+        return path_from_utf8(*value);
+    }
+
+    [[nodiscard]] LinkCacheFileError corrupt(std::string message) const {
+        return make_error(
+            LinkCacheFileErrorCode::corrupt_data,
+            file_,
+            offset_,
+            std::move(message));
+    }
+
+private:
+    const fs::path& file_;
+    std::span<const std::uint8_t> bytes_;
+    std::size_t offset_{};
+};
+
+[[nodiscard]] std::expected<std::vector<std::uint8_t>, LinkCacheFileError>
+serialize(const fs::path& file, const LinkCacheEntry& entry) {
+    if (entry.objects.size() > max_object_count) {
+        return std::unexpected(make_error(
+            LinkCacheFileErrorCode::file_write_failed,
+            file,
+            0,
+            "link input count exceeds cache safety limit"));
+    }
+
+    BinaryWriter writer;
+    writer.write_bytes(magic);
+    writer.write_u32(format_version);
+    if (!writer.write_path(entry.linker.linker)
+        || !writer.write_string(entry.linker.version)
+        || !writer.write_string(entry.linker.binary_stamp)) {
+        return std::unexpected(make_error(
+            LinkCacheFileErrorCode::file_write_failed,
+            file,
+            0,
+            "linker identity is too large for link cache format"));
+    }
+
+    writer.write_u64(entry.signature.digest().high);
+    writer.write_u64(entry.signature.digest().low);
+
+    if (!writer.write_path(entry.output)) {
+        return std::unexpected(make_error(
+            LinkCacheFileErrorCode::file_write_failed,
+            file,
+            0,
+            "link output path is too long for cache format"));
+    }
+
+    writer.write_u32(static_cast<std::uint32_t>(entry.objects.size()));
+    for (const auto& object : entry.objects) {
+        if (!writer.write_path(object)) {
+            return std::unexpected(make_error(
+                LinkCacheFileErrorCode::file_write_failed,
+                file,
+                0,
+                "link input path is too long for cache format"));
+        }
+    }
+    return writer.bytes();
+}
+
+[[nodiscard]] std::expected<LinkCacheEntry, LinkCacheFileError>
+deserialize(const fs::path& file, const std::span<const std::uint8_t> bytes) {
+    if (bytes.size() < magic.size() + sizeof(std::uint32_t)) {
+        return std::unexpected(make_error(
+            LinkCacheFileErrorCode::invalid_magic,
+            file,
+            0,
+            "link cache file is too short"));
+    }
+    for (std::size_t index = 0; index < magic.size(); ++index) {
+        if (bytes[index] != magic[index]) {
+            return std::unexpected(make_error(
+                LinkCacheFileErrorCode::invalid_magic,
+                file,
+                index,
+                "link cache magic does not match MQB format"));
+        }
+    }
+
+    BinaryReader reader{file, bytes};
+    for (std::size_t index = 0; index < magic.size(); ++index) {
+        auto ignored = reader.read_u8();
+        if (!ignored) return std::unexpected(ignored.error());
+    }
+    auto version = reader.read_u32();
+    if (!version) return std::unexpected(version.error());
+    if (*version != format_version) {
+        return std::unexpected(make_error(
+            LinkCacheFileErrorCode::unsupported_version,
+            file,
+            reader.offset(),
+            "link cache file version is not supported"));
+    }
+
+    auto linker = reader.read_path();
+    auto linker_version = reader.read_string();
+    auto linker_stamp = reader.read_string();
+    auto signature_high = reader.read_u64();
+    auto signature_low = reader.read_u64();
+    auto output = reader.read_path();
+    auto object_count = reader.read_u32();
+
+    if (!linker) return std::unexpected(linker.error());
+    if (!linker_version) return std::unexpected(linker_version.error());
+    if (!linker_stamp) return std::unexpected(linker_stamp.error());
+    if (!signature_high) return std::unexpected(signature_high.error());
+    if (!signature_low) return std::unexpected(signature_low.error());
+    if (!output) return std::unexpected(output.error());
+    if (!object_count) return std::unexpected(object_count.error());
+    if (*object_count > max_object_count) {
+        return std::unexpected(reader.corrupt("link input count exceeds safety limit"));
+    }
+
+    std::vector<fs::path> objects;
+    objects.reserve(*object_count);
+    for (std::uint32_t index = 0; index < *object_count; ++index) {
+        auto object = reader.read_path();
+        if (!object) return std::unexpected(object.error());
+        objects.push_back(std::move(*object));
+    }
+    if (!reader.at_end()) {
+        return std::unexpected(reader.corrupt("unexpected trailing bytes in link cache file"));
+    }
+
+    return LinkCacheEntry{
+        .linker = LinkerIdentity{
+            .linker = std::move(*linker),
+            .version = std::move(*linker_version),
+            .binary_stamp = std::move(*linker_stamp),
+        },
+        .signature = BuildSignature::from_digest(SignatureDigest{
+            .high = *signature_high,
+            .low = *signature_low,
+        }),
+        .objects = std::move(objects),
+        .output = std::move(*output),
+    };
+}
+
+[[nodiscard]] fs::path temporary_path_for(const fs::path& file) {
+    const auto tick = std::chrono::steady_clock::now().time_since_epoch().count();
+    fs::path temporary = file;
+    temporary += ".tmp." + std::to_string(tick);
+    return temporary;
+}
+
+} // namespace
+
+std::expected<std::optional<LinkCacheEntry>, LinkCacheFileError>
+LinkCacheFile::load(const fs::path& file) {
+    std::error_code error_code;
+    const bool exists = fs::exists(file, error_code);
+    if (error_code) {
+        return std::unexpected(make_error(
+            LinkCacheFileErrorCode::file_open_failed, file, 0, "failed to query link cache file"));
+    }
+    if (!exists) {
+        return std::optional<LinkCacheEntry>{};
+    }
+
+    const auto size = fs::file_size(file, error_code);
+    if (error_code) {
+        return std::unexpected(make_error(
+            LinkCacheFileErrorCode::file_read_failed, file, 0, "failed to query link cache file size"));
+    }
+    if (size > max_cache_file_size) {
+        return std::unexpected(make_error(
+            LinkCacheFileErrorCode::corrupt_data, file, 0, "link cache file exceeds safety size limit"));
+    }
+
+    std::ifstream stream{file, std::ios::binary};
+    if (!stream) {
+        return std::unexpected(make_error(
+            LinkCacheFileErrorCode::file_open_failed, file, 0, "failed to open link cache file"));
+    }
+
+    std::vector<std::uint8_t> bytes(static_cast<std::size_t>(size));
+    if (!bytes.empty()) {
+        stream.read(reinterpret_cast<char*>(bytes.data()), static_cast<std::streamsize>(bytes.size()));
+    }
+    if (!stream && !bytes.empty()) {
+        return std::unexpected(make_error(
+            LinkCacheFileErrorCode::file_read_failed,
+            file,
+            static_cast<std::size_t>(stream.gcount()),
+            "failed to read complete link cache file"));
+    }
+
+    auto entry = deserialize(file, bytes);
+    if (!entry) return std::unexpected(entry.error());
+    return std::optional<LinkCacheEntry>{std::move(*entry)};
+}
+
+std::expected<void, LinkCacheFileError>
+LinkCacheFile::save(const fs::path& file, const LinkCacheEntry& entry) {
+    auto bytes = serialize(file, entry);
+    if (!bytes) return std::unexpected(bytes.error());
+
+    std::error_code error_code;
+    if (!file.parent_path().empty()) {
+        fs::create_directories(file.parent_path(), error_code);
+        if (error_code) {
+            return std::unexpected(make_error(
+                LinkCacheFileErrorCode::file_write_failed, file, 0, "failed to create link cache directory"));
+        }
+    }
+
+    const fs::path temporary = temporary_path_for(file);
+    {
+        std::ofstream stream{temporary, std::ios::binary | std::ios::trunc};
+        if (!stream) {
+            return std::unexpected(make_error(
+                LinkCacheFileErrorCode::file_open_failed,
+                temporary,
+                0,
+                "failed to open temporary link cache file"));
+        }
+        if (!bytes->empty()) {
+            stream.write(
+                reinterpret_cast<const char*>(bytes->data()),
+                static_cast<std::streamsize>(bytes->size()));
+        }
+        stream.flush();
+        if (!stream) {
+            stream.close();
+            fs::remove(temporary, error_code);
+            return std::unexpected(make_error(
+                LinkCacheFileErrorCode::file_write_failed,
+                temporary,
+                0,
+                "failed to write complete link cache file"));
+        }
+    }
+
+    if (fs::exists(file, error_code) && !error_code) {
+        fs::remove(file, error_code);
+        if (error_code) {
+            std::error_code ignored;
+            fs::remove(temporary, ignored);
+            return std::unexpected(make_error(
+                LinkCacheFileErrorCode::replace_failed,
+                file,
+                0,
+                "failed to remove previous link cache entry"));
+        }
+    } else if (error_code) {
+        std::error_code ignored;
+        fs::remove(temporary, ignored);
+        return std::unexpected(make_error(
+            LinkCacheFileErrorCode::replace_failed,
+            file,
+            0,
+            "failed to query previous link cache entry"));
+    }
+
+    fs::rename(temporary, file, error_code);
+    if (error_code) {
+        std::error_code ignored;
+        fs::remove(temporary, ignored);
+        return std::unexpected(make_error(
+            LinkCacheFileErrorCode::replace_failed,
+            file,
+            0,
+            "failed to install new link cache entry"));
+    }
+    return {};
+}
+
+} // namespace mqb

--- a/cpp/orchestration/CMakeLists.txt
+++ b/cpp/orchestration/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(mqb_orchestration STATIC
     src/MsvcIncrementalCompileCoordinator.cpp
+    src/MsvcIncrementalLinkCoordinator.cpp
 )
 
 target_include_directories(mqb_orchestration

--- a/cpp/orchestration/include/mqb/orchestration/MsvcIncrementalLinkCoordinator.hpp
+++ b/cpp/orchestration/include/mqb/orchestration/MsvcIncrementalLinkCoordinator.hpp
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <expected>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "mqb/core/BuildPlan.hpp"
+#include "mqb/core/BuildPlanner.hpp"
+#include "mqb/core/LinkCache.hpp"
+#include "mqb/core/LinkCacheFile.hpp"
+#include "mqb/core/LinkOptions.hpp"
+#include "mqb/msvc/MsvcLinker.hpp"
+#include "mqb/msvc/MsvcToolchainLocator.hpp"
+#include "mqb/process/Process.hpp"
+
+namespace mqb::orchestration {
+
+struct IncrementalLinkRequest {
+    std::vector<std::filesystem::path> objects;
+    std::filesystem::path output;
+    LinkOptions options;
+    std::filesystem::path cache_file;
+    std::optional<std::filesystem::path> working_directory;
+    bool force_relink{false};
+};
+
+enum class IncrementalLinkWarningCode {
+    cache_load_failed,
+    cache_save_failed,
+    file_snapshot_failed,
+};
+
+struct IncrementalLinkWarning {
+    IncrementalLinkWarningCode code{IncrementalLinkWarningCode::file_snapshot_failed};
+    std::filesystem::path path;
+    std::string message;
+};
+
+enum class IncrementalLinkErrorCode {
+    linker_identity_failed,
+    planning_failed,
+    link_failed,
+};
+
+struct IncrementalLinkError {
+    IncrementalLinkErrorCode code{IncrementalLinkErrorCode::planning_failed};
+    std::string message;
+    std::optional<BuildPlannerError> planner_error;
+    std::optional<msvc::LinkerError> linker_error;
+};
+
+struct IncrementalLinkResult {
+    LinkCacheValidation validation;
+    BuildPlan plan;
+    bool linked{false};
+    std::optional<process::ProcessResult> process;
+    std::vector<IncrementalLinkWarning> warnings;
+};
+
+class MsvcIncrementalLinkCoordinator {
+public:
+    MsvcIncrementalLinkCoordinator(
+        const msvc::MsvcToolchain& toolchain,
+        msvc::MsvcLinker& linker)
+        : toolchain_(toolchain), linker_(linker) {}
+
+    [[nodiscard]] std::expected<IncrementalLinkResult, IncrementalLinkError>
+    run(const IncrementalLinkRequest& request) const;
+
+private:
+    const msvc::MsvcToolchain& toolchain_;
+    msvc::MsvcLinker& linker_;
+};
+
+} // namespace mqb::orchestration

--- a/cpp/orchestration/src/MsvcIncrementalLinkCoordinator.cpp
+++ b/cpp/orchestration/src/MsvcIncrementalLinkCoordinator.cpp
@@ -1,0 +1,191 @@
+#include "mqb/orchestration/MsvcIncrementalLinkCoordinator.hpp"
+
+#include <expected>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <system_error>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "mqb/core/BuildAction.hpp"
+#include "mqb/core/BuildSignature.hpp"
+#include "mqb/core/FileSnapshot.hpp"
+#include "mqb/core/LinkCache.hpp"
+#include "mqb/core/LinkCacheFile.hpp"
+#include "mqb/msvc/MsvcLinker.hpp"
+
+namespace mqb::orchestration {
+namespace {
+
+namespace fs = std::filesystem;
+
+[[nodiscard]] std::expected<FileSnapshot, std::string>
+snapshot_file(const fs::path& path) {
+    std::error_code error_code;
+    const bool exists = fs::exists(path, error_code);
+    if (error_code) {
+        return std::unexpected("failed to query file existence: " + error_code.message());
+    }
+    if (!exists) {
+        return FileSnapshot{.path = path, .exists = false};
+    }
+
+    const auto modified = fs::last_write_time(path, error_code);
+    if (error_code) {
+        return std::unexpected("failed to query file timestamp: " + error_code.message());
+    }
+    return FileSnapshot{
+        .path = path,
+        .exists = true,
+        .modified = modified,
+    };
+}
+
+[[nodiscard]] IncrementalLinkError link_failure(
+    const IncrementalLinkErrorCode code,
+    std::string message,
+    std::optional<msvc::LinkerError> linker_error = std::nullopt) {
+    return IncrementalLinkError{
+        .code = code,
+        .message = std::move(message),
+        .linker_error = std::move(linker_error),
+    };
+}
+
+} // namespace
+
+std::expected<IncrementalLinkResult, IncrementalLinkError>
+MsvcIncrementalLinkCoordinator::run(const IncrementalLinkRequest& request) const {
+    IncrementalLinkResult result;
+
+    auto linker_identity = msvc::MsvcLinker::identity(toolchain_);
+    if (!linker_identity) {
+        return std::unexpected(link_failure(
+            IncrementalLinkErrorCode::linker_identity_failed,
+            "failed to identify MSVC linker",
+            linker_identity.error()));
+    }
+
+    std::optional<LinkCacheEntry> cached_entry;
+    auto loaded = LinkCacheFile::load(request.cache_file);
+    if (loaded) {
+        cached_entry = std::move(*loaded);
+    } else {
+        result.warnings.push_back(IncrementalLinkWarning{
+            .code = IncrementalLinkWarningCode::cache_load_failed,
+            .path = request.cache_file,
+            .message = loaded.error().message,
+        });
+    }
+
+    FileSnapshot output_snapshot{.path = request.output, .exists = false};
+    if (auto snapshot = snapshot_file(request.output)) {
+        output_snapshot = std::move(*snapshot);
+    } else {
+        result.warnings.push_back(IncrementalLinkWarning{
+            .code = IncrementalLinkWarningCode::file_snapshot_failed,
+            .path = request.output,
+            .message = snapshot.error(),
+        });
+    }
+
+    std::vector<FileSnapshot> object_snapshots;
+    object_snapshots.reserve(request.objects.size());
+    for (const auto& object : request.objects) {
+        if (auto snapshot = snapshot_file(object)) {
+            object_snapshots.push_back(std::move(*snapshot));
+        } else {
+            result.warnings.push_back(IncrementalLinkWarning{
+                .code = IncrementalLinkWarningCode::file_snapshot_failed,
+                .path = object,
+                .message = snapshot.error(),
+            });
+            object_snapshots.push_back(FileSnapshot{.path = object, .exists = false});
+        }
+    }
+
+    result.validation = LinkCacheValidator::validate(
+        request.objects,
+        request.output,
+        *linker_identity,
+        request.options,
+        cached_entry,
+        output_snapshot,
+        object_snapshots,
+        request.force_relink);
+
+    const LinkPlanItem plan_item{
+        .objects = request.objects,
+        .output = request.output,
+        .cache_validation = result.validation,
+    };
+    auto plan = BuildPlanner::plan_link(plan_item);
+    if (!plan) {
+        return std::unexpected(IncrementalLinkError{
+            .code = IncrementalLinkErrorCode::planning_failed,
+            .message = "failed to create link build plan",
+            .planner_error = plan.error(),
+        });
+    }
+    result.plan = std::move(*plan);
+    if (result.plan.empty()) {
+        return result;
+    }
+
+    if (result.plan.actions.size() != 1) {
+        return std::unexpected(IncrementalLinkError{
+            .code = IncrementalLinkErrorCode::planning_failed,
+            .message = "single-target link coordinator expected exactly one build action",
+        });
+    }
+
+    const auto* action = std::get_if<LinkAction>(&result.plan.actions.front());
+    if (action == nullptr) {
+        return std::unexpected(IncrementalLinkError{
+            .code = IncrementalLinkErrorCode::planning_failed,
+            .message = "single-target link coordinator received a non-link build action",
+        });
+    }
+
+    msvc::LinkInvocation invocation{
+        .objects = action->objects,
+        .output = action->output,
+        .options = request.options,
+        .working_directory = request.working_directory.value_or(fs::path{}),
+    };
+    auto linked = linker_.link(invocation);
+    if (!linked) {
+        return std::unexpected(link_failure(
+            IncrementalLinkErrorCode::link_failed,
+            "MSVC link action failed",
+            linked.error()));
+    }
+
+    result.linked = true;
+    result.process = std::move(*linked);
+
+    const LinkCacheEntry new_entry{
+        .linker = *linker_identity,
+        .signature = BuildSignature::for_link(
+            action->objects,
+            action->output,
+            *linker_identity,
+            request.options),
+        .objects = action->objects,
+        .output = action->output,
+    };
+    auto saved = LinkCacheFile::save(request.cache_file, new_entry);
+    if (!saved) {
+        result.warnings.push_back(IncrementalLinkWarning{
+            .code = IncrementalLinkWarningCode::cache_save_failed,
+            .path = request.cache_file,
+            .message = saved.error().message,
+        });
+    }
+
+    return result;
+}
+
+} // namespace mqb::orchestration

--- a/cpp/orchestration/tests/CMakeLists.txt
+++ b/cpp/orchestration/tests/CMakeLists.txt
@@ -10,13 +10,35 @@ target_link_libraries(mqb_orchestration_incremental_tests
 
 target_compile_features(mqb_orchestration_incremental_tests PRIVATE cxx_std_23)
 
-if(MSVC)
-    target_compile_options(mqb_orchestration_incremental_tests PRIVATE /W4 /permissive-)
-else()
-    target_compile_options(mqb_orchestration_incremental_tests PRIVATE -Wall -Wextra -Wpedantic)
-endif()
+add_executable(mqb_orchestration_incremental_link_tests
+    incremental_link_coordinator_tests.cpp
+)
+
+target_link_libraries(mqb_orchestration_incremental_link_tests
+    PRIVATE
+        mqb_orchestration
+        mqb_msvc
+)
+
+target_compile_features(mqb_orchestration_incremental_link_tests PRIVATE cxx_std_23)
+
+foreach(test_target IN ITEMS
+    mqb_orchestration_incremental_tests
+    mqb_orchestration_incremental_link_tests
+)
+    if(MSVC)
+        target_compile_options(${test_target} PRIVATE /W4 /permissive-)
+    else()
+        target_compile_options(${test_target} PRIVATE -Wall -Wextra -Wpedantic)
+    endif()
+endforeach()
 
 add_test(
     NAME mqb.orchestration.incremental_compile
     COMMAND mqb_orchestration_incremental_tests
+)
+
+add_test(
+    NAME mqb.orchestration.incremental_link
+    COMMAND mqb_orchestration_incremental_link_tests
 )

--- a/cpp/orchestration/tests/incremental_link_coordinator_tests.cpp
+++ b/cpp/orchestration/tests/incremental_link_coordinator_tests.cpp
@@ -1,0 +1,228 @@
+#include <algorithm>
+#include <chrono>
+#include <expected>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <string_view>
+
+#include "mqb/core/BuildTypes.hpp"
+#include "mqb/core/LinkOptions.hpp"
+#include "mqb/msvc/MsvcLinker.hpp"
+#include "mqb/msvc/MsvcToolchainLocator.hpp"
+#include "mqb/orchestration/MsvcIncrementalLinkCoordinator.hpp"
+#include "mqb/process/Process.hpp"
+
+namespace {
+
+namespace fs = std::filesystem;
+int failures = 0;
+
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+class TemporaryDirectory {
+public:
+    TemporaryDirectory() {
+        const auto tick = std::chrono::steady_clock::now().time_since_epoch().count();
+        path_ = fs::temp_directory_path()
+            / ("mqb-link-orchestration-test-" + std::to_string(tick));
+        fs::create_directories(path_);
+    }
+
+    ~TemporaryDirectory() {
+        std::error_code ignored;
+        fs::remove_all(path_, ignored);
+    }
+
+    [[nodiscard]] const fs::path& path() const noexcept { return path_; }
+
+private:
+    fs::path path_;
+};
+
+void write_text(const fs::path& path, const std::string_view text) {
+    if (!path.parent_path().empty()) {
+        fs::create_directories(path.parent_path());
+    }
+    std::ofstream file{path, std::ios::binary | std::ios::trunc};
+    file.write(text.data(), static_cast<std::streamsize>(text.size()));
+}
+
+class LinkerLikeRunner final : public mqb::process::ProcessRunner {
+public:
+    fs::path output;
+    int calls{};
+    bool fail_link{false};
+    mqb::process::ProcessSpec last_spec;
+
+    std::expected<mqb::process::ProcessResult, mqb::process::ProcessError>
+    run(const mqb::process::ProcessSpec& spec) override {
+        ++calls;
+        last_spec = spec;
+        if (fail_link) {
+            return mqb::process::ProcessResult{
+                .exit_code = 1120,
+                .stderr_text = "simulated link.exe diagnostic",
+            };
+        }
+        write_text(output, "fake executable produced by linker runner");
+        return mqb::process::ProcessResult{
+            .exit_code = 0,
+            .stdout_text = "simulated link.exe success",
+        };
+    }
+};
+
+[[nodiscard]] bool has_reason(
+    const mqb::LinkCacheValidation& validation,
+    const mqb::BuildReason reason) {
+    return std::find(validation.reasons.begin(), validation.reasons.end(), reason)
+        != validation.reasons.end();
+}
+
+[[nodiscard]] bool has_warning(
+    const mqb::orchestration::IncrementalLinkResult& result,
+    const mqb::orchestration::IncrementalLinkWarningCode code) {
+    return std::any_of(
+        result.warnings.begin(),
+        result.warnings.end(),
+        [code](const mqb::orchestration::IncrementalLinkWarning& warning) {
+            return warning.code == code;
+        });
+}
+
+} // namespace
+
+int main() {
+    TemporaryDirectory fixture;
+    const fs::path fake_linker = fixture.path() / "toolchain" / "link.exe";
+    const fs::path fake_compiler = fixture.path() / "toolchain" / "cl.exe";
+    const fs::path object = fixture.path() / "obj" / "main.cpp.obj";
+    const fs::path output = fixture.path() / "bin" / "main.exe";
+    const fs::path cache_file = fixture.path() / "cache" / "main.linkcache";
+
+    write_text(fake_linker, "fake linker identity bytes");
+    write_text(fake_compiler, "fake compiler identity bytes");
+    write_text(object, "fake object input");
+
+    mqb::msvc::MsvcToolchain toolchain{
+        .identity = mqb::ToolchainIdentity{
+            .compiler = fake_compiler,
+            .version = "19.51.test",
+            .binary_stamp = "compiler-stamp",
+        },
+        .linker = fake_linker,
+        .librarian = fixture.path() / "toolchain" / "lib.exe",
+        .vc_tools_root = fixture.path() / "toolchain",
+        .source = mqb::msvc::ToolchainSource::visual_studio,
+    };
+
+    LinkerLikeRunner runner;
+    runner.output = output;
+    mqb::msvc::MsvcLinker linker{toolchain, runner};
+    mqb::orchestration::MsvcIncrementalLinkCoordinator coordinator{toolchain, linker};
+
+    mqb::LinkOptions debug_options;
+    debug_options.configuration = mqb::BuildConfiguration::debug;
+    debug_options.architecture = mqb::Architecture::x64;
+    debug_options.subsystem = mqb::LinkSubsystem::console;
+
+    const mqb::orchestration::IncrementalLinkRequest request{
+        .objects = {object},
+        .output = output,
+        .options = debug_options,
+        .cache_file = cache_file,
+        .working_directory = fixture.path(),
+        .force_relink = false,
+    };
+
+    const auto cold = coordinator.run(request);
+    expect(cold.has_value(), "cold incremental link should succeed");
+    if (cold) {
+        expect(cold->linked, "cold link should execute one link action");
+        expect(cold->plan.actions.size() == 1,
+               "cold link should retain one planned LinkAction");
+        expect(has_reason(cold->validation, mqb::BuildReason::missing_cache_entry),
+               "cold link should explain missing link cache");
+        expect(has_reason(cold->validation, mqb::BuildReason::missing_output),
+               "cold link should explain missing executable");
+        expect(cold->warnings.empty(),
+               "ordinary missing link cache should not be a warning");
+    }
+    expect(runner.calls == 1, "cold link should invoke link.exe exactly once");
+    expect(fs::is_regular_file(output), "cold link should create executable output");
+    expect(fs::is_regular_file(cache_file), "cold link should persist link cache metadata");
+
+    const auto warm = coordinator.run(request);
+    expect(warm.has_value(), "warm link validation should succeed");
+    if (warm) {
+        expect(!warm->linked, "unchanged warm link should skip link.exe");
+        expect(warm->plan.empty(), "unchanged warm link should produce an empty plan");
+        expect(warm->validation.reusable(), "unchanged warm link cache should be reusable");
+    }
+    expect(runner.calls == 1, "warm link cache hit should not invoke link.exe again");
+
+    auto forced_request = request;
+    forced_request.force_relink = true;
+    const auto forced = coordinator.run(forced_request);
+    expect(forced.has_value(), "forced relink should succeed");
+    if (forced) {
+        expect(forced->linked, "fresh compile signal should force a relink");
+        expect(has_reason(forced->validation, mqb::BuildReason::explicit_rebuild),
+               "forced relink should remain explainable as explicit rebuild");
+    }
+    expect(runner.calls == 2,
+           "force_relink should invoke link.exe even when timestamps otherwise match");
+
+    auto release_request = request;
+    release_request.options.configuration = mqb::BuildConfiguration::release;
+    const auto release = coordinator.run(release_request);
+    expect(release.has_value(), "link options transition should succeed");
+    if (release) {
+        expect(release->linked, "link options transition should execute link.exe");
+        expect(has_reason(release->validation, mqb::BuildReason::linker_options_changed),
+               "Debug to Release should report linker options changed");
+    }
+    expect(runner.calls == 3, "link options transition should invoke link.exe once");
+
+    write_text(cache_file, "not an MQB link cache");
+    const auto corrupt = coordinator.run(request);
+    expect(corrupt.has_value(),
+           "corrupt link cache should degrade to relink instead of failing the build");
+    if (corrupt) {
+        expect(corrupt->linked, "corrupt link cache should conservatively relink");
+        expect(has_reason(corrupt->validation, mqb::BuildReason::missing_cache_entry),
+               "corrupt link cache should be treated as unavailable metadata");
+        expect(has_warning(
+                   *corrupt,
+                   mqb::orchestration::IncrementalLinkWarningCode::cache_load_failed),
+               "corrupt link cache should remain visible as a warning");
+    }
+    expect(runner.calls == 4, "corrupt metadata should invoke link.exe exactly once more");
+
+    std::error_code ignored;
+    fs::remove(cache_file, ignored);
+    fs::remove(output, ignored);
+    runner.fail_link = true;
+    const auto failed = coordinator.run(request);
+    expect(!failed.has_value(), "linker failure should fail the incremental link operation");
+    if (!failed) {
+        expect(failed.error().code == mqb::orchestration::IncrementalLinkErrorCode::link_failed,
+               "link.exe failure should be reported as link_failed");
+        expect(failed.error().linker_error.has_value(),
+               "link.exe diagnostics should remain attached to orchestration error");
+    }
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+    std::cout << "mqb_orchestration_incremental_link_tests passed\n";
+    return 0;
+}

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -66,6 +66,10 @@ if(WIN32)
     target_link_libraries(mqb_msvc_compiler_arguments_tests PRIVATE mqb_msvc)
     target_compile_features(mqb_msvc_compiler_arguments_tests PRIVATE cxx_std_23)
 
+    add_executable(mqb_msvc_linker_arguments_tests msvc_linker_arguments_tests.cpp)
+    target_link_libraries(mqb_msvc_linker_arguments_tests PRIVATE mqb_msvc)
+    target_compile_features(mqb_msvc_linker_arguments_tests PRIVATE cxx_std_23)
+
     add_executable(mqb_msvc_compile_executor_tests msvc_compile_executor_tests.cpp)
     target_link_libraries(mqb_msvc_compile_executor_tests PRIVATE mqb_msvc)
     target_compile_features(mqb_msvc_compile_executor_tests PRIVATE cxx_std_23)
@@ -84,6 +88,7 @@ if(WIN32)
         mqb_windows_process_runner_tests
         mqb_msvc_portable_tests
         mqb_msvc_compiler_arguments_tests
+        mqb_msvc_linker_arguments_tests
         mqb_msvc_compile_executor_tests
         mqb_msvc_source_dependencies_tests
         mqb_cli_argument_tests
@@ -98,6 +103,10 @@ if(WIN32)
         target_link_libraries(mqb_msvc_compile_integration_tests PRIVATE mqb_msvc mqb_platform_windows)
         target_compile_features(mqb_msvc_compile_integration_tests PRIVATE cxx_std_23)
 
+        add_executable(mqb_msvc_link_integration_tests msvc_link_integration_tests.cpp)
+        target_link_libraries(mqb_msvc_link_integration_tests PRIVATE mqb_msvc mqb_platform_windows)
+        target_compile_features(mqb_msvc_link_integration_tests PRIVATE cxx_std_23)
+
         add_executable(mqb_msvc_incremental_loop_tests msvc_incremental_loop_tests.cpp)
         target_link_libraries(mqb_msvc_incremental_loop_tests PRIVATE mqb_core mqb_msvc mqb_platform_windows)
         target_compile_features(mqb_msvc_incremental_loop_tests PRIVATE cxx_std_23)
@@ -109,6 +118,7 @@ if(WIN32)
         list(APPEND MQB_TEST_TARGETS
             mqb_msvc_visual_studio_tests
             mqb_msvc_compile_integration_tests
+            mqb_msvc_link_integration_tests
             mqb_msvc_incremental_loop_tests
             mqb_cli_e2e_tests
         )
@@ -141,6 +151,7 @@ if(WIN32)
     )
     add_test(NAME mqb.msvc.portable COMMAND mqb_msvc_portable_tests)
     add_test(NAME mqb.msvc.compiler_arguments COMMAND mqb_msvc_compiler_arguments_tests)
+    add_test(NAME mqb.msvc.linker_arguments COMMAND mqb_msvc_linker_arguments_tests)
     add_test(NAME mqb.msvc.compile_executor COMMAND mqb_msvc_compile_executor_tests)
     add_test(NAME mqb.msvc.source_dependencies COMMAND mqb_msvc_source_dependencies_tests)
     add_test(NAME mqb.cli.arguments COMMAND mqb_cli_argument_tests)
@@ -148,6 +159,7 @@ if(WIN32)
     if(MQB_ENABLE_INSTALLED_MSVC_TESTS)
         add_test(NAME mqb.msvc.visual_studio COMMAND mqb_msvc_visual_studio_tests)
         add_test(NAME mqb.msvc.compile_integration COMMAND mqb_msvc_compile_integration_tests)
+        add_test(NAME mqb.msvc.link_integration COMMAND mqb_msvc_link_integration_tests)
         add_test(NAME mqb.msvc.incremental_loop COMMAND mqb_msvc_incremental_loop_tests)
         add_test(
             NAME mqb.cli.single_tu_e2e

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -30,6 +30,10 @@ add_executable(mqb_link_state_tests link_state_tests.cpp)
 target_link_libraries(mqb_link_state_tests PRIVATE mqb_core)
 target_compile_features(mqb_link_state_tests PRIVATE cxx_std_23)
 
+add_executable(mqb_link_cache_file_tests link_cache_file_tests.cpp)
+target_link_libraries(mqb_link_cache_file_tests PRIVATE mqb_core)
+target_compile_features(mqb_link_cache_file_tests PRIVATE cxx_std_23)
+
 add_executable(mqb_process_model_tests process_model_tests.cpp)
 target_link_libraries(mqb_process_model_tests PRIVATE mqb_process)
 target_compile_features(mqb_process_model_tests PRIVATE cxx_std_23)
@@ -43,6 +47,7 @@ set(MQB_TEST_TARGETS
     mqb_compile_cache_file_tests
     mqb_build_planner_tests
     mqb_link_state_tests
+    mqb_link_cache_file_tests
     mqb_process_model_tests
 )
 
@@ -141,6 +146,7 @@ add_test(NAME mqb.core.compile_cache COMMAND mqb_compile_cache_tests)
 add_test(NAME mqb.core.compile_cache_file COMMAND mqb_compile_cache_file_tests)
 add_test(NAME mqb.core.build_planner COMMAND mqb_build_planner_tests)
 add_test(NAME mqb.core.link_state COMMAND mqb_link_state_tests)
+add_test(NAME mqb.core.link_cache_file COMMAND mqb_link_cache_file_tests)
 add_test(NAME mqb.process.model COMMAND mqb_process_model_tests)
 
 if(WIN32)

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -26,6 +26,10 @@ add_executable(mqb_build_planner_tests build_planner_tests.cpp)
 target_link_libraries(mqb_build_planner_tests PRIVATE mqb_core)
 target_compile_features(mqb_build_planner_tests PRIVATE cxx_std_23)
 
+add_executable(mqb_link_state_tests link_state_tests.cpp)
+target_link_libraries(mqb_link_state_tests PRIVATE mqb_core)
+target_compile_features(mqb_link_state_tests PRIVATE cxx_std_23)
+
 add_executable(mqb_process_model_tests process_model_tests.cpp)
 target_link_libraries(mqb_process_model_tests PRIVATE mqb_process)
 target_compile_features(mqb_process_model_tests PRIVATE cxx_std_23)
@@ -38,6 +42,7 @@ set(MQB_TEST_TARGETS
     mqb_compile_cache_tests
     mqb_compile_cache_file_tests
     mqb_build_planner_tests
+    mqb_link_state_tests
     mqb_process_model_tests
 )
 
@@ -125,6 +130,7 @@ add_test(NAME mqb.core.dependency_graph COMMAND mqb_dependency_graph_tests)
 add_test(NAME mqb.core.compile_cache COMMAND mqb_compile_cache_tests)
 add_test(NAME mqb.core.compile_cache_file COMMAND mqb_compile_cache_file_tests)
 add_test(NAME mqb.core.build_planner COMMAND mqb_build_planner_tests)
+add_test(NAME mqb.core.link_state COMMAND mqb_link_state_tests)
 add_test(NAME mqb.process.model COMMAND mqb_process_model_tests)
 
 if(WIN32)

--- a/cpp/tests/link_cache_file_tests.cpp
+++ b/cpp/tests/link_cache_file_tests.cpp
@@ -1,0 +1,110 @@
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <vector>
+
+#include "mqb/core/BuildSignature.hpp"
+#include "mqb/core/LinkCache.hpp"
+#include "mqb/core/LinkCacheFile.hpp"
+#include "mqb/core/LinkOptions.hpp"
+#include "mqb/core/LinkerIdentity.hpp"
+
+namespace {
+
+namespace fs = std::filesystem;
+int failures = 0;
+
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+struct TempTree {
+    fs::path root;
+    ~TempTree() {
+        std::error_code ignored;
+        fs::remove_all(root, ignored);
+    }
+};
+
+} // namespace
+
+int main() {
+    const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
+    TempTree tree{
+        .root = fs::temp_directory_path() / ("mqb_link_cache_" + std::to_string(unique)),
+    };
+    fs::create_directories(tree.root);
+
+    const std::vector<fs::path> objects{"obj/main.cpp.obj", "obj/math.cpp.obj"};
+    const fs::path output{"bin/app.exe"};
+    const mqb::LinkerIdentity linker{
+        .linker = "C:/msvc/link.exe",
+        .version = "14.51",
+        .binary_stamp = "stamp-a",
+    };
+    mqb::LinkOptions options;
+    options.libraries = {"user32.lib"};
+    const auto signature = mqb::BuildSignature::for_link(objects, output, linker, options);
+    const mqb::LinkCacheEntry entry{
+        .linker = linker,
+        .signature = signature,
+        .objects = objects,
+        .output = output,
+    };
+
+    const fs::path file = tree.root / "cache" / "app.linkcache";
+    const auto missing = mqb::LinkCacheFile::load(file);
+    expect(missing.has_value() && !missing->has_value(),
+           "missing link cache should be a normal cache miss");
+
+    const auto saved = mqb::LinkCacheFile::save(file, entry);
+    expect(saved.has_value(), "valid link cache should save");
+    const auto loaded = mqb::LinkCacheFile::load(file);
+    expect(loaded.has_value() && loaded->has_value(), "saved link cache should load");
+    if (loaded && *loaded) {
+        expect((*loaded)->linker.linker == linker.linker, "linker path should round-trip");
+        expect((*loaded)->linker.version == linker.version, "linker version should round-trip");
+        expect((*loaded)->linker.binary_stamp == linker.binary_stamp, "linker stamp should round-trip");
+        expect((*loaded)->signature == signature, "link signature should round-trip");
+        expect((*loaded)->objects == objects, "link inputs should round-trip");
+        expect((*loaded)->output == output, "link output should round-trip");
+    }
+
+    {
+        std::fstream stream{file, std::ios::binary | std::ios::in | std::ios::out};
+        char bad = 'X';
+        stream.write(&bad, 1);
+    }
+    const auto bad_magic = mqb::LinkCacheFile::load(file);
+    expect(!bad_magic.has_value(), "corrupt link-cache magic should be rejected");
+    if (!bad_magic) {
+        expect(bad_magic.error().code == mqb::LinkCacheFileErrorCode::invalid_magic,
+               "corrupt magic should report invalid_magic");
+    }
+
+    const auto restored = mqb::LinkCacheFile::save(file, entry);
+    expect(restored.has_value(), "link cache should be replaceable after corruption");
+    std::error_code error_code;
+    const auto size = fs::file_size(file, error_code);
+    expect(!error_code && size > 8, "saved link cache should be non-trivial");
+    if (!error_code && size > 8) {
+        fs::resize_file(file, size - 5, error_code);
+        expect(!error_code, "test should be able to truncate cache file");
+    }
+    const auto truncated = mqb::LinkCacheFile::load(file);
+    expect(!truncated.has_value(), "truncated link cache should be rejected");
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+    std::cout << "mqb_link_cache_file_tests passed\n";
+    return 0;
+}

--- a/cpp/tests/link_state_tests.cpp
+++ b/cpp/tests/link_state_tests.cpp
@@ -1,0 +1,156 @@
+#include <algorithm>
+#include <chrono>
+#include <filesystem>
+#include <iostream>
+#include <optional>
+#include <string_view>
+#include <variant>
+#include <vector>
+
+#include "mqb/core/BuildAction.hpp"
+#include "mqb/core/BuildPlanner.hpp"
+#include "mqb/core/BuildSignature.hpp"
+#include "mqb/core/LinkCache.hpp"
+#include "mqb/core/LinkOptions.hpp"
+#include "mqb/core/LinkerIdentity.hpp"
+
+namespace {
+
+namespace fs = std::filesystem;
+int failures = 0;
+
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+[[nodiscard]] bool has_reason(
+    const mqb::LinkCacheValidation& validation,
+    const mqb::BuildReason reason) {
+    return std::find(validation.reasons.begin(), validation.reasons.end(), reason)
+        != validation.reasons.end();
+}
+
+} // namespace
+
+int main() {
+    const std::vector<fs::path> objects{"obj/main.obj", "obj/math.obj"};
+    const fs::path output{"bin/app.exe"};
+    const mqb::LinkerIdentity linker{
+        .linker = "C:/msvc/link.exe",
+        .version = "14.51",
+        .binary_stamp = "link-stamp-a",
+    };
+    mqb::LinkOptions options;
+    options.configuration = mqb::BuildConfiguration::debug;
+    options.architecture = mqb::Architecture::x64;
+    options.libraries = {"user32.lib"};
+
+    const auto signature = mqb::BuildSignature::for_link(objects, output, linker, options);
+
+    auto changed_options = options;
+    changed_options.additional_arguments.push_back("/OPT:NOREF");
+    expect(
+        mqb::BuildSignature::for_link(objects, output, linker, changed_options) != signature,
+        "linker options must participate in link signature");
+
+    auto reordered_objects = objects;
+    std::reverse(reordered_objects.begin(), reordered_objects.end());
+    expect(
+        mqb::BuildSignature::for_link(reordered_objects, output, linker, options) != signature,
+        "link input order must participate in link signature");
+
+    const auto base_time = fs::file_time_type{} + std::chrono::seconds{100};
+    const mqb::FileSnapshot output_snapshot{
+        .path = output,
+        .exists = true,
+        .modified = base_time,
+    };
+    const std::vector<mqb::FileSnapshot> object_snapshots{
+        {.path = objects[0], .exists = true, .modified = base_time - std::chrono::seconds{2}},
+        {.path = objects[1], .exists = true, .modified = base_time - std::chrono::seconds{1}},
+    };
+
+    const mqb::LinkCacheEntry cached{
+        .linker = linker,
+        .signature = signature,
+        .objects = objects,
+        .output = output,
+    };
+
+    const auto warm = mqb::LinkCacheValidator::validate(
+        objects, output, linker, options, cached, output_snapshot, object_snapshots);
+    expect(warm.reusable(), "matching link cache should be reusable");
+
+    const auto cold = mqb::LinkCacheValidator::validate(
+        objects,
+        output,
+        linker,
+        options,
+        std::nullopt,
+        mqb::FileSnapshot{.path = output, .exists = false},
+        object_snapshots);
+    expect(has_reason(cold, mqb::BuildReason::missing_cache_entry),
+           "cold link should report missing cache entry");
+    expect(has_reason(cold, mqb::BuildReason::missing_output),
+           "cold link should report missing output");
+
+    auto newer_objects = object_snapshots;
+    newer_objects[1].modified = base_time + std::chrono::seconds{1};
+    const auto object_changed = mqb::LinkCacheValidator::validate(
+        objects, output, linker, options, cached, output_snapshot, newer_objects);
+    expect(has_reason(object_changed, mqb::BuildReason::link_inputs_changed),
+           "object newer than executable should invalidate link cache");
+
+    const auto forced = mqb::LinkCacheValidator::validate(
+        objects, output, linker, options, cached, output_snapshot, object_snapshots, true);
+    expect(has_reason(forced, mqb::BuildReason::explicit_rebuild),
+           "fresh compile result must be able to force relink independent of timestamps");
+
+    auto other_linker = linker;
+    other_linker.binary_stamp = "link-stamp-b";
+    const auto linker_changed = mqb::LinkCacheValidator::validate(
+        objects, output, other_linker, options, cached, output_snapshot, object_snapshots);
+    expect(has_reason(linker_changed, mqb::BuildReason::toolchain_changed),
+           "linker identity change should invalidate link cache");
+
+    const auto options_changed = mqb::LinkCacheValidator::validate(
+        objects, output, linker, changed_options, cached, output_snapshot, object_snapshots);
+    expect(has_reason(options_changed, mqb::BuildReason::linker_options_changed),
+           "link option change should invalidate link cache");
+
+    const mqb::LinkPlanItem plan_item{
+        .objects = objects,
+        .output = output,
+        .cache_validation = object_changed,
+    };
+    const auto plan = mqb::BuildPlanner::plan_link(plan_item);
+    expect(plan.has_value() && plan->size() == 1,
+           "invalid link cache should produce exactly one link action");
+    if (plan && plan->size() == 1) {
+        const auto* action = std::get_if<mqb::LinkAction>(&plan->actions.front());
+        expect(action != nullptr, "link plan should contain a LinkAction");
+        if (action != nullptr) {
+            expect(action->objects == objects, "link action should preserve object inputs");
+            expect(action->output == output, "link action should preserve target output");
+        }
+    }
+
+    const mqb::LinkPlanItem reusable_item{
+        .objects = objects,
+        .output = output,
+        .cache_validation = warm,
+    };
+    const auto empty_plan = mqb::BuildPlanner::plan_link(reusable_item);
+    expect(empty_plan.has_value() && empty_plan->empty(),
+           "reusable link cache should produce an empty plan");
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+    std::cout << "mqb_link_state_tests passed\n";
+    return 0;
+}

--- a/cpp/tests/mqb_cli_e2e_tests.cpp
+++ b/cpp/tests/mqb_cli_e2e_tests.cpp
@@ -68,6 +68,24 @@ run_mqb(
     return std::move(*result);
 }
 
+[[nodiscard]] std::expected<mqb::process::ProcessResult, std::string>
+run_executable(
+    mqb::platform::windows::WindowsProcessRunner& runner,
+    const fs::path& executable,
+    const fs::path& working_directory) {
+    mqb::process::ProcessSpec spec;
+    spec.executable = executable;
+    spec.working_directory = working_directory;
+    spec.capture_stdout = true;
+    spec.capture_stderr = true;
+    auto result = runner.run(spec);
+    if (!result) {
+        return std::unexpected(
+            "failed to launch generated executable: " + result.error().message);
+    }
+    return std::move(*result);
+}
+
 void dump_failure(const mqb::process::ProcessResult& result) {
     std::cerr << "exit: " << result.exit_code << '\n'
               << "stdout:\n" << result.stdout_text << '\n'
@@ -94,15 +112,21 @@ int main(const int argc, char* argv[]) {
     write_text(header, "#pragma once\ninline constexpr int sample_value = 41;\n");
     write_text(
         source,
+        "#include <cstdio>\n"
         "#include \"sample.hpp\"\n"
         "#ifndef MQB_CLI_TEST\n"
         "#error MQB_CLI_TEST must be defined\n"
         "#endif\n"
-        "int value() { return sample_value + MQB_CLI_TEST; }\n");
+        "int main() {\n"
+        "    std::printf(\"mqb-cli-e2e=%d\\n\", sample_value + MQB_CLI_TEST);\n"
+        "    return 0;\n"
+        "}\n");
 
     const fs::path object = tree.root / ".mqb" / "obj" / "sample.cpp.obj";
-    const fs::path cache = tree.root / ".mqb" / "cache" / "sample.cpp.mqbcache";
+    const fs::path compile_cache = tree.root / ".mqb" / "cache" / "sample.cpp.mqbcache";
+    const fs::path link_cache = tree.root / ".mqb" / "cache" / "sample.cpp.linkcache";
     const fs::path dependencies = tree.root / ".mqb" / "deps" / "sample.cpp.json";
+    const fs::path executable = tree.root / ".mqb" / "bin" / "sample.cpp.exe";
 
     mqb::platform::windows::WindowsProcessRunner runner;
 
@@ -113,12 +137,24 @@ int main(const int argc, char* argv[]) {
             dump_failure(*cold);
         }
         expect(cold->exit_code == 0, "cold build should succeed");
-        expect(cold->stdout_text.find("[compile]") != std::string::npos,
+        expect(cold->stdout_text.find("[compile] sample.cpp") != std::string::npos,
                "cold build should report a compile action");
+        expect(cold->stdout_text.find("[link] sample.cpp.exe") != std::string::npos,
+               "cold build should report a link action");
     }
     expect(fs::is_regular_file(object), "cold build should create collision-free object artifact");
-    expect(fs::is_regular_file(cache), "cold build should persist compile cache");
+    expect(fs::is_regular_file(compile_cache), "cold build should persist compile cache");
+    expect(fs::is_regular_file(link_cache), "cold build should persist link cache");
     expect(fs::is_regular_file(dependencies), "cold build should create sourceDependencies metadata");
+    expect(fs::is_regular_file(executable), "cold build should create executable artifact");
+
+    auto first_run = run_executable(runner, executable, tree.root);
+    expect(first_run.has_value(), "cold-built executable should launch");
+    if (first_run) {
+        expect(first_run->exit_code == 0, "cold-built executable should return zero");
+        expect(first_run->stdout_text.find("mqb-cli-e2e=42") != std::string::npos,
+               "cold-built executable should contain freshly compiled behavior");
+    }
 
     auto warm = run_mqb(runner, mqb_executable, tree.root, source);
     expect(warm.has_value(), "warm invocation should launch");
@@ -127,8 +163,10 @@ int main(const int argc, char* argv[]) {
             dump_failure(*warm);
         }
         expect(warm->exit_code == 0, "warm build should succeed");
-        expect(warm->stdout_text.find("[up-to-date]") != std::string::npos,
+        expect(warm->stdout_text.find("[up-to-date] sample.cpp\n") != std::string::npos,
                "warm build should reuse the cached object");
+        expect(warm->stdout_text.find("[up-to-date] sample.cpp.exe") != std::string::npos,
+               "warm build should reuse the cached executable");
     }
 
     std::error_code error_code;
@@ -147,10 +185,22 @@ int main(const int argc, char* argv[]) {
             dump_failure(*header_changed);
         }
         expect(header_changed->exit_code == 0, "header-change build should succeed");
-        expect(header_changed->stdout_text.find("[compile]") != std::string::npos,
+        expect(header_changed->stdout_text.find("[compile] sample.cpp") != std::string::npos,
                "header change should trigger compilation");
         expect(header_changed->stdout_text.find("dependency changed") != std::string::npos,
                "header change should be explained as dependency changed");
+        expect(header_changed->stdout_text.find("[link] sample.cpp.exe") != std::string::npos,
+               "fresh compilation should force executable relink");
+        expect(header_changed->stdout_text.find("explicit rebuild") != std::string::npos,
+               "forced relink should be explainable independently of timestamp granularity");
+    }
+
+    auto changed_run = run_executable(runner, executable, tree.root);
+    expect(changed_run.has_value(), "relinked executable should launch");
+    if (changed_run) {
+        expect(changed_run->exit_code == 0, "relinked executable should return zero");
+        expect(changed_run->stdout_text.find("mqb-cli-e2e=43") != std::string::npos,
+               "relinked executable must observe the changed header, not stale object state");
     }
 
     error_code.clear();
@@ -168,8 +218,10 @@ int main(const int argc, char* argv[]) {
             dump_failure(*warm_again);
         }
         expect(warm_again->exit_code == 0, "second warm build should succeed");
-        expect(warm_again->stdout_text.find("[up-to-date]") != std::string::npos,
+        expect(warm_again->stdout_text.find("[up-to-date] sample.cpp\n") != std::string::npos,
                "rebuilt object should become reusable again");
+        expect(warm_again->stdout_text.find("[up-to-date] sample.cpp.exe") != std::string::npos,
+               "relinked executable should become reusable again");
     }
 
     auto release = run_mqb(
@@ -184,10 +236,22 @@ int main(const int argc, char* argv[]) {
             dump_failure(*release);
         }
         expect(release->exit_code == 0, "release build should succeed");
-        expect(release->stdout_text.find("[compile]") != std::string::npos,
+        expect(release->stdout_text.find("[compile] sample.cpp") != std::string::npos,
                "Debug to Release should trigger compilation without source edits");
         expect(release->stdout_text.find("compiler options changed") != std::string::npos,
-               "configuration invalidation should be explained as compiler options changed");
+               "compile configuration invalidation should remain explainable");
+        expect(release->stdout_text.find("[link] sample.cpp.exe") != std::string::npos,
+               "Debug to Release should also relink the executable");
+        expect(release->stdout_text.find("linker options changed") != std::string::npos,
+               "link configuration invalidation should remain explainable");
+    }
+
+    auto release_run = run_executable(runner, executable, tree.root);
+    expect(release_run.has_value(), "release executable should launch");
+    if (release_run) {
+        expect(release_run->exit_code == 0, "release executable should return zero");
+        expect(release_run->stdout_text.find("mqb-cli-e2e=43") != std::string::npos,
+               "release executable should preserve current program behavior");
     }
 
     if (failures != 0) {

--- a/cpp/tests/mqb_cli_e2e_tests.cpp
+++ b/cpp/tests/mqb_cli_e2e_tests.cpp
@@ -36,6 +36,28 @@ void write_text(const fs::path& path, const std::string_view text) {
     stream << text;
 }
 
+[[nodiscard]] bool contains_output_line(
+    const std::string_view output,
+    const std::string_view expected) {
+    std::size_t begin = 0;
+    while (begin <= output.size()) {
+        const std::size_t newline = output.find('\n', begin);
+        const std::size_t end = newline == std::string_view::npos ? output.size() : newline;
+        std::string_view line = output.substr(begin, end - begin);
+        if (!line.empty() && line.back() == '\r') {
+            line.remove_suffix(1);
+        }
+        if (line == expected) {
+            return true;
+        }
+        if (newline == std::string_view::npos) {
+            break;
+        }
+        begin = newline + 1;
+    }
+    return false;
+}
+
 struct TempTree {
     fs::path root;
 
@@ -163,9 +185,9 @@ int main(const int argc, char* argv[]) {
             dump_failure(*warm);
         }
         expect(warm->exit_code == 0, "warm build should succeed");
-        expect(warm->stdout_text.find("[up-to-date] sample.cpp\n") != std::string::npos,
+        expect(contains_output_line(warm->stdout_text, "[up-to-date] sample.cpp"),
                "warm build should reuse the cached object");
-        expect(warm->stdout_text.find("[up-to-date] sample.cpp.exe") != std::string::npos,
+        expect(contains_output_line(warm->stdout_text, "[up-to-date] sample.cpp.exe"),
                "warm build should reuse the cached executable");
     }
 
@@ -218,9 +240,9 @@ int main(const int argc, char* argv[]) {
             dump_failure(*warm_again);
         }
         expect(warm_again->exit_code == 0, "second warm build should succeed");
-        expect(warm_again->stdout_text.find("[up-to-date] sample.cpp\n") != std::string::npos,
+        expect(contains_output_line(warm_again->stdout_text, "[up-to-date] sample.cpp"),
                "rebuilt object should become reusable again");
-        expect(warm_again->stdout_text.find("[up-to-date] sample.cpp.exe") != std::string::npos,
+        expect(contains_output_line(warm_again->stdout_text, "[up-to-date] sample.cpp.exe"),
                "relinked executable should become reusable again");
     }
 

--- a/cpp/tests/msvc_link_integration_tests.cpp
+++ b/cpp/tests/msvc_link_integration_tests.cpp
@@ -1,0 +1,138 @@
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <string_view>
+#include <system_error>
+
+#include "mqb/core/CompilerOptions.hpp"
+#include "mqb/core/LinkOptions.hpp"
+#include "mqb/msvc/MsvcCompiler.hpp"
+#include "mqb/msvc/MsvcLinker.hpp"
+#include "mqb/msvc/MsvcToolchainLocator.hpp"
+#include "mqb/platform/windows/WindowsProcessRunner.hpp"
+
+namespace {
+
+namespace fs = std::filesystem;
+int failures = 0;
+
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+struct TempTree {
+    fs::path root;
+    ~TempTree() {
+        std::error_code ignored;
+        fs::remove_all(root, ignored);
+    }
+};
+
+} // namespace
+
+int main() {
+    const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
+    TempTree tree{
+        .root = fs::temp_directory_path() / ("mqb_msvc_link_" + std::to_string(unique)),
+    };
+    fs::create_directories(tree.root);
+
+    const fs::path source = tree.root / "main.cpp";
+    const fs::path object = tree.root / "obj" / "main.cpp.obj";
+    const fs::path dependencies = tree.root / "deps" / "main.cpp.json";
+    const fs::path executable = tree.root / "bin" / "hello.exe";
+
+    {
+        std::ofstream stream{source, std::ios::binary | std::ios::trunc};
+        stream << "#include <cstdio>\n"
+                  "int main() { std::puts(\"mqb-link-ok\"); return 0; }\n";
+    }
+
+    mqb::platform::windows::WindowsProcessRunner runner;
+    mqb::msvc::MsvcToolchainLocator locator{runner};
+    mqb::msvc::DiscoveryOptions discovery;
+    discovery.preference = mqb::msvc::ToolchainPreference::visual_studio;
+    discovery.target_architecture = mqb::Architecture::x64;
+    discovery.host_architecture = mqb::Architecture::x64;
+
+    auto toolchain = locator.discover(discovery);
+    expect(toolchain.has_value(), "installed Visual Studio toolchain should be discoverable");
+    if (!toolchain) {
+        return 1;
+    }
+
+    auto linker_identity = mqb::msvc::MsvcLinker::identity(*toolchain);
+    expect(linker_identity.has_value(), "link.exe should have an independent linker identity");
+    if (linker_identity) {
+        expect(linker_identity->linker == toolchain->linker,
+               "linker identity should name the discovered link.exe");
+        expect(!linker_identity->binary_stamp.empty(),
+               "linker identity should include a binary stamp");
+    }
+
+    mqb::msvc::MsvcCompiler compiler{*toolchain, runner};
+    mqb::msvc::CompileInvocation compile;
+    compile.source = source;
+    compile.object = object;
+    compile.source_dependencies = dependencies;
+    compile.working_directory = tree.root;
+    compile.options.configuration = mqb::BuildConfiguration::debug;
+    compile.options.architecture = mqb::Architecture::x64;
+    compile.options.standard = mqb::CppStandard::cpp23;
+
+    auto compiled = compiler.compile(compile);
+    expect(compiled.has_value(), "real MSVC compile should succeed before linking");
+    expect(fs::is_regular_file(object), "compiler should create object input for linker");
+    if (!compiled) {
+        if (compiled.error().process_result) {
+            std::cerr << compiled.error().process_result->stdout_text
+                      << compiled.error().process_result->stderr_text;
+        }
+        return 1;
+    }
+
+    mqb::msvc::MsvcLinker linker{*toolchain, runner};
+    mqb::msvc::LinkInvocation link;
+    link.objects = {object};
+    link.output = executable;
+    link.working_directory = tree.root;
+    link.options.configuration = mqb::BuildConfiguration::debug;
+    link.options.architecture = mqb::Architecture::x64;
+    link.options.subsystem = mqb::LinkSubsystem::console;
+
+    auto linked = linker.link(link);
+    expect(linked.has_value(), "real link.exe invocation should succeed");
+    expect(fs::is_regular_file(executable), "linker should create executable output");
+    if (!linked) {
+        if (linked.error().process_result) {
+            std::cerr << linked.error().process_result->stdout_text
+                      << linked.error().process_result->stderr_text;
+        }
+        return 1;
+    }
+
+    mqb::process::ProcessSpec run;
+    run.executable = executable;
+    run.working_directory = tree.root;
+    run.capture_stdout = true;
+    run.capture_stderr = true;
+    auto executed = runner.run(run);
+    expect(executed.has_value(), "linked executable should launch");
+    if (executed) {
+        expect(executed->exit_code == 0, "linked executable should return zero");
+        expect(executed->stdout_text.find("mqb-link-ok") != std::string::npos,
+               "linked executable should contain expected program behavior");
+    }
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+    std::cout << "mqb_msvc_link_integration_tests passed\n";
+    return 0;
+}

--- a/cpp/tests/msvc_linker_arguments_tests.cpp
+++ b/cpp/tests/msvc_linker_arguments_tests.cpp
@@ -1,0 +1,85 @@
+#include <algorithm>
+#include <filesystem>
+#include <iostream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "mqb/core/LinkOptions.hpp"
+#include "mqb/msvc/MsvcLinker.hpp"
+
+namespace {
+
+int failures = 0;
+
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+[[nodiscard]] bool contains(
+    const std::vector<std::string>& arguments,
+    const std::string_view expected) {
+    return std::find(arguments.begin(), arguments.end(), expected) != arguments.end();
+}
+
+} // namespace
+
+int main() {
+    mqb::msvc::LinkInvocation invocation;
+    invocation.objects = {"obj/main file.obj", "obj/math.obj"};
+    invocation.output = "bin/my app.exe";
+    invocation.options.configuration = mqb::BuildConfiguration::debug;
+    invocation.options.architecture = mqb::Architecture::x64;
+    invocation.options.subsystem = mqb::LinkSubsystem::console;
+    invocation.options.library_directories = {"vendor libs"};
+    invocation.options.libraries = {"user32.lib"};
+    invocation.options.additional_arguments = {"/MAP", "/OUT:ignored.exe"};
+
+    const auto result = mqb::msvc::MsvcLinker::build_arguments(invocation);
+    expect(result.has_value(), "valid link invocation should produce argv");
+    if (result) {
+        expect(contains(*result, "/NOLOGO"), "link should suppress banner");
+        expect(contains(*result, "/DEBUG"), "debug link should emit /DEBUG");
+        expect(contains(*result, "/INCREMENTAL"), "debug link should be incremental");
+        expect(contains(*result, "/LIBPATH:vendor libs"), "library path should stay one argv element");
+        expect(contains(*result, "user32.lib"), "library should be preserved");
+        expect(contains(*result, "/MACHINE:X64"), "x64 should map to /MACHINE:X64");
+        expect(contains(*result, "/SUBSYSTEM:CONSOLE"), "console subsystem should map correctly");
+        expect(contains(*result, "/OUT:bin/my app.exe"), "structured output should be emitted");
+
+        const auto raw_out = std::find(result->begin(), result->end(), "/OUT:ignored.exe");
+        const auto planned_out = std::find(result->begin(), result->end(), "/OUT:bin/my app.exe");
+        expect(raw_out != result->end() && planned_out != result->end() && raw_out < planned_out,
+               "planned output must override a conflicting raw /OUT");
+    }
+
+    auto release = invocation;
+    release.options.configuration = mqb::BuildConfiguration::release;
+    release.options.architecture = mqb::Architecture::x86;
+    release.options.subsystem = mqb::LinkSubsystem::windows;
+    release.options.additional_arguments.clear();
+    const auto release_result = mqb::msvc::MsvcLinker::build_arguments(release);
+    expect(release_result.has_value(), "release link invocation should produce argv");
+    if (release_result) {
+        expect(contains(*release_result, "/INCREMENTAL:NO"), "release link should disable incremental linking");
+        expect(contains(*release_result, "/OPT:REF"), "release link should enable reference elimination");
+        expect(contains(*release_result, "/OPT:ICF"), "release link should enable COMDAT folding");
+        expect(contains(*release_result, "/MACHINE:X86"), "x86 should map correctly");
+        expect(contains(*release_result, "/SUBSYSTEM:WINDOWS"), "windows subsystem should map correctly");
+    }
+
+    auto invalid = invocation;
+    invalid.objects.clear();
+    const auto invalid_result = mqb::msvc::MsvcLinker::build_arguments(invalid);
+    expect(!invalid_result, "link with no objects should be rejected");
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+    std::cout << "mqb_msvc_linker_arguments_tests passed\n";
+    return 0;
+}

--- a/docs/CPP_V2_ARCHITECTURE.md
+++ b/docs/CPP_V2_ARCHITECTURE.md
@@ -5,10 +5,11 @@ This document defines the architecture for migrating MSVC Quick Build from the P
 ## Goals
 
 - Keep the PowerShell implementation as the behavioral reference until parity is proven.
-- Separate build policy from compiler/process execution.
+- Separate build policy from compiler/linker/process execution.
 - Keep MSVC-specific spellings out of the core model.
-- Make cache invalidation explainable and regression-testable.
+- Make compile and link cache invalidation explainable and regression-testable.
 - Treat paths and argv as structured data rather than shell command strings.
+- Prefer a conservative rebuild/relink over reusing uncertain artifacts.
 
 ## Layers
 
@@ -16,39 +17,38 @@ This document defines the architecture for migrating MSVC Quick Build from the P
 CLI (mqb.exe)
     |
     v
-Core
-  BuildRequest
-  Artifact / TranslationUnit
-  BuildSignature
-  CompileCacheValidator
-  DependencyGraph
-  BuildPlanner -> BuildPlan / BuildAction
+Orchestration
+  load -> snapshot -> validate -> plan -> execute -> persist
     |
-    v
-Process abstraction
-  ProcessSpec { executable, argv, cwd, env }
-  ProcessRunner -> expected<ProcessResult, ProcessError>
-    |
-    v
-Platform implementation
-  WindowsProcessRunner / CreateProcessW
-    |
-    v
-MSVC backend
-  MsvcToolchainLocator
-  portable_msvc layout | vswhere -> vcvarsall -> environment
-  cl.exe / link.exe argument builders (next)
-  /sourceDependencies (later)
-  /scanDependencies (later)
+    +--------------------+
+    v                    v
+Core                  MSVC backend
+  BuildRequest           MsvcToolchainLocator
+  Artifact / TU          MsvcCompiler
+  BuildSignature         MsvcCompileExecutor
+  CompileCache           MsvcLinker
+  LinkCache              /sourceDependencies reader
+  DependencyGraph             |
+  BuildPlanner                v
+    |                    Process abstraction
+    |                      ProcessSpec { executable, argv, cwd, env }
+    |                           |
+    +---------------------------+
+                                v
+                         Windows platform
+                         WindowsProcessRunner
+                         CreateProcessW
 ```
 
 ## Architectural rules
 
-1. **Core does not know `cl.exe`.** MSVC flags belong to the backend.
+1. **Core does not know `cl.exe` or `link.exe`.** MSVC switches and schemas belong to the backend.
 2. **Planner does not execute.** `BuildPlanner` only creates typed actions.
-3. **Correctness beats cache hit rate.** Uncertain cache state rebuilds.
-4. **No internal shell command API.** Executable and argv remain separate until a platform adapter absolutely requires another representation.
+3. **Correctness beats cache hit rate.** Uncertain cache state rebuilds or relinks.
+4. **No internal shell command API.** Executable and argv remain separate until the Windows adapter builds the `CreateProcessW` command line.
 5. **UTF-8 at the process abstraction boundary.** Windows converts textual argv/environment data to UTF-16 immediately before `CreateProcessW`.
+6. **Compile state and link state are independent.** A compile cache hit does not imply a link cache hit, and link-only changes must never force unnecessary compilation.
+7. **A fresh compile is an explicit relink signal.** Linking must not depend solely on filesystem timestamp granularity.
 
 ## Compile identity and cache freshness
 
@@ -56,11 +56,31 @@ MSVC backend
 
 ```text
 compiler recipe identity ----> BuildSignature
-source/header freshness ----> CompileCacheValidator
-artifact placement ----------> Artifact / cache storage
+source/header freshness ------> CompileCacheValidator
+artifact placement -----------> Artifact / cache storage
 ```
 
 `CompileCacheValidator` is pure and returns typed `BuildReason` values; it does not touch the filesystem or launch a process.
+
+`CompileCacheFile` persists compile metadata in a versioned binary format. Missing metadata is a normal cold-cache condition; corrupt/truncated/unsupported metadata is rejected and conservatively rebuilt.
+
+## Link identity and cache freshness
+
+Linking has its own state machine rather than piggybacking on object timestamps.
+
+```text
+ordered object inputs --------+
+link.exe identity ------------+
+link options -----------------+--> BuildSignature::for_link
+output identity --------------+
+
+output/object freshness ----------> LinkCacheValidator
+fresh compile --------------------> force_relink / explicit rebuild
+```
+
+`LinkerIdentity` stamps `link.exe` independently from `cl.exe`, so a linker update can invalidate only link state. `LinkCacheValidator` distinguishes link-input changes, linker-option changes, toolchain changes, missing output, and explicit relink.
+
+`LinkCacheFile` uses a separate versioned cache format. Broken link metadata can only cause a safe relink; it must never permit reuse of a stale executable.
 
 ## Dependency graph and planner
 
@@ -77,7 +97,47 @@ CompilePlanItem
                                   typed rebuild reasons
 ```
 
-The executor therefore receives actions rather than policy decisions.
+For link planning:
+
+```text
+LinkPlanItem
+    +-- reusable cache ------> no action
+    +-- stale cache ---------> LinkAction
+                                  ordered object inputs
+                                  executable output
+                                  typed relink reasons
+```
+
+Executors therefore receive actions rather than policy decisions.
+
+## Orchestration
+
+The application-facing coordinators compose existing policy/backend pieces without owning their algorithms.
+
+### Incremental compile
+
+```text
+CompileCacheFile
+      -> file snapshots
+      -> CompileCacheValidator
+      -> BuildPlanner::plan_compile
+      -> MsvcCompileExecutor
+      -> /sourceDependencies reader
+      -> CompileCacheFile::save
+```
+
+### Incremental link
+
+```text
+LinkCacheFile
+      -> output/object snapshots
+      -> LinkCacheValidator
+      -> BuildPlanner::plan_link
+      -> MsvcLinker
+      -> LinkCacheFile::save
+```
+
+Ordinary cache-load/save failures are surfaced as warnings and conservatively rebuild/relink. Compiler/linker execution failures are build errors.
 
 ## Process boundary
 
@@ -112,19 +172,34 @@ The locator first tries the standard `vswhere.exe` location, then known VS 2026/
 
 The captured environment is returned as structured name/value overrides; the locator does not mutate MQB's own process environment. `VCToolsInstallDir` is used to resolve the selected compiler/linker/librarian binaries.
 
-GitHub CI enables an installed-MSVC integration test explicitly; local tests keep that test opt-in so a portable-only development machine is not forced to have a registered Visual Studio installation.
+GitHub CI enables installed-MSVC integration tests explicitly; local tests keep those tests opt-in so a portable-only development machine is not forced to have a registered Visual Studio installation.
+
+## Current CLI milestone
+
+`mqb.exe` currently supports one ordinary C++ translation unit (`.cpp`, `.cc`, `.cxx`) and produces collision-free internal artifacts under a source-local `.mqb/` directory:
+
+```text
+.mqb/
+  obj/    <source filename>.obj
+  deps/   compiler dependency JSON
+  cache/  compile cache + link cache
+  bin/    <source filename>.exe
+```
+
+The CLI composes the incremental compile coordinator followed by the incremental link coordinator. Warm builds can therefore skip both compiler and linker independently, while a fresh compile explicitly forces relink even when filesystem timestamps are ambiguous.
 
 ## Migration sequence
 
 1. **Scaffold** — CMake, `mqb_core`, CLI executable, CTest. ✅
-2. **Pure core** — artifacts, signatures, plan model, dependency graph, cache validation, compile planner. ✅
+2. **Pure core** — artifacts, signatures, plan model, dependency graph, compile cache validation/planning. ✅
 3. **Process abstraction** — typed process spec, Windows quoting, Win32 runner. ✅
-4. **MSVC toolchain backend** — portable discovery plus `vswhere/vcvarsall` environment capture. **In progress / verification.**
-5. **Ordinary translation units** — typed compiler arguments, compile execution, `/sourceDependencies`, cache persistence/refresh.
-6. **Link state** — explicit linker signature and link planning.
-7. **Modules** — P1689 `/scanDependencies`, module graph, IFC/object artifacts.
-8. **Parity** — run PowerShell and C++ against the same E2E fixtures.
-9. **Cutover** — make `mqb.exe` primary only after parity tests pass.
+4. **MSVC toolchain backend** — portable discovery plus `vswhere/vcvarsall` environment capture. ✅
+5. **Ordinary single TU** — typed compiler arguments, `/sourceDependencies`, cache persistence, real incremental CLI. ✅
+6. **Link state** — independent linker identity/signature/cache/planning/backend/orchestration and executable production. ✅
+7. **Multi-TU and target CLI** — source discovery, multiple objects, output naming, libraries, run mode, project-level artifact layout.
+8. **Modules** — P1689 `/scanDependencies`, module graph, IFC/object artifacts, `import std`.
+9. **Parity** — run PowerShell and C++ against the same E2E fixtures.
+10. **Cutover** — make `mqb.exe` primary only after parity tests pass.
 
 ## Local build
 
@@ -134,10 +209,10 @@ cmake --build cpp/build
 ctest --test-dir cpp/build --output-on-failure
 ```
 
-To opt into the installed Visual Studio integration test:
+To opt into tests that require a registered Visual Studio installation:
 
 ```powershell
 cmake -S cpp -B cpp/build -DMQB_ENABLE_INSTALLED_MSVC_TESTS=ON
 ```
 
-GitHub Windows CI currently uses the Visual Studio 2026 CMake generator and enables that integration test.
+GitHub Windows CI currently uses the Visual Studio 2026 CMake generator and enables those integration tests.


### PR DESCRIPTION
Milestone 2B in progress.

First checkpoint establishes link state in Core before any real linker execution:
- shared FileSnapshot core type
- LinkerIdentity and LinkOptions
- versioned link BuildSignature
- LinkCacheValidator with explicit force-relink support
- separate `link inputs changed` vs linker-options/toolchain reasons
- BuildPlanner link actions
- unit coverage for warm reuse, object freshness, toolchain/options invalidation, and timestamp-independent forced relink

The next commits on this PR will add link cache persistence, the MSVC linker backend, orchestration, and finally CLI executable production.