### PR TITLE
feat: add target output and structured run argv

### DIFF
--- a/cpp/apps/mqb/Cli.cpp
+++ b/cpp/apps/mqb/Cli.cpp
@@ -82,12 +82,38 @@ parse_arguments(const std::span<const std::string_view> arguments) {
     for (std::size_t index = 0; index < arguments.size(); ++index) {
         const std::string_view argument = arguments[index];
 
+        if (argument == "--") {
+            for (++index; index < arguments.size(); ++index) {
+                options.build.run_arguments.emplace_back(arguments[index]);
+            }
+            break;
+        }
         if (argument == "-h" || argument == "--help") {
             options.show_help = true;
             continue;
         }
         if (argument == "--verbose" || argument == "-v") {
             options.verbose = true;
+            continue;
+        }
+        if (argument == "--run") {
+            options.build.run_after_build = true;
+            continue;
+        }
+        if (argument == "-o" || argument == "--output") {
+            auto value = require_value(arguments, index, argument);
+            if (!value) {
+                return std::unexpected(value.error());
+            }
+            options.build.output_name = std::string{*value};
+            continue;
+        }
+        if (argument.starts_with("--output=")) {
+            const std::string_view value = argument.substr(std::string_view{"--output="}.size());
+            if (value.empty()) {
+                return std::unexpected(error("empty value for --output"));
+            }
+            options.build.output_name = std::string{value};
             continue;
         }
         if (argument == "--debug") {
@@ -170,6 +196,11 @@ parse_arguments(const std::span<const std::string_view> arguments) {
     if (!options.show_help && options.build.sources.empty()) {
         return std::unexpected(error("missing source file"));
     }
+    if (!options.show_help
+        && !options.build.run_after_build
+        && !options.build.run_arguments.empty()) {
+        return std::unexpected(error("arguments after -- require --run"));
+    }
     return options;
 }
 
@@ -177,22 +208,26 @@ std::string_view usage() noexcept {
     return R"(MQB - MSVC Quick Build (C++ V2)
 
 Usage:
-  mqb <source.cpp> [more-sources...] [options]
+  mqb <source.cpp> [more-sources...] [options] [-- program-args...]
 
 Current milestone:
-  Incrementally compile an explicit C++ source set and link one executable.
+  Incrementally compile an explicit C++ source set, link one executable,
+  and optionally run it without shell re-parsing.
 
 Options:
   --debug                  Debug compile/link preset (default)
   --release                Release compile/link preset
   --std <20|23|latest>     C++ language standard (default: 23)
   --x86 | --x64            Target architecture (default: x64)
+  -o, --output <name>      Set target executable name under .mqb/bin/
+  --run                    Run the executable after a successful build
   -I <dir>, -I<dir>        Add an include directory
   -D <value>, -D<value>    Add a preprocessor definition
   --env <auto|vs|portable> Toolchain selection (default: auto)
   --portable-root <dir>    Add a portable_msvc root candidate
   -v, --verbose            Show toolchain and artifact details
   -h, --help               Show this help
+  --                       Pass all remaining argv elements to the program
 
 Generated state:
   .mqb/obj/    collision-free object files

--- a/cpp/apps/mqb/main.cpp
+++ b/cpp/apps/mqb/main.cpp
@@ -87,15 +87,27 @@ void add_portable_root_if_missing(
     }
 }
 
+void write_forwarded_text(std::ostream& stream, const std::string_view text) {
+    for (std::size_t index = 0; index < text.size(); ++index) {
+        const char ch = text[index];
+        if (ch == '\r' && index + 1 < text.size() && text[index + 1] == '\n') {
+            stream.put('\n');
+            ++index;
+            continue;
+        }
+        stream.put(ch);
+    }
+}
+
 void print_process_output(const mqb::process::ProcessResult& process) {
     if (!process.stdout_text.empty()) {
-        std::cout << process.stdout_text;
+        write_forwarded_text(std::cout, process.stdout_text);
         if (process.stdout_text.back() != '\n') {
             std::cout << '\n';
         }
     }
     if (!process.stderr_text.empty()) {
-        std::cerr << process.stderr_text;
+        write_forwarded_text(std::cerr, process.stderr_text);
         if (process.stderr_text.back() != '\n') {
             std::cerr << '\n';
         }

--- a/cpp/apps/mqb/main.cpp
+++ b/cpp/apps/mqb/main.cpp
@@ -282,7 +282,7 @@ int main(const int argc, char* argv[]) {
         });
     }
 
-    const std::string target_name = sources.front().stem().string();
+    const std::string target_name = options.build.output_name.value_or(sources.front().stem().string());
     auto target_artifacts = layout->for_target(target_name);
     if (!target_artifacts) {
         std::cerr << "error: " << target_artifacts.error().message << '\n';
@@ -391,5 +391,24 @@ int main(const int argc, char* argv[]) {
     }
 
     std::cout << "executable: " << path_text(request.target.executable) << '\n';
-    return 0;
+
+    if (!options.build.run_after_build) {
+        return 0;
+    }
+
+    std::cout << "[run] " << path_text(request.target.executable.filename()) << '\n';
+    mqb::process::ProcessSpec run_spec;
+    run_spec.executable = request.target.executable;
+    run_spec.arguments = options.build.run_arguments;
+    run_spec.working_directory = project_root;
+    run_spec.capture_stdout = true;
+    run_spec.capture_stderr = true;
+
+    auto run_result = runner.run(run_spec);
+    if (!run_result) {
+        std::cerr << "error: failed to run executable: " << run_result.error().message << '\n';
+        return 6;
+    }
+    print_process_output(*run_result);
+    return run_result->exit_code;
 }

--- a/cpp/core/include/mqb/core/BuildRequest.hpp
+++ b/cpp/core/include/mqb/core/BuildRequest.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <filesystem>
+#include <optional>
+#include <string>
 #include <vector>
 
 #include "mqb/core/BuildTypes.hpp"
@@ -9,10 +11,12 @@ namespace mqb {
 
 struct BuildRequest {
     std::vector<std::filesystem::path> sources;
+    std::optional<std::string> output_name;
     BuildConfiguration configuration{BuildConfiguration::debug};
     Architecture architecture{Architecture::x64};
     CppStandard standard{CppStandard::cpp23};
     bool run_after_build{false};
+    std::vector<std::string> run_arguments;
 };
 
 } // namespace mqb

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -174,7 +174,7 @@ if(WIN32)
         add_test(NAME mqb.msvc.link_integration COMMAND mqb_msvc_link_integration_tests)
         add_test(NAME mqb.msvc.incremental_loop COMMAND mqb_msvc_incremental_loop_tests)
         add_test(
-            NAME mqb.cli.single_tu_e2e
+            NAME mqb.cli.target_e2e
             COMMAND mqb_cli_e2e_tests $<TARGET_FILE:mqb>
         )
     endif()

--- a/cpp/tests/build_request_tests.cpp
+++ b/cpp/tests/build_request_tests.cpp
@@ -21,6 +21,7 @@ int main() {
     const mqb::BuildRequest request{};
 
     expect(request.sources.empty(), "source list should be empty by default");
+    expect(!request.output_name.has_value(), "output name should be unset by default");
     expect(request.configuration == mqb::BuildConfiguration::debug,
            "default configuration should be debug");
     expect(request.architecture == mqb::Architecture::x64,
@@ -29,6 +30,8 @@ int main() {
            "default C++ standard should be C++23");
     expect(!request.run_after_build,
            "run_after_build should be false by default");
+    expect(request.run_arguments.empty(),
+           "run argument list should be empty by default");
 
     expect(mqb::to_string(mqb::BuildConfiguration::release) == "release",
            "release configuration should stringify correctly");

--- a/cpp/tests/cli_argument_tests.cpp
+++ b/cpp/tests/cli_argument_tests.cpp
@@ -35,6 +35,12 @@ int main() {
         if (parsed) {
             expect(parsed->build.sources.size() == 1 && parsed->build.sources.front() == "main.cpp",
                    "single source should be preserved in ordered source list");
+            expect(!parsed->build.output_name.has_value(),
+                   "output name should remain unset by default");
+            expect(!parsed->build.run_after_build,
+                   "run mode should remain disabled by default");
+            expect(parsed->build.run_arguments.empty(),
+                   "run argument list should remain empty by default");
             expect(parsed->build.configuration == mqb::BuildConfiguration::debug,
                    "default configuration should be debug");
             expect(parsed->build.architecture == mqb::Architecture::x64,
@@ -55,6 +61,9 @@ int main() {
             "--std"sv,
             "latest"sv,
             "--x86"sv,
+            "--output"sv,
+            "product"sv,
+            "--run"sv,
             "--env"sv,
             "portable"sv,
             "--portable-root"sv,
@@ -63,9 +72,14 @@ int main() {
             "-D"sv,
             "VALUE=42"sv,
             "--verbose"sv,
+            "--"sv,
+            "hello world"sv,
+            "--child-option"sv,
+            ""sv,
+            "a b c"sv,
         };
         auto parsed = mqb::cli::parse_arguments(arguments);
-        expect(parsed.has_value(), "multi-source option set should parse");
+        expect(parsed.has_value(), "multi-source run option set should parse");
         if (parsed) {
             expect(parsed->build.sources.size() == 3,
                    "all explicit sources should be collected");
@@ -74,6 +88,20 @@ int main() {
                            && parsed->build.sources[1] == "src/utils.cpp"
                            && parsed->build.sources[2] == "tests/helper.cxx",
                        "source order should remain stable for deterministic linking");
+            }
+            expect(parsed->build.output_name.has_value()
+                       && *parsed->build.output_name == "product",
+                   "output name should be parsed");
+            expect(parsed->build.run_after_build,
+                   "run flag should be parsed");
+            expect(parsed->build.run_arguments.size() == 4,
+                   "all argv elements after -- should be preserved");
+            if (parsed->build.run_arguments.size() == 4) {
+                expect(parsed->build.run_arguments[0] == "hello world"
+                           && parsed->build.run_arguments[1] == "--child-option"
+                           && parsed->build.run_arguments[2].empty()
+                           && parsed->build.run_arguments[3] == "a b c",
+                       "run argv must preserve spaces, leading dashes, and empty arguments");
             }
             expect(parsed->build.configuration == mqb::BuildConfiguration::release,
                    "release flag should override default");
@@ -91,6 +119,41 @@ int main() {
                    "separate define value should be collected");
             expect(parsed->verbose, "verbose flag should be parsed");
         }
+    }
+
+    {
+        const std::vector arguments{"main.cpp"sv, "--output=demo"sv};
+        auto parsed = mqb::cli::parse_arguments(arguments);
+        expect(parsed.has_value(), "attached long output form should parse");
+        if (parsed) {
+            expect(parsed->build.output_name.has_value() && *parsed->build.output_name == "demo",
+                   "attached long output value should be preserved");
+        }
+    }
+
+    {
+        const std::vector arguments{"main.cpp"sv, "--run"sv, "--"sv, "--release"sv};
+        auto parsed = mqb::cli::parse_arguments(arguments);
+        expect(parsed.has_value(), "options after -- should become program arguments");
+        if (parsed) {
+            expect(parsed->build.configuration == mqb::BuildConfiguration::debug,
+                   "MQB option parsing must stop at --");
+            expect(parsed->build.run_arguments.size() == 1
+                       && parsed->build.run_arguments.front() == "--release",
+                   "option-looking argv after -- must be preserved verbatim");
+        }
+    }
+
+    {
+        const std::vector arguments{"main.cpp"sv, "--"sv, "argument"sv};
+        auto parsed = mqb::cli::parse_arguments(arguments);
+        expect(!parsed, "program arguments without --run should be rejected");
+    }
+
+    {
+        const std::vector arguments{"main.cpp"sv, "-o"sv};
+        auto parsed = mqb::cli::parse_arguments(arguments);
+        expect(!parsed, "missing output value should be rejected");
     }
 
     {

--- a/cpp/tests/mqb_cli_e2e_tests.cpp
+++ b/cpp/tests/mqb_cli_e2e_tests.cpp
@@ -241,12 +241,17 @@ int main(const int argc, char* argv[]) {
     expect(run_with_args.has_value(), "warm --run invocation should launch");
     if (run_with_args) {
         if (run_with_args->exit_code != 0) dump_failure(*run_with_args);
+        const bool child_argv_visible = contains_output_line(run_with_args->stdout_text, "argc=5");
+        if (!child_argv_visible) {
+            std::cerr << "DIAGNOSTIC: child argv output missing or unexpected\n";
+            dump_failure(*run_with_args);
+        }
         expect(run_with_args->exit_code == 0, "warm --run should return child success code");
         expect(contains_output_line(run_with_args->stdout_text, "[up-to-date] product.exe"),
                "--run should still reuse warm link state");
         expect(contains_output_line(run_with_args->stdout_text, "[run] product.exe"),
                "--run should report the launched target");
-        expect(contains_output_line(run_with_args->stdout_text, "argc=5"),
+        expect(child_argv_visible,
                "child should receive four exact argv elements");
         expect(contains_output_line(run_with_args->stdout_text, "arg1=<hello world>"),
                "argv with spaces should remain one element");

--- a/cpp/tests/mqb_cli_e2e_tests.cpp
+++ b/cpp/tests/mqb_cli_e2e_tests.cpp
@@ -241,17 +241,12 @@ int main(const int argc, char* argv[]) {
     expect(run_with_args.has_value(), "warm --run invocation should launch");
     if (run_with_args) {
         if (run_with_args->exit_code != 0) dump_failure(*run_with_args);
-        const bool child_argv_visible = contains_output_line(run_with_args->stdout_text, "argc=5");
-        if (!child_argv_visible) {
-            std::cerr << "DIAGNOSTIC: child argv output missing or unexpected\n";
-            dump_failure(*run_with_args);
-        }
         expect(run_with_args->exit_code == 0, "warm --run should return child success code");
         expect(contains_output_line(run_with_args->stdout_text, "[up-to-date] product.exe"),
                "--run should still reuse warm link state");
         expect(contains_output_line(run_with_args->stdout_text, "[run] product.exe"),
                "--run should report the launched target");
-        expect(child_argv_visible,
+        expect(contains_output_line(run_with_args->stdout_text, "argc=5"),
                "child should receive four exact argv elements");
         expect(contains_output_line(run_with_args->stdout_text, "arg1=<hello world>"),
                "argv with spaces should remain one element");

--- a/cpp/tests/mqb_cli_e2e_tests.cpp
+++ b/cpp/tests/mqb_cli_e2e_tests.cpp
@@ -130,7 +130,7 @@ int main(const int argc, char* argv[]) {
     const fs::path mqb_executable{argv[1]};
     const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
     TempTree tree{
-        .root = fs::temp_directory_path() / ("mqb_cli_multi_tu_" + std::to_string(unique)),
+        .root = fs::temp_directory_path() / ("mqb_cli_target_ux_" + std::to_string(unique)),
     };
     fs::create_directories(tree.root);
 
@@ -160,8 +160,12 @@ int main(const int argc, char* argv[]) {
         "#endif\n"
         "int helper_a();\n"
         "int helper_b();\n"
-        "int main() {\n"
+        "int main(int argc, char** argv) {\n"
         "    std::printf(\"mqb-multi=%d\\n\", util_value() + helper_a() + helper_b() + MQB_CLI_TEST);\n"
+        "    std::printf(\"argc=%d\\n\", argc);\n"
+        "    for (int i = 1; i < argc; ++i) {\n"
+        "        std::printf(\"arg%d=<%s>\\n\", i, argv[i]);\n"
+        "    }\n"
         "    return 0;\n"
         "}\n");
 
@@ -170,16 +174,17 @@ int main(const int argc, char* argv[]) {
     const fs::path utils_object = tree.root / ".mqb" / "obj" / "src" / "utils.cpp.obj";
     const fs::path helper_a_object = tree.root / ".mqb" / "obj" / "a" / "helper.cpp.obj";
     const fs::path helper_b_object = tree.root / ".mqb" / "obj" / "b" / "helper.cpp.obj";
-    const fs::path executable = tree.root / ".mqb" / "bin" / "main.exe";
-    const fs::path link_cache = tree.root / ".mqb" / "cache" / "link" / "main.linkcache";
+    const fs::path executable = tree.root / ".mqb" / "bin" / "product.exe";
+    const fs::path link_cache = tree.root / ".mqb" / "cache" / "link" / "product.linkcache";
 
     mqb::platform::windows::WindowsProcessRunner runner;
+    const std::vector<std::string> target_arguments{"-o", "product"};
 
-    auto cold = run_mqb(runner, mqb_executable, tree.root, sources, include_dir);
-    expect(cold.has_value(), "cold multi-TU invocation should launch");
+    auto cold = run_mqb(runner, mqb_executable, tree.root, sources, include_dir, target_arguments);
+    expect(cold.has_value(), "cold target invocation should launch");
     if (cold) {
         if (cold->exit_code != 0) dump_failure(*cold);
-        expect(cold->exit_code == 0, "cold multi-TU build should succeed");
+        expect(cold->exit_code == 0, "cold target build should succeed");
         expect(cold->stdout_text.find("[compile] main.cpp") != std::string::npos,
                "cold build should compile main.cpp");
         expect(cold->stdout_text.find("[compile] src/utils.cpp") != std::string::npos,
@@ -188,8 +193,8 @@ int main(const int argc, char* argv[]) {
                "cold build should compile first same-basename helper");
         expect(cold->stdout_text.find("[compile] b/helper.cpp") != std::string::npos,
                "cold build should compile second same-basename helper");
-        expect(cold->stdout_text.find("[link] main.exe") != std::string::npos,
-               "cold build should link one target executable");
+        expect(cold->stdout_text.find("[link] product.exe") != std::string::npos,
+               "custom output name should drive target link artifact");
     }
 
     expect(fs::is_regular_file(main_object), "main object should use project-level layout");
@@ -198,22 +203,22 @@ int main(const int argc, char* argv[]) {
     expect(fs::is_regular_file(helper_b_object), "second helper object should exist independently");
     expect(helper_a_object != helper_b_object,
            "same-basename sources from different directories must have different artifacts");
-    expect(fs::is_regular_file(executable), "multi-TU build should create target executable");
-    expect(fs::is_regular_file(link_cache), "multi-TU build should persist one target link cache");
+    expect(fs::is_regular_file(executable), "custom target build should create product.exe");
+    expect(fs::is_regular_file(link_cache), "custom target build should persist product link cache");
 
     auto cold_run = run_executable(runner, executable, tree.root);
-    expect(cold_run.has_value(), "cold-built multi-TU executable should launch");
+    expect(cold_run.has_value(), "cold-built target executable should launch directly");
     if (cold_run) {
         expect(cold_run->exit_code == 0, "cold-built executable should return zero");
         expect(cold_run->stdout_text.find("mqb-multi=72") != std::string::npos,
                "cold-built executable should combine all translation units");
     }
 
-    auto warm = run_mqb(runner, mqb_executable, tree.root, sources, include_dir);
-    expect(warm.has_value(), "warm multi-TU invocation should launch");
+    auto warm = run_mqb(runner, mqb_executable, tree.root, sources, include_dir, target_arguments);
+    expect(warm.has_value(), "warm target invocation should launch");
     if (warm) {
         if (warm->exit_code != 0) dump_failure(*warm);
-        expect(warm->exit_code == 0, "warm multi-TU build should succeed");
+        expect(warm->exit_code == 0, "warm target build should succeed");
         expect(contains_output_line(warm->stdout_text, "[up-to-date] main.cpp"),
                "warm build should skip main.cpp");
         expect(contains_output_line(warm->stdout_text, "[up-to-date] src/utils.cpp"),
@@ -222,8 +227,35 @@ int main(const int argc, char* argv[]) {
                "warm build should skip helper A");
         expect(contains_output_line(warm->stdout_text, "[up-to-date] b/helper.cpp"),
                "warm build should skip helper B");
-        expect(contains_output_line(warm->stdout_text, "[up-to-date] main.exe"),
-               "warm build should skip link.exe");
+        expect(contains_output_line(warm->stdout_text, "[up-to-date] product.exe"),
+               "warm build should skip link.exe for custom target");
+    }
+
+    auto run_with_args = run_mqb(
+        runner,
+        mqb_executable,
+        tree.root,
+        sources,
+        include_dir,
+        {"-o", "product", "--run", "--", "hello world", "--child-option", "", "a b c"});
+    expect(run_with_args.has_value(), "warm --run invocation should launch");
+    if (run_with_args) {
+        if (run_with_args->exit_code != 0) dump_failure(*run_with_args);
+        expect(run_with_args->exit_code == 0, "warm --run should return child success code");
+        expect(contains_output_line(run_with_args->stdout_text, "[up-to-date] product.exe"),
+               "--run should still reuse warm link state");
+        expect(contains_output_line(run_with_args->stdout_text, "[run] product.exe"),
+               "--run should report the launched target");
+        expect(contains_output_line(run_with_args->stdout_text, "argc=5"),
+               "child should receive four exact argv elements");
+        expect(contains_output_line(run_with_args->stdout_text, "arg1=<hello world>"),
+               "argv with spaces should remain one element");
+        expect(contains_output_line(run_with_args->stdout_text, "arg2=<--child-option>"),
+               "option-looking child argv should bypass MQB parsing");
+        expect(contains_output_line(run_with_args->stdout_text, "arg3=<>") ,
+               "empty child argv should be preserved");
+        expect(contains_output_line(run_with_args->stdout_text, "arg4=<a b c>"),
+               "second spaced child argv should remain one element");
     }
 
     std::error_code error_code;
@@ -235,8 +267,8 @@ int main(const int argc, char* argv[]) {
         expect(!error_code, "value header timestamp should be made newer deterministically");
     }
 
-    auto header_changed = run_mqb(runner, mqb_executable, tree.root, sources, include_dir);
-    expect(header_changed.has_value(), "header-change multi-TU invocation should launch");
+    auto header_changed = run_mqb(runner, mqb_executable, tree.root, sources, include_dir, target_arguments);
+    expect(header_changed.has_value(), "header-change target invocation should launch");
     if (header_changed) {
         if (header_changed->exit_code != 0) dump_failure(*header_changed);
         expect(header_changed->exit_code == 0, "header-change build should succeed");
@@ -250,8 +282,8 @@ int main(const int argc, char* argv[]) {
                "unrelated helper A should remain cached");
         expect(contains_output_line(header_changed->stdout_text, "[up-to-date] b/helper.cpp"),
                "unrelated helper B should remain cached");
-        expect(header_changed->stdout_text.find("[link] main.exe") != std::string::npos,
-               "any rebuilt TU should force target relink");
+        expect(header_changed->stdout_text.find("[link] product.exe") != std::string::npos,
+               "any rebuilt TU should force custom target relink");
         expect(header_changed->stdout_text.find("explicit rebuild") != std::string::npos,
                "compile-to-link handoff should not depend only on timestamps");
     }
@@ -277,17 +309,34 @@ int main(const int argc, char* argv[]) {
         tree.root,
         sources,
         include_dir,
-        {"--release"});
-    expect(release.has_value(), "release multi-TU invocation should launch");
+        {"-o", "product", "--release"});
+    expect(release.has_value(), "release target invocation should launch");
     if (release) {
         if (release->exit_code != 0) dump_failure(*release);
-        expect(release->exit_code == 0, "release multi-TU build should succeed");
+        expect(release->exit_code == 0, "release target build should succeed");
         expect(release->stdout_text.find("compiler options changed") != std::string::npos,
                "Debug to Release should invalidate compile recipes");
-        expect(release->stdout_text.find("[link] main.exe") != std::string::npos,
-               "Debug to Release should relink target");
+        expect(release->stdout_text.find("[link] product.exe") != std::string::npos,
+               "Debug to Release should relink custom target");
         expect(release->stdout_text.find("linker options changed") != std::string::npos,
                "Debug to Release should invalidate link recipe");
+    }
+
+    const fs::path exit_source = tree.root / "exit7.cpp";
+    write_text(exit_source, "int main() { return 7; }\n");
+    auto exit7 = run_mqb(
+        runner,
+        mqb_executable,
+        tree.root,
+        {exit_source},
+        include_dir,
+        {"-o", "exit7", "--run"});
+    expect(exit7.has_value(), "non-zero child invocation should launch");
+    if (exit7) {
+        expect(exit7->exit_code == 7,
+               "MQB should propagate the child executable exit code exactly");
+        expect(contains_output_line(exit7->stdout_text, "[run] exit7.exe"),
+               "non-zero child should still be reported as a run action");
     }
 
     if (failures != 0) {

--- a/docs/CPP_V2_ARCHITECTURE.md
+++ b/docs/CPP_V2_ARCHITECTURE.md
@@ -50,6 +50,7 @@ Core                  MSVC backend
 6. **Compile state and link state are independent.** A compile cache hit does not imply a link cache hit, and link-only changes must never force unnecessary compilation.
 7. **A fresh compile is an explicit relink signal.** Linking must not depend solely on filesystem timestamp granularity.
 8. **Source identity is not a basename.** Project artifacts preserve relative source identity; external sources receive a stable hashed namespace, and duplicate object mappings are rejected before execution.
+9. **Run-time argv is not build identity.** `--run` and arguments after `--` are execution state only; changing them must not invalidate compile or link caches.
 
 ## Compile identity and cache freshness
 
@@ -190,6 +191,8 @@ Ordinary cache-load/save failures are surfaced as warnings and conservatively re
 
 `mqb_platform_windows` isolates Windows command-line quoting and the real `CreateProcessW` runner. Tests cover complex argv round-trips, explicit/inherited Unicode environment blocks, separate stdout/stderr capture, non-zero child exit codes, native launch errors, and concurrent draining of large output streams.
 
+The CLI also uses the same structured process boundary for `--run`. Arguments after `--` are preserved as distinct argv elements, including whitespace-containing strings, option-looking strings, and empty arguments. MQB propagates the child exit code exactly; a failure to launch the child remains an MQB error. Captured CRLF is normalized before forwarding through Windows text streams so nested process output does not become `\r\r\n`; lone carriage returns are preserved.
+
 The current runner uses RAII for process/thread/pipe handles. Before final cutover, handle inheritance should be hardened further with `STARTUPINFOEXW` + `PROC_THREAD_ATTRIBUTE_HANDLE_LIST`.
 
 ## MSVC toolchain boundary
@@ -213,13 +216,16 @@ GitHub CI enables installed-MSVC integration tests explicitly; local tests keep 
 
 ## Current CLI milestone
 
-`mqb.exe` now supports an **explicit ordered set of ordinary C++ translation units** (`.cpp`, `.cc`, `.cxx`):
+`mqb.exe` supports an **explicit ordered set of ordinary C++ translation units** (`.cpp`, `.cc`, `.cxx`), target naming, and structured post-build execution:
 
 ```powershell
-mqb main.cpp src/utils.cpp a/helper.cpp b/helper.cpp
+mqb main.cpp src/utils.cpp a/helper.cpp b/helper.cpp -o product
+mqb main.cpp src/utils.cpp -o product --run -- "hello world" --child-option ""
 ```
 
-The first source currently supplies the default target name (`main.cpp` -> `main.exe`). Every source is incrementally validated independently; only stale TUs compile, and all resulting objects feed one independently cached link action.
+The first source supplies the default target name when `-o/--output` is omitted. Every source is incrementally validated independently; only stale TUs compile, and all resulting objects feed one independently cached link action. `-o/--output` selects a validated target filename under `.mqb/bin/`; it is not an arbitrary escape path.
+
+`--run` executes the resulting target through `ProcessSpec`/`CreateProcessW`, not through a shell. The `--` sentinel ends MQB option parsing and passes every remaining argv element to the child verbatim. Run mode and child argv do not participate in build signatures, so changing only execution arguments reuses warm compile/link state.
 
 The real VS2026 E2E suite verifies:
 
@@ -229,9 +235,12 @@ The real VS2026 E2E suite verifies:
 - a header private to one TU rebuilds only that TU;
 - any rebuilt TU explicitly forces relink;
 - the resulting executable behavior changes after the partial rebuild;
-- Debug -> Release invalidates compile and link recipes without source edits.
+- Debug -> Release invalidates compile and link recipes without source edits;
+- custom target naming produces independent executable/link-cache paths;
+- warm `--run` preserves spaced, option-looking, and empty child argv elements;
+- a non-zero child process exit code is propagated exactly.
 
-Not yet exposed in the C++ CLI: automatic source discovery, `-o/--output`, `--run`, user libraries/library paths, project config files, and C++ Modules.
+Not yet exposed in the C++ CLI: automatic source discovery, user libraries/library paths, project config files, and C++ Modules. Translation-unit scheduling is still sequential.
 
 ## Migration sequence
 
@@ -242,10 +251,11 @@ Not yet exposed in the C++ CLI: automatic source discovery, `-o/--output`, `--ru
 5. **Ordinary single TU** — typed compiler arguments, `/sourceDependencies`, cache persistence, real incremental CLI. ✅
 6. **Link state** — independent linker identity/signature/cache/planning/backend/orchestration and executable production. ✅
 7. **Explicit multi-TU target** — project artifact layout, ordered source set, per-TU incremental compile, single incremental link. ✅
-8. **Target UX and discovery** — `-o`, `--run`, libraries, project config, smart source discovery, then parallel compile scheduling.
-9. **Modules** — P1689 `/scanDependencies`, module graph, IFC/object artifacts, `import std`.
-10. **Parity** — run PowerShell and C++ against the same E2E fixtures.
-11. **Cutover** — make `mqb.exe` primary only after parity tests pass.
+8. **Target UX** — `-o/--output`, `--run`, structured `--` argv passthrough, child exit propagation. ✅
+9. **Target discovery and libraries** — resolved library freshness, library search paths, project config, smart source discovery, then parallel compile scheduling.
+10. **Modules** — P1689 `/scanDependencies`, module graph, IFC/object artifacts, `import std`.
+11. **Parity** — run PowerShell and C++ against the same E2E fixtures.
+12. **Cutover** — make `mqb.exe` primary only after parity tests pass.
 
 ## Local build
 


### PR DESCRIPTION
Completes the next target-UX milestone from the verified multi-TU main branch.

- adds `-o/--output` target naming under `.mqb/bin/`
- adds `--run` without shell re-parsing
- adds `--` argv passthrough preserving spaces, leading dashes, and empty arguments
- propagates child process exit codes exactly; MQB uses exit code 6 only for launch failures
- keeps compile cache identity independent from run mode/argv
- adds CLI parser regression coverage and VS2026 E2E coverage for cold/warm builds, custom target names, structured child argv, and non-zero child exit propagation