### PR TITLE
feat: track exact static library inputs and link-only freshness

### DIFF
--- a/cpp/apps/mqb/Cli.cpp
+++ b/cpp/apps/mqb/Cli.cpp
@@ -73,6 +73,17 @@ attached_or_next(
     return require_value(arguments, index, option);
 }
 
+[[nodiscard]] std::expected<std::string_view, Error>
+long_equals_value(
+    const std::string_view argument,
+    const std::string_view prefix) {
+    const std::string_view value = argument.substr(prefix.size());
+    if (value.empty()) {
+        return std::unexpected(error("empty value for " + std::string{prefix.substr(0, prefix.size() - 1)}));
+    }
+    return value;
+}
+
 } // namespace
 
 std::expected<Options, Error>
@@ -102,18 +113,14 @@ parse_arguments(const std::span<const std::string_view> arguments) {
         }
         if (argument == "-o" || argument == "--output") {
             auto value = require_value(arguments, index, argument);
-            if (!value) {
-                return std::unexpected(value.error());
-            }
+            if (!value) return std::unexpected(value.error());
             options.build.output_name = std::string{*value};
             continue;
         }
         if (argument.starts_with("--output=")) {
-            const std::string_view value = argument.substr(std::string_view{"--output="}.size());
-            if (value.empty()) {
-                return std::unexpected(error("empty value for --output"));
-            }
-            options.build.output_name = std::string{value};
+            auto value = long_equals_value(argument, "--output=");
+            if (!value) return std::unexpected(value.error());
+            options.build.output_name = std::string{*value};
             continue;
         }
         if (argument == "--debug") {
@@ -134,56 +141,76 @@ parse_arguments(const std::span<const std::string_view> arguments) {
         }
         if (argument == "--std") {
             auto value = require_value(arguments, index, argument);
-            if (!value) {
-                return std::unexpected(value.error());
-            }
+            if (!value) return std::unexpected(value.error());
             auto standard = parse_standard(*value);
-            if (!standard) {
-                return std::unexpected(standard.error());
-            }
+            if (!standard) return std::unexpected(standard.error());
             options.build.standard = *standard;
             continue;
         }
         if (argument == "--env") {
             auto value = require_value(arguments, index, argument);
-            if (!value) {
-                return std::unexpected(value.error());
-            }
+            if (!value) return std::unexpected(value.error());
             auto preference = parse_toolchain_preference(*value);
-            if (!preference) {
-                return std::unexpected(preference.error());
-            }
+            if (!preference) return std::unexpected(preference.error());
             options.toolchain_preference = *preference;
             continue;
         }
         if (argument == "--portable-root") {
             auto value = require_value(arguments, index, argument);
-            if (!value) {
-                return std::unexpected(value.error());
-            }
+            if (!value) return std::unexpected(value.error());
             options.portable_roots.emplace_back(std::string{*value});
+            continue;
+        }
+        if (argument == "--lib-path") {
+            auto value = require_value(arguments, index, argument);
+            if (!value) return std::unexpected(value.error());
+            options.library_directories.emplace_back(std::string{*value});
+            continue;
+        }
+        if (argument.starts_with("--lib-path=")) {
+            auto value = long_equals_value(argument, "--lib-path=");
+            if (!value) return std::unexpected(value.error());
+            options.library_directories.emplace_back(std::string{*value});
+            continue;
+        }
+        if (argument == "--lib") {
+            auto value = require_value(arguments, index, argument);
+            if (!value) return std::unexpected(value.error());
+            options.libraries.emplace_back(*value);
+            continue;
+        }
+        if (argument.starts_with("--lib=")) {
+            auto value = long_equals_value(argument, "--lib=");
+            if (!value) return std::unexpected(value.error());
+            options.libraries.emplace_back(*value);
             continue;
         }
         if (argument == "-I" || argument.starts_with("-I")) {
             auto value = attached_or_next(arguments, index, argument, "-I");
-            if (!value) {
-                return std::unexpected(value.error());
-            }
-            if (value->empty()) {
-                return std::unexpected(error("empty include directory"));
-            }
+            if (!value) return std::unexpected(value.error());
+            if (value->empty()) return std::unexpected(error("empty include directory"));
             options.include_directories.emplace_back(std::string{*value});
             continue;
         }
         if (argument == "-D" || argument.starts_with("-D")) {
             auto value = attached_or_next(arguments, index, argument, "-D");
-            if (!value) {
-                return std::unexpected(value.error());
-            }
-            if (value->empty()) {
-                return std::unexpected(error("empty preprocessor define"));
-            }
+            if (!value) return std::unexpected(value.error());
+            if (value->empty()) return std::unexpected(error("empty preprocessor define"));
             options.defines.emplace_back(*value);
+            continue;
+        }
+        if (argument == "-L" || argument.starts_with("-L")) {
+            auto value = attached_or_next(arguments, index, argument, "-L");
+            if (!value) return std::unexpected(value.error());
+            if (value->empty()) return std::unexpected(error("empty library directory"));
+            options.library_directories.emplace_back(std::string{*value});
+            continue;
+        }
+        if (argument == "-l" || argument.starts_with("-l")) {
+            auto value = attached_or_next(arguments, index, argument, "-l");
+            if (!value) return std::unexpected(value.error());
+            if (value->empty()) return std::unexpected(error("empty library name"));
+            options.libraries.emplace_back(*value);
             continue;
         }
         if (!argument.empty() && argument.front() == '-') {
@@ -211,8 +238,8 @@ Usage:
   mqb <source.cpp> [more-sources...] [options] [-- program-args...]
 
 Current milestone:
-  Incrementally compile an explicit C++ source set, link one executable,
-  and optionally run it without shell re-parsing.
+  Incrementally compile an explicit C++ source set, resolve exact library files,
+  link one executable, and optionally run it without shell re-parsing.
 
 Options:
   --debug                  Debug compile/link preset (default)
@@ -223,6 +250,10 @@ Options:
   --run                    Run the executable after a successful build
   -I <dir>, -I<dir>        Add an include directory
   -D <value>, -D<value>    Add a preprocessor definition
+  -L <dir>, -L<dir>        Add a library search directory
+  --lib-path <dir>         Add a library search directory
+  -l <name>, -l<name>      Link a library ('.lib' is optional)
+  --lib <name>             Link a library (name or explicit path)
   --env <auto|vs|portable> Toolchain selection (default: auto)
   --portable-root <dir>    Add a portable_msvc root candidate
   -v, --verbose            Show toolchain and artifact details

--- a/cpp/apps/mqb/Cli.hpp
+++ b/cpp/apps/mqb/Cli.hpp
@@ -16,6 +16,8 @@ struct Options {
     BuildRequest build;
     std::vector<std::string> defines;
     std::vector<std::filesystem::path> include_directories;
+    std::vector<std::filesystem::path> library_directories;
+    std::vector<std::string> libraries;
     msvc::ToolchainPreference toolchain_preference{msvc::ToolchainPreference::automatic};
     std::vector<std::filesystem::path> portable_roots;
     bool verbose{false};

--- a/cpp/apps/mqb/main.cpp
+++ b/cpp/apps/mqb/main.cpp
@@ -149,6 +149,17 @@ void print_compile_failure(const mqb::orchestration::IncrementalCompileError& er
 
 void print_link_failure(const mqb::orchestration::IncrementalLinkError& error) {
     std::cerr << "error: " << error.message << '\n';
+    if (error.library_resolution_error) {
+        const auto& resolution = *error.library_resolution_error;
+        std::cerr << "  " << resolution.message;
+        if (!resolution.library.empty()) {
+            std::cerr << ": " << resolution.library;
+        }
+        if (!resolution.path.empty()) {
+            std::cerr << " (" << path_text(resolution.path) << ')';
+        }
+        std::cerr << '\n';
+    }
     if (!error.linker_error) {
         return;
     }
@@ -264,6 +275,14 @@ int main(const int argc, char* argv[]) {
         }
         include_directory = std::move(*resolved);
     }
+    for (auto& library_directory : options.library_directories) {
+        auto resolved = absolute_path(library_directory, "library directory");
+        if (!resolved) {
+            std::cerr << "error: " << resolved.error() << '\n';
+            return 2;
+        }
+        library_directory = std::move(*resolved);
+    }
     for (auto& portable_root : options.portable_roots) {
         auto resolved = absolute_path(portable_root, "portable toolchain root");
         if (!resolved) {
@@ -335,6 +354,8 @@ int main(const int argc, char* argv[]) {
     link_options.configuration = options.build.configuration;
     link_options.architecture = options.build.architecture;
     link_options.subsystem = mqb::LinkSubsystem::console;
+    link_options.library_directories = std::move(options.library_directories);
+    link_options.libraries = std::move(options.libraries);
 
     if (options.verbose) {
         std::cout << "[target] " << target_name << "\n"
@@ -346,6 +367,12 @@ int main(const int argc, char* argv[]) {
                       << "    obj:   " << path_text(source.artifacts.object) << '\n'
                       << "    deps:  " << path_text(source.artifacts.dependencies) << '\n'
                       << "    cache: " << path_text(source.artifacts.compile_cache) << '\n';
+        }
+        for (const auto& directory : link_options.library_directories) {
+            std::cout << "  libpath: " << path_text(directory) << '\n';
+        }
+        for (const auto& library : link_options.libraries) {
+            std::cout << "  lib:     " << library << '\n';
         }
         std::cout << "  exe:     " << path_text(target_artifacts->executable) << '\n'
                   << "  cache:   " << path_text(target_artifacts->link_cache) << '\n';

--- a/cpp/backends/msvc/CMakeLists.txt
+++ b/cpp/backends/msvc/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(mqb_msvc STATIC
     src/MsvcCompileExecutor.cpp
     src/MsvcCompiler.cpp
+    src/MsvcLibraryResolver.cpp
     src/MsvcLinker.cpp
     src/MsvcSourceDependenciesReader.cpp
     src/MsvcToolchainLocator.cpp

--- a/cpp/backends/msvc/include/mqb/msvc/MsvcLibraryResolver.hpp
+++ b/cpp/backends/msvc/include/mqb/msvc/MsvcLibraryResolver.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <expected>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include "mqb/core/LinkOptions.hpp"
+#include "mqb/msvc/MsvcToolchainLocator.hpp"
+
+namespace mqb::msvc {
+
+enum class LibraryResolutionErrorCode {
+    invalid_request,
+    working_directory_failed,
+    library_not_found,
+};
+
+struct LibraryResolutionError {
+    LibraryResolutionErrorCode code{LibraryResolutionErrorCode::invalid_request};
+    std::string library;
+    std::filesystem::path path;
+    std::string message;
+};
+
+struct ResolvedLibraries {
+    std::vector<std::filesystem::path> files;
+};
+
+class MsvcLibraryResolver {
+public:
+    [[nodiscard]] static std::expected<ResolvedLibraries, LibraryResolutionError>
+    resolve(
+        const MsvcToolchain& toolchain,
+        const LinkOptions& options,
+        const std::filesystem::path& working_directory = {});
+};
+
+} // namespace mqb::msvc

--- a/cpp/backends/msvc/include/mqb/msvc/MsvcLinker.hpp
+++ b/cpp/backends/msvc/include/mqb/msvc/MsvcLinker.hpp
@@ -16,6 +16,7 @@ namespace mqb::msvc {
 struct LinkInvocation {
     std::vector<std::filesystem::path> objects;
     std::filesystem::path output;
+    std::vector<std::filesystem::path> libraries;
     LinkOptions options;
     std::filesystem::path working_directory;
 };

--- a/cpp/backends/msvc/src/MsvcLibraryResolver.cpp
+++ b/cpp/backends/msvc/src/MsvcLibraryResolver.cpp
@@ -1,0 +1,217 @@
+#include "mqb/msvc/MsvcLibraryResolver.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <expected>
+#include <filesystem>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+namespace mqb::msvc {
+namespace {
+
+namespace fs = std::filesystem;
+
+[[nodiscard]] LibraryResolutionError failure(
+    const LibraryResolutionErrorCode code,
+    std::string library,
+    fs::path path,
+    std::string message) {
+    return LibraryResolutionError{
+        .code = code,
+        .library = std::move(library),
+        .path = std::move(path),
+        .message = std::move(message),
+    };
+}
+
+[[nodiscard]] fs::path path_from_utf8(const std::string_view value) {
+    std::u8string bytes;
+    bytes.assign(
+        reinterpret_cast<const char8_t*>(value.data()),
+        reinterpret_cast<const char8_t*>(value.data() + value.size()));
+    return fs::path{bytes};
+}
+
+[[nodiscard]] bool ascii_iequals(
+    const std::string_view left,
+    const std::string_view right) {
+    if (left.size() != right.size()) {
+        return false;
+    }
+    for (std::size_t index = 0; index < left.size(); ++index) {
+        const auto a = static_cast<unsigned char>(left[index]);
+        const auto b = static_cast<unsigned char>(right[index]);
+        if (std::tolower(a) != std::tolower(b)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+[[nodiscard]] std::string_view environment_value(
+    const MsvcToolchain& toolchain,
+    const std::string_view name) {
+    for (const auto& variable : toolchain.environment) {
+        if (ascii_iequals(variable.name, name)) {
+            return variable.value;
+        }
+    }
+    return {};
+}
+
+[[nodiscard]] std::vector<fs::path> split_library_path(const std::string_view value) {
+    std::vector<fs::path> result;
+    std::size_t begin = 0;
+    while (begin <= value.size()) {
+        const std::size_t separator = value.find(';', begin);
+        const std::size_t end = separator == std::string_view::npos ? value.size() : separator;
+        std::string_view token = value.substr(begin, end - begin);
+        while (!token.empty() && (token.front() == ' ' || token.front() == '\t')) {
+            token.remove_prefix(1);
+        }
+        while (!token.empty() && (token.back() == ' ' || token.back() == '\t')) {
+            token.remove_suffix(1);
+        }
+        if (token.size() >= 2 && token.front() == '"' && token.back() == '"') {
+            token.remove_prefix(1);
+            token.remove_suffix(1);
+        }
+        if (!token.empty()) {
+            result.push_back(path_from_utf8(token));
+        }
+        if (separator == std::string_view::npos) {
+            break;
+        }
+        begin = separator + 1;
+    }
+    return result;
+}
+
+[[nodiscard]] std::expected<fs::path, LibraryResolutionError>
+resolve_working_directory(const fs::path& requested) {
+    std::error_code error_code;
+    fs::path result;
+    if (requested.empty()) {
+        result = fs::current_path(error_code);
+    } else {
+        result = fs::absolute(requested, error_code);
+    }
+    if (error_code) {
+        return std::unexpected(failure(
+            LibraryResolutionErrorCode::working_directory_failed,
+            {},
+            requested,
+            "failed to resolve library working directory: " + error_code.message()));
+    }
+    return result.lexically_normal();
+}
+
+[[nodiscard]] fs::path make_absolute(
+    const fs::path& working_directory,
+    const fs::path& path) {
+    if (path.is_absolute()) {
+        return path.lexically_normal();
+    }
+    return (working_directory / path).lexically_normal();
+}
+
+void add_search_directory(
+    std::vector<fs::path>& directories,
+    const fs::path& working_directory,
+    const fs::path& directory) {
+    if (directory.empty()) {
+        return;
+    }
+    const fs::path normalized = make_absolute(working_directory, directory);
+    if (std::find(directories.begin(), directories.end(), normalized) == directories.end()) {
+        directories.push_back(normalized);
+    }
+}
+
+[[nodiscard]] bool regular_file(const fs::path& path) {
+    std::error_code error_code;
+    return fs::is_regular_file(path, error_code) && !error_code;
+}
+
+[[nodiscard]] fs::path normalized_library_name(const std::string_view requested) {
+    fs::path library = path_from_utf8(requested);
+    if (library.extension().empty()) {
+        library += ".lib";
+    }
+    return library;
+}
+
+} // namespace
+
+std::expected<ResolvedLibraries, LibraryResolutionError>
+MsvcLibraryResolver::resolve(
+    const MsvcToolchain& toolchain,
+    const LinkOptions& options,
+    const fs::path& requested_working_directory) {
+    auto working_directory = resolve_working_directory(requested_working_directory);
+    if (!working_directory) {
+        return std::unexpected(working_directory.error());
+    }
+
+    std::vector<fs::path> search_directories;
+    search_directories.reserve(options.library_directories.size() + 8);
+    for (const auto& directory : options.library_directories) {
+        add_search_directory(search_directories, *working_directory, directory);
+    }
+    add_search_directory(search_directories, *working_directory, *working_directory);
+    for (const auto& directory : split_library_path(environment_value(toolchain, "LIB"))) {
+        add_search_directory(search_directories, *working_directory, directory);
+    }
+
+    ResolvedLibraries result;
+    result.files.reserve(options.libraries.size());
+    for (const auto& requested : options.libraries) {
+        if (requested.empty()) {
+            return std::unexpected(failure(
+                LibraryResolutionErrorCode::invalid_request,
+                requested,
+                {},
+                "library name must not be empty"));
+        }
+
+        const fs::path library = normalized_library_name(requested);
+        if (library.has_root_path() || library.has_parent_path()) {
+            const fs::path candidate = make_absolute(*working_directory, library);
+            if (!regular_file(candidate)) {
+                return std::unexpected(failure(
+                    LibraryResolutionErrorCode::library_not_found,
+                    requested,
+                    candidate,
+                    "requested library file does not exist"));
+            }
+            result.files.push_back(candidate);
+            continue;
+        }
+
+        bool found = false;
+        for (const auto& directory : search_directories) {
+            const fs::path candidate = (directory / library).lexically_normal();
+            if (!regular_file(candidate)) {
+                continue;
+            }
+            result.files.push_back(candidate);
+            found = true;
+            break;
+        }
+        if (!found) {
+            return std::unexpected(failure(
+                LibraryResolutionErrorCode::library_not_found,
+                requested,
+                library,
+                "could not resolve requested library in -L paths, working directory, or MSVC LIB environment"));
+        }
+    }
+
+    return result;
+}
+
+} // namespace mqb::msvc

--- a/cpp/backends/msvc/src/MsvcLinker.cpp
+++ b/cpp/backends/msvc/src/MsvcLinker.cpp
@@ -114,13 +114,25 @@ MsvcLinker::build_arguments(const LinkInvocation& invocation) {
             LinkerErrorCode::invalid_request,
             "link output path is empty"));
     }
+    if (invocation.libraries.size() != invocation.options.libraries.size()) {
+        return std::unexpected(failure(
+            LinkerErrorCode::invalid_request,
+            "resolved library inputs must match requested library count"));
+    }
+    for (const auto& library : invocation.libraries) {
+        if (library.empty()) {
+            return std::unexpected(failure(
+                LinkerErrorCode::invalid_request,
+                "resolved library path must not be empty"));
+        }
+    }
 
     std::vector<std::string> arguments;
     arguments.reserve(
         12
         + invocation.objects.size()
         + invocation.options.library_directories.size()
-        + invocation.options.libraries.size()
+        + invocation.libraries.size()
         + invocation.options.additional_arguments.size());
 
     arguments.emplace_back("/NOLOGO");
@@ -141,13 +153,8 @@ MsvcLinker::build_arguments(const LinkInvocation& invocation) {
         }
         arguments.push_back("/LIBPATH:" + path_to_utf8(directory));
     }
-    for (const auto& library : invocation.options.libraries) {
-        if (library.empty()) {
-            return std::unexpected(failure(
-                LinkerErrorCode::invalid_request,
-                "library name must not be empty"));
-        }
-        arguments.push_back(library);
+    for (const auto& library : invocation.libraries) {
+        arguments.push_back(path_to_utf8(library));
     }
     for (const auto& argument : invocation.options.additional_arguments) {
         if (argument.empty()) {

--- a/cpp/core/include/mqb/core/BuildAction.hpp
+++ b/cpp/core/include/mqb/core/BuildAction.hpp
@@ -18,6 +18,7 @@ struct CompileAction {
 struct LinkAction {
     std::vector<std::filesystem::path> objects;
     std::filesystem::path output;
+    std::vector<std::filesystem::path> libraries;
     std::vector<BuildReason> reasons;
 };
 

--- a/cpp/core/include/mqb/core/BuildPlanner.hpp
+++ b/cpp/core/include/mqb/core/BuildPlanner.hpp
@@ -34,6 +34,7 @@ struct CompilePlanItem {
 struct LinkPlanItem {
     std::vector<std::filesystem::path> objects;
     std::filesystem::path output;
+    std::vector<std::filesystem::path> libraries;
     LinkCacheValidation cache_validation;
 };
 

--- a/cpp/core/include/mqb/core/BuildSignature.hpp
+++ b/cpp/core/include/mqb/core/BuildSignature.hpp
@@ -34,6 +34,13 @@ public:
         const LinkerIdentity& linker,
         const LinkOptions& options);
 
+    [[nodiscard]] static BuildSignature for_link(
+        std::span<const std::filesystem::path> objects,
+        std::span<const std::filesystem::path> resolved_libraries,
+        const std::filesystem::path& output,
+        const LinkerIdentity& linker,
+        const LinkOptions& options);
+
     [[nodiscard]] static BuildSignature from_digest(const SignatureDigest digest) noexcept {
         return BuildSignature{digest};
     }

--- a/cpp/core/include/mqb/core/LinkCache.hpp
+++ b/cpp/core/include/mqb/core/LinkCache.hpp
@@ -18,6 +18,7 @@ struct LinkCacheEntry {
     BuildSignature signature;
     std::vector<std::filesystem::path> objects;
     std::filesystem::path output;
+    std::vector<std::filesystem::path> libraries;
 };
 
 struct LinkCacheValidation {
@@ -38,6 +39,18 @@ public:
         const std::optional<LinkCacheEntry>& cached_entry,
         const FileSnapshot& output_snapshot,
         std::span<const FileSnapshot> object_snapshots,
+        bool force_relink = false);
+
+    [[nodiscard]] static LinkCacheValidation validate(
+        std::span<const std::filesystem::path> current_objects,
+        std::span<const std::filesystem::path> current_libraries,
+        const std::filesystem::path& current_output,
+        const LinkerIdentity& current_linker,
+        const LinkOptions& current_options,
+        const std::optional<LinkCacheEntry>& cached_entry,
+        const FileSnapshot& output_snapshot,
+        std::span<const FileSnapshot> object_snapshots,
+        std::span<const FileSnapshot> library_snapshots,
         bool force_relink = false);
 };
 

--- a/cpp/core/src/BuildPlanner.cpp
+++ b/cpp/core/src/BuildPlanner.cpp
@@ -74,6 +74,13 @@ std::expected<BuildPlan, BuildPlannerError> BuildPlanner::plan_link(
             });
         }
     }
+    for (const auto& library : item.libraries) {
+        if (library.empty()) {
+            return std::unexpected(BuildPlannerError{
+                .code = BuildPlannerErrorCode::missing_link_input,
+            });
+        }
+    }
     if (item.output.empty()) {
         return std::unexpected(BuildPlannerError{
             .code = BuildPlannerErrorCode::missing_link_output,
@@ -83,6 +90,7 @@ std::expected<BuildPlan, BuildPlannerError> BuildPlanner::plan_link(
     plan.actions.emplace_back(LinkAction{
         .objects = item.objects,
         .output = item.output,
+        .libraries = item.libraries,
         .reasons = item.cache_validation.reasons,
     });
     return plan;

--- a/cpp/core/src/BuildSignature.cpp
+++ b/cpp/core/src/BuildSignature.cpp
@@ -132,13 +132,29 @@ BuildSignature BuildSignature::for_link(
     const std::filesystem::path& output,
     const LinkerIdentity& linker,
     const LinkOptions& options) {
-    StableHasher hasher;
-    hasher.add_string("mqb.link.signature.v1");
+    return for_link(
+        objects,
+        std::span<const std::filesystem::path>{},
+        output,
+        linker,
+        options);
+}
 
-    // Link input order is intentionally preserved. Although ordinary COFF
-    // objects are often order-insensitive, libraries and future link inputs are
-    // not universally so; signature identity should mirror the requested argv.
+BuildSignature BuildSignature::for_link(
+    const std::span<const std::filesystem::path> objects,
+    const std::span<const std::filesystem::path> resolved_libraries,
+    const std::filesystem::path& output,
+    const LinkerIdentity& linker,
+    const LinkOptions& options) {
+    StableHasher hasher;
+    hasher.add_string("mqb.link.signature.v2");
+
+    // File-input order is intentionally preserved. Library resolution is kept
+    // separate from the requested library recipe, but the exact resolved files
+    // still participate in action identity so a changed search result cannot
+    // silently reuse a link built against a different file.
     hasher.add_paths(objects);
+    hasher.add_paths(resolved_libraries);
     hasher.add_path(output);
 
     hasher.add_path(linker.linker);

--- a/cpp/core/src/LinkCache.cpp
+++ b/cpp/core/src/LinkCache.cpp
@@ -53,6 +53,23 @@ void add_reason(std::vector<BuildReason>& reasons, const BuildReason reason) {
     return it == snapshots.end() ? nullptr : &*it;
 }
 
+void validate_freshness(
+    const std::span<const std::filesystem::path> inputs,
+    const std::span<const FileSnapshot> snapshots,
+    const FileSnapshot& output_snapshot,
+    std::vector<BuildReason>& reasons) {
+    for (const auto& input : inputs) {
+        const auto* snapshot = find_snapshot(snapshots, input);
+        if (snapshot == nullptr || !snapshot->exists) {
+            add_reason(reasons, BuildReason::link_inputs_changed);
+            continue;
+        }
+        if (output_snapshot.exists && snapshot->modified > output_snapshot.modified) {
+            add_reason(reasons, BuildReason::link_inputs_changed);
+        }
+    }
+}
+
 } // namespace
 
 LinkCacheValidation LinkCacheValidator::validate(
@@ -63,6 +80,30 @@ LinkCacheValidation LinkCacheValidator::validate(
     const std::optional<LinkCacheEntry>& cached_entry,
     const FileSnapshot& output_snapshot,
     const std::span<const FileSnapshot> object_snapshots,
+    const bool force_relink) {
+    return validate(
+        current_objects,
+        std::span<const std::filesystem::path>{},
+        current_output,
+        current_linker,
+        current_options,
+        cached_entry,
+        output_snapshot,
+        object_snapshots,
+        std::span<const FileSnapshot>{},
+        force_relink);
+}
+
+LinkCacheValidation LinkCacheValidator::validate(
+    const std::span<const std::filesystem::path> current_objects,
+    const std::span<const std::filesystem::path> current_libraries,
+    const std::filesystem::path& current_output,
+    const LinkerIdentity& current_linker,
+    const LinkOptions& current_options,
+    const std::optional<LinkCacheEntry>& cached_entry,
+    const FileSnapshot& output_snapshot,
+    const std::span<const FileSnapshot> object_snapshots,
+    const std::span<const FileSnapshot> library_snapshots,
     const bool force_relink) {
     LinkCacheValidation result;
 
@@ -84,13 +125,16 @@ LinkCacheValidation LinkCacheValidator::validate(
         add_reason(result.reasons, BuildReason::toolchain_changed);
     }
 
-    const bool inputs_match = same_paths(cached.objects, current_objects);
+    const bool object_inputs_match = same_paths(cached.objects, current_objects);
+    const bool library_inputs_match = same_paths(cached.libraries, current_libraries);
+    const bool inputs_match = object_inputs_match && library_inputs_match;
     if (!inputs_match) {
         add_reason(result.reasons, BuildReason::link_inputs_changed);
     }
 
     const auto current_signature = BuildSignature::for_link(
         current_objects,
+        current_libraries,
         current_output,
         current_linker,
         current_options);
@@ -106,16 +150,8 @@ LinkCacheValidation LinkCacheValidator::validate(
         add_reason(result.reasons, BuildReason::missing_output);
     }
 
-    for (const auto& object : current_objects) {
-        const auto* snapshot = find_snapshot(object_snapshots, object);
-        if (snapshot == nullptr || !snapshot->exists) {
-            add_reason(result.reasons, BuildReason::link_inputs_changed);
-            continue;
-        }
-        if (output_snapshot.exists && snapshot->modified > output_snapshot.modified) {
-            add_reason(result.reasons, BuildReason::link_inputs_changed);
-        }
-    }
+    validate_freshness(current_objects, object_snapshots, output_snapshot, result.reasons);
+    validate_freshness(current_libraries, library_snapshots, output_snapshot, result.reasons);
 
     return result;
 }

--- a/cpp/core/src/LinkCacheFile.cpp
+++ b/cpp/core/src/LinkCacheFile.cpp
@@ -25,10 +25,10 @@ namespace fs = std::filesystem;
 
 constexpr std::array<std::uint8_t, 8> magic{
     'M', 'Q', 'B', 'L', 'I', 'N', 'K', 'C'};
-constexpr std::uint32_t format_version = 1;
+constexpr std::uint32_t format_version = 2;
 constexpr std::size_t max_cache_file_size = 64u * 1024u * 1024u;
 constexpr std::uint32_t max_string_size = 4u * 1024u * 1024u;
-constexpr std::uint32_t max_object_count = 100000u;
+constexpr std::uint32_t max_link_input_count = 100000u;
 
 [[nodiscard]] LinkCacheFileError make_error(
     const LinkCacheFileErrorCode code,
@@ -172,16 +172,61 @@ private:
     std::size_t offset_{};
 };
 
-[[nodiscard]] std::expected<std::vector<std::uint8_t>, LinkCacheFileError>
-serialize(const fs::path& file, const LinkCacheEntry& entry) {
-    if (entry.objects.size() > max_object_count) {
+[[nodiscard]] bool input_count_valid(const std::size_t size) {
+    return size <= max_link_input_count
+        && size <= std::numeric_limits<std::uint32_t>::max();
+}
+
+[[nodiscard]] std::expected<void, LinkCacheFileError>
+write_paths(
+    BinaryWriter& writer,
+    const fs::path& file,
+    const std::span<const fs::path> paths,
+    const std::string_view description) {
+    if (!input_count_valid(paths.size())) {
         return std::unexpected(make_error(
             LinkCacheFileErrorCode::file_write_failed,
             file,
             0,
-            "link input count exceeds cache safety limit"));
+            std::string{description} + " count exceeds cache safety limit"));
     }
 
+    writer.write_u32(static_cast<std::uint32_t>(paths.size()));
+    for (const auto& path : paths) {
+        if (!writer.write_path(path)) {
+            return std::unexpected(make_error(
+                LinkCacheFileErrorCode::file_write_failed,
+                file,
+                0,
+                std::string{description} + " path is too long for cache format"));
+        }
+    }
+    return {};
+}
+
+[[nodiscard]] std::expected<std::vector<fs::path>, LinkCacheFileError>
+read_paths(
+    BinaryReader& reader,
+    const std::string_view description) {
+    auto count = reader.read_u32();
+    if (!count) return std::unexpected(count.error());
+    if (*count > max_link_input_count) {
+        return std::unexpected(reader.corrupt(
+            std::string{description} + " count exceeds safety limit"));
+    }
+
+    std::vector<fs::path> paths;
+    paths.reserve(*count);
+    for (std::uint32_t index = 0; index < *count; ++index) {
+        auto path = reader.read_path();
+        if (!path) return std::unexpected(path.error());
+        paths.push_back(std::move(*path));
+    }
+    return paths;
+}
+
+[[nodiscard]] std::expected<std::vector<std::uint8_t>, LinkCacheFileError>
+serialize(const fs::path& file, const LinkCacheEntry& entry) {
     BinaryWriter writer;
     writer.write_bytes(magic);
     writer.write_u32(format_version);
@@ -206,16 +251,11 @@ serialize(const fs::path& file, const LinkCacheEntry& entry) {
             "link output path is too long for cache format"));
     }
 
-    writer.write_u32(static_cast<std::uint32_t>(entry.objects.size()));
-    for (const auto& object : entry.objects) {
-        if (!writer.write_path(object)) {
-            return std::unexpected(make_error(
-                LinkCacheFileErrorCode::file_write_failed,
-                file,
-                0,
-                "link input path is too long for cache format"));
-        }
-    }
+    auto objects = write_paths(writer, file, entry.objects, "object input");
+    if (!objects) return std::unexpected(objects.error());
+    auto libraries = write_paths(writer, file, entry.libraries, "library input");
+    if (!libraries) return std::unexpected(libraries.error());
+
     return writer.bytes();
 }
 
@@ -259,7 +299,6 @@ deserialize(const fs::path& file, const std::span<const std::uint8_t> bytes) {
     auto signature_high = reader.read_u64();
     auto signature_low = reader.read_u64();
     auto output = reader.read_path();
-    auto object_count = reader.read_u32();
 
     if (!linker) return std::unexpected(linker.error());
     if (!linker_version) return std::unexpected(linker_version.error());
@@ -267,18 +306,12 @@ deserialize(const fs::path& file, const std::span<const std::uint8_t> bytes) {
     if (!signature_high) return std::unexpected(signature_high.error());
     if (!signature_low) return std::unexpected(signature_low.error());
     if (!output) return std::unexpected(output.error());
-    if (!object_count) return std::unexpected(object_count.error());
-    if (*object_count > max_object_count) {
-        return std::unexpected(reader.corrupt("link input count exceeds safety limit"));
-    }
 
-    std::vector<fs::path> objects;
-    objects.reserve(*object_count);
-    for (std::uint32_t index = 0; index < *object_count; ++index) {
-        auto object = reader.read_path();
-        if (!object) return std::unexpected(object.error());
-        objects.push_back(std::move(*object));
-    }
+    auto objects = read_paths(reader, "object input");
+    if (!objects) return std::unexpected(objects.error());
+    auto libraries = read_paths(reader, "library input");
+    if (!libraries) return std::unexpected(libraries.error());
+
     if (!reader.at_end()) {
         return std::unexpected(reader.corrupt("unexpected trailing bytes in link cache file"));
     }
@@ -293,8 +326,9 @@ deserialize(const fs::path& file, const std::span<const std::uint8_t> bytes) {
             .high = *signature_high,
             .low = *signature_low,
         }),
-        .objects = std::move(objects),
+        .objects = std::move(*objects),
         .output = std::move(*output),
+        .libraries = std::move(*libraries),
     };
 }
 

--- a/cpp/orchestration/include/mqb/orchestration/MsvcIncrementalLinkCoordinator.hpp
+++ b/cpp/orchestration/include/mqb/orchestration/MsvcIncrementalLinkCoordinator.hpp
@@ -11,6 +11,7 @@
 #include "mqb/core/LinkCache.hpp"
 #include "mqb/core/LinkCacheFile.hpp"
 #include "mqb/core/LinkOptions.hpp"
+#include "mqb/msvc/MsvcLibraryResolver.hpp"
 #include "mqb/msvc/MsvcLinker.hpp"
 #include "mqb/msvc/MsvcToolchainLocator.hpp"
 #include "mqb/process/Process.hpp"
@@ -40,6 +41,7 @@ struct IncrementalLinkWarning {
 
 enum class IncrementalLinkErrorCode {
     linker_identity_failed,
+    library_resolution_failed,
     planning_failed,
     link_failed,
 };
@@ -48,6 +50,7 @@ struct IncrementalLinkError {
     IncrementalLinkErrorCode code{IncrementalLinkErrorCode::planning_failed};
     std::string message;
     std::optional<BuildPlannerError> planner_error;
+    std::optional<msvc::LibraryResolutionError> library_resolution_error;
     std::optional<msvc::LinkerError> linker_error;
 };
 

--- a/cpp/orchestration/src/MsvcIncrementalLinkCoordinator.cpp
+++ b/cpp/orchestration/src/MsvcIncrementalLinkCoordinator.cpp
@@ -14,6 +14,7 @@
 #include "mqb/core/FileSnapshot.hpp"
 #include "mqb/core/LinkCache.hpp"
 #include "mqb/core/LinkCacheFile.hpp"
+#include "mqb/msvc/MsvcLibraryResolver.hpp"
 #include "mqb/msvc/MsvcLinker.hpp"
 
 namespace mqb::orchestration {
@@ -43,6 +44,25 @@ snapshot_file(const fs::path& path) {
     };
 }
 
+void snapshot_inputs(
+    const std::vector<fs::path>& paths,
+    std::vector<FileSnapshot>& snapshots,
+    std::vector<IncrementalLinkWarning>& warnings) {
+    snapshots.reserve(paths.size());
+    for (const auto& path : paths) {
+        if (auto snapshot = snapshot_file(path)) {
+            snapshots.push_back(std::move(*snapshot));
+        } else {
+            warnings.push_back(IncrementalLinkWarning{
+                .code = IncrementalLinkWarningCode::file_snapshot_failed,
+                .path = path,
+                .message = snapshot.error(),
+            });
+            snapshots.push_back(FileSnapshot{.path = path, .exists = false});
+        }
+    }
+}
+
 [[nodiscard]] IncrementalLinkError link_failure(
     const IncrementalLinkErrorCode code,
     std::string message,
@@ -66,6 +86,20 @@ MsvcIncrementalLinkCoordinator::run(const IncrementalLinkRequest& request) const
             IncrementalLinkErrorCode::linker_identity_failed,
             "failed to identify MSVC linker",
             linker_identity.error()));
+    }
+
+    auto resolved_libraries = msvc::MsvcLibraryResolver::resolve(
+        toolchain_,
+        request.options,
+        request.working_directory.value_or(fs::path{}));
+    if (!resolved_libraries) {
+        IncrementalLinkError error{
+            .code = IncrementalLinkErrorCode::library_resolution_failed,
+            .message = "failed to resolve requested MSVC library: "
+                + resolved_libraries.error().message,
+            .library_resolution_error = resolved_libraries.error(),
+        };
+        return std::unexpected(std::move(error));
     }
 
     std::optional<LinkCacheEntry> cached_entry;
@@ -92,33 +126,27 @@ MsvcIncrementalLinkCoordinator::run(const IncrementalLinkRequest& request) const
     }
 
     std::vector<FileSnapshot> object_snapshots;
-    object_snapshots.reserve(request.objects.size());
-    for (const auto& object : request.objects) {
-        if (auto snapshot = snapshot_file(object)) {
-            object_snapshots.push_back(std::move(*snapshot));
-        } else {
-            result.warnings.push_back(IncrementalLinkWarning{
-                .code = IncrementalLinkWarningCode::file_snapshot_failed,
-                .path = object,
-                .message = snapshot.error(),
-            });
-            object_snapshots.push_back(FileSnapshot{.path = object, .exists = false});
-        }
-    }
+    snapshot_inputs(request.objects, object_snapshots, result.warnings);
+
+    std::vector<FileSnapshot> library_snapshots;
+    snapshot_inputs(resolved_libraries->files, library_snapshots, result.warnings);
 
     result.validation = LinkCacheValidator::validate(
         request.objects,
+        resolved_libraries->files,
         request.output,
         *linker_identity,
         request.options,
         cached_entry,
         output_snapshot,
         object_snapshots,
+        library_snapshots,
         request.force_relink);
 
     const LinkPlanItem plan_item{
         .objects = request.objects,
         .output = request.output,
+        .libraries = resolved_libraries->files,
         .cache_validation = result.validation,
     };
     auto plan = BuildPlanner::plan_link(plan_item);
@@ -152,6 +180,7 @@ MsvcIncrementalLinkCoordinator::run(const IncrementalLinkRequest& request) const
     msvc::LinkInvocation invocation{
         .objects = action->objects,
         .output = action->output,
+        .libraries = action->libraries,
         .options = request.options,
         .working_directory = request.working_directory.value_or(fs::path{}),
     };
@@ -170,11 +199,13 @@ MsvcIncrementalLinkCoordinator::run(const IncrementalLinkRequest& request) const
         .linker = *linker_identity,
         .signature = BuildSignature::for_link(
             action->objects,
+            action->libraries,
             action->output,
             *linker_identity,
             request.options),
         .objects = action->objects,
         .output = action->output,
+        .libraries = action->libraries,
     };
     auto saved = LinkCacheFile::save(request.cache_file, new_entry);
     if (!saved) {

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -80,6 +80,10 @@ if(WIN32)
     target_link_libraries(mqb_msvc_linker_arguments_tests PRIVATE mqb_msvc)
     target_compile_features(mqb_msvc_linker_arguments_tests PRIVATE cxx_std_23)
 
+    add_executable(mqb_msvc_library_resolver_tests msvc_library_resolver_tests.cpp)
+    target_link_libraries(mqb_msvc_library_resolver_tests PRIVATE mqb_msvc)
+    target_compile_features(mqb_msvc_library_resolver_tests PRIVATE cxx_std_23)
+
     add_executable(mqb_msvc_compile_executor_tests msvc_compile_executor_tests.cpp)
     target_link_libraries(mqb_msvc_compile_executor_tests PRIVATE mqb_msvc)
     target_compile_features(mqb_msvc_compile_executor_tests PRIVATE cxx_std_23)
@@ -99,6 +103,7 @@ if(WIN32)
         mqb_msvc_portable_tests
         mqb_msvc_compiler_arguments_tests
         mqb_msvc_linker_arguments_tests
+        mqb_msvc_library_resolver_tests
         mqb_msvc_compile_executor_tests
         mqb_msvc_source_dependencies_tests
         mqb_cli_argument_tests
@@ -164,6 +169,7 @@ if(WIN32)
     add_test(NAME mqb.msvc.portable COMMAND mqb_msvc_portable_tests)
     add_test(NAME mqb.msvc.compiler_arguments COMMAND mqb_msvc_compiler_arguments_tests)
     add_test(NAME mqb.msvc.linker_arguments COMMAND mqb_msvc_linker_arguments_tests)
+    add_test(NAME mqb.msvc.library_resolver COMMAND mqb_msvc_library_resolver_tests)
     add_test(NAME mqb.msvc.compile_executor COMMAND mqb_msvc_compile_executor_tests)
     add_test(NAME mqb.msvc.source_dependencies COMMAND mqb_msvc_source_dependencies_tests)
     add_test(NAME mqb.cli.arguments COMMAND mqb_cli_argument_tests)

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -127,7 +127,7 @@ if(WIN32)
         target_compile_features(mqb_msvc_incremental_loop_tests PRIVATE cxx_std_23)
 
         add_executable(mqb_cli_e2e_tests mqb_cli_e2e_tests.cpp)
-        target_link_libraries(mqb_cli_e2e_tests PRIVATE mqb_platform_windows)
+        target_link_libraries(mqb_cli_e2e_tests PRIVATE mqb_msvc mqb_platform_windows)
         target_compile_features(mqb_cli_e2e_tests PRIVATE cxx_std_23)
 
         list(APPEND MQB_TEST_TARGETS

--- a/cpp/tests/cli_argument_tests.cpp
+++ b/cpp/tests/cli_argument_tests.cpp
@@ -41,6 +41,8 @@ int main() {
                    "run mode should remain disabled by default");
             expect(parsed->build.run_arguments.empty(),
                    "run argument list should remain empty by default");
+            expect(parsed->library_directories.empty() && parsed->libraries.empty(),
+                   "library inputs should be empty by default");
             expect(parsed->build.configuration == mqb::BuildConfiguration::debug,
                    "default configuration should be debug");
             expect(parsed->build.architecture == mqb::Architecture::x64,
@@ -71,6 +73,12 @@ int main() {
             "-Iinclude dir"sv,
             "-D"sv,
             "VALUE=42"sv,
+            "-Lvendor libs"sv,
+            "--lib-path"sv,
+            "other libs"sv,
+            "-lmath"sv,
+            "--lib"sv,
+            "codec.lib"sv,
             "--verbose"sv,
             "--"sv,
             "hello world"sv,
@@ -103,6 +111,19 @@ int main() {
                            && parsed->build.run_arguments[3] == "a b c",
                        "run argv must preserve spaces, leading dashes, and empty arguments");
             }
+            expect(parsed->library_directories.size() == 2,
+                   "all library search directories should be collected");
+            if (parsed->library_directories.size() == 2) {
+                expect(parsed->library_directories[0] == "vendor libs"
+                           && parsed->library_directories[1] == "other libs",
+                       "library search directory order should be preserved");
+            }
+            expect(parsed->libraries.size() == 2,
+                   "all requested libraries should be collected");
+            if (parsed->libraries.size() == 2) {
+                expect(parsed->libraries[0] == "math" && parsed->libraries[1] == "codec.lib",
+                       "requested library order should be preserved");
+            }
             expect(parsed->build.configuration == mqb::BuildConfiguration::release,
                    "release flag should override default");
             expect(parsed->build.architecture == mqb::Architecture::x86,
@@ -122,24 +143,33 @@ int main() {
     }
 
     {
-        const std::vector arguments{"main.cpp"sv, "--output=demo"sv};
+        const std::vector arguments{
+            "main.cpp"sv,
+            "--output=demo"sv,
+            "--lib-path=vendor"sv,
+            "--lib=foo"sv,
+        };
         auto parsed = mqb::cli::parse_arguments(arguments);
-        expect(parsed.has_value(), "attached long output form should parse");
+        expect(parsed.has_value(), "attached long forms should parse");
         if (parsed) {
             expect(parsed->build.output_name.has_value() && *parsed->build.output_name == "demo",
                    "attached long output value should be preserved");
+            expect(parsed->library_directories.size() == 1
+                       && parsed->library_directories.front() == "vendor",
+                   "attached long library path should be preserved");
+            expect(parsed->libraries.size() == 1 && parsed->libraries.front() == "foo",
+                   "attached long library value should be preserved");
         }
     }
 
     {
-        const std::vector arguments{"main.cpp"sv, "--run"sv, "--"sv, "--release"sv};
+        const std::vector arguments{"main.cpp"sv, "--run"sv, "--"sv, "-lnot-a-library"sv};
         auto parsed = mqb::cli::parse_arguments(arguments);
         expect(parsed.has_value(), "options after -- should become program arguments");
         if (parsed) {
-            expect(parsed->build.configuration == mqb::BuildConfiguration::debug,
-                   "MQB option parsing must stop at --");
+            expect(parsed->libraries.empty(), "library parsing must stop at --");
             expect(parsed->build.run_arguments.size() == 1
-                       && parsed->build.run_arguments.front() == "--release",
+                       && parsed->build.run_arguments.front() == "-lnot-a-library",
                    "option-looking argv after -- must be preserved verbatim");
         }
     }
@@ -154,6 +184,18 @@ int main() {
         const std::vector arguments{"main.cpp"sv, "-o"sv};
         auto parsed = mqb::cli::parse_arguments(arguments);
         expect(!parsed, "missing output value should be rejected");
+    }
+
+    {
+        const std::vector arguments{"main.cpp"sv, "-L"sv};
+        auto parsed = mqb::cli::parse_arguments(arguments);
+        expect(!parsed, "missing library directory should be rejected");
+    }
+
+    {
+        const std::vector arguments{"main.cpp"sv, "-l"sv};
+        auto parsed = mqb::cli::parse_arguments(arguments);
+        expect(!parsed, "missing library name should be rejected");
     }
 
     {

--- a/cpp/tests/link_cache_file_tests.cpp
+++ b/cpp/tests/link_cache_file_tests.cpp
@@ -43,6 +43,7 @@ int main() {
     fs::create_directories(tree.root);
 
     const std::vector<fs::path> objects{"obj/main.cpp.obj", "obj/math.cpp.obj"};
+    const std::vector<fs::path> libraries{"vendor/math.lib", "vendor/codec.lib"};
     const fs::path output{"bin/app.exe"};
     const mqb::LinkerIdentity linker{
         .linker = "C:/msvc/link.exe",
@@ -50,13 +51,16 @@ int main() {
         .binary_stamp = "stamp-a",
     };
     mqb::LinkOptions options;
-    options.libraries = {"user32.lib"};
-    const auto signature = mqb::BuildSignature::for_link(objects, output, linker, options);
+    options.library_directories = {"vendor"};
+    options.libraries = {"math.lib", "codec.lib"};
+    const auto signature = mqb::BuildSignature::for_link(
+        objects, libraries, output, linker, options);
     const mqb::LinkCacheEntry entry{
         .linker = linker,
         .signature = signature,
         .objects = objects,
         .output = output,
+        .libraries = libraries,
     };
 
     const fs::path file = tree.root / "cache" / "app.linkcache";
@@ -73,9 +77,26 @@ int main() {
         expect((*loaded)->linker.version == linker.version, "linker version should round-trip");
         expect((*loaded)->linker.binary_stamp == linker.binary_stamp, "linker stamp should round-trip");
         expect((*loaded)->signature == signature, "link signature should round-trip");
-        expect((*loaded)->objects == objects, "link inputs should round-trip");
+        expect((*loaded)->objects == objects, "object inputs should round-trip");
+        expect((*loaded)->libraries == libraries, "resolved library inputs should round-trip");
         expect((*loaded)->output == output, "link output should round-trip");
     }
+
+    {
+        std::fstream stream{file, std::ios::binary | std::ios::in | std::ios::out};
+        stream.seekp(8, std::ios::beg);
+        const char old_version[4]{1, 0, 0, 0};
+        stream.write(old_version, 4);
+    }
+    const auto old_version = mqb::LinkCacheFile::load(file);
+    expect(!old_version.has_value(), "older link-cache format should be rejected safely");
+    if (!old_version) {
+        expect(old_version.error().code == mqb::LinkCacheFileErrorCode::unsupported_version,
+               "old cache version should report unsupported_version");
+    }
+
+    const auto restored_after_version = mqb::LinkCacheFile::save(file, entry);
+    expect(restored_after_version.has_value(), "link cache should upgrade by safe replacement");
 
     {
         std::fstream stream{file, std::ios::binary | std::ios::in | std::ios::out};

--- a/cpp/tests/link_state_tests.cpp
+++ b/cpp/tests/link_state_tests.cpp
@@ -37,6 +37,7 @@ void expect(const bool condition, const std::string_view message) {
 
 int main() {
     const std::vector<fs::path> objects{"obj/main.obj", "obj/math.obj"};
+    const std::vector<fs::path> libraries{"lib/math.lib"};
     const fs::path output{"bin/app.exe"};
     const mqb::LinkerIdentity linker{
         .linker = "C:/msvc/link.exe",
@@ -46,21 +47,32 @@ int main() {
     mqb::LinkOptions options;
     options.configuration = mqb::BuildConfiguration::debug;
     options.architecture = mqb::Architecture::x64;
-    options.libraries = {"user32.lib"};
+    options.library_directories = {"lib"};
+    options.libraries = {"math.lib"};
 
-    const auto signature = mqb::BuildSignature::for_link(objects, output, linker, options);
+    const auto signature = mqb::BuildSignature::for_link(
+        objects, libraries, output, linker, options);
 
     auto changed_options = options;
     changed_options.additional_arguments.push_back("/OPT:NOREF");
     expect(
-        mqb::BuildSignature::for_link(objects, output, linker, changed_options) != signature,
+        mqb::BuildSignature::for_link(objects, libraries, output, linker, changed_options)
+            != signature,
         "linker options must participate in link signature");
 
     auto reordered_objects = objects;
     std::reverse(reordered_objects.begin(), reordered_objects.end());
     expect(
-        mqb::BuildSignature::for_link(reordered_objects, output, linker, options) != signature,
-        "link input order must participate in link signature");
+        mqb::BuildSignature::for_link(reordered_objects, libraries, output, linker, options)
+            != signature,
+        "object input order must participate in link signature");
+
+    auto other_libraries = libraries;
+    other_libraries[0] = "other/math.lib";
+    expect(
+        mqb::BuildSignature::for_link(objects, other_libraries, output, linker, options)
+            != signature,
+        "resolved library identity must participate in link signature");
 
     const auto base_time = fs::file_time_type{} + std::chrono::seconds{100};
     const mqb::FileSnapshot output_snapshot{
@@ -72,26 +84,40 @@ int main() {
         {.path = objects[0], .exists = true, .modified = base_time - std::chrono::seconds{2}},
         {.path = objects[1], .exists = true, .modified = base_time - std::chrono::seconds{1}},
     };
+    const std::vector<mqb::FileSnapshot> library_snapshots{
+        {.path = libraries[0], .exists = true, .modified = base_time - std::chrono::seconds{1}},
+    };
 
     const mqb::LinkCacheEntry cached{
         .linker = linker,
         .signature = signature,
         .objects = objects,
         .output = output,
+        .libraries = libraries,
     };
 
     const auto warm = mqb::LinkCacheValidator::validate(
-        objects, output, linker, options, cached, output_snapshot, object_snapshots);
-    expect(warm.reusable(), "matching link cache should be reusable");
+        objects,
+        libraries,
+        output,
+        linker,
+        options,
+        cached,
+        output_snapshot,
+        object_snapshots,
+        library_snapshots);
+    expect(warm.reusable(), "matching object and library inputs should be reusable");
 
     const auto cold = mqb::LinkCacheValidator::validate(
         objects,
+        libraries,
         output,
         linker,
         options,
         std::nullopt,
         mqb::FileSnapshot{.path = output, .exists = false},
-        object_snapshots);
+        object_snapshots,
+        library_snapshots);
     expect(has_reason(cold, mqb::BuildReason::missing_cache_entry),
            "cold link should report missing cache entry");
     expect(has_reason(cold, mqb::BuildReason::missing_output),
@@ -100,31 +126,110 @@ int main() {
     auto newer_objects = object_snapshots;
     newer_objects[1].modified = base_time + std::chrono::seconds{1};
     const auto object_changed = mqb::LinkCacheValidator::validate(
-        objects, output, linker, options, cached, output_snapshot, newer_objects);
+        objects,
+        libraries,
+        output,
+        linker,
+        options,
+        cached,
+        output_snapshot,
+        newer_objects,
+        library_snapshots);
     expect(has_reason(object_changed, mqb::BuildReason::link_inputs_changed),
            "object newer than executable should invalidate link cache");
 
+    auto newer_libraries = library_snapshots;
+    newer_libraries[0].modified = base_time + std::chrono::seconds{1};
+    const auto library_changed = mqb::LinkCacheValidator::validate(
+        objects,
+        libraries,
+        output,
+        linker,
+        options,
+        cached,
+        output_snapshot,
+        object_snapshots,
+        newer_libraries);
+    expect(has_reason(library_changed, mqb::BuildReason::link_inputs_changed),
+           "resolved library newer than executable should invalidate link cache");
+
+    const auto library_missing = mqb::LinkCacheValidator::validate(
+        objects,
+        libraries,
+        output,
+        linker,
+        options,
+        cached,
+        output_snapshot,
+        object_snapshots,
+        std::vector<mqb::FileSnapshot>{
+            {.path = libraries[0], .exists = false},
+        });
+    expect(has_reason(library_missing, mqb::BuildReason::link_inputs_changed),
+           "missing resolved library should invalidate link cache");
+
+    const auto library_resolution_changed = mqb::LinkCacheValidator::validate(
+        objects,
+        other_libraries,
+        output,
+        linker,
+        options,
+        cached,
+        output_snapshot,
+        object_snapshots,
+        std::vector<mqb::FileSnapshot>{
+            {.path = other_libraries[0], .exists = true, .modified = base_time},
+        });
+    expect(has_reason(library_resolution_changed, mqb::BuildReason::link_inputs_changed),
+           "changed resolved library path should invalidate link cache");
+
     const auto forced = mqb::LinkCacheValidator::validate(
-        objects, output, linker, options, cached, output_snapshot, object_snapshots, true);
+        objects,
+        libraries,
+        output,
+        linker,
+        options,
+        cached,
+        output_snapshot,
+        object_snapshots,
+        library_snapshots,
+        true);
     expect(has_reason(forced, mqb::BuildReason::explicit_rebuild),
            "fresh compile result must be able to force relink independent of timestamps");
 
     auto other_linker = linker;
     other_linker.binary_stamp = "link-stamp-b";
     const auto linker_changed = mqb::LinkCacheValidator::validate(
-        objects, output, other_linker, options, cached, output_snapshot, object_snapshots);
+        objects,
+        libraries,
+        output,
+        other_linker,
+        options,
+        cached,
+        output_snapshot,
+        object_snapshots,
+        library_snapshots);
     expect(has_reason(linker_changed, mqb::BuildReason::toolchain_changed),
            "linker identity change should invalidate link cache");
 
     const auto options_changed = mqb::LinkCacheValidator::validate(
-        objects, output, linker, changed_options, cached, output_snapshot, object_snapshots);
+        objects,
+        libraries,
+        output,
+        linker,
+        changed_options,
+        cached,
+        output_snapshot,
+        object_snapshots,
+        library_snapshots);
     expect(has_reason(options_changed, mqb::BuildReason::linker_options_changed),
            "link option change should invalidate link cache");
 
     const mqb::LinkPlanItem plan_item{
         .objects = objects,
         .output = output,
-        .cache_validation = object_changed,
+        .libraries = libraries,
+        .cache_validation = library_changed,
     };
     const auto plan = mqb::BuildPlanner::plan_link(plan_item);
     expect(plan.has_value() && plan->size() == 1,
@@ -134,6 +239,8 @@ int main() {
         expect(action != nullptr, "link plan should contain a LinkAction");
         if (action != nullptr) {
             expect(action->objects == objects, "link action should preserve object inputs");
+            expect(action->libraries == libraries,
+                   "link action should preserve resolved library inputs");
             expect(action->output == output, "link action should preserve target output");
         }
     }
@@ -141,6 +248,7 @@ int main() {
     const mqb::LinkPlanItem reusable_item{
         .objects = objects,
         .output = output,
+        .libraries = libraries,
         .cache_validation = warm,
     };
     const auto empty_plan = mqb::BuildPlanner::plan_link(reusable_item);

--- a/cpp/tests/mqb_cli_e2e_tests.cpp
+++ b/cpp/tests/mqb_cli_e2e_tests.cpp
@@ -9,6 +9,8 @@
 #include <utility>
 #include <vector>
 
+#include "mqb/core/BuildTypes.hpp"
+#include "mqb/msvc/MsvcToolchainLocator.hpp"
 #include "mqb/platform/windows/WindowsProcessRunner.hpp"
 #include "mqb/process/Process.hpp"
 
@@ -67,6 +69,12 @@ struct TempTree {
     }
 };
 
+void dump_failure(const mqb::process::ProcessResult& result) {
+    std::cerr << "exit: " << result.exit_code << '\n'
+              << "stdout:\n" << result.stdout_text << '\n'
+              << "stderr:\n" << result.stderr_text << '\n';
+}
+
 [[nodiscard]] std::expected<mqb::process::ProcessResult, std::string>
 run_mqb(
     mqb::platform::windows::WindowsProcessRunner& runner,
@@ -113,10 +121,71 @@ run_executable(
     return std::move(*result);
 }
 
-void dump_failure(const mqb::process::ProcessResult& result) {
-    std::cerr << "exit: " << result.exit_code << '\n'
-              << "stdout:\n" << result.stdout_text << '\n'
-              << "stderr:\n" << result.stderr_text << '\n';
+[[nodiscard]] std::expected<void, std::string>
+build_static_library(
+    mqb::platform::windows::WindowsProcessRunner& runner,
+    const mqb::msvc::MsvcToolchain& toolchain,
+    const fs::path& working_directory,
+    const fs::path& library_directory,
+    const int value) {
+    const fs::path source = library_directory / "math_library.cpp";
+    const fs::path object = library_directory / "math_library.obj";
+    const fs::path library = library_directory / "math.lib";
+    fs::create_directories(library_directory);
+    write_text(
+        source,
+        "int library_value() { return " + std::to_string(value) + "; }\n");
+
+    mqb::process::ProcessSpec compile;
+    compile.executable = toolchain.identity.compiler;
+    compile.arguments = {
+        "/nologo",
+        "/c",
+        "/Zl",
+        "/Fo:" + path_text(object),
+        path_text(source),
+    };
+    compile.working_directory = working_directory;
+    compile.environment = toolchain.environment;
+    compile.inherit_environment = true;
+    compile.capture_stdout = true;
+    compile.capture_stderr = true;
+    auto compiled = runner.run(compile);
+    if (!compiled) {
+        return std::unexpected("failed to launch cl.exe for static library: " + compiled.error().message);
+    }
+    if (compiled->exit_code != 0) {
+        dump_failure(*compiled);
+        return std::unexpected("cl.exe failed while building static library fixture");
+    }
+
+    std::error_code remove_error;
+    fs::remove(library, remove_error);
+
+    mqb::process::ProcessSpec archive;
+    archive.executable = toolchain.librarian;
+    archive.arguments = {
+        "/NOLOGO",
+        "/OUT:" + path_text(library),
+        path_text(object),
+    };
+    archive.working_directory = working_directory;
+    archive.environment = toolchain.environment;
+    archive.inherit_environment = true;
+    archive.capture_stdout = true;
+    archive.capture_stderr = true;
+    auto archived = runner.run(archive);
+    if (!archived) {
+        return std::unexpected("failed to launch lib.exe: " + archived.error().message);
+    }
+    if (archived->exit_code != 0) {
+        dump_failure(*archived);
+        return std::unexpected("lib.exe failed while building static library fixture");
+    }
+    if (!fs::is_regular_file(library)) {
+        return std::unexpected("lib.exe did not produce math.lib");
+    }
+    return {};
 }
 
 } // namespace
@@ -130,17 +199,39 @@ int main(const int argc, char* argv[]) {
     const fs::path mqb_executable{argv[1]};
     const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
     TempTree tree{
-        .root = fs::temp_directory_path() / ("mqb_cli_target_ux_" + std::to_string(unique)),
+        .root = fs::temp_directory_path() / ("mqb_cli_library_e2e_" + std::to_string(unique)),
     };
     fs::create_directories(tree.root);
 
+    mqb::platform::windows::WindowsProcessRunner runner;
+    mqb::msvc::MsvcToolchainLocator locator{runner};
+    mqb::msvc::DiscoveryOptions discovery;
+    discovery.target_architecture = mqb::Architecture::x64;
+    discovery.host_architecture = mqb::Architecture::x64;
+    discovery.preference = mqb::msvc::ToolchainPreference::visual_studio;
+    auto toolchain = locator.discover(discovery);
+    expect(toolchain.has_value(), "VS2026 toolchain should be discoverable for library E2E");
+    if (!toolchain) {
+        std::cerr << "toolchain discovery failed: " << toolchain.error().message << '\n';
+        return 1;
+    }
+
     const fs::path include_dir = tree.root / "include";
+    const fs::path library_dir = tree.root / "vendor libs";
+    const fs::path library_file = library_dir / "math.lib";
     const fs::path value_header = include_dir / "value.hpp";
     const fs::path utils_header = include_dir / "utils.hpp";
     const fs::path main_source = tree.root / "main.cpp";
     const fs::path utils_source = tree.root / "src" / "utils.cpp";
     const fs::path helper_a = tree.root / "a" / "helper.cpp";
     const fs::path helper_b = tree.root / "b" / "helper.cpp";
+
+    auto initial_library = build_static_library(runner, *toolchain, tree.root, library_dir, 100);
+    expect(initial_library.has_value(), "initial static library fixture should build");
+    if (!initial_library) {
+        std::cerr << initial_library.error() << '\n';
+        return 1;
+    }
 
     write_text(value_header, "#pragma once\ninline constexpr int configured_value = 41;\n");
     write_text(utils_header, "#pragma once\nint util_value();\n");
@@ -160,8 +251,9 @@ int main(const int argc, char* argv[]) {
         "#endif\n"
         "int helper_a();\n"
         "int helper_b();\n"
+        "int library_value();\n"
         "int main(int argc, char** argv) {\n"
-        "    std::printf(\"mqb-multi=%d\\n\", util_value() + helper_a() + helper_b() + MQB_CLI_TEST);\n"
+        "    std::printf(\"mqb-multi=%d\\n\", util_value() + helper_a() + helper_b() + library_value() + MQB_CLI_TEST);\n"
         "    std::printf(\"argc=%d\\n\", argc);\n"
         "    for (int i = 1; i < argc; ++i) {\n"
         "        std::printf(\"arg%d=<%s>\\n\", i, argv[i]);\n"
@@ -176,15 +268,14 @@ int main(const int argc, char* argv[]) {
     const fs::path helper_b_object = tree.root / ".mqb" / "obj" / "b" / "helper.cpp.obj";
     const fs::path executable = tree.root / ".mqb" / "bin" / "product.exe";
     const fs::path link_cache = tree.root / ".mqb" / "cache" / "link" / "product.linkcache";
-
-    mqb::platform::windows::WindowsProcessRunner runner;
-    const std::vector<std::string> target_arguments{"-o", "product"};
+    const std::vector<std::string> target_arguments{
+        "-o", "product", "-L", path_text(library_dir), "-l", "math"};
 
     auto cold = run_mqb(runner, mqb_executable, tree.root, sources, include_dir, target_arguments);
-    expect(cold.has_value(), "cold target invocation should launch");
+    expect(cold.has_value(), "cold library target invocation should launch");
     if (cold) {
         if (cold->exit_code != 0) dump_failure(*cold);
-        expect(cold->exit_code == 0, "cold target build should succeed");
+        expect(cold->exit_code == 0, "cold library target build should succeed");
         expect(cold->stdout_text.find("[compile] main.cpp") != std::string::npos,
                "cold build should compile main.cpp");
         expect(cold->stdout_text.find("[compile] src/utils.cpp") != std::string::npos,
@@ -194,7 +285,7 @@ int main(const int argc, char* argv[]) {
         expect(cold->stdout_text.find("[compile] b/helper.cpp") != std::string::npos,
                "cold build should compile second same-basename helper");
         expect(cold->stdout_text.find("[link] product.exe") != std::string::npos,
-               "custom output name should drive target link artifact");
+               "cold build should link custom target with static library");
     }
 
     expect(fs::is_regular_file(main_object), "main object should use project-level layout");
@@ -203,22 +294,22 @@ int main(const int argc, char* argv[]) {
     expect(fs::is_regular_file(helper_b_object), "second helper object should exist independently");
     expect(helper_a_object != helper_b_object,
            "same-basename sources from different directories must have different artifacts");
-    expect(fs::is_regular_file(executable), "custom target build should create product.exe");
-    expect(fs::is_regular_file(link_cache), "custom target build should persist product link cache");
+    expect(fs::is_regular_file(executable), "library target should create product.exe");
+    expect(fs::is_regular_file(link_cache), "library target should persist link cache");
 
     auto cold_run = run_executable(runner, executable, tree.root);
-    expect(cold_run.has_value(), "cold-built target executable should launch directly");
+    expect(cold_run.has_value(), "cold-built library target should launch");
     if (cold_run) {
         expect(cold_run->exit_code == 0, "cold-built executable should return zero");
-        expect(cold_run->stdout_text.find("mqb-multi=72") != std::string::npos,
-               "cold-built executable should combine all translation units");
+        expect(cold_run->stdout_text.find("mqb-multi=172") != std::string::npos,
+               "cold-built executable should consume initial math.lib behavior");
     }
 
     auto warm = run_mqb(runner, mqb_executable, tree.root, sources, include_dir, target_arguments);
-    expect(warm.has_value(), "warm target invocation should launch");
+    expect(warm.has_value(), "warm library target invocation should launch");
     if (warm) {
         if (warm->exit_code != 0) dump_failure(*warm);
-        expect(warm->exit_code == 0, "warm target build should succeed");
+        expect(warm->exit_code == 0, "warm library target build should succeed");
         expect(contains_output_line(warm->stdout_text, "[up-to-date] main.cpp"),
                "warm build should skip main.cpp");
         expect(contains_output_line(warm->stdout_text, "[up-to-date] src/utils.cpp"),
@@ -228,22 +319,21 @@ int main(const int argc, char* argv[]) {
         expect(contains_output_line(warm->stdout_text, "[up-to-date] b/helper.cpp"),
                "warm build should skip helper B");
         expect(contains_output_line(warm->stdout_text, "[up-to-date] product.exe"),
-               "warm build should skip link.exe for custom target");
+               "warm build should reuse executable while library is unchanged");
     }
 
+    std::vector<std::string> run_arguments = target_arguments;
+    run_arguments.insert(
+        run_arguments.end(),
+        {"--run", "--", "hello world", "--child-option", "", "a b c"});
     auto run_with_args = run_mqb(
-        runner,
-        mqb_executable,
-        tree.root,
-        sources,
-        include_dir,
-        {"-o", "product", "--run", "--", "hello world", "--child-option", "", "a b c"});
+        runner, mqb_executable, tree.root, sources, include_dir, run_arguments);
     expect(run_with_args.has_value(), "warm --run invocation should launch");
     if (run_with_args) {
         if (run_with_args->exit_code != 0) dump_failure(*run_with_args);
         expect(run_with_args->exit_code == 0, "warm --run should return child success code");
         expect(contains_output_line(run_with_args->stdout_text, "[up-to-date] product.exe"),
-               "--run should still reuse warm link state");
+               "--run should still reuse warm library link state");
         expect(contains_output_line(run_with_args->stdout_text, "[run] product.exe"),
                "--run should report the launched target");
         expect(contains_output_line(run_with_args->stdout_text, "argc=5"),
@@ -259,6 +349,60 @@ int main(const int argc, char* argv[]) {
     }
 
     std::error_code error_code;
+    const auto executable_before_library_change = fs::last_write_time(executable, error_code);
+    expect(!error_code, "executable timestamp should be readable before library-only rebuild");
+    auto rebuilt_library = build_static_library(runner, *toolchain, tree.root, library_dir, 101);
+    expect(rebuilt_library.has_value(), "changed static library fixture should rebuild");
+    if (!rebuilt_library) {
+        std::cerr << rebuilt_library.error() << '\n';
+    }
+    if (!error_code && rebuilt_library) {
+        fs::last_write_time(
+            library_file,
+            executable_before_library_change + std::chrono::seconds{2},
+            error_code);
+        expect(!error_code, "library timestamp should be newer than executable deterministically");
+    }
+
+    auto library_changed = run_mqb(
+        runner, mqb_executable, tree.root, sources, include_dir, target_arguments);
+    expect(library_changed.has_value(), "library-only change invocation should launch");
+    if (library_changed) {
+        if (library_changed->exit_code != 0) dump_failure(*library_changed);
+        expect(library_changed->exit_code == 0, "library-only change should link successfully");
+        expect(contains_output_line(library_changed->stdout_text, "[up-to-date] main.cpp"),
+               "library-only change must not recompile main.cpp");
+        expect(contains_output_line(library_changed->stdout_text, "[up-to-date] src/utils.cpp"),
+               "library-only change must not recompile utils.cpp");
+        expect(contains_output_line(library_changed->stdout_text, "[up-to-date] a/helper.cpp"),
+               "library-only change must not recompile helper A");
+        expect(contains_output_line(library_changed->stdout_text, "[up-to-date] b/helper.cpp"),
+               "library-only change must not recompile helper B");
+        expect(library_changed->stdout_text.find("[link] product.exe") != std::string::npos,
+               "newer resolved library must trigger relink");
+        expect(library_changed->stdout_text.find("link inputs changed") != std::string::npos,
+               "library-driven relink should be explained as link inputs changed");
+    }
+
+    auto library_changed_run = run_executable(runner, executable, tree.root);
+    expect(library_changed_run.has_value(), "library-relinked executable should launch");
+    if (library_changed_run) {
+        expect(library_changed_run->exit_code == 0,
+               "library-relinked executable should return zero");
+        expect(library_changed_run->stdout_text.find("mqb-multi=173") != std::string::npos,
+               "library-only relink must update executable behavior");
+    }
+
+    error_code.clear();
+    const auto executable_after_library_change = fs::last_write_time(executable, error_code);
+    if (!error_code) {
+        fs::last_write_time(
+            library_file,
+            executable_after_library_change - std::chrono::seconds{2},
+            error_code);
+    }
+    expect(!error_code, "library timestamp should be normalized after library-only relink");
+
     const auto utils_object_time = fs::last_write_time(utils_object, error_code);
     expect(!error_code, "utils object timestamp should be readable");
     if (!error_code) {
@@ -267,7 +411,8 @@ int main(const int argc, char* argv[]) {
         expect(!error_code, "value header timestamp should be made newer deterministically");
     }
 
-    auto header_changed = run_mqb(runner, mqb_executable, tree.root, sources, include_dir, target_arguments);
+    auto header_changed = run_mqb(
+        runner, mqb_executable, tree.root, sources, include_dir, target_arguments);
     expect(header_changed.has_value(), "header-change target invocation should launch");
     if (header_changed) {
         if (header_changed->exit_code != 0) dump_failure(*header_changed);
@@ -283,7 +428,7 @@ int main(const int argc, char* argv[]) {
         expect(contains_output_line(header_changed->stdout_text, "[up-to-date] b/helper.cpp"),
                "unrelated helper B should remain cached");
         expect(header_changed->stdout_text.find("[link] product.exe") != std::string::npos,
-               "any rebuilt TU should force custom target relink");
+               "any rebuilt TU should force target relink");
         expect(header_changed->stdout_text.find("explicit rebuild") != std::string::npos,
                "compile-to-link handoff should not depend only on timestamps");
     }
@@ -292,8 +437,8 @@ int main(const int argc, char* argv[]) {
     expect(changed_run.has_value(), "partially rebuilt executable should launch");
     if (changed_run) {
         expect(changed_run->exit_code == 0, "partially rebuilt executable should return zero");
-        expect(changed_run->stdout_text.find("mqb-multi=73") != std::string::npos,
-               "partial rebuild must update final executable behavior");
+        expect(changed_run->stdout_text.find("mqb-multi=174") != std::string::npos,
+               "partial rebuild must preserve current static library behavior");
     }
 
     error_code.clear();
@@ -303,13 +448,10 @@ int main(const int argc, char* argv[]) {
     }
     expect(!error_code, "test should normalize value header timestamp after rebuild");
 
+    std::vector<std::string> release_arguments = target_arguments;
+    release_arguments.push_back("--release");
     auto release = run_mqb(
-        runner,
-        mqb_executable,
-        tree.root,
-        sources,
-        include_dir,
-        {"-o", "product", "--release"});
+        runner, mqb_executable, tree.root, sources, include_dir, release_arguments);
     expect(release.has_value(), "release target invocation should launch");
     if (release) {
         if (release->exit_code != 0) dump_failure(*release);
@@ -317,9 +459,17 @@ int main(const int argc, char* argv[]) {
         expect(release->stdout_text.find("compiler options changed") != std::string::npos,
                "Debug to Release should invalidate compile recipes");
         expect(release->stdout_text.find("[link] product.exe") != std::string::npos,
-               "Debug to Release should relink custom target");
+               "Debug to Release should relink target with static library");
         expect(release->stdout_text.find("linker options changed") != std::string::npos,
                "Debug to Release should invalidate link recipe");
+    }
+
+    auto release_run = run_executable(runner, executable, tree.root);
+    expect(release_run.has_value(), "release library target should launch");
+    if (release_run) {
+        expect(release_run->exit_code == 0, "release executable should return zero");
+        expect(release_run->stdout_text.find("mqb-multi=174") != std::string::npos,
+               "release executable should preserve current library behavior");
     }
 
     const fs::path exit_source = tree.root / "exit7.cpp";

--- a/cpp/tests/msvc_library_resolver_tests.cpp
+++ b/cpp/tests/msvc_library_resolver_tests.cpp
@@ -1,0 +1,123 @@
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <string_view>
+#include <system_error>
+
+#include "mqb/core/LinkOptions.hpp"
+#include "mqb/msvc/MsvcLibraryResolver.hpp"
+#include "mqb/msvc/MsvcToolchainLocator.hpp"
+
+namespace {
+
+namespace fs = std::filesystem;
+int failures = 0;
+
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+void touch(const fs::path& file) {
+    fs::create_directories(file.parent_path());
+    std::ofstream stream{file, std::ios::binary | std::ios::trunc};
+    stream << "lib";
+}
+
+[[nodiscard]] std::string path_text(const fs::path& path) {
+    const auto bytes = path.generic_u8string();
+    return std::string{
+        reinterpret_cast<const char*>(bytes.data()),
+        bytes.size()};
+}
+
+struct TempTree {
+    fs::path root;
+    ~TempTree() {
+        std::error_code ignored;
+        fs::remove_all(root, ignored);
+    }
+};
+
+} // namespace
+
+int main() {
+    const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
+    TempTree tree{
+        .root = fs::temp_directory_path() / ("mqb_library_resolver_" + std::to_string(unique)),
+    };
+    const fs::path work = tree.root / "work";
+    const fs::path explicit_dir = tree.root / "explicit";
+    const fs::path env_dir = tree.root / "env libs";
+
+    const fs::path explicit_math = explicit_dir / "math.lib";
+    const fs::path env_math = env_dir / "math.lib";
+    const fs::path env_codec = env_dir / "codec.lib";
+    const fs::path direct = work / "nested" / "direct.lib";
+    touch(explicit_math);
+    touch(env_math);
+    touch(env_codec);
+    touch(direct);
+    fs::create_directories(work);
+
+    mqb::msvc::MsvcToolchain toolchain;
+    toolchain.environment.push_back({
+        .name = "Lib",
+        .value = path_text(env_dir),
+    });
+
+    mqb::LinkOptions options;
+    options.library_directories = {explicit_dir};
+    options.libraries = {"math", "codec.lib", "nested/direct"};
+
+    const auto resolved = mqb::msvc::MsvcLibraryResolver::resolve(toolchain, options, work);
+    expect(resolved.has_value(), "valid requested libraries should resolve");
+    if (resolved) {
+        expect(resolved->files.size() == 3,
+               "resolver should preserve one resolved file per requested library");
+        if (resolved->files.size() == 3) {
+            expect(resolved->files[0] == explicit_math.lexically_normal(),
+                   "explicit -L directory should take precedence over toolchain LIB");
+            expect(resolved->files[1] == env_codec.lexically_normal(),
+                   "toolchain LIB environment should resolve bare library names");
+            expect(resolved->files[2] == direct.lexically_normal(),
+                   "relative explicit library path should resolve from link working directory");
+        }
+    }
+
+    mqb::LinkOptions current_directory_options;
+    touch(work / "local.lib");
+    current_directory_options.libraries = {"local"};
+    const auto from_current = mqb::msvc::MsvcLibraryResolver::resolve(
+        toolchain, current_directory_options, work);
+    expect(from_current.has_value()
+               && from_current->files.size() == 1
+               && from_current->files.front() == (work / "local.lib").lexically_normal(),
+           "working directory should be searched before toolchain LIB fallback");
+
+    mqb::LinkOptions missing_options;
+    missing_options.libraries = {"does-not-exist"};
+    const auto missing = mqb::msvc::MsvcLibraryResolver::resolve(
+        toolchain, missing_options, work);
+    expect(!missing, "unresolved requested library must fail before link.exe runs");
+    if (!missing) {
+        expect(missing.error().code == mqb::msvc::LibraryResolutionErrorCode::library_not_found,
+               "missing library should report library_not_found");
+    }
+
+    mqb::LinkOptions empty_options;
+    empty_options.libraries = {""};
+    const auto empty = mqb::msvc::MsvcLibraryResolver::resolve(toolchain, empty_options, work);
+    expect(!empty, "empty requested library should be rejected");
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+    std::cout << "mqb_msvc_library_resolver_tests passed\n";
+    return 0;
+}

--- a/cpp/tests/msvc_linker_arguments_tests.cpp
+++ b/cpp/tests/msvc_linker_arguments_tests.cpp
@@ -31,6 +31,7 @@ int main() {
     mqb::msvc::LinkInvocation invocation;
     invocation.objects = {"obj/main file.obj", "obj/math.obj"};
     invocation.output = "bin/my app.exe";
+    invocation.libraries = {"C:/sdk libs/user32.lib"};
     invocation.options.configuration = mqb::BuildConfiguration::debug;
     invocation.options.architecture = mqb::Architecture::x64;
     invocation.options.subsystem = mqb::LinkSubsystem::console;
@@ -45,7 +46,10 @@ int main() {
         expect(contains(*result, "/DEBUG"), "debug link should emit /DEBUG");
         expect(contains(*result, "/INCREMENTAL"), "debug link should be incremental");
         expect(contains(*result, "/LIBPATH:vendor libs"), "library path should stay one argv element");
-        expect(contains(*result, "user32.lib"), "library should be preserved");
+        expect(contains(*result, "C:/sdk libs/user32.lib"),
+               "linker should consume exact resolved library path");
+        expect(!contains(*result, "user32.lib"),
+               "unresolved library token must not be emitted alongside resolved file");
         expect(contains(*result, "/MACHINE:X64"), "x64 should map to /MACHINE:X64");
         expect(contains(*result, "/SUBSYSTEM:CONSOLE"), "console subsystem should map correctly");
         expect(contains(*result, "/OUT:bin/my app.exe"), "structured output should be emitted");
@@ -70,6 +74,12 @@ int main() {
         expect(contains(*release_result, "/MACHINE:X86"), "x86 should map correctly");
         expect(contains(*release_result, "/SUBSYSTEM:WINDOWS"), "windows subsystem should map correctly");
     }
+
+    auto unresolved = invocation;
+    unresolved.libraries.clear();
+    const auto unresolved_result = mqb::msvc::MsvcLinker::build_arguments(unresolved);
+    expect(!unresolved_result,
+           "linker should reject requested libraries without exact resolved inputs");
 
     auto invalid = invocation;
     invalid.objects.clear();


### PR DESCRIPTION
Completes explicit user-library support with correctness-first link invalidation.

Implemented:
- resolved `.lib` paths are first-class ordered link inputs in `BuildSignature`, `LinkAction`, `LinkPlanItem`, and `LinkCacheEntry`
- link-cache format v2 persists exact resolved library paths; older v1 state is rejected safely and rebuilt/relinked
- `LinkCacheValidator` invalidates on resolved-library path changes, missing files, and library mtimes newer than the executable
- `MsvcLibraryResolver` deterministically resolves requested libraries from ordered `-L` paths, the link working directory, then the MSVC `LIB` environment
- `MsvcLinker` consumes exact resolved library file paths instead of re-emitting unresolved user tokens
- CLI supports `-L`, `--lib-path`, `-l`, and `--lib`
- library resolution failures happen before `link.exe` and report the requested library/path

Real VS2026 E2E:
- discovers the installed MSVC toolchain
- uses real `cl.exe` + `lib.exe` to build `math.lib`
- builds MQB target with `-L ... -l math`
- proves warm compile/link reuse
- rebuilds only `math.lib` from behavior 100 -> 101 without touching executable TUs
- proves all four TUs remain `[up-to-date]`, only link runs with `link inputs changed`, and executable behavior updates from 172 -> 173
- existing header-only partial rebuild, Debug->Release, structured run argv, and child exit-code tests remain green

Final VS2026 PR validation: 27/27 CTest passed.

Boundary: this milestone precisely tracks libraries explicitly requested by the user. Indirect `/DEFAULTLIB` dependencies embedded in objects/libraries are still resolved by `link.exe` and are not yet claimed as fully tracked transitive link dependencies.