### PR TITLE
feat: add explicit multi-TU target building

### DIFF
--- a/cpp/apps/mqb/Cli.cpp
+++ b/cpp/apps/mqb/Cli.cpp
@@ -78,7 +78,6 @@ attached_or_next(
 std::expected<Options, Error>
 parse_arguments(const std::span<const std::string_view> arguments) {
     Options options;
-    bool saw_source = false;
 
     for (std::size_t index = 0; index < arguments.size(); ++index) {
         const std::string_view argument = arguments[index];
@@ -164,15 +163,11 @@ parse_arguments(const std::span<const std::string_view> arguments) {
         if (!argument.empty() && argument.front() == '-') {
             return std::unexpected(error("unknown option '" + std::string{argument} + "'"));
         }
-        if (saw_source) {
-            return std::unexpected(error("only one source file is supported in this milestone"));
-        }
 
-        options.build.entry = std::filesystem::path{std::string{argument}};
-        saw_source = true;
+        options.build.sources.emplace_back(std::string{argument});
     }
 
-    if (!options.show_help && !saw_source) {
+    if (!options.show_help && options.build.sources.empty()) {
         return std::unexpected(error("missing source file"));
     }
     return options;
@@ -182,10 +177,10 @@ std::string_view usage() noexcept {
     return R"(MQB - MSVC Quick Build (C++ V2)
 
 Usage:
-  mqb <source.cpp> [options]
+  mqb <source.cpp> [more-sources...] [options]
 
 Current milestone:
-  Incrementally compile and link one C++ translation unit into .mqb/bin/.
+  Incrementally compile an explicit C++ source set and link one executable.
 
 Options:
   --debug                  Debug compile/link preset (default)
@@ -200,10 +195,10 @@ Options:
   -h, --help               Show this help
 
 Generated state:
-  .mqb/obj/    object files
+  .mqb/obj/    collision-free object files
   .mqb/deps/   compiler dependency metadata
   .mqb/cache/  compile and link cache metadata
-  .mqb/bin/    linked executables
+  .mqb/bin/    linked executable
 )";
 }
 

--- a/cpp/apps/mqb/main.cpp
+++ b/cpp/apps/mqb/main.cpp
@@ -11,16 +11,16 @@
 #include <vector>
 
 #include "Cli.hpp"
-#include "mqb/core/Artifact.hpp"
 #include "mqb/core/BuildTypes.hpp"
 #include "mqb/core/CompilerOptions.hpp"
 #include "mqb/core/LinkOptions.hpp"
-#include "mqb/core/TranslationUnit.hpp"
+#include "mqb/core/ProjectArtifactLayout.hpp"
 #include "mqb/msvc/MsvcCompileExecutor.hpp"
 #include "mqb/msvc/MsvcLinker.hpp"
 #include "mqb/msvc/MsvcToolchainLocator.hpp"
 #include "mqb/orchestration/MsvcIncrementalCompileCoordinator.hpp"
 #include "mqb/orchestration/MsvcIncrementalLinkCoordinator.hpp"
+#include "mqb/orchestration/MsvcIncrementalTargetCoordinator.hpp"
 #include "mqb/platform/windows/WindowsProcessRunner.hpp"
 #include "mqb/process/Process.hpp"
 
@@ -54,6 +54,25 @@ absolute_path(const fs::path& path, const std::string_view description) {
         extension.begin(),
         [](const unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
     return extension == ".cpp" || extension == ".cc" || extension == ".cxx";
+}
+
+[[nodiscard]] bool safe_relative(const fs::path& relative) {
+    if (relative.empty() || relative.is_absolute() || relative == ".") {
+        return false;
+    }
+    for (const auto& component : relative) {
+        if (component == "..") {
+            return false;
+        }
+    }
+    return true;
+}
+
+[[nodiscard]] fs::path display_source(
+    const fs::path& project_root,
+    const fs::path& source) {
+    const fs::path relative = source.lexically_relative(project_root);
+    return safe_relative(relative) ? relative : source;
 }
 
 void add_portable_root_if_missing(
@@ -102,7 +121,6 @@ void print_compile_failure(const mqb::orchestration::IncrementalCompileError& er
     if (!error.compile_error) {
         return;
     }
-
     const auto& compile_error = *error.compile_error;
     std::cerr << "  " << compile_error.message << '\n';
     if (compile_error.compiler_error) {
@@ -122,7 +140,6 @@ void print_link_failure(const mqb::orchestration::IncrementalLinkError& error) {
     if (!error.linker_error) {
         return;
     }
-
     const auto& linker_error = *error.linker_error;
     std::cerr << "  " << linker_error.message << '\n';
     if (linker_error.process_result) {
@@ -133,9 +150,40 @@ void print_link_failure(const mqb::orchestration::IncrementalLinkError& error) {
     }
 }
 
-[[nodiscard]] fs::path with_suffix(fs::path path, const std::string_view suffix) {
-    path += std::string{suffix};
-    return path;
+void print_target_failure(const mqb::orchestration::IncrementalTargetError& error) {
+    std::cerr << "error: " << error.message;
+    if (!error.source.empty()) {
+        std::cerr << ": " << path_text(error.source);
+    }
+    std::cerr << '\n';
+    if (error.compile_error) {
+        print_compile_failure(*error.compile_error);
+    }
+    if (error.link_error) {
+        print_link_failure(*error.link_error);
+    }
+}
+
+void print_compile_warnings(
+    const mqb::orchestration::IncrementalCompileResult& result) {
+    for (const auto& warning : result.warnings) {
+        std::cerr << "warning: " << warning.message;
+        if (!warning.path.empty()) {
+            std::cerr << ": " << path_text(warning.path);
+        }
+        std::cerr << '\n';
+    }
+}
+
+void print_link_warnings(
+    const mqb::orchestration::IncrementalLinkResult& result) {
+    for (const auto& warning : result.warnings) {
+        std::cerr << "warning: " << warning.message;
+        if (!warning.path.empty()) {
+            std::cerr << ": " << path_text(warning.path);
+        }
+        std::cerr << '\n';
+    }
 }
 
 } // namespace
@@ -147,11 +195,9 @@ int main(const int argc, char* argv[]) {
         arguments.emplace_back(argv[index]);
     }
 
-    auto parsed = mqb::cli::parse_arguments(
-        std::span<const std::string_view>{arguments});
+    auto parsed = mqb::cli::parse_arguments(std::span<const std::string_view>{arguments});
     if (!parsed) {
-        std::cerr << "error: " << parsed.error().message << "\n\n"
-                  << mqb::cli::usage();
+        std::cerr << "error: " << parsed.error().message << "\n\n" << mqb::cli::usage();
         return 2;
     }
     auto options = std::move(*parsed);
@@ -160,22 +206,43 @@ int main(const int argc, char* argv[]) {
         return 0;
     }
 
-    auto source = absolute_path(options.build.entry, "source file");
-    if (!source) {
-        std::cerr << "error: " << source.error() << '\n';
-        return 2;
-    }
-
     std::error_code error_code;
-    if (!fs::is_regular_file(*source, error_code) || error_code) {
-        std::cerr << "error: source file does not exist: " << path_text(*source) << '\n';
+    fs::path project_root = fs::current_path(error_code);
+    if (error_code) {
+        std::cerr << "error: failed to resolve current project directory: "
+                  << error_code.message() << '\n';
         return 2;
     }
-    if (!supported_source(*source)) {
-        std::cerr << "error: this milestone supports .cpp, .cc, and .cxx files only\n";
-        return 2;
+    project_root = project_root.lexically_normal();
+
+    std::vector<fs::path> sources;
+    sources.reserve(options.build.sources.size());
+    for (const auto& requested_source : options.build.sources) {
+        auto source = absolute_path(requested_source, "source file");
+        if (!source) {
+            std::cerr << "error: " << source.error() << '\n';
+            return 2;
+        }
+        if (!fs::is_regular_file(*source, error_code) || error_code) {
+            std::cerr << "error: source file does not exist: " << path_text(*source) << '\n';
+            return 2;
+        }
+        if (!supported_source(*source)) {
+            std::cerr << "error: only .cpp, .cc, and .cxx sources are supported in this milestone: "
+                      << path_text(*source) << '\n';
+            return 2;
+        }
+        for (const auto& previous : sources) {
+            error_code.clear();
+            if (fs::equivalent(previous, *source, error_code) && !error_code) {
+                std::cerr << "error: source file was provided more than once: "
+                          << path_text(*source) << '\n';
+                return 2;
+            }
+        }
+        sources.push_back(std::move(*source));
     }
-    options.build.entry = *source;
+    options.build.sources = sources;
 
     for (auto& include_directory : options.include_directories) {
         auto resolved = absolute_path(include_directory, "include directory");
@@ -194,26 +261,37 @@ int main(const int argc, char* argv[]) {
         portable_root = std::move(*resolved);
     }
 
-    const fs::path source_directory = source->parent_path();
-    const fs::path artifact_root = source_directory / ".mqb";
+    auto layout = mqb::ProjectArtifactLayout::create(project_root);
+    if (!layout) {
+        std::cerr << "error: " << layout.error().message << '\n';
+        return 2;
+    }
 
-    // Keep the source extension in internal artifact names so sibling files
-    // such as foo.cpp and foo.cxx cannot alias one another.
-    fs::path object_name = source->filename();
-    object_name += ".obj";
-    fs::path executable_name = source->filename();
-    executable_name += ".exe";
+    std::vector<mqb::orchestration::TargetSourceRequest> target_sources;
+    target_sources.reserve(sources.size());
+    for (const auto& source : sources) {
+        auto artifacts = layout->for_source(source);
+        if (!artifacts) {
+            std::cerr << "error: " << artifacts.error().message << ": "
+                      << path_text(source) << '\n';
+            return 2;
+        }
+        target_sources.push_back(mqb::orchestration::TargetSourceRequest{
+            .source = source,
+            .artifacts = std::move(*artifacts),
+        });
+    }
 
-    const fs::path object_file = artifact_root / "obj" / object_name;
-    const fs::path dependency_file = artifact_root / "deps" / with_suffix(source->filename(), ".json");
-    const fs::path compile_cache_file = artifact_root / "cache" / with_suffix(source->filename(), ".mqbcache");
-    const fs::path link_cache_file = artifact_root / "cache" / with_suffix(source->filename(), ".linkcache");
-    const fs::path executable_file = artifact_root / "bin" / executable_name;
+    const std::string target_name = sources.front().stem().string();
+    auto target_artifacts = layout->for_target(target_name);
+    if (!target_artifacts) {
+        std::cerr << "error: " << target_artifacts.error().message << '\n';
+        return 2;
+    }
 
-    add_portable_root_if_missing(options.portable_roots, source_directory / "portable_msvc");
-    const fs::path current_directory = fs::current_path(error_code);
-    if (!error_code) {
-        add_portable_root_if_missing(options.portable_roots, current_directory / "portable_msvc");
+    add_portable_root_if_missing(options.portable_roots, project_root / "portable_msvc");
+    for (const auto& source : sources) {
+        add_portable_root_if_missing(options.portable_roots, source.parent_path() / "portable_msvc");
     }
 
     mqb::platform::windows::WindowsProcessRunner runner;
@@ -241,104 +319,77 @@ int main(const int argc, char* argv[]) {
     compiler_options.defines = std::move(options.defines);
     compiler_options.include_directories = std::move(options.include_directories);
 
-    mqb::TranslationUnit unit;
-    unit.source = *source;
-    unit.kind = mqb::TranslationUnitKind::source;
-    unit.outputs.push_back(mqb::Artifact{
-        .path = object_file,
-        .kind = mqb::ArtifactKind::object,
-    });
+    mqb::LinkOptions link_options;
+    link_options.configuration = options.build.configuration;
+    link_options.architecture = options.build.architecture;
+    link_options.subsystem = mqb::LinkSubsystem::console;
 
     if (options.verbose) {
-        std::cout << "[toolchain] MSVC " << toolchain->identity.version
-                  << " (" << mqb::to_string(options.build.architecture) << ")\n"
-                  << "  cl:         " << path_text(toolchain->identity.compiler) << '\n'
-                  << "  link:       " << path_text(toolchain->linker) << '\n'
-                  << "  obj:        " << path_text(object_file) << '\n'
-                  << "  deps:       " << path_text(dependency_file) << '\n'
-                  << "  cc-cache:   " << path_text(compile_cache_file) << '\n'
-                  << "  link-cache: " << path_text(link_cache_file) << '\n'
-                  << "  exe:        " << path_text(executable_file) << '\n';
+        std::cout << "[target] " << target_name << "\n"
+                  << "  project: " << path_text(project_root) << '\n'
+                  << "  cl:      " << path_text(toolchain->identity.compiler) << '\n'
+                  << "  link:    " << path_text(toolchain->linker) << '\n';
+        for (const auto& source : target_sources) {
+            std::cout << "  source:  " << path_text(display_source(project_root, source.source)) << '\n'
+                      << "    obj:   " << path_text(source.artifacts.object) << '\n'
+                      << "    deps:  " << path_text(source.artifacts.dependencies) << '\n'
+                      << "    cache: " << path_text(source.artifacts.compile_cache) << '\n';
+        }
+        std::cout << "  exe:     " << path_text(target_artifacts->executable) << '\n'
+                  << "  cache:   " << path_text(target_artifacts->link_cache) << '\n';
     }
 
     mqb::msvc::MsvcCompileExecutor compile_executor{*toolchain, runner};
     mqb::orchestration::MsvcIncrementalCompileCoordinator compile_coordinator{
         *toolchain,
         compile_executor};
-    mqb::orchestration::IncrementalCompileRequest compile_request{
-        .unit = std::move(unit),
-        .options = std::move(compiler_options),
-        .cache_file = compile_cache_file,
-        .source_dependencies_file = dependency_file,
-        .working_directory = source_directory,
-    };
-
-    auto compile_result = compile_coordinator.run(compile_request);
-    if (!compile_result) {
-        print_compile_failure(compile_result.error());
-        return 4;
-    }
-
-    for (const auto& warning : compile_result->warnings) {
-        std::cerr << "warning: " << warning.message;
-        if (!warning.path.empty()) {
-            std::cerr << ": " << path_text(warning.path);
-        }
-        std::cerr << '\n';
-    }
-
-    if (compile_result->compiled) {
-        std::cout << "[compile] " << path_text(source->filename());
-        print_reasons(compile_result->validation.reasons);
-        std::cout << '\n';
-        if (compile_result->process) {
-            print_process_output(*compile_result->process);
-        }
-    } else {
-        std::cout << "[up-to-date] " << path_text(source->filename()) << '\n';
-    }
-
-    mqb::LinkOptions link_options;
-    link_options.configuration = options.build.configuration;
-    link_options.architecture = options.build.architecture;
-    link_options.subsystem = mqb::LinkSubsystem::console;
-
     mqb::msvc::MsvcLinker linker{*toolchain, runner};
     mqb::orchestration::MsvcIncrementalLinkCoordinator link_coordinator{*toolchain, linker};
-    mqb::orchestration::IncrementalLinkRequest link_request{
-        .objects = {object_file},
-        .output = executable_file,
-        .options = std::move(link_options),
-        .cache_file = link_cache_file,
-        .working_directory = source_directory,
-        .force_relink = compile_result->compiled,
+    mqb::orchestration::MsvcIncrementalTargetCoordinator target_coordinator{
+        compile_coordinator,
+        link_coordinator};
+
+    const mqb::orchestration::IncrementalTargetRequest request{
+        .sources = std::move(target_sources),
+        .target = std::move(*target_artifacts),
+        .compiler_options = std::move(compiler_options),
+        .link_options = std::move(link_options),
+        .working_directory = project_root,
     };
 
-    auto link_result = link_coordinator.run(link_request);
-    if (!link_result) {
-        print_link_failure(link_result.error());
-        return 5;
+    auto result = target_coordinator.run(request);
+    if (!result) {
+        print_target_failure(result.error());
+        return result.error().code == mqb::orchestration::IncrementalTargetErrorCode::link_failed ? 5 : 4;
     }
 
-    for (const auto& warning : link_result->warnings) {
-        std::cerr << "warning: " << warning.message;
-        if (!warning.path.empty()) {
-            std::cerr << ": " << path_text(warning.path);
+    for (const auto& compile : result->compiles) {
+        print_compile_warnings(compile.result);
+        const fs::path label = display_source(project_root, compile.source);
+        if (compile.result.compiled) {
+            std::cout << "[compile] " << path_text(label);
+            print_reasons(compile.result.validation.reasons);
+            std::cout << '\n';
+            if (compile.result.process) {
+                print_process_output(*compile.result.process);
+            }
+        } else {
+            std::cout << "[up-to-date] " << path_text(label) << '\n';
         }
-        std::cerr << '\n';
     }
 
-    if (link_result->linked) {
-        std::cout << "[link] " << path_text(executable_file.filename());
-        print_reasons(link_result->validation.reasons);
+    print_link_warnings(result->link);
+    if (result->link.linked) {
+        std::cout << "[link] " << path_text(request.target.executable.filename());
+        print_reasons(result->link.validation.reasons);
         std::cout << '\n';
-        if (link_result->process) {
-            print_process_output(*link_result->process);
+        if (result->link.process) {
+            print_process_output(*result->link.process);
         }
     } else {
-        std::cout << "[up-to-date] " << path_text(executable_file.filename()) << '\n';
+        std::cout << "[up-to-date] " << path_text(request.target.executable.filename()) << '\n';
     }
 
-    std::cout << "executable: " << path_text(executable_file) << '\n';
+    std::cout << "executable: " << path_text(request.target.executable) << '\n';
     return 0;
 }

--- a/cpp/core/CMakeLists.txt
+++ b/cpp/core/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(mqb_core STATIC
     src/DependencyGraph.cpp
     src/LinkCache.cpp
     src/LinkCacheFile.cpp
+    src/ProjectArtifactLayout.cpp
 )
 
 target_include_directories(mqb_core

--- a/cpp/core/include/mqb/core/BuildRequest.hpp
+++ b/cpp/core/include/mqb/core/BuildRequest.hpp
@@ -1,13 +1,14 @@
 #pragma once
 
 #include <filesystem>
+#include <vector>
 
 #include "mqb/core/BuildTypes.hpp"
 
 namespace mqb {
 
 struct BuildRequest {
-    std::filesystem::path entry;
+    std::vector<std::filesystem::path> sources;
     BuildConfiguration configuration{BuildConfiguration::debug};
     Architecture architecture{Architecture::x64};
     CppStandard standard{CppStandard::cpp23};

--- a/cpp/core/include/mqb/core/ProjectArtifactLayout.hpp
+++ b/cpp/core/include/mqb/core/ProjectArtifactLayout.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <expected>
+#include <filesystem>
+#include <string>
+#include <string_view>
+
+namespace mqb {
+
+struct SourceArtifacts {
+    std::filesystem::path object;
+    std::filesystem::path dependencies;
+    std::filesystem::path compile_cache;
+};
+
+struct TargetArtifacts {
+    std::filesystem::path executable;
+    std::filesystem::path link_cache;
+};
+
+enum class ArtifactLayoutErrorCode {
+    empty_project_root,
+    empty_source,
+    invalid_source_filename,
+    invalid_target_name,
+};
+
+struct ArtifactLayoutError {
+    ArtifactLayoutErrorCode code{ArtifactLayoutErrorCode::empty_project_root};
+    std::filesystem::path path;
+    std::string message;
+};
+
+class ProjectArtifactLayout {
+public:
+    [[nodiscard]] static std::expected<ProjectArtifactLayout, ArtifactLayoutError>
+    create(std::filesystem::path project_root);
+
+    [[nodiscard]] std::expected<SourceArtifacts, ArtifactLayoutError>
+    for_source(const std::filesystem::path& source) const;
+
+    [[nodiscard]] std::expected<TargetArtifacts, ArtifactLayoutError>
+    for_target(std::string_view target_name) const;
+
+    [[nodiscard]] const std::filesystem::path& project_root() const noexcept {
+        return project_root_;
+    }
+
+    [[nodiscard]] const std::filesystem::path& artifact_root() const noexcept {
+        return artifact_root_;
+    }
+
+private:
+    ProjectArtifactLayout(
+        std::filesystem::path project_root,
+        std::filesystem::path artifact_root)
+        : project_root_(std::move(project_root)),
+          artifact_root_(std::move(artifact_root)) {}
+
+    std::filesystem::path project_root_;
+    std::filesystem::path artifact_root_;
+};
+
+} // namespace mqb

--- a/cpp/core/src/ProjectArtifactLayout.cpp
+++ b/cpp/core/src/ProjectArtifactLayout.cpp
@@ -1,0 +1,145 @@
+#include "mqb/core/ProjectArtifactLayout.hpp"
+
+#include <cstdint>
+#include <filesystem>
+#include <iomanip>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace mqb {
+namespace {
+
+namespace fs = std::filesystem;
+
+[[nodiscard]] ArtifactLayoutError failure(
+    const ArtifactLayoutErrorCode code,
+    fs::path path,
+    std::string message) {
+    return ArtifactLayoutError{
+        .code = code,
+        .path = std::move(path),
+        .message = std::move(message),
+    };
+}
+
+[[nodiscard]] bool safe_relative(const fs::path& relative) {
+    if (relative.empty() || relative.is_absolute() || relative == ".") {
+        return false;
+    }
+    for (const auto& component : relative) {
+        if (component == "..") {
+            return false;
+        }
+    }
+    return true;
+}
+
+[[nodiscard]] std::string stable_path_hash(const fs::path& path) {
+    constexpr std::uint64_t offset = 14695981039346656037ull;
+    constexpr std::uint64_t prime = 1099511628211ull;
+    std::uint64_t hash = offset;
+    const auto bytes = path.lexically_normal().generic_u8string();
+    for (const char8_t byte : bytes) {
+        hash ^= static_cast<std::uint8_t>(byte);
+        hash *= prime;
+    }
+
+    std::ostringstream stream;
+    stream << std::hex << std::setfill('0') << std::setw(16) << hash;
+    return stream.str();
+}
+
+[[nodiscard]] fs::path source_key(
+    const fs::path& project_root,
+    const fs::path& source) {
+    const fs::path normalized_source = source.lexically_normal();
+    const fs::path relative = normalized_source.lexically_relative(project_root);
+    if (safe_relative(relative)) {
+        return relative;
+    }
+    return fs::path{".external"}
+        / stable_path_hash(normalized_source)
+        / normalized_source.filename();
+}
+
+[[nodiscard]] bool valid_target_name(const std::string_view target_name) {
+    if (target_name.empty()) {
+        return false;
+    }
+    const fs::path path{std::string{target_name}};
+    return !path.has_root_path()
+        && !path.has_parent_path()
+        && path.filename() == path
+        && path != "."
+        && path != "..";
+}
+
+[[nodiscard]] fs::path append_suffix(fs::path path, const std::string_view suffix) {
+    path += std::string{suffix};
+    return path;
+}
+
+} // namespace
+
+std::expected<ProjectArtifactLayout, ArtifactLayoutError>
+ProjectArtifactLayout::create(fs::path project_root) {
+    if (project_root.empty()) {
+        return std::unexpected(failure(
+            ArtifactLayoutErrorCode::empty_project_root,
+            {},
+            "project root must not be empty"));
+    }
+    project_root = project_root.lexically_normal();
+    return ProjectArtifactLayout{
+        project_root,
+        project_root / ".mqb",
+    };
+}
+
+std::expected<SourceArtifacts, ArtifactLayoutError>
+ProjectArtifactLayout::for_source(const fs::path& source) const {
+    if (source.empty()) {
+        return std::unexpected(failure(
+            ArtifactLayoutErrorCode::empty_source,
+            source,
+            "source path must not be empty"));
+    }
+    if (source.filename().empty()) {
+        return std::unexpected(failure(
+            ArtifactLayoutErrorCode::invalid_source_filename,
+            source,
+            "source path must name a file"));
+    }
+
+    const fs::path key = source_key(project_root_, source);
+    return SourceArtifacts{
+        .object = append_suffix(artifact_root_ / "obj" / key, ".obj"),
+        .dependencies = append_suffix(artifact_root_ / "deps" / key, ".json"),
+        .compile_cache = append_suffix(
+            artifact_root_ / "cache" / "compile" / key,
+            ".mqbcache"),
+    };
+}
+
+std::expected<TargetArtifacts, ArtifactLayoutError>
+ProjectArtifactLayout::for_target(const std::string_view target_name) const {
+    if (!valid_target_name(target_name)) {
+        return std::unexpected(failure(
+            ArtifactLayoutErrorCode::invalid_target_name,
+            fs::path{std::string{target_name}},
+            "target name must be one filename component"));
+    }
+
+    fs::path executable = artifact_root_ / "bin" / std::string{target_name};
+    executable += ".exe";
+    fs::path link_cache = artifact_root_ / "cache" / "link" / std::string{target_name};
+    link_cache += ".linkcache";
+    return TargetArtifacts{
+        .executable = std::move(executable),
+        .link_cache = std::move(link_cache),
+    };
+}
+
+} // namespace mqb

--- a/cpp/orchestration/CMakeLists.txt
+++ b/cpp/orchestration/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(mqb_orchestration STATIC
     src/MsvcIncrementalCompileCoordinator.cpp
     src/MsvcIncrementalLinkCoordinator.cpp
+    src/MsvcIncrementalTargetCoordinator.cpp
 )
 
 target_include_directories(mqb_orchestration

--- a/cpp/orchestration/include/mqb/orchestration/MsvcIncrementalTargetCoordinator.hpp
+++ b/cpp/orchestration/include/mqb/orchestration/MsvcIncrementalTargetCoordinator.hpp
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <expected>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "mqb/core/CompilerOptions.hpp"
+#include "mqb/core/LinkOptions.hpp"
+#include "mqb/core/ProjectArtifactLayout.hpp"
+#include "mqb/orchestration/MsvcIncrementalCompileCoordinator.hpp"
+#include "mqb/orchestration/MsvcIncrementalLinkCoordinator.hpp"
+
+namespace mqb::orchestration {
+
+struct TargetSourceRequest {
+    std::filesystem::path source;
+    SourceArtifacts artifacts;
+};
+
+struct IncrementalTargetRequest {
+    std::vector<TargetSourceRequest> sources;
+    TargetArtifacts target;
+    CompilerOptions compiler_options;
+    LinkOptions link_options;
+    std::filesystem::path working_directory;
+};
+
+struct TargetCompileResult {
+    std::filesystem::path source;
+    IncrementalCompileResult result;
+};
+
+enum class IncrementalTargetErrorCode {
+    no_sources,
+    duplicate_source,
+    duplicate_object,
+    compile_failed,
+    link_failed,
+};
+
+struct IncrementalTargetError {
+    IncrementalTargetErrorCode code{IncrementalTargetErrorCode::no_sources};
+    std::string message;
+    std::filesystem::path source;
+    std::optional<IncrementalCompileError> compile_error;
+    std::optional<IncrementalLinkError> link_error;
+};
+
+struct IncrementalTargetResult {
+    std::vector<TargetCompileResult> compiles;
+    IncrementalLinkResult link;
+    bool any_compiled{false};
+};
+
+class MsvcIncrementalTargetCoordinator {
+public:
+    MsvcIncrementalTargetCoordinator(
+        MsvcIncrementalCompileCoordinator& compile_coordinator,
+        MsvcIncrementalLinkCoordinator& link_coordinator)
+        : compile_coordinator_(compile_coordinator),
+          link_coordinator_(link_coordinator) {}
+
+    [[nodiscard]] std::expected<IncrementalTargetResult, IncrementalTargetError>
+    run(const IncrementalTargetRequest& request) const;
+
+private:
+    MsvcIncrementalCompileCoordinator& compile_coordinator_;
+    MsvcIncrementalLinkCoordinator& link_coordinator_;
+};
+
+} // namespace mqb::orchestration

--- a/cpp/orchestration/src/MsvcIncrementalTargetCoordinator.cpp
+++ b/cpp/orchestration/src/MsvcIncrementalTargetCoordinator.cpp
@@ -1,0 +1,135 @@
+#include "mqb/orchestration/MsvcIncrementalTargetCoordinator.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <expected>
+#include <filesystem>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "mqb/core/Artifact.hpp"
+#include "mqb/core/TranslationUnit.hpp"
+
+namespace mqb::orchestration {
+namespace {
+
+namespace fs = std::filesystem;
+
+[[nodiscard]] std::string windows_path_key(const fs::path& path) {
+    std::string value = path.lexically_normal().generic_string();
+    std::transform(
+        value.begin(),
+        value.end(),
+        value.begin(),
+        [](const unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+    return value;
+}
+
+[[nodiscard]] IncrementalTargetError failure(
+    const IncrementalTargetErrorCode code,
+    std::string message,
+    fs::path source = {}) {
+    return IncrementalTargetError{
+        .code = code,
+        .message = std::move(message),
+        .source = std::move(source),
+    };
+}
+
+} // namespace
+
+std::expected<IncrementalTargetResult, IncrementalTargetError>
+MsvcIncrementalTargetCoordinator::run(const IncrementalTargetRequest& request) const {
+    if (request.sources.empty()) {
+        return std::unexpected(failure(
+            IncrementalTargetErrorCode::no_sources,
+            "target build requires at least one source file"));
+    }
+
+    std::vector<std::string> seen_sources;
+    std::vector<std::string> seen_objects;
+    seen_sources.reserve(request.sources.size());
+    seen_objects.reserve(request.sources.size());
+
+    for (const auto& source : request.sources) {
+        const std::string source_key = windows_path_key(source.source);
+        if (std::find(seen_sources.begin(), seen_sources.end(), source_key) != seen_sources.end()) {
+            return std::unexpected(failure(
+                IncrementalTargetErrorCode::duplicate_source,
+                "target build contains the same source more than once",
+                source.source));
+        }
+        seen_sources.push_back(source_key);
+
+        const std::string object_key = windows_path_key(source.artifacts.object);
+        if (std::find(seen_objects.begin(), seen_objects.end(), object_key) != seen_objects.end()) {
+            return std::unexpected(failure(
+                IncrementalTargetErrorCode::duplicate_object,
+                "two translation units map to the same object artifact",
+                source.source));
+        }
+        seen_objects.push_back(object_key);
+    }
+
+    IncrementalTargetResult result;
+    result.compiles.reserve(request.sources.size());
+    std::vector<fs::path> objects;
+    objects.reserve(request.sources.size());
+
+    for (const auto& source : request.sources) {
+        TranslationUnit unit;
+        unit.source = source.source;
+        unit.kind = TranslationUnitKind::source;
+        unit.outputs.push_back(Artifact{
+            .path = source.artifacts.object,
+            .kind = ArtifactKind::object,
+        });
+
+        IncrementalCompileRequest compile_request{
+            .unit = std::move(unit),
+            .options = request.compiler_options,
+            .cache_file = source.artifacts.compile_cache,
+            .source_dependencies_file = source.artifacts.dependencies,
+            .working_directory = source.source.parent_path(),
+        };
+
+        auto compiled = compile_coordinator_.run(compile_request);
+        if (!compiled) {
+            IncrementalTargetError error = failure(
+                IncrementalTargetErrorCode::compile_failed,
+                "translation unit compilation failed",
+                source.source);
+            error.compile_error = compiled.error();
+            return std::unexpected(std::move(error));
+        }
+
+        result.any_compiled = result.any_compiled || compiled->compiled;
+        result.compiles.push_back(TargetCompileResult{
+            .source = source.source,
+            .result = std::move(*compiled),
+        });
+        objects.push_back(source.artifacts.object);
+    }
+
+    IncrementalLinkRequest link_request{
+        .objects = std::move(objects),
+        .output = request.target.executable,
+        .options = request.link_options,
+        .cache_file = request.target.link_cache,
+        .working_directory = request.working_directory,
+        .force_relink = result.any_compiled,
+    };
+    auto linked = link_coordinator_.run(link_request);
+    if (!linked) {
+        IncrementalTargetError error = failure(
+            IncrementalTargetErrorCode::link_failed,
+            "target link failed");
+        error.link_error = linked.error();
+        return std::unexpected(std::move(error));
+    }
+    result.link = std::move(*linked);
+    return result;
+}
+
+} // namespace mqb::orchestration

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -34,6 +34,10 @@ add_executable(mqb_link_cache_file_tests link_cache_file_tests.cpp)
 target_link_libraries(mqb_link_cache_file_tests PRIVATE mqb_core)
 target_compile_features(mqb_link_cache_file_tests PRIVATE cxx_std_23)
 
+add_executable(mqb_project_artifact_layout_tests project_artifact_layout_tests.cpp)
+target_link_libraries(mqb_project_artifact_layout_tests PRIVATE mqb_core)
+target_compile_features(mqb_project_artifact_layout_tests PRIVATE cxx_std_23)
+
 add_executable(mqb_process_model_tests process_model_tests.cpp)
 target_link_libraries(mqb_process_model_tests PRIVATE mqb_process)
 target_compile_features(mqb_process_model_tests PRIVATE cxx_std_23)
@@ -48,6 +52,7 @@ set(MQB_TEST_TARGETS
     mqb_build_planner_tests
     mqb_link_state_tests
     mqb_link_cache_file_tests
+    mqb_project_artifact_layout_tests
     mqb_process_model_tests
 )
 
@@ -147,6 +152,7 @@ add_test(NAME mqb.core.compile_cache_file COMMAND mqb_compile_cache_file_tests)
 add_test(NAME mqb.core.build_planner COMMAND mqb_build_planner_tests)
 add_test(NAME mqb.core.link_state COMMAND mqb_link_state_tests)
 add_test(NAME mqb.core.link_cache_file COMMAND mqb_link_cache_file_tests)
+add_test(NAME mqb.core.project_artifact_layout COMMAND mqb_project_artifact_layout_tests)
 add_test(NAME mqb.process.model COMMAND mqb_process_model_tests)
 
 if(WIN32)

--- a/cpp/tests/build_request_tests.cpp
+++ b/cpp/tests/build_request_tests.cpp
@@ -20,7 +20,7 @@ void expect(const bool condition, const std::string_view message) {
 int main() {
     const mqb::BuildRequest request{};
 
-    expect(request.entry.empty(), "entry should be empty by default");
+    expect(request.sources.empty(), "source list should be empty by default");
     expect(request.configuration == mqb::BuildConfiguration::debug,
            "default configuration should be debug");
     expect(request.architecture == mqb::Architecture::x64,

--- a/cpp/tests/cli_argument_tests.cpp
+++ b/cpp/tests/cli_argument_tests.cpp
@@ -33,7 +33,8 @@ int main() {
         auto parsed = mqb::cli::parse_arguments(arguments);
         expect(parsed.has_value(), "single source should parse");
         if (parsed) {
-            expect(parsed->build.entry == "main.cpp", "source path should be preserved");
+            expect(parsed->build.sources.size() == 1 && parsed->build.sources.front() == "main.cpp",
+                   "single source should be preserved in ordered source list");
             expect(parsed->build.configuration == mqb::BuildConfiguration::debug,
                    "default configuration should be debug");
             expect(parsed->build.architecture == mqb::Architecture::x64,
@@ -47,7 +48,9 @@ int main() {
 
     {
         const std::vector arguments{
-            "source.cpp"sv,
+            "main.cpp"sv,
+            "src/utils.cpp"sv,
+            "tests/helper.cxx"sv,
             "--release"sv,
             "--std"sv,
             "latest"sv,
@@ -62,8 +65,16 @@ int main() {
             "--verbose"sv,
         };
         auto parsed = mqb::cli::parse_arguments(arguments);
-        expect(parsed.has_value(), "full option set should parse");
+        expect(parsed.has_value(), "multi-source option set should parse");
         if (parsed) {
+            expect(parsed->build.sources.size() == 3,
+                   "all explicit sources should be collected");
+            if (parsed->build.sources.size() == 3) {
+                expect(parsed->build.sources[0] == "main.cpp"
+                           && parsed->build.sources[1] == "src/utils.cpp"
+                           && parsed->build.sources[2] == "tests/helper.cxx",
+                       "source order should remain stable for deterministic linking");
+            }
             expect(parsed->build.configuration == mqb::BuildConfiguration::release,
                    "release flag should override default");
             expect(parsed->build.architecture == mqb::Architecture::x86,
@@ -93,12 +104,6 @@ int main() {
         const std::vector arguments{"main.cpp"sv, "--wat"sv};
         auto parsed = mqb::cli::parse_arguments(arguments);
         expect(!parsed, "unknown options should be rejected");
-    }
-
-    {
-        const std::vector arguments{"a.cpp"sv, "b.cpp"sv};
-        auto parsed = mqb::cli::parse_arguments(arguments);
-        expect(!parsed, "multiple sources should be rejected until multi-TU milestone");
     }
 
     if (failures != 0) {

--- a/cpp/tests/mqb_cli_e2e_tests.cpp
+++ b/cpp/tests/mqb_cli_e2e_tests.cpp
@@ -32,6 +32,7 @@ void expect(const bool condition, const std::string_view message) {
 }
 
 void write_text(const fs::path& path, const std::string_view text) {
+    fs::create_directories(path.parent_path());
     std::ofstream stream{path, std::ios::binary | std::ios::trunc};
     stream << text;
 }
@@ -60,7 +61,6 @@ void write_text(const fs::path& path, const std::string_view text) {
 
 struct TempTree {
     fs::path root;
-
     ~TempTree() {
         std::error_code ignored;
         fs::remove_all(root, ignored);
@@ -72,11 +72,17 @@ run_mqb(
     mqb::platform::windows::WindowsProcessRunner& runner,
     const fs::path& executable,
     const fs::path& working_directory,
-    const fs::path& source,
+    const std::vector<fs::path>& sources,
+    const fs::path& include_directory,
     const std::vector<std::string>& extra_arguments = {}) {
     mqb::process::ProcessSpec spec;
     spec.executable = executable;
-    spec.arguments = {path_text(source), "--env", "vs", "-DMQB_CLI_TEST=1"};
+    for (const auto& source : sources) {
+        spec.arguments.push_back(path_text(source));
+    }
+    spec.arguments.insert(
+        spec.arguments.end(),
+        {"--env", "vs", "-DMQB_CLI_TEST=1", "-I", path_text(include_directory)});
     spec.arguments.insert(spec.arguments.end(), extra_arguments.begin(), extra_arguments.end());
     spec.working_directory = working_directory;
     spec.capture_stdout = true;
@@ -84,8 +90,7 @@ run_mqb(
 
     auto result = runner.run(spec);
     if (!result) {
-        return std::unexpected(
-            "failed to launch mqb: " + result.error().message);
+        return std::unexpected("failed to launch mqb: " + result.error().message);
     }
     return std::move(*result);
 }
@@ -125,162 +130,170 @@ int main(const int argc, char* argv[]) {
     const fs::path mqb_executable{argv[1]};
     const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
     TempTree tree{
-        .root = fs::temp_directory_path() / ("mqb_cli_e2e_" + std::to_string(unique)),
+        .root = fs::temp_directory_path() / ("mqb_cli_multi_tu_" + std::to_string(unique)),
     };
     fs::create_directories(tree.root);
 
-    const fs::path header = tree.root / "sample.hpp";
-    const fs::path source = tree.root / "sample.cpp";
-    write_text(header, "#pragma once\ninline constexpr int sample_value = 41;\n");
+    const fs::path include_dir = tree.root / "include";
+    const fs::path value_header = include_dir / "value.hpp";
+    const fs::path utils_header = include_dir / "utils.hpp";
+    const fs::path main_source = tree.root / "main.cpp";
+    const fs::path utils_source = tree.root / "src" / "utils.cpp";
+    const fs::path helper_a = tree.root / "a" / "helper.cpp";
+    const fs::path helper_b = tree.root / "b" / "helper.cpp";
+
+    write_text(value_header, "#pragma once\ninline constexpr int configured_value = 41;\n");
+    write_text(utils_header, "#pragma once\nint util_value();\n");
     write_text(
-        source,
+        utils_source,
+        "#include \"utils.hpp\"\n"
+        "#include \"value.hpp\"\n"
+        "int util_value() { return configured_value; }\n");
+    write_text(helper_a, "int helper_a() { return 10; }\n");
+    write_text(helper_b, "int helper_b() { return 20; }\n");
+    write_text(
+        main_source,
         "#include <cstdio>\n"
-        "#include \"sample.hpp\"\n"
+        "#include \"utils.hpp\"\n"
         "#ifndef MQB_CLI_TEST\n"
         "#error MQB_CLI_TEST must be defined\n"
         "#endif\n"
+        "int helper_a();\n"
+        "int helper_b();\n"
         "int main() {\n"
-        "    std::printf(\"mqb-cli-e2e=%d\\n\", sample_value + MQB_CLI_TEST);\n"
+        "    std::printf(\"mqb-multi=%d\\n\", util_value() + helper_a() + helper_b() + MQB_CLI_TEST);\n"
         "    return 0;\n"
         "}\n");
 
-    const fs::path object = tree.root / ".mqb" / "obj" / "sample.cpp.obj";
-    const fs::path compile_cache = tree.root / ".mqb" / "cache" / "sample.cpp.mqbcache";
-    const fs::path link_cache = tree.root / ".mqb" / "cache" / "sample.cpp.linkcache";
-    const fs::path dependencies = tree.root / ".mqb" / "deps" / "sample.cpp.json";
-    const fs::path executable = tree.root / ".mqb" / "bin" / "sample.cpp.exe";
+    const std::vector<fs::path> sources{main_source, utils_source, helper_a, helper_b};
+    const fs::path main_object = tree.root / ".mqb" / "obj" / "main.cpp.obj";
+    const fs::path utils_object = tree.root / ".mqb" / "obj" / "src" / "utils.cpp.obj";
+    const fs::path helper_a_object = tree.root / ".mqb" / "obj" / "a" / "helper.cpp.obj";
+    const fs::path helper_b_object = tree.root / ".mqb" / "obj" / "b" / "helper.cpp.obj";
+    const fs::path executable = tree.root / ".mqb" / "bin" / "main.exe";
+    const fs::path link_cache = tree.root / ".mqb" / "cache" / "link" / "main.linkcache";
 
     mqb::platform::windows::WindowsProcessRunner runner;
 
-    auto cold = run_mqb(runner, mqb_executable, tree.root, source);
-    expect(cold.has_value(), "cold invocation should launch");
+    auto cold = run_mqb(runner, mqb_executable, tree.root, sources, include_dir);
+    expect(cold.has_value(), "cold multi-TU invocation should launch");
     if (cold) {
-        if (cold->exit_code != 0) {
-            dump_failure(*cold);
-        }
-        expect(cold->exit_code == 0, "cold build should succeed");
-        expect(cold->stdout_text.find("[compile] sample.cpp") != std::string::npos,
-               "cold build should report a compile action");
-        expect(cold->stdout_text.find("[link] sample.cpp.exe") != std::string::npos,
-               "cold build should report a link action");
-    }
-    expect(fs::is_regular_file(object), "cold build should create collision-free object artifact");
-    expect(fs::is_regular_file(compile_cache), "cold build should persist compile cache");
-    expect(fs::is_regular_file(link_cache), "cold build should persist link cache");
-    expect(fs::is_regular_file(dependencies), "cold build should create sourceDependencies metadata");
-    expect(fs::is_regular_file(executable), "cold build should create executable artifact");
-
-    auto first_run = run_executable(runner, executable, tree.root);
-    expect(first_run.has_value(), "cold-built executable should launch");
-    if (first_run) {
-        expect(first_run->exit_code == 0, "cold-built executable should return zero");
-        expect(first_run->stdout_text.find("mqb-cli-e2e=42") != std::string::npos,
-               "cold-built executable should contain freshly compiled behavior");
+        if (cold->exit_code != 0) dump_failure(*cold);
+        expect(cold->exit_code == 0, "cold multi-TU build should succeed");
+        expect(cold->stdout_text.find("[compile] main.cpp") != std::string::npos,
+               "cold build should compile main.cpp");
+        expect(cold->stdout_text.find("[compile] src/utils.cpp") != std::string::npos,
+               "cold build should compile nested utils.cpp");
+        expect(cold->stdout_text.find("[compile] a/helper.cpp") != std::string::npos,
+               "cold build should compile first same-basename helper");
+        expect(cold->stdout_text.find("[compile] b/helper.cpp") != std::string::npos,
+               "cold build should compile second same-basename helper");
+        expect(cold->stdout_text.find("[link] main.exe") != std::string::npos,
+               "cold build should link one target executable");
     }
 
-    auto warm = run_mqb(runner, mqb_executable, tree.root, source);
-    expect(warm.has_value(), "warm invocation should launch");
+    expect(fs::is_regular_file(main_object), "main object should use project-level layout");
+    expect(fs::is_regular_file(utils_object), "nested object should preserve relative source path");
+    expect(fs::is_regular_file(helper_a_object), "first helper object should exist");
+    expect(fs::is_regular_file(helper_b_object), "second helper object should exist independently");
+    expect(helper_a_object != helper_b_object,
+           "same-basename sources from different directories must have different artifacts");
+    expect(fs::is_regular_file(executable), "multi-TU build should create target executable");
+    expect(fs::is_regular_file(link_cache), "multi-TU build should persist one target link cache");
+
+    auto cold_run = run_executable(runner, executable, tree.root);
+    expect(cold_run.has_value(), "cold-built multi-TU executable should launch");
+    if (cold_run) {
+        expect(cold_run->exit_code == 0, "cold-built executable should return zero");
+        expect(cold_run->stdout_text.find("mqb-multi=72") != std::string::npos,
+               "cold-built executable should combine all translation units");
+    }
+
+    auto warm = run_mqb(runner, mqb_executable, tree.root, sources, include_dir);
+    expect(warm.has_value(), "warm multi-TU invocation should launch");
     if (warm) {
-        if (warm->exit_code != 0) {
-            dump_failure(*warm);
-        }
-        expect(warm->exit_code == 0, "warm build should succeed");
-        expect(contains_output_line(warm->stdout_text, "[up-to-date] sample.cpp"),
-               "warm build should reuse the cached object");
-        expect(contains_output_line(warm->stdout_text, "[up-to-date] sample.cpp.exe"),
-               "warm build should reuse the cached executable");
+        if (warm->exit_code != 0) dump_failure(*warm);
+        expect(warm->exit_code == 0, "warm multi-TU build should succeed");
+        expect(contains_output_line(warm->stdout_text, "[up-to-date] main.cpp"),
+               "warm build should skip main.cpp");
+        expect(contains_output_line(warm->stdout_text, "[up-to-date] src/utils.cpp"),
+               "warm build should skip utils.cpp");
+        expect(contains_output_line(warm->stdout_text, "[up-to-date] a/helper.cpp"),
+               "warm build should skip helper A");
+        expect(contains_output_line(warm->stdout_text, "[up-to-date] b/helper.cpp"),
+               "warm build should skip helper B");
+        expect(contains_output_line(warm->stdout_text, "[up-to-date] main.exe"),
+               "warm build should skip link.exe");
     }
 
     std::error_code error_code;
-    const auto first_object_time = fs::last_write_time(object, error_code);
-    expect(!error_code, "object timestamp should be readable");
+    const auto utils_object_time = fs::last_write_time(utils_object, error_code);
+    expect(!error_code, "utils object timestamp should be readable");
     if (!error_code) {
-        write_text(header, "#pragma once\ninline constexpr int sample_value = 42;\n");
-        fs::last_write_time(header, first_object_time + std::chrono::seconds{2}, error_code);
-        expect(!error_code, "header timestamp should be adjustable for deterministic invalidation");
+        write_text(value_header, "#pragma once\ninline constexpr int configured_value = 42;\n");
+        fs::last_write_time(value_header, utils_object_time + std::chrono::seconds{2}, error_code);
+        expect(!error_code, "value header timestamp should be made newer deterministically");
     }
 
-    auto header_changed = run_mqb(runner, mqb_executable, tree.root, source);
-    expect(header_changed.has_value(), "header-change invocation should launch");
+    auto header_changed = run_mqb(runner, mqb_executable, tree.root, sources, include_dir);
+    expect(header_changed.has_value(), "header-change multi-TU invocation should launch");
     if (header_changed) {
-        if (header_changed->exit_code != 0) {
-            dump_failure(*header_changed);
-        }
+        if (header_changed->exit_code != 0) dump_failure(*header_changed);
         expect(header_changed->exit_code == 0, "header-change build should succeed");
-        expect(header_changed->stdout_text.find("[compile] sample.cpp") != std::string::npos,
-               "header change should trigger compilation");
+        expect(contains_output_line(header_changed->stdout_text, "[up-to-date] main.cpp"),
+               "header private to utils.cpp must not rebuild main.cpp");
+        expect(header_changed->stdout_text.find("[compile] src/utils.cpp") != std::string::npos,
+               "header private to utils.cpp should rebuild utils.cpp");
         expect(header_changed->stdout_text.find("dependency changed") != std::string::npos,
-               "header change should be explained as dependency changed");
-        expect(header_changed->stdout_text.find("[link] sample.cpp.exe") != std::string::npos,
-               "fresh compilation should force executable relink");
+               "partial rebuild should remain explainable");
+        expect(contains_output_line(header_changed->stdout_text, "[up-to-date] a/helper.cpp"),
+               "unrelated helper A should remain cached");
+        expect(contains_output_line(header_changed->stdout_text, "[up-to-date] b/helper.cpp"),
+               "unrelated helper B should remain cached");
+        expect(header_changed->stdout_text.find("[link] main.exe") != std::string::npos,
+               "any rebuilt TU should force target relink");
         expect(header_changed->stdout_text.find("explicit rebuild") != std::string::npos,
-               "forced relink should be explainable independently of timestamp granularity");
+               "compile-to-link handoff should not depend only on timestamps");
     }
 
     auto changed_run = run_executable(runner, executable, tree.root);
-    expect(changed_run.has_value(), "relinked executable should launch");
+    expect(changed_run.has_value(), "partially rebuilt executable should launch");
     if (changed_run) {
-        expect(changed_run->exit_code == 0, "relinked executable should return zero");
-        expect(changed_run->stdout_text.find("mqb-cli-e2e=43") != std::string::npos,
-               "relinked executable must observe the changed header, not stale object state");
+        expect(changed_run->exit_code == 0, "partially rebuilt executable should return zero");
+        expect(changed_run->stdout_text.find("mqb-multi=73") != std::string::npos,
+               "partial rebuild must update final executable behavior");
     }
 
     error_code.clear();
-    const auto rebuilt_object_time = fs::last_write_time(object, error_code);
-    expect(!error_code, "rebuilt object timestamp should be readable");
+    const auto rebuilt_utils_time = fs::last_write_time(utils_object, error_code);
     if (!error_code) {
-        fs::last_write_time(header, rebuilt_object_time - std::chrono::seconds{2}, error_code);
-        expect(!error_code, "header timestamp should be normalized after rebuild");
+        fs::last_write_time(value_header, rebuilt_utils_time - std::chrono::seconds{2}, error_code);
     }
-
-    auto warm_again = run_mqb(runner, mqb_executable, tree.root, source);
-    expect(warm_again.has_value(), "second warm invocation should launch");
-    if (warm_again) {
-        if (warm_again->exit_code != 0) {
-            dump_failure(*warm_again);
-        }
-        expect(warm_again->exit_code == 0, "second warm build should succeed");
-        expect(contains_output_line(warm_again->stdout_text, "[up-to-date] sample.cpp"),
-               "rebuilt object should become reusable again");
-        expect(contains_output_line(warm_again->stdout_text, "[up-to-date] sample.cpp.exe"),
-               "relinked executable should become reusable again");
-    }
+    expect(!error_code, "test should normalize value header timestamp after rebuild");
 
     auto release = run_mqb(
         runner,
         mqb_executable,
         tree.root,
-        source,
+        sources,
+        include_dir,
         {"--release"});
-    expect(release.has_value(), "release invocation should launch");
+    expect(release.has_value(), "release multi-TU invocation should launch");
     if (release) {
-        if (release->exit_code != 0) {
-            dump_failure(*release);
-        }
-        expect(release->exit_code == 0, "release build should succeed");
-        expect(release->stdout_text.find("[compile] sample.cpp") != std::string::npos,
-               "Debug to Release should trigger compilation without source edits");
+        if (release->exit_code != 0) dump_failure(*release);
+        expect(release->exit_code == 0, "release multi-TU build should succeed");
         expect(release->stdout_text.find("compiler options changed") != std::string::npos,
-               "compile configuration invalidation should remain explainable");
-        expect(release->stdout_text.find("[link] sample.cpp.exe") != std::string::npos,
-               "Debug to Release should also relink the executable");
+               "Debug to Release should invalidate compile recipes");
+        expect(release->stdout_text.find("[link] main.exe") != std::string::npos,
+               "Debug to Release should relink target");
         expect(release->stdout_text.find("linker options changed") != std::string::npos,
-               "link configuration invalidation should remain explainable");
-    }
-
-    auto release_run = run_executable(runner, executable, tree.root);
-    expect(release_run.has_value(), "release executable should launch");
-    if (release_run) {
-        expect(release_run->exit_code == 0, "release executable should return zero");
-        expect(release_run->stdout_text.find("mqb-cli-e2e=43") != std::string::npos,
-               "release executable should preserve current program behavior");
+               "Debug to Release should invalidate link recipe");
     }
 
     if (failures != 0) {
         std::cerr << failures << " test(s) failed\n";
         return 1;
     }
-
     std::cout << "mqb_cli_e2e_tests passed\n";
     return 0;
 }

--- a/cpp/tests/project_artifact_layout_tests.cpp
+++ b/cpp/tests/project_artifact_layout_tests.cpp
@@ -1,0 +1,77 @@
+#include <filesystem>
+#include <iostream>
+#include <string>
+#include <string_view>
+
+#include "mqb/core/ProjectArtifactLayout.hpp"
+
+namespace {
+
+namespace fs = std::filesystem;
+int failures = 0;
+
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+} // namespace
+
+int main() {
+    const fs::path root = fs::path{"C:/work/project"}.lexically_normal();
+    auto layout = mqb::ProjectArtifactLayout::create(root);
+    expect(layout.has_value(), "non-empty project root should create an artifact layout");
+    if (!layout) {
+        return 1;
+    }
+
+    auto src_foo = layout->for_source(root / "src" / "foo.cpp");
+    auto tests_foo = layout->for_source(root / "tests" / "foo.cpp");
+    auto src_cxx = layout->for_source(root / "src" / "foo.cxx");
+    expect(src_foo.has_value() && tests_foo.has_value() && src_cxx.has_value(),
+           "ordinary project sources should map to artifacts");
+    if (src_foo && tests_foo && src_cxx) {
+        expect(src_foo->object != tests_foo->object,
+               "same basename in different directories must not collide");
+        expect(src_foo->object != src_cxx->object,
+               "same stem with different source extensions must not collide");
+        expect(src_foo->object == root / ".mqb" / "obj" / "src" / "foo.cpp.obj",
+               "in-project object path should preserve relative source identity");
+        expect(src_foo->dependencies == root / ".mqb" / "deps" / "src" / "foo.cpp.json",
+               "dependency metadata should preserve relative source identity");
+        expect(src_foo->compile_cache
+                   == root / ".mqb" / "cache" / "compile" / "src" / "foo.cpp.mqbcache",
+               "compile cache should preserve relative source identity");
+    }
+
+    auto outside = layout->for_source(fs::path{"D:/vendor/foo.cpp"});
+    expect(outside.has_value(), "external sources should still receive a stable artifact key");
+    if (outside) {
+        const auto generic = outside->object.generic_string();
+        expect(generic.find(".mqb/obj/.external/") != std::string::npos,
+               "external source artifacts should be isolated under .external hash namespace");
+        expect(generic.ends_with("/foo.cpp.obj"),
+               "external artifact should retain source filename for diagnostics");
+    }
+
+    auto target = layout->for_target("demo");
+    expect(target.has_value(), "simple target name should map to target artifacts");
+    if (target) {
+        expect(target->executable == root / ".mqb" / "bin" / "demo.exe",
+               "target executable should live in project-level bin directory");
+        expect(target->link_cache == root / ".mqb" / "cache" / "link" / "demo.linkcache",
+               "link cache should be isolated from compile cache metadata");
+    }
+
+    expect(!layout->for_target("../demo"), "target names with parent traversal must be rejected");
+    expect(!mqb::ProjectArtifactLayout::create({}), "empty project root must be rejected");
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+    std::cout << "mqb_project_artifact_layout_tests passed\n";
+    return 0;
+}

--- a/docs/CPP_V2_ARCHITECTURE.md
+++ b/docs/CPP_V2_ARCHITECTURE.md
@@ -17,27 +17,27 @@ This document defines the architecture for migrating MSVC Quick Build from the P
 CLI (mqb.exe)
     |
     v
-Orchestration
-  load -> snapshot -> validate -> plan -> execute -> persist
+Target orchestration
+  N x compile coordinator -> collect objects -> one link coordinator
     |
     +--------------------+
     v                    v
 Core                  MSVC backend
   BuildRequest           MsvcToolchainLocator
   Artifact / TU          MsvcCompiler
-  BuildSignature         MsvcCompileExecutor
-  CompileCache           MsvcLinker
-  LinkCache              /sourceDependencies reader
-  DependencyGraph             |
-  BuildPlanner                v
-    |                    Process abstraction
-    |                      ProcessSpec { executable, argv, cwd, env }
-    |                           |
-    +---------------------------+
-                                v
-                         Windows platform
-                         WindowsProcessRunner
-                         CreateProcessW
+  ProjectArtifactLayout  MsvcCompileExecutor
+  BuildSignature         MsvcLinker
+  CompileCache           /sourceDependencies reader
+  LinkCache                    |
+  DependencyGraph              v
+  BuildPlanner           Process abstraction
+    |                     ProcessSpec { executable, argv, cwd, env }
+    |                          |
+    +--------------------------+
+                               v
+                        Windows platform
+                        WindowsProcessRunner
+                        CreateProcessW
 ```
 
 ## Architectural rules
@@ -49,6 +49,7 @@ Core                  MSVC backend
 5. **UTF-8 at the process abstraction boundary.** Windows converts textual argv/environment data to UTF-16 immediately before `CreateProcessW`.
 6. **Compile state and link state are independent.** A compile cache hit does not imply a link cache hit, and link-only changes must never force unnecessary compilation.
 7. **A fresh compile is an explicit relink signal.** Linking must not depend solely on filesystem timestamp granularity.
+8. **Source identity is not a basename.** Project artifacts preserve relative source identity; external sources receive a stable hashed namespace, and duplicate object mappings are rejected before execution.
 
 ## Compile identity and cache freshness
 
@@ -57,7 +58,7 @@ Core                  MSVC backend
 ```text
 compiler recipe identity ----> BuildSignature
 source/header freshness ------> CompileCacheValidator
-artifact placement -----------> Artifact / cache storage
+artifact placement -----------> ProjectArtifactLayout
 ```
 
 `CompileCacheValidator` is pure and returns typed `BuildReason` values; it does not touch the filesystem or launch a process.
@@ -81,6 +82,37 @@ fresh compile --------------------> force_relink / explicit rebuild
 `LinkerIdentity` stamps `link.exe` independently from `cl.exe`, so a linker update can invalidate only link state. `LinkCacheValidator` distinguishes link-input changes, linker-option changes, toolchain changes, missing output, and explicit relink.
 
 `LinkCacheFile` uses a separate versioned cache format. Broken link metadata can only cause a safe relink; it must never permit reuse of a stale executable.
+
+When user-facing library support is added, resolved library-file freshness must join the link input state. Library names and search paths in the signature alone are not sufficient to detect an updated `.lib` file.
+
+## Project artifact layout
+
+The current explicit-target CLI uses the process working directory as the project root. Sources inside that root preserve their relative path; sources outside it are isolated under `.external/<stable-path-hash>/`.
+
+For example:
+
+```text
+project/
+  main.cpp
+  src/foo.cpp
+  tests/foo.cpp
+  .mqb/
+    obj/
+      main.cpp.obj
+      src/foo.cpp.obj
+      tests/foo.cpp.obj
+    deps/
+      main.cpp.json
+      src/foo.cpp.json
+      tests/foo.cpp.json
+    cache/
+      compile/...
+      link/main.linkcache
+    bin/
+      main.exe
+```
+
+This prevents `src/foo.cpp`, `tests/foo.cpp`, `foo.cpp`, and `foo.cxx` from aliasing one object/cache artifact.
 
 ## Dependency graph and planner
 
@@ -137,6 +169,19 @@ LinkCacheFile
       -> LinkCacheFile::save
 ```
 
+### Incremental target
+
+```text
+ordered source requests
+      -> compile each TU with IncrementalCompileCoordinator
+      -> collect collision-free object artifacts
+      -> any TU compiled? ---- yes ----> force_relink
+      -> IncrementalLinkCoordinator
+      -> one target executable
+```
+
+`MsvcIncrementalTargetCoordinator` currently schedules translation units sequentially. This is deliberate: correctness and stable target semantics are established before parallel scheduling is introduced. Parallel compilation can later replace the scheduling strategy without moving compiler/linker policy into the CLI.
+
 Ordinary cache-load/save failures are surfaced as warnings and conservatively rebuild/relink. Compiler/linker execution failures are build errors.
 
 ## Process boundary
@@ -162,31 +207,31 @@ forced portable --> portable only
 forced VS -------> Visual Studio only
 ```
 
-### Portable track
-
-The locator selects the latest VC Tools and Windows Kit version directories, resolves `cl.exe`, `link.exe`, and `lib.exe` for the requested host/target architecture, creates PATH/INCLUDE/LIB overrides, and stamps the compiler binary for cache identity. Discovery itself launches no subprocess.
-
-### Visual Studio track
-
-The locator first tries the standard `vswhere.exe` location, then known VS 2026/2022 edition directories as a fallback. After finding `vcvarsall.bat`, it captures the initialized environment through an isolated temporary batch wrapper and `cmd.exe /u`, so the environment dump is parsed as UTF-16 rather than depending on the active console code page.
-
-The captured environment is returned as structured name/value overrides; the locator does not mutate MQB's own process environment. `VCToolsInstallDir` is used to resolve the selected compiler/linker/librarian binaries.
+The portable track resolves VC Tools and Windows Kit layout without launching a subprocess. The Visual Studio track uses `vswhere`/fallback discovery and captures `vcvarsall.bat` output through an isolated UTF-16 environment dump. The captured environment is returned as structured overrides rather than mutating MQB's own process environment.
 
 GitHub CI enables installed-MSVC integration tests explicitly; local tests keep those tests opt-in so a portable-only development machine is not forced to have a registered Visual Studio installation.
 
 ## Current CLI milestone
 
-`mqb.exe` currently supports one ordinary C++ translation unit (`.cpp`, `.cc`, `.cxx`) and produces collision-free internal artifacts under a source-local `.mqb/` directory:
+`mqb.exe` now supports an **explicit ordered set of ordinary C++ translation units** (`.cpp`, `.cc`, `.cxx`):
 
-```text
-.mqb/
-  obj/    <source filename>.obj
-  deps/   compiler dependency JSON
-  cache/  compile cache + link cache
-  bin/    <source filename>.exe
+```powershell
+mqb main.cpp src/utils.cpp a/helper.cpp b/helper.cpp
 ```
 
-The CLI composes the incremental compile coordinator followed by the incremental link coordinator. Warm builds can therefore skip both compiler and linker independently, while a fresh compile explicitly forces relink even when filesystem timestamps are ambiguous.
+The first source currently supplies the default target name (`main.cpp` -> `main.exe`). Every source is incrementally validated independently; only stale TUs compile, and all resulting objects feed one independently cached link action.
+
+The real VS2026 E2E suite verifies:
+
+- cold multi-TU compile + link + executable launch;
+- warm build with zero compiler and linker actions;
+- same-basename sources in different directories have distinct artifacts;
+- a header private to one TU rebuilds only that TU;
+- any rebuilt TU explicitly forces relink;
+- the resulting executable behavior changes after the partial rebuild;
+- Debug -> Release invalidates compile and link recipes without source edits.
+
+Not yet exposed in the C++ CLI: automatic source discovery, `-o/--output`, `--run`, user libraries/library paths, project config files, and C++ Modules.
 
 ## Migration sequence
 
@@ -196,10 +241,11 @@ The CLI composes the incremental compile coordinator followed by the incremental
 4. **MSVC toolchain backend** — portable discovery plus `vswhere/vcvarsall` environment capture. ✅
 5. **Ordinary single TU** — typed compiler arguments, `/sourceDependencies`, cache persistence, real incremental CLI. ✅
 6. **Link state** — independent linker identity/signature/cache/planning/backend/orchestration and executable production. ✅
-7. **Multi-TU and target CLI** — source discovery, multiple objects, output naming, libraries, run mode, project-level artifact layout.
-8. **Modules** — P1689 `/scanDependencies`, module graph, IFC/object artifacts, `import std`.
-9. **Parity** — run PowerShell and C++ against the same E2E fixtures.
-10. **Cutover** — make `mqb.exe` primary only after parity tests pass.
+7. **Explicit multi-TU target** — project artifact layout, ordered source set, per-TU incremental compile, single incremental link. ✅
+8. **Target UX and discovery** — `-o`, `--run`, libraries, project config, smart source discovery, then parallel compile scheduling.
+9. **Modules** — P1689 `/scanDependencies`, module graph, IFC/object artifacts, `import std`.
+10. **Parity** — run PowerShell and C++ against the same E2E fixtures.
+11. **Cutover** — make `mqb.exe` primary only after parity tests pass.
 
 ## Local build
 


### PR DESCRIPTION
Milestone 2C in progress.

First checkpoint introduces a project-level artifact layout before changing CLI execution:
- preserves relative source identity under `.mqb/` for in-project sources
- isolates external sources under a stable hashed namespace
- prevents same-basename cross-directory and same-stem cross-extension collisions
- separates compile-cache and link-cache namespaces
- establishes project-level target executable/link-cache paths

Next commits will upgrade BuildRequest/CLI to ordered source lists and add target orchestration for compiling multiple TUs then linking once.