### PR TITLE
fix: restore complete smart discovery integration

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -11,6 +11,7 @@ option(MQB_ENABLE_INSTALLED_MSVC_TESTS "Run tests that require an installed Visu
 
 add_subdirectory(core)
 add_subdirectory(process)
+add_subdirectory(discovery)
 
 if(WIN32)
     add_subdirectory(platform/windows)

--- a/cpp/apps/mqb/CMakeLists.txt
+++ b/cpp/apps/mqb/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(mqb
 target_link_libraries(mqb
     PRIVATE
         mqb_cli
+        mqb_discovery
         mqb_orchestration
         mqb_platform_windows
 )

--- a/cpp/apps/mqb/Cli.cpp
+++ b/cpp/apps/mqb/Cli.cpp
@@ -79,7 +79,8 @@ long_equals_value(
     const std::string_view prefix) {
     const std::string_view value = argument.substr(prefix.size());
     if (value.empty()) {
-        return std::unexpected(error("empty value for " + std::string{prefix.substr(0, prefix.size() - 1)}));
+        return std::unexpected(error(
+            "empty value for " + std::string{prefix.substr(0, prefix.size() - 1)}));
     }
     return value;
 }
@@ -105,6 +106,10 @@ parse_arguments(const std::span<const std::string_view> arguments) {
         }
         if (argument == "--verbose" || argument == "-v") {
             options.verbose = true;
+            continue;
+        }
+        if (argument == "--no-discover") {
+            options.discover_sources = false;
             continue;
         }
         if (argument == "--run") {
@@ -235,11 +240,13 @@ std::string_view usage() noexcept {
     return R"(MQB - MSVC Quick Build (C++ V2)
 
 Usage:
-  mqb <source.cpp> [more-sources...] [options] [-- program-args...]
+  mqb <entry.cpp> [options] [-- program-args...]
+  mqb <source.cpp> <more-sources...> [options] [-- program-args...]
 
-Current milestone:
-  Incrementally compile an explicit C++ source set, resolve exact library files,
-  link one executable, and optionally run it without shell re-parsing.
+Source selection:
+  One positional source       Smart-discover connected ordinary C++ TUs (default)
+  Multiple positional sources Build exactly that explicit ordered source set
+  --no-discover               Disable smart discovery for a single source
 
 Options:
   --debug                  Debug compile/link preset (default)
@@ -256,9 +263,12 @@ Options:
   --lib <name>             Link a library (name or explicit path)
   --env <auto|vs|portable> Toolchain selection (default: auto)
   --portable-root <dir>    Add a portable_msvc root candidate
-  -v, --verbose            Show toolchain and artifact details
+  -v, --verbose            Show discovery, toolchain, and artifact details
   -h, --help               Show this help
   --                       Pass all remaining argv elements to the program
+
+Discovery is source selection only. Incremental header freshness continues to use
+MSVC /sourceDependencies metadata.
 
 Generated state:
   .mqb/obj/    collision-free object files

--- a/cpp/apps/mqb/Cli.hpp
+++ b/cpp/apps/mqb/Cli.hpp
@@ -20,6 +20,7 @@ struct Options {
     std::vector<std::string> libraries;
     msvc::ToolchainPreference toolchain_preference{msvc::ToolchainPreference::automatic};
     std::vector<std::filesystem::path> portable_roots;
+    bool discover_sources{true};
     bool verbose{false};
     bool show_help{false};
 };

--- a/cpp/apps/mqb/main.cpp
+++ b/cpp/apps/mqb/main.cpp
@@ -15,6 +15,7 @@
 #include "mqb/core/CompilerOptions.hpp"
 #include "mqb/core/LinkOptions.hpp"
 #include "mqb/core/ProjectArtifactLayout.hpp"
+#include "mqb/discovery/SourceDiscovery.hpp"
 #include "mqb/msvc/MsvcCompileExecutor.hpp"
 #include "mqb/msvc/MsvcLinker.hpp"
 #include "mqb/msvc/MsvcToolchainLocator.hpp"
@@ -66,6 +67,12 @@ absolute_path(const fs::path& path, const std::string_view description) {
         }
     }
     return true;
+}
+
+[[nodiscard]] bool inside_project(
+    const fs::path& project_root,
+    const fs::path& path) {
+    return safe_relative(path.lexically_normal().lexically_relative(project_root.lexically_normal()));
 }
 
 [[nodiscard]] fs::path display_source(
@@ -238,8 +245,8 @@ int main(const int argc, char* argv[]) {
     }
     project_root = project_root.lexically_normal();
 
-    std::vector<fs::path> sources;
-    sources.reserve(options.build.sources.size());
+    std::vector<fs::path> requested_sources;
+    requested_sources.reserve(options.build.sources.size());
     for (const auto& requested_source : options.build.sources) {
         auto source = absolute_path(requested_source, "source file");
         if (!source) {
@@ -255,7 +262,7 @@ int main(const int argc, char* argv[]) {
                       << path_text(*source) << '\n';
             return 2;
         }
-        for (const auto& previous : sources) {
+        for (const auto& previous : requested_sources) {
             error_code.clear();
             if (fs::equivalent(previous, *source, error_code) && !error_code) {
                 std::cerr << "error: source file was provided more than once: "
@@ -263,9 +270,8 @@ int main(const int argc, char* argv[]) {
                 return 2;
             }
         }
-        sources.push_back(std::move(*source));
+        requested_sources.push_back(std::move(*source));
     }
-    options.build.sources = sources;
 
     for (auto& include_directory : options.include_directories) {
         auto resolved = absolute_path(include_directory, "include directory");
@@ -292,6 +298,44 @@ int main(const int argc, char* argv[]) {
         portable_root = std::move(*resolved);
     }
 
+    std::vector<fs::path> sources = requested_sources;
+    if (options.discover_sources && requested_sources.size() == 1) {
+        const fs::path& entry = requested_sources.front();
+        const fs::path discovery_root = inside_project(project_root, entry)
+            ? project_root
+            : entry.parent_path();
+        const mqb::discovery::Request discovery_request{
+            .project_root = discovery_root,
+            .entry = entry,
+            .include_directories = options.include_directories,
+        };
+        auto discovered = mqb::discovery::SourceDiscovery::discover(discovery_request);
+        if (!discovered) {
+            std::cerr << "error: source discovery failed: " << discovered.error().message;
+            if (!discovered.error().path.empty()) {
+                std::cerr << ": " << path_text(discovered.error().path);
+            }
+            std::cerr << '\n';
+            return 2;
+        }
+        for (const auto& warning : discovered->warnings) {
+            std::cerr << "warning: source discovery: " << warning.message;
+            if (!warning.path.empty()) {
+                std::cerr << ": " << path_text(warning.path);
+            }
+            std::cerr << '\n';
+        }
+        sources = std::move(discovered->sources);
+        if (sources.size() > 1 || options.verbose) {
+            std::cout << "[discover] " << sources.size() << " translation units";
+            if (options.verbose) {
+                std::cout << " from " << discovered->indexed_files << " indexed C/C++ files";
+            }
+            std::cout << '\n';
+        }
+    }
+    options.build.sources = sources;
+
     auto layout = mqb::ProjectArtifactLayout::create(project_root);
     if (!layout) {
         std::cerr << "error: " << layout.error().message << '\n';
@@ -313,7 +357,7 @@ int main(const int argc, char* argv[]) {
         });
     }
 
-    const std::string target_name = options.build.output_name.value_or(sources.front().stem().string());
+    const std::string target_name = options.build.output_name.value_or(requested_sources.front().stem().string());
     auto target_artifacts = layout->for_target(target_name);
     if (!target_artifacts) {
         std::cerr << "error: " << target_artifacts.error().message << '\n';
@@ -327,13 +371,13 @@ int main(const int argc, char* argv[]) {
 
     mqb::platform::windows::WindowsProcessRunner runner;
     mqb::msvc::MsvcToolchainLocator locator{runner};
-    mqb::msvc::DiscoveryOptions discovery;
-    discovery.target_architecture = options.build.architecture;
-    discovery.host_architecture = mqb::Architecture::x64;
-    discovery.preference = options.toolchain_preference;
-    discovery.portable_roots = options.portable_roots;
+    mqb::msvc::DiscoveryOptions toolchain_discovery;
+    toolchain_discovery.target_architecture = options.build.architecture;
+    toolchain_discovery.host_architecture = mqb::Architecture::x64;
+    toolchain_discovery.preference = options.toolchain_preference;
+    toolchain_discovery.portable_roots = options.portable_roots;
 
-    auto toolchain = locator.discover(discovery);
+    auto toolchain = locator.discover(toolchain_discovery);
     if (!toolchain) {
         std::cerr << "error: " << toolchain.error().message;
         if (!toolchain.error().path.empty()) {

--- a/cpp/discovery/CMakeLists.txt
+++ b/cpp/discovery/CMakeLists.txt
@@ -1,0 +1,20 @@
+add_library(mqb_discovery STATIC
+    src/SourceDiscovery.cpp
+)
+
+target_include_directories(mqb_discovery
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+
+target_compile_features(mqb_discovery PUBLIC cxx_std_23)
+
+if(MSVC)
+    target_compile_options(mqb_discovery PRIVATE /W4 /permissive-)
+else()
+    target_compile_options(mqb_discovery PRIVATE -Wall -Wextra -Wpedantic)
+endif()
+
+if(MQB_BUILD_TESTS)
+    add_subdirectory(tests)
+endif()

--- a/cpp/discovery/include/mqb/discovery/SourceDiscovery.hpp
+++ b/cpp/discovery/include/mqb/discovery/SourceDiscovery.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <cstddef>
+#include <expected>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace mqb::discovery {
+
+enum class WarningCode {
+    file_read_failed,
+};
+
+struct Warning {
+    WarningCode code{WarningCode::file_read_failed};
+    std::filesystem::path path;
+    std::string message;
+};
+
+enum class ErrorCode {
+    invalid_project_root,
+    invalid_entry,
+    enumeration_failed,
+};
+
+struct Error {
+    ErrorCode code{ErrorCode::invalid_project_root};
+    std::filesystem::path path;
+    std::string message;
+};
+
+struct Request {
+    std::filesystem::path project_root;
+    std::filesystem::path entry;
+    std::vector<std::filesystem::path> include_directories;
+};
+
+struct Result {
+    std::vector<std::filesystem::path> sources;
+    std::size_t indexed_files{};
+    std::vector<Warning> warnings;
+};
+
+class SourceDiscovery {
+public:
+    [[nodiscard]] static std::expected<Result, Error>
+    discover(const Request& request);
+};
+
+} // namespace mqb::discovery

--- a/cpp/discovery/tests/CMakeLists.txt
+++ b/cpp/discovery/tests/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_executable(mqb_source_discovery_tests
+    source_discovery_tests.cpp
+)
+
+target_link_libraries(mqb_source_discovery_tests PRIVATE mqb_discovery)
+target_compile_features(mqb_source_discovery_tests PRIVATE cxx_std_23)
+
+if(MSVC)
+    target_compile_options(mqb_source_discovery_tests PRIVATE /W4 /permissive-)
+else()
+    target_compile_options(mqb_source_discovery_tests PRIVATE -Wall -Wextra -Wpedantic)
+endif()
+
+add_test(NAME mqb.discovery.source_graph COMMAND mqb_source_discovery_tests)

--- a/cpp/tests/cli_argument_tests.cpp
+++ b/cpp/tests/cli_argument_tests.cpp
@@ -35,6 +35,8 @@ int main() {
         if (parsed) {
             expect(parsed->build.sources.size() == 1 && parsed->build.sources.front() == "main.cpp",
                    "single source should be preserved in ordered source list");
+            expect(parsed->discover_sources,
+                   "single-source smart discovery should be enabled by default");
             expect(!parsed->build.output_name.has_value(),
                    "output name should remain unset by default");
             expect(!parsed->build.run_after_build,
@@ -52,6 +54,13 @@ int main() {
             expect(parsed->toolchain_preference == mqb::msvc::ToolchainPreference::automatic,
                    "default toolchain preference should be automatic");
         }
+    }
+
+    {
+        const std::vector arguments{"main.cpp"sv, "--no-discover"sv};
+        auto parsed = mqb::cli::parse_arguments(arguments);
+        expect(parsed.has_value() && !parsed->discover_sources,
+               "--no-discover should disable single-source smart discovery");
     }
 
     {
@@ -97,6 +106,8 @@ int main() {
                            && parsed->build.sources[2] == "tests/helper.cxx",
                        "source order should remain stable for deterministic linking");
             }
+            expect(parsed->discover_sources,
+                   "parser keeps discovery policy enabled; main treats multi-source sets as explicit");
             expect(parsed->build.output_name.has_value()
                        && *parsed->build.output_name == "product",
                    "output name should be parsed");
@@ -163,13 +174,14 @@ int main() {
     }
 
     {
-        const std::vector arguments{"main.cpp"sv, "--run"sv, "--"sv, "-lnot-a-library"sv};
+        const std::vector arguments{"main.cpp"sv, "--run"sv, "--"sv, "--no-discover"sv};
         auto parsed = mqb::cli::parse_arguments(arguments);
         expect(parsed.has_value(), "options after -- should become program arguments");
         if (parsed) {
-            expect(parsed->libraries.empty(), "library parsing must stop at --");
+            expect(parsed->discover_sources,
+                   "discovery parsing must stop at --");
             expect(parsed->build.run_arguments.size() == 1
-                       && parsed->build.run_arguments.front() == "-lnot-a-library",
+                       && parsed->build.run_arguments.front() == "--no-discover",
                    "option-looking argv after -- must be preserved verbatim");
         }
     }

--- a/cpp/tests/mqb_cli_e2e_tests.cpp
+++ b/cpp/tests/mqb_cli_e2e_tests.cpp
@@ -199,7 +199,7 @@ int main(const int argc, char* argv[]) {
     const fs::path mqb_executable{argv[1]};
     const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
     TempTree tree{
-        .root = fs::temp_directory_path() / ("mqb_cli_library_e2e_" + std::to_string(unique)),
+        .root = fs::temp_directory_path() / ("mqb_cli_discovery_e2e_" + std::to_string(unique)),
     };
     fs::create_directories(tree.root);
 
@@ -210,7 +210,7 @@ int main(const int argc, char* argv[]) {
     discovery.host_architecture = mqb::Architecture::x64;
     discovery.preference = mqb::msvc::ToolchainPreference::visual_studio;
     auto toolchain = locator.discover(discovery);
-    expect(toolchain.has_value(), "VS2026 toolchain should be discoverable for library E2E");
+    expect(toolchain.has_value(), "VS2026 toolchain should be discoverable for discovery E2E");
     if (!toolchain) {
         std::cerr << "toolchain discovery failed: " << toolchain.error().message << '\n';
         return 1;
@@ -223,8 +223,13 @@ int main(const int argc, char* argv[]) {
     const fs::path utils_header = include_dir / "utils.hpp";
     const fs::path main_source = tree.root / "main.cpp";
     const fs::path utils_source = tree.root / "src" / "utils.cpp";
+    const fs::path helper_a_header = tree.root / "a" / "helper.hpp";
     const fs::path helper_a = tree.root / "a" / "helper.cpp";
+    const fs::path helper_b_header = tree.root / "b" / "helper.hpp";
     const fs::path helper_b = tree.root / "b" / "helper.cpp";
+    const fs::path other_main = tree.root / "tests" / "other_main.cpp";
+    const fs::path unrelated = tree.root / "unrelated.cpp";
+    const fs::path generated = tree.root / "build" / "generated.cpp";
 
     auto initial_library = build_static_library(runner, *toolchain, tree.root, library_dir, 100);
     expect(initial_library.has_value(), "initial static library fixture should build");
@@ -240,17 +245,31 @@ int main(const int argc, char* argv[]) {
         "#include \"utils.hpp\"\n"
         "#include \"value.hpp\"\n"
         "int util_value() { return configured_value; }\n");
-    write_text(helper_a, "int helper_a() { return 10; }\n");
-    write_text(helper_b, "int helper_b() { return 20; }\n");
+    write_text(helper_a_header, "#pragma once\nint helper_a();\n");
+    write_text(
+        helper_a,
+        "// Deliberately no include: sibling header ownership should discover this TU.\n"
+        "int helper_a() { return 10; }\n");
+    write_text(helper_b_header, "#pragma once\nint helper_b();\n");
+    write_text(helper_b, "#include \"helper.hpp\"\nint helper_b() { return 20; }\n");
+    write_text(
+        other_main,
+        "#include \"../include/utils.hpp\"\n"
+        "int main() { return util_value(); }\n");
+    write_text(unrelated, "int unrelated() { return 999; }\n");
+    write_text(
+        generated,
+        "#include \"../include/utils.hpp\"\n"
+        "int generated() { return util_value(); }\n");
     write_text(
         main_source,
         "#include <cstdio>\n"
         "#include \"utils.hpp\"\n"
+        "#include \"a/helper.hpp\"\n"
+        "#include \"b/helper.hpp\"\n"
         "#ifndef MQB_CLI_TEST\n"
         "#error MQB_CLI_TEST must be defined\n"
         "#endif\n"
-        "int helper_a();\n"
-        "int helper_b();\n"
         "int library_value();\n"
         "int main(int argc, char** argv) {\n"
         "    std::printf(\"mqb-multi=%d\\n\", util_value() + helper_a() + helper_b() + library_value() + MQB_CLI_TEST);\n"
@@ -261,65 +280,77 @@ int main(const int argc, char* argv[]) {
         "    return 0;\n"
         "}\n");
 
-    const std::vector<fs::path> sources{main_source, utils_source, helper_a, helper_b};
+    const std::vector<fs::path> entry_only{main_source};
     const fs::path main_object = tree.root / ".mqb" / "obj" / "main.cpp.obj";
     const fs::path utils_object = tree.root / ".mqb" / "obj" / "src" / "utils.cpp.obj";
     const fs::path helper_a_object = tree.root / ".mqb" / "obj" / "a" / "helper.cpp.obj";
     const fs::path helper_b_object = tree.root / ".mqb" / "obj" / "b" / "helper.cpp.obj";
+    const fs::path other_main_object = tree.root / ".mqb" / "obj" / "tests" / "other_main.cpp.obj";
+    const fs::path unrelated_object = tree.root / ".mqb" / "obj" / "unrelated.cpp.obj";
+    const fs::path generated_object = tree.root / ".mqb" / "obj" / "build" / "generated.cpp.obj";
     const fs::path executable = tree.root / ".mqb" / "bin" / "product.exe";
     const fs::path link_cache = tree.root / ".mqb" / "cache" / "link" / "product.linkcache";
     const std::vector<std::string> target_arguments{
         "-o", "product", "-L", path_text(library_dir), "-l", "math"};
 
-    auto cold = run_mqb(runner, mqb_executable, tree.root, sources, include_dir, target_arguments);
-    expect(cold.has_value(), "cold library target invocation should launch");
+    auto cold = run_mqb(runner, mqb_executable, tree.root, entry_only, include_dir, target_arguments);
+    expect(cold.has_value(), "cold smart-discovery invocation should launch");
     if (cold) {
         if (cold->exit_code != 0) dump_failure(*cold);
-        expect(cold->exit_code == 0, "cold library target build should succeed");
+        expect(cold->exit_code == 0, "cold smart-discovery build should succeed");
+        expect(contains_output_line(cold->stdout_text, "[discover] 4 translation units"),
+               "single entry should discover exactly four target TUs");
         expect(cold->stdout_text.find("[compile] main.cpp") != std::string::npos,
-               "cold build should compile main.cpp");
+               "cold build should compile entry main.cpp");
         expect(cold->stdout_text.find("[compile] src/utils.cpp") != std::string::npos,
-               "cold build should compile nested utils.cpp");
+               "cold build should discover and compile utils.cpp");
         expect(cold->stdout_text.find("[compile] a/helper.cpp") != std::string::npos,
-               "cold build should compile first same-basename helper");
+               "cold build should discover helper A through sibling header ownership");
         expect(cold->stdout_text.find("[compile] b/helper.cpp") != std::string::npos,
-               "cold build should compile second same-basename helper");
+               "cold build should discover helper B through include graph");
+        expect(cold->stdout_text.find("other_main.cpp") == std::string::npos,
+               "reachable second main must not enter target output");
+        expect(cold->stdout_text.find("unrelated.cpp") == std::string::npos,
+               "disconnected source must not enter target output");
+        expect(cold->stdout_text.find("generated.cpp") == std::string::npos,
+               "default build-directory source must not enter target output");
         expect(cold->stdout_text.find("[link] product.exe") != std::string::npos,
                "cold build should link custom target with static library");
     }
 
-    expect(fs::is_regular_file(main_object), "main object should use project-level layout");
-    expect(fs::is_regular_file(utils_object), "nested object should preserve relative source path");
-    expect(fs::is_regular_file(helper_a_object), "first helper object should exist");
-    expect(fs::is_regular_file(helper_b_object), "second helper object should exist independently");
-    expect(helper_a_object != helper_b_object,
-           "same-basename sources from different directories must have different artifacts");
-    expect(fs::is_regular_file(executable), "library target should create product.exe");
-    expect(fs::is_regular_file(link_cache), "library target should persist link cache");
+    expect(fs::is_regular_file(main_object), "entry object should exist");
+    expect(fs::is_regular_file(utils_object), "discovered nested object should exist");
+    expect(fs::is_regular_file(helper_a_object), "discovered helper A object should exist");
+    expect(fs::is_regular_file(helper_b_object), "discovered helper B object should exist");
+    expect(!fs::exists(other_main_object), "second-main object must not be produced");
+    expect(!fs::exists(unrelated_object), "disconnected source object must not be produced");
+    expect(!fs::exists(generated_object), "excluded build source object must not be produced");
+    expect(fs::is_regular_file(executable), "smart-discovered target should create product.exe");
+    expect(fs::is_regular_file(link_cache), "smart-discovered target should persist link cache");
 
     auto cold_run = run_executable(runner, executable, tree.root);
-    expect(cold_run.has_value(), "cold-built library target should launch");
+    expect(cold_run.has_value(), "cold-built smart-discovered target should launch");
     if (cold_run) {
         expect(cold_run->exit_code == 0, "cold-built executable should return zero");
         expect(cold_run->stdout_text.find("mqb-multi=172") != std::string::npos,
-               "cold-built executable should consume initial math.lib behavior");
+               "cold-built executable should consume discovered TUs and initial math.lib behavior");
     }
 
-    auto warm = run_mqb(runner, mqb_executable, tree.root, sources, include_dir, target_arguments);
-    expect(warm.has_value(), "warm library target invocation should launch");
+    auto warm = run_mqb(runner, mqb_executable, tree.root, entry_only, include_dir, target_arguments);
+    expect(warm.has_value(), "warm smart-discovery invocation should launch");
     if (warm) {
         if (warm->exit_code != 0) dump_failure(*warm);
-        expect(warm->exit_code == 0, "warm library target build should succeed");
+        expect(warm->exit_code == 0, "warm smart-discovery build should succeed");
         expect(contains_output_line(warm->stdout_text, "[up-to-date] main.cpp"),
                "warm build should skip main.cpp");
         expect(contains_output_line(warm->stdout_text, "[up-to-date] src/utils.cpp"),
-               "warm build should skip utils.cpp");
+               "warm build should skip discovered utils.cpp");
         expect(contains_output_line(warm->stdout_text, "[up-to-date] a/helper.cpp"),
-               "warm build should skip helper A");
+               "warm build should skip discovered helper A");
         expect(contains_output_line(warm->stdout_text, "[up-to-date] b/helper.cpp"),
-               "warm build should skip helper B");
+               "warm build should skip discovered helper B");
         expect(contains_output_line(warm->stdout_text, "[up-to-date] product.exe"),
-               "warm build should reuse executable while library is unchanged");
+               "warm build should reuse executable while sources/library are unchanged");
     }
 
     std::vector<std::string> run_arguments = target_arguments;
@@ -327,13 +358,13 @@ int main(const int argc, char* argv[]) {
         run_arguments.end(),
         {"--run", "--", "hello world", "--child-option", "", "a b c"});
     auto run_with_args = run_mqb(
-        runner, mqb_executable, tree.root, sources, include_dir, run_arguments);
+        runner, mqb_executable, tree.root, entry_only, include_dir, run_arguments);
     expect(run_with_args.has_value(), "warm --run invocation should launch");
     if (run_with_args) {
         if (run_with_args->exit_code != 0) dump_failure(*run_with_args);
         expect(run_with_args->exit_code == 0, "warm --run should return child success code");
         expect(contains_output_line(run_with_args->stdout_text, "[up-to-date] product.exe"),
-               "--run should still reuse warm library link state");
+               "--run should still reuse warm link state");
         expect(contains_output_line(run_with_args->stdout_text, "[run] product.exe"),
                "--run should report the launched target");
         expect(contains_output_line(run_with_args->stdout_text, "argc=5"),
@@ -365,7 +396,7 @@ int main(const int argc, char* argv[]) {
     }
 
     auto library_changed = run_mqb(
-        runner, mqb_executable, tree.root, sources, include_dir, target_arguments);
+        runner, mqb_executable, tree.root, entry_only, include_dir, target_arguments);
     expect(library_changed.has_value(), "library-only change invocation should launch");
     if (library_changed) {
         if (library_changed->exit_code != 0) dump_failure(*library_changed);
@@ -373,7 +404,7 @@ int main(const int argc, char* argv[]) {
         expect(contains_output_line(library_changed->stdout_text, "[up-to-date] main.cpp"),
                "library-only change must not recompile main.cpp");
         expect(contains_output_line(library_changed->stdout_text, "[up-to-date] src/utils.cpp"),
-               "library-only change must not recompile utils.cpp");
+               "library-only change must not recompile discovered utils.cpp");
         expect(contains_output_line(library_changed->stdout_text, "[up-to-date] a/helper.cpp"),
                "library-only change must not recompile helper A");
         expect(contains_output_line(library_changed->stdout_text, "[up-to-date] b/helper.cpp"),
@@ -412,17 +443,17 @@ int main(const int argc, char* argv[]) {
     }
 
     auto header_changed = run_mqb(
-        runner, mqb_executable, tree.root, sources, include_dir, target_arguments);
-    expect(header_changed.has_value(), "header-change target invocation should launch");
+        runner, mqb_executable, tree.root, entry_only, include_dir, target_arguments);
+    expect(header_changed.has_value(), "header-change smart-discovery invocation should launch");
     if (header_changed) {
         if (header_changed->exit_code != 0) dump_failure(*header_changed);
         expect(header_changed->exit_code == 0, "header-change build should succeed");
         expect(contains_output_line(header_changed->stdout_text, "[up-to-date] main.cpp"),
                "header private to utils.cpp must not rebuild main.cpp");
         expect(header_changed->stdout_text.find("[compile] src/utils.cpp") != std::string::npos,
-               "header private to utils.cpp should rebuild utils.cpp");
+               "header private to utils.cpp should rebuild only discovered utils.cpp");
         expect(header_changed->stdout_text.find("dependency changed") != std::string::npos,
-               "partial rebuild should remain explainable");
+               "partial rebuild should remain explainable through compiler dependency metadata");
         expect(contains_output_line(header_changed->stdout_text, "[up-to-date] a/helper.cpp"),
                "unrelated helper A should remain cached");
         expect(contains_output_line(header_changed->stdout_text, "[up-to-date] b/helper.cpp"),
@@ -451,13 +482,13 @@ int main(const int argc, char* argv[]) {
     std::vector<std::string> release_arguments = target_arguments;
     release_arguments.push_back("--release");
     auto release = run_mqb(
-        runner, mqb_executable, tree.root, sources, include_dir, release_arguments);
-    expect(release.has_value(), "release target invocation should launch");
+        runner, mqb_executable, tree.root, entry_only, include_dir, release_arguments);
+    expect(release.has_value(), "release smart-discovery invocation should launch");
     if (release) {
         if (release->exit_code != 0) dump_failure(*release);
         expect(release->exit_code == 0, "release target build should succeed");
         expect(release->stdout_text.find("compiler options changed") != std::string::npos,
-               "Debug to Release should invalidate compile recipes");
+               "Debug to Release should invalidate discovered TU compile recipes");
         expect(release->stdout_text.find("[link] product.exe") != std::string::npos,
                "Debug to Release should relink target with static library");
         expect(release->stdout_text.find("linker options changed") != std::string::npos,
@@ -465,11 +496,11 @@ int main(const int argc, char* argv[]) {
     }
 
     auto release_run = run_executable(runner, executable, tree.root);
-    expect(release_run.has_value(), "release library target should launch");
+    expect(release_run.has_value(), "release smart-discovered target should launch");
     if (release_run) {
         expect(release_run->exit_code == 0, "release executable should return zero");
         expect(release_run->stdout_text.find("mqb-multi=174") != std::string::npos,
-               "release executable should preserve current library behavior");
+               "release executable should preserve current discovered/library behavior");
     }
 
     const fs::path exit_source = tree.root / "exit7.cpp";


### PR DESCRIPTION
Restores the smart-discovery integration that was validated on PR #6 but never actually merged into `main`.

The current main branch contained only the later hardening source/test files, while the CMake/CLI/application/E2E integration from PR #6 was absent.

This recovery commit reuses the exact already-validated PR #6 blobs for the 10 missing integration paths:
- top-level CMake discovery registration
- `mqb` target linkage to `mqb_discovery`
- CLI `--no-discover` policy
- application single-entry discovery wiring
- discovery CMake/header/test target registration
- CLI parser regression tests
- real VS2026 single-entry discovery E2E

It deliberately does NOT replace `SourceDiscovery.cpp` or `source_discovery_tests.cpp`, so the newer secondary-`main()` traversal barrier from PR #7 remains in place.

Acceptance: full VS2026 C++ V2 workflow must pass before merge.