### PR TITLE
fix: stop smart discovery at secondary entry points

### DIFF
--- a/cpp/discovery/src/SourceDiscovery.cpp
+++ b/cpp/discovery/src/SourceDiscovery.cpp
@@ -1,0 +1,525 @@
+#include "mqb/discovery/SourceDiscovery.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <deque>
+#include <expected>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace mqb::discovery {
+namespace {
+
+namespace fs = std::filesystem;
+
+enum class FileKind {
+    source,
+    header,
+};
+
+struct FileRecord {
+    fs::path path;
+    FileKind kind{FileKind::header};
+    std::vector<std::string> local_includes;
+    bool defines_main{false};
+};
+
+[[nodiscard]] Error failure(
+    const ErrorCode code,
+    fs::path path,
+    std::string message) {
+    return Error{
+        .code = code,
+        .path = std::move(path),
+        .message = std::move(message),
+    };
+}
+
+[[nodiscard]] std::string ascii_lower(std::string value) {
+    std::transform(
+        value.begin(),
+        value.end(),
+        value.begin(),
+        [](const unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+    return value;
+}
+
+[[nodiscard]] std::string path_key(const fs::path& path) {
+    return ascii_lower(path.lexically_normal().generic_string());
+}
+
+[[nodiscard]] std::string extension_lower(const fs::path& path) {
+    return ascii_lower(path.extension().string());
+}
+
+[[nodiscard]] bool source_extension(const fs::path& path) {
+    const std::string extension = extension_lower(path);
+    return extension == ".cpp" || extension == ".cc" || extension == ".cxx";
+}
+
+[[nodiscard]] bool header_extension(const fs::path& path) {
+    const std::string extension = extension_lower(path);
+    return extension == ".h"
+        || extension == ".hh"
+        || extension == ".hpp"
+        || extension == ".hxx"
+        || extension == ".inl"
+        || extension == ".ipp";
+}
+
+[[nodiscard]] bool indexed_extension(const fs::path& path) {
+    return source_extension(path) || header_extension(path);
+}
+
+[[nodiscard]] bool excluded_directory(const fs::path& path) {
+    const std::string name = ascii_lower(path.filename().string());
+    return name == ".mqb"
+        || name == ".git"
+        || name == ".vs"
+        || name == "build"
+        || name == "out"
+        || name.starts_with("cmake-build-");
+}
+
+[[nodiscard]] bool inside_root(const fs::path& root, const fs::path& path) {
+    const fs::path relative = path.lexically_normal().lexically_relative(root.lexically_normal());
+    if (relative.empty() || relative.is_absolute()) {
+        return false;
+    }
+    for (const auto& component : relative) {
+        if (component == "..") {
+            return false;
+        }
+    }
+    return true;
+}
+
+[[nodiscard]] std::expected<std::string, std::string>
+read_text(const fs::path& path) {
+    std::ifstream stream{path, std::ios::binary};
+    if (!stream) {
+        return std::unexpected("failed to open source-discovery input");
+    }
+    std::string text{
+        std::istreambuf_iterator<char>{stream},
+        std::istreambuf_iterator<char>{}};
+    if (!stream.eof() && stream.fail()) {
+        return std::unexpected("failed while reading source-discovery input");
+    }
+    return text;
+}
+
+[[nodiscard]] std::string strip_comments_preserve_literals(const std::string_view input) {
+    enum class State {
+        normal,
+        line_comment,
+        block_comment,
+        string_literal,
+        char_literal,
+    };
+
+    State state = State::normal;
+    bool escaped = false;
+    std::string output;
+    output.reserve(input.size());
+
+    for (std::size_t index = 0; index < input.size(); ++index) {
+        const char ch = input[index];
+        const char next = index + 1 < input.size() ? input[index + 1] : '\0';
+
+        switch (state) {
+        case State::normal:
+            if (ch == '/' && next == '/') {
+                output.append("  ");
+                ++index;
+                state = State::line_comment;
+            } else if (ch == '/' && next == '*') {
+                output.append("  ");
+                ++index;
+                state = State::block_comment;
+            } else {
+                output.push_back(ch);
+                if (ch == '"') {
+                    state = State::string_literal;
+                    escaped = false;
+                } else if (ch == '\'') {
+                    state = State::char_literal;
+                    escaped = false;
+                }
+            }
+            break;
+
+        case State::line_comment:
+            if (ch == '\n') {
+                output.push_back('\n');
+                state = State::normal;
+            } else {
+                output.push_back(' ');
+            }
+            break;
+
+        case State::block_comment:
+            if (ch == '*' && next == '/') {
+                output.append("  ");
+                ++index;
+                state = State::normal;
+            } else {
+                output.push_back(ch == '\n' ? '\n' : ' ');
+            }
+            break;
+
+        case State::string_literal:
+        case State::char_literal: {
+            output.push_back(ch);
+            const char closing = state == State::string_literal ? '"' : '\'';
+            if (escaped) {
+                escaped = false;
+            } else if (ch == '\\') {
+                escaped = true;
+            } else if (ch == closing) {
+                state = State::normal;
+            }
+            break;
+        }
+        }
+    }
+    return output;
+}
+
+[[nodiscard]] std::string blank_literals(const std::string_view input) {
+    enum class State {
+        normal,
+        string_literal,
+        char_literal,
+    };
+    State state = State::normal;
+    bool escaped = false;
+    std::string output;
+    output.reserve(input.size());
+
+    for (const char ch : input) {
+        switch (state) {
+        case State::normal:
+            if (ch == '"') {
+                output.push_back(' ');
+                state = State::string_literal;
+                escaped = false;
+            } else if (ch == '\'') {
+                output.push_back(' ');
+                state = State::char_literal;
+                escaped = false;
+            } else {
+                output.push_back(ch);
+            }
+            break;
+        case State::string_literal:
+        case State::char_literal: {
+            output.push_back(ch == '\n' ? '\n' : ' ');
+            const char closing = state == State::string_literal ? '"' : '\'';
+            if (escaped) {
+                escaped = false;
+            } else if (ch == '\\') {
+                escaped = true;
+            } else if (ch == closing) {
+                state = State::normal;
+            }
+            break;
+        }
+        }
+    }
+    return output;
+}
+
+[[nodiscard]] std::vector<std::string>
+parse_local_includes(const std::string_view comment_free) {
+    std::vector<std::string> includes;
+    std::size_t line_begin = 0;
+    while (line_begin <= comment_free.size()) {
+        const std::size_t newline = comment_free.find('\n', line_begin);
+        const std::size_t line_end = newline == std::string_view::npos
+            ? comment_free.size()
+            : newline;
+        std::string_view line = comment_free.substr(line_begin, line_end - line_begin);
+
+        std::size_t cursor = 0;
+        while (cursor < line.size() && std::isspace(static_cast<unsigned char>(line[cursor]))) {
+            ++cursor;
+        }
+        if (cursor < line.size() && line[cursor] == '#') {
+            ++cursor;
+            while (cursor < line.size() && std::isspace(static_cast<unsigned char>(line[cursor]))) {
+                ++cursor;
+            }
+            constexpr std::string_view keyword = "include";
+            if (line.substr(cursor, keyword.size()) == keyword) {
+                cursor += keyword.size();
+                if (cursor == line.size()
+                    || !std::isalnum(static_cast<unsigned char>(line[cursor]))) {
+                    while (cursor < line.size()
+                           && std::isspace(static_cast<unsigned char>(line[cursor]))) {
+                        ++cursor;
+                    }
+                    if (cursor < line.size() && line[cursor] == '"') {
+                        const std::size_t end_quote = line.find('"', cursor + 1);
+                        if (end_quote != std::string_view::npos && end_quote > cursor + 1) {
+                            includes.emplace_back(line.substr(cursor + 1, end_quote - cursor - 1));
+                        }
+                    }
+                }
+            }
+        }
+
+        if (newline == std::string_view::npos) {
+            break;
+        }
+        line_begin = newline + 1;
+    }
+    return includes;
+}
+
+[[nodiscard]] bool contains_main(const std::string_view comment_free) {
+    const std::string code = blank_literals(comment_free);
+    std::size_t cursor = 0;
+    while ((cursor = code.find("main", cursor)) != std::string::npos) {
+        const bool left_boundary = cursor == 0
+            || !(std::isalnum(static_cast<unsigned char>(code[cursor - 1]))
+                 || code[cursor - 1] == '_');
+        const std::size_t after_name = cursor + 4;
+        const bool right_boundary = after_name >= code.size()
+            || !(std::isalnum(static_cast<unsigned char>(code[after_name]))
+                 || code[after_name] == '_');
+        if (left_boundary && right_boundary) {
+            std::size_t next = after_name;
+            while (next < code.size() && std::isspace(static_cast<unsigned char>(code[next]))) {
+                ++next;
+            }
+            if (next < code.size() && code[next] == '(') {
+                return true;
+            }
+        }
+        cursor = after_name;
+    }
+    return false;
+}
+
+void add_undirected_edge(
+    std::vector<std::vector<std::size_t>>& adjacency,
+    const std::size_t left,
+    const std::size_t right) {
+    if (left == right) {
+        return;
+    }
+    auto& left_edges = adjacency[left];
+    if (std::find(left_edges.begin(), left_edges.end(), right) == left_edges.end()) {
+        left_edges.push_back(right);
+    }
+    auto& right_edges = adjacency[right];
+    if (std::find(right_edges.begin(), right_edges.end(), left) == right_edges.end()) {
+        right_edges.push_back(left);
+    }
+}
+
+} // namespace
+
+std::expected<Result, Error>
+SourceDiscovery::discover(const Request& request) {
+    std::error_code error_code;
+    fs::path root = fs::absolute(request.project_root, error_code).lexically_normal();
+    if (error_code || !fs::is_directory(root, error_code) || error_code) {
+        return std::unexpected(failure(
+            ErrorCode::invalid_project_root,
+            request.project_root,
+            "source discovery project root must be an existing directory"));
+    }
+
+    fs::path entry = fs::absolute(request.entry, error_code).lexically_normal();
+    if (error_code
+        || !fs::is_regular_file(entry, error_code)
+        || error_code
+        || !source_extension(entry)
+        || !inside_root(root, entry)) {
+        return std::unexpected(failure(
+            ErrorCode::invalid_entry,
+            request.entry,
+            "source discovery entry must be an ordinary C++ source inside the project root"));
+    }
+
+    Result result;
+    std::vector<FileRecord> files;
+    std::unordered_map<std::string, std::size_t> index_by_path;
+
+    fs::recursive_directory_iterator iterator{
+        root,
+        fs::directory_options::skip_permission_denied,
+        error_code};
+    const fs::recursive_directory_iterator end;
+    if (error_code) {
+        return std::unexpected(failure(
+            ErrorCode::enumeration_failed,
+            root,
+            "failed to enumerate source discovery project root"));
+    }
+
+    for (; iterator != end; iterator.increment(error_code)) {
+        if (error_code) {
+            return std::unexpected(failure(
+                ErrorCode::enumeration_failed,
+                root,
+                "failed while enumerating source discovery project root: " + error_code.message()));
+        }
+        const fs::directory_entry& item = *iterator;
+        if (item.is_directory(error_code)) {
+            if (!error_code && excluded_directory(item.path())) {
+                iterator.disable_recursion_pending();
+            }
+            error_code.clear();
+            continue;
+        }
+        error_code.clear();
+        if (!item.is_regular_file(error_code) || error_code || !indexed_extension(item.path())) {
+            error_code.clear();
+            continue;
+        }
+
+        FileRecord record;
+        record.path = fs::absolute(item.path(), error_code).lexically_normal();
+        if (error_code) {
+            error_code.clear();
+            continue;
+        }
+        record.kind = source_extension(record.path) ? FileKind::source : FileKind::header;
+
+        if (auto text = read_text(record.path)) {
+            const std::string comment_free = strip_comments_preserve_literals(*text);
+            record.local_includes = parse_local_includes(comment_free);
+            record.defines_main = record.kind == FileKind::source && contains_main(comment_free);
+        } else {
+            result.warnings.push_back(Warning{
+                .code = WarningCode::file_read_failed,
+                .path = record.path,
+                .message = text.error(),
+            });
+        }
+
+        const std::size_t index = files.size();
+        index_by_path.emplace(path_key(record.path), index);
+        files.push_back(std::move(record));
+    }
+
+    result.indexed_files = files.size();
+    const auto entry_it = index_by_path.find(path_key(entry));
+    if (entry_it == index_by_path.end()) {
+        return std::unexpected(failure(
+            ErrorCode::invalid_entry,
+            entry,
+            "source discovery entry was not indexed"));
+    }
+
+    std::vector<fs::path> include_directories;
+    include_directories.reserve(request.include_directories.size());
+    for (const auto& directory : request.include_directories) {
+        fs::path absolute = fs::absolute(directory, error_code).lexically_normal();
+        if (!error_code) {
+            include_directories.push_back(std::move(absolute));
+        }
+        error_code.clear();
+    }
+
+    std::vector<std::vector<std::size_t>> adjacency(files.size());
+    for (std::size_t file_index = 0; file_index < files.size(); ++file_index) {
+        const auto& file = files[file_index];
+        for (const auto& include : file.local_includes) {
+            std::vector<fs::path> candidates;
+            candidates.reserve(1 + include_directories.size());
+            candidates.push_back((file.path.parent_path() / include).lexically_normal());
+            for (const auto& include_directory : include_directories) {
+                candidates.push_back((include_directory / include).lexically_normal());
+            }
+
+            for (const auto& candidate : candidates) {
+                const auto found = index_by_path.find(path_key(candidate));
+                if (found != index_by_path.end()) {
+                    add_undirected_edge(adjacency, file_index, found->second);
+                    break;
+                }
+            }
+        }
+    }
+
+    constexpr std::string_view source_extensions[]{".cpp", ".cc", ".cxx"};
+    for (std::size_t file_index = 0; file_index < files.size(); ++file_index) {
+        const auto& file = files[file_index];
+        if (file.kind != FileKind::header) {
+            continue;
+        }
+        for (const auto extension : source_extensions) {
+            fs::path sibling = file.path;
+            sibling.replace_extension(extension);
+            const auto found = index_by_path.find(path_key(sibling));
+            if (found != index_by_path.end()) {
+                add_undirected_edge(adjacency, file_index, found->second);
+            }
+        }
+    }
+
+    const std::size_t entry_index = entry_it->second;
+    std::vector<bool> visited(files.size(), false);
+    std::deque<std::size_t> queue;
+    queue.push_back(entry_index);
+    visited[entry_index] = true;
+    while (!queue.empty()) {
+        const std::size_t current = queue.front();
+        queue.pop_front();
+        for (const std::size_t next : adjacency[current]) {
+            if (visited[next]) {
+                continue;
+            }
+            visited[next] = true;
+
+            const bool second_main = next != entry_index
+                && files[next].kind == FileKind::source
+                && files[next].defines_main;
+            if (!second_main) {
+                queue.push_back(next);
+            }
+        }
+    }
+
+    for (std::size_t index = 0; index < files.size(); ++index) {
+        if (!visited[index] || files[index].kind != FileKind::source) {
+            continue;
+        }
+        if (files[index].path != entry && files[index].defines_main) {
+            continue;
+        }
+        result.sources.push_back(files[index].path);
+    }
+
+    std::sort(
+        result.sources.begin(),
+        result.sources.end(),
+        [](const fs::path& left, const fs::path& right) {
+            return path_key(left) < path_key(right);
+        });
+    const auto entry_position = std::find(result.sources.begin(), result.sources.end(), entry);
+    if (entry_position != result.sources.end() && entry_position != result.sources.begin()) {
+        std::rotate(result.sources.begin(), entry_position, entry_position + 1);
+    }
+
+    if (result.sources.empty() || result.sources.front() != entry) {
+        return std::unexpected(failure(
+            ErrorCode::invalid_entry,
+            entry,
+            "source discovery did not retain the entry translation unit"));
+    }
+    return result;
+}
+
+} // namespace mqb

--- a/cpp/discovery/tests/source_discovery_tests.cpp
+++ b/cpp/discovery/tests/source_discovery_tests.cpp
@@ -1,0 +1,194 @@
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <vector>
+
+#include "mqb/discovery/SourceDiscovery.hpp"
+
+namespace {
+
+namespace fs = std::filesystem;
+int failures = 0;
+
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+void write_text(const fs::path& path, const std::string_view text) {
+    fs::create_directories(path.parent_path());
+    std::ofstream stream{path, std::ios::binary | std::ios::trunc};
+    stream << text;
+}
+
+[[nodiscard]] bool contains_source(
+    const std::vector<fs::path>& sources,
+    const fs::path& source) {
+    const fs::path normalized = source.lexically_normal();
+    for (const auto& candidate : sources) {
+        if (candidate.lexically_normal() == normalized) {
+            return true;
+        }
+    }
+    return false;
+}
+
+struct TempTree {
+    fs::path root;
+    ~TempTree() {
+        std::error_code ignored;
+        fs::remove_all(root, ignored);
+    }
+};
+
+} // namespace
+
+int main() {
+    const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
+    TempTree tree{
+        .root = fs::temp_directory_path() / ("mqb_source_discovery_" + std::to_string(unique)),
+    };
+    fs::create_directories(tree.root);
+
+    const fs::path main_source = tree.root / "main.cpp";
+    const fs::path app_header = tree.root / "src" / "app.hpp";
+    const fs::path app_source = tree.root / "src" / "app.cpp";
+    const fs::path stringy_source = tree.root / "src" / "stringy.cpp";
+    const fs::path helper_a_header = tree.root / "a" / "helper.hpp";
+    const fs::path helper_a_source = tree.root / "a" / "helper.cpp";
+    const fs::path helper_b_header = tree.root / "b" / "helper.hpp";
+    const fs::path helper_b_source = tree.root / "b" / "helper.cpp";
+    const fs::path include_dir = tree.root / "include";
+    const fs::path widget_header = include_dir / "widget.hpp";
+    const fs::path widget_source = include_dir / "widget.cpp";
+    const fs::path other_main = tree.root / "tests" / "other_main.cpp";
+    const fs::path test_only_header = tree.root / "tests" / "test_only.hpp";
+    const fs::path test_only_source = tree.root / "tests" / "test_only.cpp";
+    const fs::path unrelated_header = tree.root / "unrelated.hpp";
+    const fs::path unrelated_source = tree.root / "unrelated.cpp";
+    const fs::path comment_only = tree.root / "comment_only.cpp";
+    const fs::path generated = tree.root / "build" / "generated.cpp";
+
+    write_text(
+        main_source,
+        "#include \"src/app.hpp\"\n"
+        "#include \"a/helper.hpp\"\n"
+        "#include \"b/helper.hpp\"\n"
+        "#include \"widget.hpp\"\n"
+        "int main() { return app() + helper_a() + helper_b() + widget(); }\n");
+    write_text(app_header, "#pragma once\nint app();\n");
+    write_text(app_source, "#include \"app.hpp\"\nint app() { return 1; }\n");
+    write_text(
+        stringy_source,
+        "#include \"app.hpp\"\n"
+        "const char* text_that_is_not_a_main = \"main(\";\n"
+        "int stringy() { return text_that_is_not_a_main[0]; }\n");
+    write_text(helper_a_header, "#pragma once\nint helper_a();\n");
+    write_text(
+        helper_a_source,
+        "// Deliberately no include: same-basename header ownership should connect this TU.\n"
+        "int helper_a() { return 10; }\n");
+    write_text(helper_b_header, "#pragma once\nint helper_b();\n");
+    write_text(helper_b_source, "#include \"helper.hpp\"\nint helper_b() { return 20; }\n");
+    write_text(widget_header, "#pragma once\nint widget();\n");
+    write_text(
+        widget_source,
+        "// Same-basename ownership connects this source through include/widget.hpp.\n"
+        "int widget() { return 30; }\n");
+    write_text(test_only_header, "#pragma once\nint test_only();\n");
+    write_text(test_only_source, "#include \"test_only.hpp\"\nint test_only() { return 77; }\n");
+    write_text(
+        other_main,
+        "#include \"../src/app.hpp\"\n"
+        "#include \"test_only.hpp\"\n"
+        "int main() { return app() + test_only(); }\n");
+    write_text(unrelated_header, "#pragma once\nint unrelated();\n");
+    write_text(unrelated_source, "#include \"unrelated.hpp\"\nint unrelated() { return 9; }\n");
+    write_text(
+        comment_only,
+        "// #include \"src/app.hpp\"\n"
+        "/* #include \"a/helper.hpp\" */\n"
+        "int comment_only() { return 0; }\n");
+    write_text(
+        generated,
+        "#include \"../src/app.hpp\"\n"
+        "int generated() { return app(); }\n");
+
+    const mqb::discovery::Request request{
+        .project_root = tree.root,
+        .entry = main_source,
+        .include_directories = {include_dir},
+    };
+    const auto discovered = mqb::discovery::SourceDiscovery::discover(request);
+    expect(discovered.has_value(), "valid discovery fixture should succeed");
+    if (discovered) {
+        expect(discovered->warnings.empty(), "readable fixture should not emit warnings");
+        expect(!discovered->sources.empty() && discovered->sources.front() == main_source,
+               "entry translation unit must remain first");
+        expect(contains_source(discovered->sources, app_source),
+               "shared header should connect app.cpp");
+        expect(contains_source(discovered->sources, stringy_source),
+               "string literal containing main( must not classify a TU as another entry point");
+        expect(contains_source(discovered->sources, helper_a_source),
+               "same-basename header ownership should connect helper A");
+        expect(contains_source(discovered->sources, helper_b_source),
+               "quoted include should connect helper B");
+        expect(contains_source(discovered->sources, widget_source),
+               "configured include directory plus same-basename ownership should connect widget.cpp");
+        expect(!contains_source(discovered->sources, other_main),
+               "reachable non-entry source defining main() must be excluded");
+        expect(!contains_source(discovered->sources, test_only_source),
+               "second main must be a traversal barrier for its test-only subgraph");
+        expect(!contains_source(discovered->sources, unrelated_source),
+               "disconnected source must not be discovered");
+        expect(!contains_source(discovered->sources, comment_only),
+               "include-like text in comments must not create graph edges");
+        expect(!contains_source(discovered->sources, generated),
+               "default build directories must not be indexed");
+        expect(discovered->sources.size() == 6,
+               "fixture should discover exactly entry + five connected non-main TUs");
+
+        const auto repeated = mqb::discovery::SourceDiscovery::discover(request);
+        expect(repeated.has_value() && repeated->sources == discovered->sources,
+               "discovery output ordering should be deterministic");
+    }
+
+    const auto invalid_root = mqb::discovery::SourceDiscovery::discover({
+        .project_root = tree.root / "missing-root",
+        .entry = main_source,
+        .include_directories = {},
+    });
+    expect(!invalid_root, "missing project root should be rejected");
+    if (!invalid_root) {
+        expect(invalid_root.error().code == mqb::discovery::ErrorCode::invalid_project_root,
+               "missing root should report invalid_project_root");
+    }
+
+    const fs::path outside = tree.root.parent_path() / ("outside_" + std::to_string(unique) + ".cpp");
+    write_text(outside, "int main() { return 0; }\n");
+    const auto invalid_entry = mqb::discovery::SourceDiscovery::discover({
+        .project_root = tree.root,
+        .entry = outside,
+        .include_directories = {},
+    });
+    expect(!invalid_entry, "entry outside project root should be rejected");
+    if (!invalid_entry) {
+        expect(invalid_entry.error().code == mqb::discovery::ErrorCode::invalid_entry,
+               "outside entry should report invalid_entry");
+    }
+    std::error_code ignored;
+    fs::remove(outside, ignored);
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+    std::cout << "mqb_source_discovery_tests passed\n";
+    return 0;
+}


### PR DESCRIPTION
Hardens ordinary-C++ smart discovery after the initial one-entry milestone.

Change:
- a reachable non-entry source that defines `main(...)` is now a traversal barrier, not merely filtered from the final source list
- it may share production headers with the selected target, but BFS does not continue through it into its test/tool-only dependency subgraph

Regression fixture:
- product `main.cpp` reaches production `app.hpp`
- `tests/other_main.cpp` also reaches `app.hpp` and additionally reaches `tests/test_only.hpp`
- `tests/test_only.hpp <-> tests/test_only.cpp` would be reachable only if the second main were allowed to bridge the graph
- expected result excludes both `other_main.cpp` and `test_only.cpp`

This remains source-selection logic only; compile/header freshness continues to be driven by MSVC `/sourceDependencies`.