### PR TITLE
feat: add versioned mqb.json project configuration

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -9,8 +9,14 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 option(MQB_BUILD_TESTS "Build MQB tests" ON)
 option(MQB_ENABLE_INSTALLED_MSVC_TESTS "Run tests that require an installed Visual Studio toolchain" OFF)
 
+if(MQB_BUILD_TESTS)
+    include(CTest)
+    enable_testing()
+endif()
+
 add_subdirectory(core)
 add_subdirectory(process)
+add_subdirectory(config)
 add_subdirectory(discovery)
 
 if(WIN32)
@@ -22,8 +28,6 @@ endif()
 add_subdirectory(apps/mqb)
 
 if(MQB_BUILD_TESTS)
-    include(CTest)
-    enable_testing()
     add_subdirectory(tests)
     if(WIN32)
         add_subdirectory(orchestration/tests)

--- a/cpp/apps/mqb/CMakeLists.txt
+++ b/cpp/apps/mqb/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(mqb
 target_link_libraries(mqb
     PRIVATE
         mqb_cli
+        mqb_config
         mqb_discovery
         mqb_orchestration
         mqb_platform_windows

--- a/cpp/apps/mqb/Cli.cpp
+++ b/cpp/apps/mqb/Cli.cpp
@@ -31,15 +31,9 @@ require_value(
 
 [[nodiscard]] std::expected<CppStandard, Error>
 parse_standard(const std::string_view value) {
-    if (value == "20" || value == "c++20") {
-        return CppStandard::cpp20;
-    }
-    if (value == "23" || value == "c++23") {
-        return CppStandard::cpp23;
-    }
-    if (value == "latest" || value == "c++latest") {
-        return CppStandard::latest;
-    }
+    if (value == "20" || value == "c++20") return CppStandard::cpp20;
+    if (value == "23" || value == "c++23") return CppStandard::cpp23;
+    if (value == "latest" || value == "c++latest") return CppStandard::latest;
     return std::unexpected(error(
         "unsupported C++ standard '" + std::string{value}
         + "' (expected 20, 23, or latest)"));
@@ -47,15 +41,9 @@ parse_standard(const std::string_view value) {
 
 [[nodiscard]] std::expected<msvc::ToolchainPreference, Error>
 parse_toolchain_preference(const std::string_view value) {
-    if (value == "auto") {
-        return msvc::ToolchainPreference::automatic;
-    }
-    if (value == "vs") {
-        return msvc::ToolchainPreference::visual_studio;
-    }
-    if (value == "portable") {
-        return msvc::ToolchainPreference::portable;
-    }
+    if (value == "auto") return msvc::ToolchainPreference::automatic;
+    if (value == "vs") return msvc::ToolchainPreference::visual_studio;
+    if (value == "portable") return msvc::ToolchainPreference::portable;
     return std::unexpected(error(
         "unsupported toolchain preference '" + std::string{value}
         + "' (expected auto, vs, or portable)"));
@@ -67,9 +55,7 @@ attached_or_next(
     std::size_t& index,
     const std::string_view argument,
     const std::string_view option) {
-    if (argument.size() > option.size()) {
-        return argument.substr(option.size());
-    }
+    if (argument.size() > option.size()) return argument.substr(option.size());
     return require_value(arguments, index, option);
 }
 
@@ -108,8 +94,14 @@ parse_arguments(const std::span<const std::string_view> arguments) {
             options.verbose = true;
             continue;
         }
+        if (argument == "--discover") {
+            options.discover_sources = true;
+            options.discovery_override = true;
+            continue;
+        }
         if (argument == "--no-discover") {
             options.discover_sources = false;
+            options.discovery_override = false;
             continue;
         }
         if (argument == "--run") {
@@ -130,18 +122,22 @@ parse_arguments(const std::span<const std::string_view> arguments) {
         }
         if (argument == "--debug") {
             options.build.configuration = BuildConfiguration::debug;
+            options.configuration_override = BuildConfiguration::debug;
             continue;
         }
         if (argument == "--release") {
             options.build.configuration = BuildConfiguration::release;
+            options.configuration_override = BuildConfiguration::release;
             continue;
         }
         if (argument == "--x86") {
             options.build.architecture = Architecture::x86;
+            options.architecture_override = Architecture::x86;
             continue;
         }
         if (argument == "--x64") {
             options.build.architecture = Architecture::x64;
+            options.architecture_override = Architecture::x64;
             continue;
         }
         if (argument == "--std") {
@@ -150,6 +146,7 @@ parse_arguments(const std::span<const std::string_view> arguments) {
             auto standard = parse_standard(*value);
             if (!standard) return std::unexpected(standard.error());
             options.build.standard = *standard;
+            options.standard_override = *standard;
             continue;
         }
         if (argument == "--env") {
@@ -246,6 +243,7 @@ Usage:
 Source selection:
   One positional source       Smart-discover connected ordinary C++ TUs (default)
   Multiple positional sources Build exactly that explicit ordered source set
+  --discover                  Explicitly enable smart discovery for one source
   --no-discover               Disable smart discovery for a single source
 
 Options:

--- a/cpp/apps/mqb/Cli.cpp
+++ b/cpp/apps/mqb/Cli.cpp
@@ -240,6 +240,11 @@ Usage:
   mqb <entry.cpp> [options] [-- program-args...]
   mqb <source.cpp> <more-sources...> [options] [-- program-args...]
 
+Project configuration:
+  MQB searches upward from the invocation directory for the nearest mqb.json.
+  Scalar precedence is: explicit CLI > mqb.json > built-in defaults.
+  Config paths are relative to mqb.json; CLI paths are relative to the invocation directory.
+
 Source selection:
   One positional source       Smart-discover connected ordinary C++ TUs (default)
   Multiple positional sources Build exactly that explicit ordered source set
@@ -247,10 +252,10 @@ Source selection:
   --no-discover               Disable smart discovery for a single source
 
 Options:
-  --debug                  Debug compile/link preset (default)
-  --release                Release compile/link preset
-  --std <20|23|latest>     C++ language standard (default: 23)
-  --x86 | --x64            Target architecture (default: x64)
+  --debug                  Explicitly select Debug compile/link preset
+  --release                Explicitly select Release compile/link preset
+  --std <20|23|latest>     Explicitly select C++ language standard
+  --x86 | --x64            Explicitly select target architecture
   -o, --output <name>      Set target executable name under .mqb/bin/
   --run                    Run the executable after a successful build
   -I <dir>, -I<dir>        Add an include directory
@@ -261,7 +266,7 @@ Options:
   --lib <name>             Link a library (name or explicit path)
   --env <auto|vs|portable> Toolchain selection (default: auto)
   --portable-root <dir>    Add a portable_msvc root candidate
-  -v, --verbose            Show discovery, toolchain, and artifact details
+  -v, --verbose            Show config, discovery, toolchain, and artifact details
   -h, --help               Show this help
   --                       Pass all remaining argv elements to the program
 

--- a/cpp/apps/mqb/Cli.hpp
+++ b/cpp/apps/mqb/Cli.hpp
@@ -2,6 +2,7 @@
 
 #include <expected>
 #include <filesystem>
+#include <optional>
 #include <span>
 #include <string>
 #include <string_view>
@@ -14,12 +15,16 @@ namespace mqb::cli {
 
 struct Options {
     BuildRequest build;
+    std::optional<BuildConfiguration> configuration_override;
+    std::optional<Architecture> architecture_override;
+    std::optional<CppStandard> standard_override;
     std::vector<std::string> defines;
     std::vector<std::filesystem::path> include_directories;
     std::vector<std::filesystem::path> library_directories;
     std::vector<std::string> libraries;
     msvc::ToolchainPreference toolchain_preference{msvc::ToolchainPreference::automatic};
     std::vector<std::filesystem::path> portable_roots;
+    std::optional<bool> discovery_override;
     bool discover_sources{true};
     bool verbose{false};
     bool show_help{false};

--- a/cpp/apps/mqb/main.cpp
+++ b/cpp/apps/mqb/main.cpp
@@ -3,6 +3,7 @@
 #include <expected>
 #include <filesystem>
 #include <iostream>
+#include <optional>
 #include <span>
 #include <string>
 #include <string_view>
@@ -11,6 +12,8 @@
 #include <vector>
 
 #include "Cli.hpp"
+#include "mqb/config/ProjectConfig.hpp"
+#include "mqb/config/ProjectOptions.hpp"
 #include "mqb/core/BuildTypes.hpp"
 #include "mqb/core/CompilerOptions.hpp"
 #include "mqb/core/LinkOptions.hpp"
@@ -37,9 +40,13 @@ namespace fs = std::filesystem;
 }
 
 [[nodiscard]] std::expected<fs::path, std::string>
-absolute_path(const fs::path& path, const std::string_view description) {
+absolute_path_from(
+    const fs::path& base,
+    const fs::path& path,
+    const std::string_view description) {
     std::error_code error_code;
-    fs::path absolute = fs::absolute(path, error_code);
+    const fs::path candidate = path.is_absolute() ? path : base / path;
+    fs::path absolute = fs::absolute(candidate, error_code);
     if (error_code) {
         return std::unexpected(
             "failed to resolve " + std::string{description} + ": " + error_code.message());
@@ -133,6 +140,17 @@ void print_reasons(const std::vector<mqb::BuildReason>& reasons) {
         std::cout << mqb::to_string(reasons[index]);
     }
     std::cout << ']';
+}
+
+void print_config_error(const mqb::config::Error& error) {
+    std::cerr << "error: project config: " << error.message;
+    if (!error.path.empty()) {
+        std::cerr << ": " << path_text(error.path);
+        if (error.line != 0 && error.column != 0) {
+            std::cerr << ':' << error.line << ':' << error.column;
+        }
+    }
+    std::cerr << '\n';
 }
 
 void print_compile_failure(const mqb::orchestration::IncrementalCompileError& error) {
@@ -237,18 +255,18 @@ int main(const int argc, char* argv[]) {
     }
 
     std::error_code error_code;
-    fs::path project_root = fs::current_path(error_code);
+    fs::path invocation_directory = fs::current_path(error_code);
     if (error_code) {
-        std::cerr << "error: failed to resolve current project directory: "
+        std::cerr << "error: failed to resolve current working directory: "
                   << error_code.message() << '\n';
         return 2;
     }
-    project_root = project_root.lexically_normal();
+    invocation_directory = invocation_directory.lexically_normal();
 
     std::vector<fs::path> requested_sources;
     requested_sources.reserve(options.build.sources.size());
     for (const auto& requested_source : options.build.sources) {
-        auto source = absolute_path(requested_source, "source file");
+        auto source = absolute_path_from(invocation_directory, requested_source, "source file");
         if (!source) {
             std::cerr << "error: " << source.error() << '\n';
             return 2;
@@ -274,7 +292,7 @@ int main(const int argc, char* argv[]) {
     }
 
     for (auto& include_directory : options.include_directories) {
-        auto resolved = absolute_path(include_directory, "include directory");
+        auto resolved = absolute_path_from(invocation_directory, include_directory, "include directory");
         if (!resolved) {
             std::cerr << "error: " << resolved.error() << '\n';
             return 2;
@@ -282,7 +300,7 @@ int main(const int argc, char* argv[]) {
         include_directory = std::move(*resolved);
     }
     for (auto& library_directory : options.library_directories) {
-        auto resolved = absolute_path(library_directory, "library directory");
+        auto resolved = absolute_path_from(invocation_directory, library_directory, "library directory");
         if (!resolved) {
             std::cerr << "error: " << resolved.error() << '\n';
             return 2;
@@ -290,7 +308,7 @@ int main(const int argc, char* argv[]) {
         library_directory = std::move(*resolved);
     }
     for (auto& portable_root : options.portable_roots) {
-        auto resolved = absolute_path(portable_root, "portable toolchain root");
+        auto resolved = absolute_path_from(invocation_directory, portable_root, "portable toolchain root");
         if (!resolved) {
             std::cerr << "error: " << resolved.error() << '\n';
             return 2;
@@ -298,17 +316,66 @@ int main(const int argc, char* argv[]) {
         portable_root = std::move(*resolved);
     }
 
+    std::optional<mqb::config::ProjectConfig> project_config;
+    auto located_config = mqb::config::ProjectConfigLoader::find_upwards(invocation_directory);
+    if (!located_config) {
+        print_config_error(located_config.error());
+        return 2;
+    }
+    if (located_config->has_value()) {
+        auto loaded = mqb::config::ProjectConfigLoader::load(**located_config);
+        if (!loaded) {
+            print_config_error(loaded.error());
+            return 2;
+        }
+        project_config = std::move(*loaded);
+    }
+
+    const fs::path project_root = project_config
+        ? project_config->project_root
+        : invocation_directory;
+
+    mqb::config::ProjectOverrides cli_overrides;
+    cli_overrides.build.configuration = options.configuration_override;
+    cli_overrides.build.architecture = options.architecture_override;
+    cli_overrides.build.standard = options.standard_override;
+    cli_overrides.build.output_name = options.build.output_name;
+    cli_overrides.build.defines = options.defines;
+    cli_overrides.build.include_directories = options.include_directories;
+    cli_overrides.build.library_directories = options.library_directories;
+    cli_overrides.build.libraries = options.libraries;
+    cli_overrides.discovery.enabled = options.discovery_override;
+
+    auto effective = mqb::config::resolve_project_options(
+        project_config ? &*project_config : nullptr,
+        cli_overrides);
+    options.build.configuration = effective.configuration;
+    options.build.architecture = effective.architecture;
+    options.build.standard = effective.standard;
+    options.build.output_name = effective.output_name;
+    options.discover_sources = effective.discovery_enabled;
+    options.defines = effective.defines;
+    options.include_directories = effective.include_directories;
+    options.library_directories = effective.library_directories;
+    options.libraries = effective.libraries;
+
     std::vector<fs::path> sources = requested_sources;
     if (options.discover_sources && requested_sources.size() == 1) {
         const fs::path& entry = requested_sources.front();
-        const fs::path discovery_root = inside_project(project_root, entry)
+        const bool project_scoped = inside_project(project_root, entry);
+        const fs::path discovery_root = project_scoped
             ? project_root
             : entry.parent_path();
-        const mqb::discovery::Request discovery_request{
+        mqb::discovery::Request discovery_request{
             .project_root = discovery_root,
             .entry = entry,
             .include_directories = options.include_directories,
         };
+        if (project_scoped) {
+            discovery_request.excluded_directories = effective.discovery_exclude_directories;
+            discovery_request.extra_sources = effective.discovery_extra_sources;
+            discovery_request.excluded_sources = effective.discovery_exclude_sources;
+        }
         auto discovered = mqb::discovery::SourceDiscovery::discover(discovery_request);
         if (!discovered) {
             std::cerr << "error: source discovery failed: " << discovered.error().message;
@@ -357,7 +424,8 @@ int main(const int argc, char* argv[]) {
         });
     }
 
-    const std::string target_name = options.build.output_name.value_or(requested_sources.front().stem().string());
+    const std::string target_name = options.build.output_name.value_or(
+        requested_sources.front().stem().string());
     auto target_artifacts = layout->for_target(target_name);
     if (!target_artifacts) {
         std::cerr << "error: " << target_artifacts.error().message << '\n';
@@ -403,8 +471,11 @@ int main(const int argc, char* argv[]) {
 
     if (options.verbose) {
         std::cout << "[target] " << target_name << "\n"
-                  << "  project: " << path_text(project_root) << '\n'
-                  << "  cl:      " << path_text(toolchain->identity.compiler) << '\n'
+                  << "  project: " << path_text(project_root) << '\n';
+        if (project_config) {
+            std::cout << "  config:  " << path_text(project_config->file) << '\n';
+        }
+        std::cout << "  cl:      " << path_text(toolchain->identity.compiler) << '\n'
                   << "  link:    " << path_text(toolchain->linker) << '\n';
         for (const auto& source : target_sources) {
             std::cout << "  source:  " << path_text(display_source(project_root, source.source)) << '\n'

--- a/cpp/config/CMakeLists.txt
+++ b/cpp/config/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(mqb_config STATIC
     src/ProjectConfig.cpp
+    src/ProjectOptions.cpp
 )
 
 target_include_directories(mqb_config

--- a/cpp/config/CMakeLists.txt
+++ b/cpp/config/CMakeLists.txt
@@ -1,0 +1,21 @@
+add_library(mqb_config STATIC
+    src/ProjectConfig.cpp
+)
+
+target_include_directories(mqb_config
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+
+target_link_libraries(mqb_config PUBLIC mqb_core)
+target_compile_features(mqb_config PUBLIC cxx_std_23)
+
+if(MSVC)
+    target_compile_options(mqb_config PRIVATE /W4 /permissive-)
+else()
+    target_compile_options(mqb_config PRIVATE -Wall -Wextra -Wpedantic)
+endif()
+
+if(MQB_BUILD_TESTS)
+    add_subdirectory(tests)
+endif()

--- a/cpp/config/include/mqb/config/ProjectConfig.hpp
+++ b/cpp/config/include/mqb/config/ProjectConfig.hpp
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <expected>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "mqb/core/BuildTypes.hpp"
+
+namespace mqb::config {
+
+struct BuildOverrides {
+    std::optional<BuildConfiguration> configuration;
+    std::optional<Architecture> architecture;
+    std::optional<CppStandard> standard;
+    std::optional<std::string> output_name;
+    std::vector<std::string> defines;
+    std::vector<std::filesystem::path> include_directories;
+    std::vector<std::filesystem::path> library_directories;
+    std::vector<std::string> libraries;
+};
+
+struct DiscoveryOverrides {
+    std::optional<bool> enabled;
+    std::vector<std::filesystem::path> exclude_directories;
+    std::vector<std::filesystem::path> extra_sources;
+    std::vector<std::filesystem::path> exclude_sources;
+};
+
+struct ProjectConfig {
+    int version{1};
+    std::filesystem::path file;
+    std::filesystem::path project_root;
+    BuildOverrides build;
+    DiscoveryOverrides discovery;
+};
+
+enum class ErrorCode {
+    io_error,
+    parse_error,
+    schema_error,
+    unsupported_version,
+};
+
+struct Error {
+    ErrorCode code{ErrorCode::parse_error};
+    std::filesystem::path path;
+    std::size_t line{1};
+    std::size_t column{1};
+    std::string message;
+};
+
+class ProjectConfigLoader {
+public:
+    [[nodiscard]] static std::expected<std::optional<std::filesystem::path>, Error>
+    find_upwards(const std::filesystem::path& start_directory);
+
+    [[nodiscard]] static std::expected<ProjectConfig, Error>
+    load(const std::filesystem::path& file);
+};
+
+} // namespace mqb::config

--- a/cpp/config/include/mqb/config/ProjectOptions.hpp
+++ b/cpp/config/include/mqb/config/ProjectOptions.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "mqb/config/ProjectConfig.hpp"
+
+namespace mqb::config {
+
+struct ProjectOverrides {
+    BuildOverrides build;
+    DiscoveryOverrides discovery;
+};
+
+struct EffectiveProjectOptions {
+    BuildConfiguration configuration{BuildConfiguration::debug};
+    Architecture architecture{Architecture::x64};
+    CppStandard standard{CppStandard::cpp23};
+    std::optional<std::string> output_name;
+    std::vector<std::string> defines;
+    std::vector<std::filesystem::path> include_directories;
+    std::vector<std::filesystem::path> library_directories;
+    std::vector<std::string> libraries;
+
+    bool discovery_enabled{true};
+    std::vector<std::filesystem::path> discovery_exclude_directories;
+    std::vector<std::filesystem::path> discovery_extra_sources;
+    std::vector<std::filesystem::path> discovery_exclude_sources;
+};
+
+[[nodiscard]] EffectiveProjectOptions resolve_project_options(
+    const ProjectConfig* project_config,
+    const ProjectOverrides& cli_overrides);
+
+} // namespace mqb::config

--- a/cpp/config/src/ProjectConfig.cpp
+++ b/cpp/config/src/ProjectConfig.cpp
@@ -1,0 +1,581 @@
+#include "mqb/config/ProjectConfig.hpp"
+
+#include <algorithm>
+#include <charconv>
+#include <cctype>
+#include <cstdint>
+#include <fstream>
+#include <map>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+namespace mqb::config {
+namespace {
+
+namespace fs = std::filesystem;
+
+struct JsonValue {
+    enum class Kind { null_value, boolean, number, string, array, object };
+    Kind kind{Kind::null_value};
+    std::size_t line{1};
+    std::size_t column{1};
+    bool boolean{};
+    std::string scalar;
+    std::vector<JsonValue> array;
+    std::map<std::string, JsonValue, std::less<>> object;
+};
+using JsonObject = decltype(JsonValue{}.object);
+
+[[nodiscard]] Error make_error(
+    const ErrorCode code,
+    const fs::path& path,
+    const std::size_t line,
+    const std::size_t column,
+    std::string message) {
+    return Error{code, path, line, column, std::move(message)};
+}
+
+class JsonParser {
+public:
+    JsonParser(std::string_view text, fs::path path)
+        : text_(text), path_(std::move(path)) {}
+
+    [[nodiscard]] std::expected<JsonValue, Error> parse() {
+        skip_ws();
+        auto value = parse_value();
+        if (!value) return std::unexpected(value.error());
+        skip_ws();
+        if (!eof()) return std::unexpected(error("unexpected characters after JSON value"));
+        return value;
+    }
+
+private:
+    [[nodiscard]] bool eof() const noexcept { return pos_ >= text_.size(); }
+    [[nodiscard]] char peek() const noexcept { return eof() ? '\0' : text_[pos_]; }
+    char take() {
+        const char ch = text_[pos_++];
+        if (ch == '\n') { ++line_; column_ = 1; }
+        else { ++column_; }
+        return ch;
+    }
+    void skip_ws() {
+        while (!eof()) {
+            const char ch = peek();
+            if (ch != ' ' && ch != '\t' && ch != '\r' && ch != '\n') break;
+            take();
+        }
+    }
+    [[nodiscard]] Error error(std::string message) const {
+        return make_error(ErrorCode::parse_error, path_, line_, column_, std::move(message));
+    }
+
+    [[nodiscard]] std::expected<JsonValue, Error> parse_value() {
+        if (eof()) return std::unexpected(error("unexpected end of JSON input"));
+        const auto start_line = line_;
+        const auto start_column = column_;
+        switch (peek()) {
+        case '{': return parse_object(start_line, start_column);
+        case '[': return parse_array(start_line, start_column);
+        case '"': {
+            auto text = parse_string();
+            if (!text) return std::unexpected(text.error());
+            JsonValue value;
+            value.kind = JsonValue::Kind::string;
+            value.line = start_line;
+            value.column = start_column;
+            value.scalar = std::move(*text);
+            return value;
+        }
+        case 't': return parse_literal("true", JsonValue::Kind::boolean, true, start_line, start_column);
+        case 'f': return parse_literal("false", JsonValue::Kind::boolean, false, start_line, start_column);
+        case 'n': return parse_literal("null", JsonValue::Kind::null_value, false, start_line, start_column);
+        default:
+            if (peek() == '-' || std::isdigit(static_cast<unsigned char>(peek()))) {
+                return parse_number(start_line, start_column);
+            }
+            return std::unexpected(error("unexpected token in JSON input"));
+        }
+    }
+
+    [[nodiscard]] std::expected<JsonValue, Error> parse_literal(
+        std::string_view literal,
+        JsonValue::Kind kind,
+        bool boolean,
+        std::size_t start_line,
+        std::size_t start_column) {
+        for (const char expected : literal) {
+            if (eof() || take() != expected) return std::unexpected(error("invalid JSON literal"));
+        }
+        JsonValue value;
+        value.kind = kind;
+        value.line = start_line;
+        value.column = start_column;
+        value.boolean = boolean;
+        return value;
+    }
+
+    [[nodiscard]] std::expected<JsonValue, Error> parse_object(
+        std::size_t start_line,
+        std::size_t start_column) {
+        take();
+        JsonValue value;
+        value.kind = JsonValue::Kind::object;
+        value.line = start_line;
+        value.column = start_column;
+        skip_ws();
+        if (!eof() && peek() == '}') { take(); return value; }
+        while (true) {
+            skip_ws();
+            if (eof() || peek() != '"') return std::unexpected(error("expected string key in JSON object"));
+            const auto key_line = line_;
+            const auto key_column = column_;
+            auto key = parse_string();
+            if (!key) return std::unexpected(key.error());
+            skip_ws();
+            if (eof() || take() != ':') return std::unexpected(error("expected ':' after JSON object key"));
+            skip_ws();
+            auto member = parse_value();
+            if (!member) return std::unexpected(member.error());
+            if (value.object.contains(*key)) {
+                return std::unexpected(make_error(
+                    ErrorCode::parse_error,
+                    path_,
+                    key_line,
+                    key_column,
+                    "duplicate JSON object key '" + *key + "'"));
+            }
+            value.object.emplace(std::move(*key), std::move(*member));
+            skip_ws();
+            if (eof()) return std::unexpected(error("unterminated JSON object"));
+            const char delimiter = take();
+            if (delimiter == '}') break;
+            if (delimiter != ',') return std::unexpected(error("expected ',' or '}' in JSON object"));
+        }
+        return value;
+    }
+
+    [[nodiscard]] std::expected<JsonValue, Error> parse_array(
+        std::size_t start_line,
+        std::size_t start_column) {
+        take();
+        JsonValue value;
+        value.kind = JsonValue::Kind::array;
+        value.line = start_line;
+        value.column = start_column;
+        skip_ws();
+        if (!eof() && peek() == ']') { take(); return value; }
+        while (true) {
+            skip_ws();
+            auto element = parse_value();
+            if (!element) return std::unexpected(element.error());
+            value.array.push_back(std::move(*element));
+            skip_ws();
+            if (eof()) return std::unexpected(error("unterminated JSON array"));
+            const char delimiter = take();
+            if (delimiter == ']') break;
+            if (delimiter != ',') return std::unexpected(error("expected ',' or ']' in JSON array"));
+        }
+        return value;
+    }
+
+    [[nodiscard]] static int hex(char ch) noexcept {
+        if (ch >= '0' && ch <= '9') return ch - '0';
+        if (ch >= 'a' && ch <= 'f') return 10 + ch - 'a';
+        if (ch >= 'A' && ch <= 'F') return 10 + ch - 'A';
+        return -1;
+    }
+    [[nodiscard]] std::expected<std::uint32_t, Error> parse_hex_quad() {
+        std::uint32_t value = 0;
+        for (int i = 0; i < 4; ++i) {
+            if (eof()) return std::unexpected(error("incomplete Unicode escape"));
+            const int digit = hex(take());
+            if (digit < 0) return std::unexpected(error("invalid Unicode escape"));
+            value = (value << 4u) | static_cast<std::uint32_t>(digit);
+        }
+        return value;
+    }
+    static void append_utf8(std::string& out, std::uint32_t cp) {
+        if (cp <= 0x7fu) out.push_back(static_cast<char>(cp));
+        else if (cp <= 0x7ffu) {
+            out.push_back(static_cast<char>(0xc0u | (cp >> 6u)));
+            out.push_back(static_cast<char>(0x80u | (cp & 0x3fu)));
+        } else if (cp <= 0xffffu) {
+            out.push_back(static_cast<char>(0xe0u | (cp >> 12u)));
+            out.push_back(static_cast<char>(0x80u | ((cp >> 6u) & 0x3fu)));
+            out.push_back(static_cast<char>(0x80u | (cp & 0x3fu)));
+        } else {
+            out.push_back(static_cast<char>(0xf0u | (cp >> 18u)));
+            out.push_back(static_cast<char>(0x80u | ((cp >> 12u) & 0x3fu)));
+            out.push_back(static_cast<char>(0x80u | ((cp >> 6u) & 0x3fu)));
+            out.push_back(static_cast<char>(0x80u | (cp & 0x3fu)));
+        }
+    }
+
+    [[nodiscard]] std::expected<std::string, Error> parse_string() {
+        if (eof() || take() != '"') return std::unexpected(error("expected JSON string"));
+        std::string out;
+        while (!eof()) {
+            const unsigned char raw = static_cast<unsigned char>(take());
+            if (raw == '"') return out;
+            if (raw < 0x20u) return std::unexpected(error("unescaped control character in JSON string"));
+            if (raw != '\\') { out.push_back(static_cast<char>(raw)); continue; }
+            if (eof()) return std::unexpected(error("incomplete JSON string escape"));
+            switch (take()) {
+            case '"': out.push_back('"'); break;
+            case '\\': out.push_back('\\'); break;
+            case '/': out.push_back('/'); break;
+            case 'b': out.push_back('\b'); break;
+            case 'f': out.push_back('\f'); break;
+            case 'n': out.push_back('\n'); break;
+            case 'r': out.push_back('\r'); break;
+            case 't': out.push_back('\t'); break;
+            case 'u': {
+                auto first = parse_hex_quad();
+                if (!first) return std::unexpected(first.error());
+                std::uint32_t cp = *first;
+                if (cp >= 0xd800u && cp <= 0xdbffu) {
+                    if (eof() || take() != '\\' || eof() || take() != 'u') {
+                        return std::unexpected(error("high surrogate must be followed by low surrogate"));
+                    }
+                    auto second = parse_hex_quad();
+                    if (!second) return std::unexpected(second.error());
+                    if (*second < 0xdc00u || *second > 0xdfffu) {
+                        return std::unexpected(error("invalid low surrogate in Unicode escape"));
+                    }
+                    cp = 0x10000u + ((cp - 0xd800u) << 10u) + (*second - 0xdc00u);
+                } else if (cp >= 0xdc00u && cp <= 0xdfffu) {
+                    return std::unexpected(error("unexpected low surrogate in Unicode escape"));
+                }
+                append_utf8(out, cp);
+                break;
+            }
+            default: return std::unexpected(error("invalid JSON string escape"));
+            }
+        }
+        return std::unexpected(error("unterminated JSON string"));
+    }
+
+    [[nodiscard]] std::expected<JsonValue, Error> parse_number(
+        std::size_t start_line,
+        std::size_t start_column) {
+        const std::size_t begin = pos_;
+        if (peek() == '-') take();
+        if (eof()) return std::unexpected(error("incomplete JSON number"));
+        if (peek() == '0') {
+            take();
+            if (!eof() && std::isdigit(static_cast<unsigned char>(peek()))) {
+                return std::unexpected(error("leading zero in JSON number"));
+            }
+        } else if (peek() >= '1' && peek() <= '9') {
+            while (!eof() && std::isdigit(static_cast<unsigned char>(peek()))) take();
+        } else return std::unexpected(error("invalid JSON number"));
+        if (!eof() && peek() == '.') {
+            take();
+            if (eof() || !std::isdigit(static_cast<unsigned char>(peek()))) {
+                return std::unexpected(error("JSON fraction requires digits"));
+            }
+            while (!eof() && std::isdigit(static_cast<unsigned char>(peek()))) take();
+        }
+        if (!eof() && (peek() == 'e' || peek() == 'E')) {
+            take();
+            if (!eof() && (peek() == '+' || peek() == '-')) take();
+            if (eof() || !std::isdigit(static_cast<unsigned char>(peek()))) {
+                return std::unexpected(error("JSON exponent requires digits"));
+            }
+            while (!eof() && std::isdigit(static_cast<unsigned char>(peek()))) take();
+        }
+        JsonValue value;
+        value.kind = JsonValue::Kind::number;
+        value.line = start_line;
+        value.column = start_column;
+        value.scalar = std::string{text_.substr(begin, pos_ - begin)};
+        return value;
+    }
+
+    std::string_view text_;
+    fs::path path_;
+    std::size_t pos_{};
+    std::size_t line_{1};
+    std::size_t column_{1};
+};
+
+[[nodiscard]] Error schema_error(const fs::path& path, const JsonValue& value, std::string message) {
+    return make_error(ErrorCode::schema_error, path, value.line, value.column, std::move(message));
+}
+
+[[nodiscard]] std::expected<std::string, Error> read_file(const fs::path& path) {
+    std::ifstream stream{path, std::ios::binary};
+    if (!stream) return std::unexpected(make_error(ErrorCode::io_error, path, 1, 1, "failed to open project config"));
+    std::string text{std::istreambuf_iterator<char>{stream}, std::istreambuf_iterator<char>{}};
+    if (!stream.eof() && stream.fail()) {
+        return std::unexpected(make_error(ErrorCode::io_error, path, 1, 1, "failed while reading project config"));
+    }
+    return text;
+}
+
+[[nodiscard]] std::expected<const JsonObject*, Error>
+require_object(const fs::path& path, const JsonValue& value, std::string_view name) {
+    if (value.kind != JsonValue::Kind::object) {
+        return std::unexpected(schema_error(path, value, std::string{name} + " must be a JSON object"));
+    }
+    return &value.object;
+}
+
+[[nodiscard]] std::expected<std::string, Error>
+require_string(const fs::path& path, const JsonValue& value, std::string_view name) {
+    if (value.kind != JsonValue::Kind::string) {
+        return std::unexpected(schema_error(path, value, std::string{name} + " must be a JSON string"));
+    }
+    if (value.scalar.empty()) {
+        return std::unexpected(schema_error(path, value, std::string{name} + " must not be empty"));
+    }
+    return value.scalar;
+}
+
+[[nodiscard]] std::expected<bool, Error>
+require_bool(const fs::path& path, const JsonValue& value, std::string_view name) {
+    if (value.kind != JsonValue::Kind::boolean) {
+        return std::unexpected(schema_error(path, value, std::string{name} + " must be a JSON boolean"));
+    }
+    return value.boolean;
+}
+
+[[nodiscard]] std::expected<std::vector<std::string>, Error>
+require_strings(const fs::path& path, const JsonValue& value, std::string_view name) {
+    if (value.kind != JsonValue::Kind::array) {
+        return std::unexpected(schema_error(path, value, std::string{name} + " must be a JSON array"));
+    }
+    std::vector<std::string> result;
+    result.reserve(value.array.size());
+    for (const auto& element : value.array) {
+        auto text = require_string(path, element, name);
+        if (!text) return std::unexpected(text.error());
+        result.push_back(std::move(*text));
+    }
+    return result;
+}
+
+[[nodiscard]] fs::path resolve_path(const fs::path& root, const std::string& text) {
+    fs::path value = fs::u8path(text);
+    return (value.is_absolute() ? value : root / value).lexically_normal();
+}
+
+[[nodiscard]] std::expected<std::vector<fs::path>, Error>
+require_paths(const fs::path& file, const fs::path& root, const JsonValue& value, std::string_view name) {
+    auto strings = require_strings(file, value, name);
+    if (!strings) return std::unexpected(strings.error());
+    std::vector<fs::path> result;
+    result.reserve(strings->size());
+    for (const auto& text : *strings) result.push_back(resolve_path(root, text));
+    return result;
+}
+
+[[nodiscard]] std::expected<void, Error> reject_unknown(
+    const fs::path& file,
+    const JsonObject& object,
+    const std::vector<std::string_view>& allowed,
+    std::string_view scope) {
+    for (const auto& [key, value] : object) {
+        if (std::find(allowed.begin(), allowed.end(), key) == allowed.end()) {
+            return std::unexpected(schema_error(file, value, "unknown " + std::string{scope} + " field '" + key + "'"));
+        }
+    }
+    return {};
+}
+
+[[nodiscard]] std::optional<BuildConfiguration> configuration(std::string_view value) {
+    if (value == "debug") return BuildConfiguration::debug;
+    if (value == "release") return BuildConfiguration::release;
+    return std::nullopt;
+}
+[[nodiscard]] std::optional<Architecture> architecture(std::string_view value) {
+    if (value == "x86") return Architecture::x86;
+    if (value == "x64") return Architecture::x64;
+    return std::nullopt;
+}
+[[nodiscard]] std::optional<CppStandard> standard(std::string_view value) {
+    if (value == "20" || value == "c++20") return CppStandard::cpp20;
+    if (value == "23" || value == "c++23") return CppStandard::cpp23;
+    if (value == "latest" || value == "c++latest") return CppStandard::latest;
+    return std::nullopt;
+}
+
+[[nodiscard]] std::expected<void, Error>
+decode_build(const fs::path& file, const fs::path& root, const JsonValue& value, BuildOverrides& out) {
+    auto object = require_object(file, value, "build");
+    if (!object) return std::unexpected(object.error());
+    auto known = reject_unknown(file, **object,
+        {"configuration", "architecture", "standard", "output", "defines", "include_dirs", "library_dirs", "libraries"},
+        "build");
+    if (!known) return std::unexpected(known.error());
+
+    if (auto it = (**object).find("configuration"); it != (**object).end()) {
+        auto text = require_string(file, it->second, "build.configuration");
+        if (!text) return std::unexpected(text.error());
+        auto parsed = configuration(*text);
+        if (!parsed) return std::unexpected(schema_error(file, it->second, "build.configuration must be 'debug' or 'release'"));
+        out.configuration = *parsed;
+    }
+    if (auto it = (**object).find("architecture"); it != (**object).end()) {
+        auto text = require_string(file, it->second, "build.architecture");
+        if (!text) return std::unexpected(text.error());
+        auto parsed = architecture(*text);
+        if (!parsed) return std::unexpected(schema_error(file, it->second, "build.architecture must be 'x86' or 'x64'"));
+        out.architecture = *parsed;
+    }
+    if (auto it = (**object).find("standard"); it != (**object).end()) {
+        auto text = require_string(file, it->second, "build.standard");
+        if (!text) return std::unexpected(text.error());
+        auto parsed = standard(*text);
+        if (!parsed) return std::unexpected(schema_error(file, it->second, "build.standard must be '20', '23', or 'latest'"));
+        out.standard = *parsed;
+    }
+    if (auto it = (**object).find("output"); it != (**object).end()) {
+        auto text = require_string(file, it->second, "build.output");
+        if (!text) return std::unexpected(text.error());
+        out.output_name = std::move(*text);
+    }
+    if (auto it = (**object).find("defines"); it != (**object).end()) {
+        auto values = require_strings(file, it->second, "build.defines");
+        if (!values) return std::unexpected(values.error());
+        out.defines = std::move(*values);
+    }
+    if (auto it = (**object).find("include_dirs"); it != (**object).end()) {
+        auto values = require_paths(file, root, it->second, "build.include_dirs");
+        if (!values) return std::unexpected(values.error());
+        out.include_directories = std::move(*values);
+    }
+    if (auto it = (**object).find("library_dirs"); it != (**object).end()) {
+        auto values = require_paths(file, root, it->second, "build.library_dirs");
+        if (!values) return std::unexpected(values.error());
+        out.library_directories = std::move(*values);
+    }
+    if (auto it = (**object).find("libraries"); it != (**object).end()) {
+        auto values = require_strings(file, it->second, "build.libraries");
+        if (!values) return std::unexpected(values.error());
+        out.libraries = std::move(*values);
+    }
+    return {};
+}
+
+[[nodiscard]] std::expected<void, Error>
+decode_discovery(const fs::path& file, const fs::path& root, const JsonValue& value, DiscoveryOverrides& out) {
+    auto object = require_object(file, value, "discovery");
+    if (!object) return std::unexpected(object.error());
+    auto known = reject_unknown(file, **object,
+        {"enabled", "exclude_dirs", "extra_sources", "exclude_sources"}, "discovery");
+    if (!known) return std::unexpected(known.error());
+
+    if (auto it = (**object).find("enabled"); it != (**object).end()) {
+        auto enabled = require_bool(file, it->second, "discovery.enabled");
+        if (!enabled) return std::unexpected(enabled.error());
+        out.enabled = *enabled;
+    }
+    if (auto it = (**object).find("exclude_dirs"); it != (**object).end()) {
+        auto values = require_paths(file, root, it->second, "discovery.exclude_dirs");
+        if (!values) return std::unexpected(values.error());
+        out.exclude_directories = std::move(*values);
+    }
+    if (auto it = (**object).find("extra_sources"); it != (**object).end()) {
+        auto values = require_paths(file, root, it->second, "discovery.extra_sources");
+        if (!values) return std::unexpected(values.error());
+        out.extra_sources = std::move(*values);
+    }
+    if (auto it = (**object).find("exclude_sources"); it != (**object).end()) {
+        auto values = require_paths(file, root, it->second, "discovery.exclude_sources");
+        if (!values) return std::unexpected(values.error());
+        out.exclude_sources = std::move(*values);
+    }
+    return {};
+}
+
+} // namespace
+
+std::expected<std::optional<fs::path>, Error>
+ProjectConfigLoader::find_upwards(const fs::path& start_directory) {
+    std::error_code ec;
+    fs::path current = fs::absolute(start_directory, ec).lexically_normal();
+    if (ec || !fs::is_directory(current, ec) || ec) {
+        return std::unexpected(make_error(
+            ErrorCode::io_error, start_directory, 1, 1,
+            "project config search must start from an existing directory"));
+    }
+    while (true) {
+        const fs::path candidate = current / "mqb.json";
+        ec.clear();
+        if (fs::exists(candidate, ec)) {
+            if (ec || !fs::is_regular_file(candidate, ec) || ec) {
+                return std::unexpected(make_error(
+                    ErrorCode::io_error, candidate, 1, 1,
+                    "mqb.json exists but is not a regular file"));
+            }
+            return std::optional<fs::path>{candidate.lexically_normal()};
+        }
+        const fs::path parent = current.parent_path();
+        if (parent.empty() || parent == current) break;
+        current = parent;
+    }
+    return std::optional<fs::path>{};
+}
+
+std::expected<ProjectConfig, Error>
+ProjectConfigLoader::load(const fs::path& requested_file) {
+    std::error_code ec;
+    fs::path file = fs::absolute(requested_file, ec).lexically_normal();
+    if (ec || !fs::is_regular_file(file, ec) || ec) {
+        return std::unexpected(make_error(
+            ErrorCode::io_error, requested_file, 1, 1,
+            "project config must be an existing regular file"));
+    }
+    auto text = read_file(file);
+    if (!text) return std::unexpected(text.error());
+    JsonParser parser{*text, file};
+    auto root = parser.parse();
+    if (!root) return std::unexpected(root.error());
+    auto object = require_object(file, *root, "project config root");
+    if (!object) return std::unexpected(object.error());
+    auto known = reject_unknown(file, **object, {"version", "build", "discovery"}, "root");
+    if (!known) return std::unexpected(known.error());
+
+    const auto version_it = (**object).find("version");
+    if (version_it == (**object).end()) {
+        return std::unexpected(schema_error(file, *root, "project config requires integer field 'version'"));
+    }
+    if (version_it->second.kind != JsonValue::Kind::number) {
+        return std::unexpected(schema_error(file, version_it->second, "version must be integer 1"));
+    }
+    int version = 0;
+    const auto& version_text = version_it->second.scalar;
+    const auto [end, err] = std::from_chars(
+        version_text.data(), version_text.data() + version_text.size(), version);
+    if (err != std::errc{} || end != version_text.data() + version_text.size()) {
+        return std::unexpected(schema_error(file, version_it->second, "version must be integer 1"));
+    }
+    if (version != 1) {
+        return std::unexpected(make_error(
+            ErrorCode::unsupported_version,
+            file,
+            version_it->second.line,
+            version_it->second.column,
+            "unsupported mqb.json version " + std::to_string(version) + " (expected 1)"));
+    }
+
+    ProjectConfig config;
+    config.version = version;
+    config.file = file;
+    config.project_root = file.parent_path().lexically_normal();
+    if (auto it = (**object).find("build"); it != (**object).end()) {
+        auto decoded = decode_build(file, config.project_root, it->second, config.build);
+        if (!decoded) return std::unexpected(decoded.error());
+    }
+    if (auto it = (**object).find("discovery"); it != (**object).end()) {
+        auto decoded = decode_discovery(file, config.project_root, it->second, config.discovery);
+        if (!decoded) return std::unexpected(decoded.error());
+    }
+    return config;
+}
+
+} // namespace mqb::config

--- a/cpp/config/src/ProjectOptions.cpp
+++ b/cpp/config/src/ProjectOptions.cpp
@@ -1,0 +1,50 @@
+#include "mqb/config/ProjectOptions.hpp"
+
+#include <utility>
+
+namespace mqb::config {
+namespace {
+
+template <typename T>
+void append_all(std::vector<T>& destination, const std::vector<T>& source) {
+    destination.insert(destination.end(), source.begin(), source.end());
+}
+
+void apply_build(
+    EffectiveProjectOptions& effective,
+    const BuildOverrides& overrides) {
+    if (overrides.configuration) effective.configuration = *overrides.configuration;
+    if (overrides.architecture) effective.architecture = *overrides.architecture;
+    if (overrides.standard) effective.standard = *overrides.standard;
+    if (overrides.output_name) effective.output_name = overrides.output_name;
+    append_all(effective.defines, overrides.defines);
+    append_all(effective.include_directories, overrides.include_directories);
+    append_all(effective.library_directories, overrides.library_directories);
+    append_all(effective.libraries, overrides.libraries);
+}
+
+void apply_discovery(
+    EffectiveProjectOptions& effective,
+    const DiscoveryOverrides& overrides) {
+    if (overrides.enabled) effective.discovery_enabled = *overrides.enabled;
+    append_all(effective.discovery_exclude_directories, overrides.exclude_directories);
+    append_all(effective.discovery_extra_sources, overrides.extra_sources);
+    append_all(effective.discovery_exclude_sources, overrides.exclude_sources);
+}
+
+} // namespace
+
+EffectiveProjectOptions resolve_project_options(
+    const ProjectConfig* project_config,
+    const ProjectOverrides& cli_overrides) {
+    EffectiveProjectOptions effective;
+    if (project_config != nullptr) {
+        apply_build(effective, project_config->build);
+        apply_discovery(effective, project_config->discovery);
+    }
+    apply_build(effective, cli_overrides.build);
+    apply_discovery(effective, cli_overrides.discovery);
+    return effective;
+}
+
+} // namespace mqb::config

--- a/cpp/config/tests/CMakeLists.txt
+++ b/cpp/config/tests/CMakeLists.txt
@@ -1,14 +1,22 @@
 add_executable(mqb_project_config_tests
     project_config_tests.cpp
 )
-
 target_link_libraries(mqb_project_config_tests PRIVATE mqb_config)
 target_compile_features(mqb_project_config_tests PRIVATE cxx_std_23)
 
-if(MSVC)
-    target_compile_options(mqb_project_config_tests PRIVATE /W4 /permissive-)
-else()
-    target_compile_options(mqb_project_config_tests PRIVATE -Wall -Wextra -Wpedantic)
-endif()
+add_executable(mqb_project_options_tests
+    project_options_tests.cpp
+)
+target_link_libraries(mqb_project_options_tests PRIVATE mqb_config)
+target_compile_features(mqb_project_options_tests PRIVATE cxx_std_23)
+
+foreach(target IN ITEMS mqb_project_config_tests mqb_project_options_tests)
+    if(MSVC)
+        target_compile_options(${target} PRIVATE /W4 /permissive-)
+    else()
+        target_compile_options(${target} PRIVATE -Wall -Wextra -Wpedantic)
+    endif()
+endforeach()
 
 add_test(NAME mqb.config.project_config COMMAND mqb_project_config_tests)
+add_test(NAME mqb.config.project_options COMMAND mqb_project_options_tests)

--- a/cpp/config/tests/CMakeLists.txt
+++ b/cpp/config/tests/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_executable(mqb_project_config_tests
+    project_config_tests.cpp
+)
+
+target_link_libraries(mqb_project_config_tests PRIVATE mqb_config)
+target_compile_features(mqb_project_config_tests PRIVATE cxx_std_23)
+
+if(MSVC)
+    target_compile_options(mqb_project_config_tests PRIVATE /W4 /permissive-)
+else()
+    target_compile_options(mqb_project_config_tests PRIVATE -Wall -Wextra -Wpedantic)
+endif()
+
+add_test(NAME mqb.config.project_config COMMAND mqb_project_config_tests)

--- a/cpp/config/tests/project_config_tests.cpp
+++ b/cpp/config/tests/project_config_tests.cpp
@@ -1,0 +1,195 @@
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <string_view>
+#include <system_error>
+
+#include "mqb/config/ProjectConfig.hpp"
+
+namespace {
+
+namespace fs = std::filesystem;
+int failures = 0;
+
+void expect(bool condition, std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+void write_text(const fs::path& path, std::string_view text) {
+    fs::create_directories(path.parent_path());
+    std::ofstream stream{path, std::ios::binary | std::ios::trunc};
+    stream << text;
+}
+
+struct TempTree {
+    fs::path root;
+    ~TempTree() {
+        std::error_code ignored;
+        fs::remove_all(root, ignored);
+    }
+};
+
+} // namespace
+
+int main() {
+    const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
+    TempTree tree{
+        .root = fs::temp_directory_path() / ("mqb_project_config_" + std::to_string(unique)),
+    };
+    const fs::path nested = tree.root / "src" / "feature";
+    fs::create_directories(nested);
+    const fs::path config_file = tree.root / "mqb.json";
+
+    write_text(config_file, R"json({
+  "version": 1,
+  "build": {
+    "configuration": "release",
+    "architecture": "x86",
+    "standard": "latest",
+    "output": "demo",
+    "defines": ["ONE=1", "TEXT=\u6d4b\u8bd5"],
+    "include_dirs": ["include", "unicode/\u6d4b\u8bd5"],
+    "library_dirs": ["vendor libs"],
+    "libraries": ["math", "codec.lib"]
+  },
+  "discovery": {
+    "enabled": false,
+    "exclude_dirs": ["tests"],
+    "extra_sources": ["src/manual.cpp"],
+    "exclude_sources": ["src/legacy.cpp"]
+  }
+})json");
+
+    auto found = mqb::config::ProjectConfigLoader::find_upwards(nested);
+    expect(found.has_value(), "upward config lookup should succeed");
+    if (found) {
+        expect(found->has_value(), "nested directory should find root mqb.json");
+        if (*found) expect((**found).lexically_normal() == config_file.lexically_normal(),
+                           "upward lookup should return exact root config path");
+    }
+
+    auto loaded = mqb::config::ProjectConfigLoader::load(config_file);
+    expect(loaded.has_value(), "full version-1 config should load");
+    if (loaded) {
+        expect(loaded->version == 1, "config version should be retained");
+        expect(loaded->project_root == tree.root.lexically_normal(),
+               "project root should be the config file directory");
+        expect(loaded->build.configuration == mqb::BuildConfiguration::release,
+               "release override should decode");
+        expect(loaded->build.architecture == mqb::Architecture::x86,
+               "x86 override should decode");
+        expect(loaded->build.standard == mqb::CppStandard::latest,
+               "latest standard override should decode");
+        expect(loaded->build.output_name && *loaded->build.output_name == "demo",
+               "output override should decode");
+        expect(loaded->build.defines.size() == 2,
+               "define array should preserve all entries");
+        if (loaded->build.defines.size() == 2) {
+            const std::string expected_unicode = std::string{"TEXT="} + "\xE6\xB5\x8B\xE8\xAF\x95";
+            expect(loaded->build.defines[1] == expected_unicode,
+                   "Unicode escapes should decode to UTF-8");
+        }
+        expect(loaded->build.include_directories.size() == 2,
+               "include path array should decode");
+        if (loaded->build.include_directories.size() == 2) {
+            expect(loaded->build.include_directories[0] == (tree.root / "include").lexically_normal(),
+                   "relative include path should resolve from config directory");
+            const fs::path expected_unicode_path = fs::u8path(
+                std::string{"unicode/"} + "\xE6\xB5\x8B\xE8\xAF\x95");
+            expect(loaded->build.include_directories[1]
+                       == (tree.root / expected_unicode_path).lexically_normal(),
+                   "Unicode config path should resolve from config directory");
+        }
+        expect(loaded->build.library_directories.size() == 1
+                   && loaded->build.library_directories[0]
+                       == (tree.root / "vendor libs").lexically_normal(),
+               "library path should resolve from config directory");
+        expect(loaded->build.libraries.size() == 2
+                   && loaded->build.libraries[0] == "math"
+                   && loaded->build.libraries[1] == "codec.lib",
+               "library order should be preserved");
+        expect(loaded->discovery.enabled && !*loaded->discovery.enabled,
+               "discovery enabled override should decode false");
+        expect(loaded->discovery.exclude_directories.size() == 1
+                   && loaded->discovery.exclude_directories[0]
+                       == (tree.root / "tests").lexically_normal(),
+               "discovery exclude directory should resolve from config directory");
+        expect(loaded->discovery.extra_sources.size() == 1
+                   && loaded->discovery.extra_sources[0]
+                       == (tree.root / "src/manual.cpp").lexically_normal(),
+               "extra source should resolve from config directory");
+        expect(loaded->discovery.exclude_sources.size() == 1
+                   && loaded->discovery.exclude_sources[0]
+                       == (tree.root / "src/legacy.cpp").lexically_normal(),
+               "excluded source should resolve from config directory");
+    }
+
+    write_text(config_file, R"json({"version":1})json");
+    auto minimal = mqb::config::ProjectConfigLoader::load(config_file);
+    expect(minimal.has_value(), "minimal version-only config should load");
+    if (minimal) {
+        expect(!minimal->build.configuration && !minimal->build.architecture
+                   && !minimal->build.standard && !minimal->build.output_name,
+               "missing build scalar fields must remain unset rather than receiving defaults");
+        expect(minimal->build.defines.empty() && minimal->build.include_directories.empty()
+                   && minimal->build.library_directories.empty() && minimal->build.libraries.empty(),
+               "missing build list fields must remain empty overrides");
+        expect(!minimal->discovery.enabled,
+               "missing discovery enabled field must remain unset");
+    }
+
+    write_text(config_file, R"json({"version":2})json");
+    auto unsupported = mqb::config::ProjectConfigLoader::load(config_file);
+    expect(!unsupported, "unsupported config version should fail");
+    if (!unsupported) {
+        expect(unsupported.error().code == mqb::config::ErrorCode::unsupported_version,
+               "unsupported config version should report dedicated error code");
+    }
+
+    write_text(config_file, R"json({"version":1,"surprise":true})json");
+    auto unknown = mqb::config::ProjectConfigLoader::load(config_file);
+    expect(!unknown && unknown.error().code == mqb::config::ErrorCode::schema_error,
+           "unknown root fields should be rejected by strict schema");
+
+    write_text(config_file, R"json({"version":1,"build":{"architecture":"arm64"}})json");
+    auto bad_enum = mqb::config::ProjectConfigLoader::load(config_file);
+    expect(!bad_enum && bad_enum.error().code == mqb::config::ErrorCode::schema_error,
+           "invalid enum value should be rejected");
+
+    write_text(config_file, R"json({"version":1,"discovery":{"enabled":"yes"}})json");
+    auto bad_type = mqb::config::ProjectConfigLoader::load(config_file);
+    expect(!bad_type && bad_type.error().code == mqb::config::ErrorCode::schema_error,
+           "wrong field type should be rejected");
+
+    write_text(config_file, R"json({"version":1,"version":1})json");
+    auto duplicate = mqb::config::ProjectConfigLoader::load(config_file);
+    expect(!duplicate && duplicate.error().code == mqb::config::ErrorCode::parse_error,
+           "duplicate JSON keys should be rejected");
+
+    write_text(config_file, "{\n  \"version\": 1,\n  \"build\": [\n}\n");
+    auto malformed = mqb::config::ProjectConfigLoader::load(config_file);
+    expect(!malformed && malformed.error().code == mqb::config::ErrorCode::parse_error,
+           "malformed JSON should report parse error");
+    if (!malformed) {
+        expect(malformed.error().line >= 3,
+               "parse errors should retain useful line information");
+    }
+
+    std::error_code ignored;
+    fs::remove(config_file, ignored);
+    auto missing = mqb::config::ProjectConfigLoader::find_upwards(nested);
+    expect(missing.has_value() && !missing->has_value(),
+           "upward lookup should return empty optional when no config exists");
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+    std::cout << "mqb_project_config_tests passed\n";
+    return 0;
+}

--- a/cpp/config/tests/project_options_tests.cpp
+++ b/cpp/config/tests/project_options_tests.cpp
@@ -1,0 +1,124 @@
+#include <filesystem>
+#include <iostream>
+#include <string_view>
+
+#include "mqb/config/ProjectOptions.hpp"
+
+namespace {
+int failures = 0;
+void expect(bool condition, std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+} // namespace
+
+int main() {
+    namespace fs = std::filesystem;
+
+    {
+        const mqb::config::ProjectOverrides cli;
+        const auto effective = mqb::config::resolve_project_options(nullptr, cli);
+        expect(effective.configuration == mqb::BuildConfiguration::debug,
+               "built-in configuration default should be debug");
+        expect(effective.architecture == mqb::Architecture::x64,
+               "built-in architecture default should be x64");
+        expect(effective.standard == mqb::CppStandard::cpp23,
+               "built-in language default should be C++23");
+        expect(effective.discovery_enabled,
+               "smart discovery should be enabled by default");
+        expect(!effective.output_name,
+               "output should remain unset by default");
+    }
+
+    mqb::config::ProjectConfig project;
+    project.build.configuration = mqb::BuildConfiguration::release;
+    project.build.architecture = mqb::Architecture::x86;
+    project.build.standard = mqb::CppStandard::latest;
+    project.build.output_name = "from-config";
+    project.build.defines = {"CONFIG_A=1", "SHARED=config"};
+    project.build.include_directories = {fs::path{"config/include"}};
+    project.build.library_directories = {fs::path{"config/lib"}};
+    project.build.libraries = {"configlib"};
+    project.discovery.enabled = false;
+    project.discovery.exclude_directories = {fs::path{"tests"}};
+    project.discovery.extra_sources = {fs::path{"src/config-extra.cpp"}};
+    project.discovery.exclude_sources = {fs::path{"src/config-old.cpp"}};
+
+    {
+        const mqb::config::ProjectOverrides cli;
+        const auto effective = mqb::config::resolve_project_options(&project, cli);
+        expect(effective.configuration == mqb::BuildConfiguration::release,
+               "project config should override built-in configuration");
+        expect(effective.architecture == mqb::Architecture::x86,
+               "project config should override built-in architecture");
+        expect(effective.standard == mqb::CppStandard::latest,
+               "project config should override built-in standard");
+        expect(effective.output_name && *effective.output_name == "from-config",
+               "project output should override built-in unset output");
+        expect(!effective.discovery_enabled,
+               "project config should disable discovery");
+        expect(effective.defines == project.build.defines,
+               "project list values should populate effective options");
+    }
+
+    {
+        mqb::config::ProjectOverrides cli;
+        cli.build.configuration = mqb::BuildConfiguration::debug;
+        cli.build.architecture = mqb::Architecture::x64;
+        cli.build.standard = mqb::CppStandard::cpp20;
+        cli.build.output_name = "from-cli";
+        cli.build.defines = {"CLI_B=2", "SHARED=cli"};
+        cli.build.include_directories = {fs::path{"cli/include"}};
+        cli.build.library_directories = {fs::path{"cli/lib"}};
+        cli.build.libraries = {"clilib"};
+        cli.discovery.enabled = true;
+        cli.discovery.exclude_directories = {fs::path{"cli-tests"}};
+        cli.discovery.extra_sources = {fs::path{"src/cli-extra.cpp"}};
+        cli.discovery.exclude_sources = {fs::path{"src/cli-old.cpp"}};
+
+        const auto effective = mqb::config::resolve_project_options(&project, cli);
+        expect(effective.configuration == mqb::BuildConfiguration::debug,
+               "CLI configuration should override project config");
+        expect(effective.architecture == mqb::Architecture::x64,
+               "CLI architecture should override project config");
+        expect(effective.standard == mqb::CppStandard::cpp20,
+               "CLI standard should override project config");
+        expect(effective.output_name && *effective.output_name == "from-cli",
+               "CLI output should override project config");
+        expect(effective.discovery_enabled,
+               "CLI discovery override should override project config");
+        expect(effective.defines.size() == 4
+                   && effective.defines[0] == "CONFIG_A=1"
+                   && effective.defines[1] == "SHARED=config"
+                   && effective.defines[2] == "CLI_B=2"
+                   && effective.defines[3] == "SHARED=cli",
+               "CLI list values should append after config list values in stable order");
+        expect(effective.include_directories.size() == 2
+                   && effective.include_directories[0] == fs::path{"config/include"}
+                   && effective.include_directories[1] == fs::path{"cli/include"},
+               "include path precedence should preserve config then CLI order");
+        expect(effective.library_directories.size() == 2
+                   && effective.library_directories[0] == fs::path{"config/lib"}
+                   && effective.library_directories[1] == fs::path{"cli/lib"},
+               "library path lists should append CLI after config");
+        expect(effective.libraries.size() == 2
+                   && effective.libraries[0] == "configlib"
+                   && effective.libraries[1] == "clilib",
+               "libraries should append CLI after config");
+        expect(effective.discovery_exclude_directories.size() == 2,
+               "discovery exclude directories should be additive");
+        expect(effective.discovery_extra_sources.size() == 2,
+               "discovery extra sources should be additive");
+        expect(effective.discovery_exclude_sources.size() == 2,
+               "discovery excluded sources should be additive");
+    }
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+    std::cout << "mqb_project_options_tests passed\n";
+    return 0;
+}

--- a/cpp/discovery/include/mqb/discovery/SourceDiscovery.hpp
+++ b/cpp/discovery/include/mqb/discovery/SourceDiscovery.hpp
@@ -21,6 +21,7 @@ struct Warning {
 enum class ErrorCode {
     invalid_project_root,
     invalid_entry,
+    invalid_correction,
     enumeration_failed,
 };
 
@@ -34,6 +35,9 @@ struct Request {
     std::filesystem::path project_root;
     std::filesystem::path entry;
     std::vector<std::filesystem::path> include_directories;
+    std::vector<std::filesystem::path> excluded_directories;
+    std::vector<std::filesystem::path> extra_sources;
+    std::vector<std::filesystem::path> excluded_sources;
 };
 
 struct Result {

--- a/cpp/discovery/src/SourceDiscovery.cpp
+++ b/cpp/discovery/src/SourceDiscovery.cpp
@@ -11,6 +11,7 @@
 #include <string_view>
 #include <system_error>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -78,7 +79,7 @@ struct FileRecord {
     return source_extension(path) || header_extension(path);
 }
 
-[[nodiscard]] bool excluded_directory(const fs::path& path) {
+[[nodiscard]] bool default_excluded_directory(const fs::path& path) {
     const std::string name = ascii_lower(path.filename().string());
     return name == ".mqb"
         || name == ".git"
@@ -99,6 +100,10 @@ struct FileRecord {
         }
     }
     return true;
+}
+
+[[nodiscard]] bool same_or_inside(const fs::path& root, const fs::path& path) {
+    return path.lexically_normal() == root.lexically_normal() || inside_root(root, path);
 }
 
 [[nodiscard]] std::expected<std::string, std::string>
@@ -326,6 +331,43 @@ void add_undirected_edge(
     }
 }
 
+[[nodiscard]] std::expected<fs::path, Error> normalize_directory_correction(
+    const fs::path& requested,
+    const fs::path& root) {
+    std::error_code error_code;
+    fs::path absolute = fs::absolute(requested, error_code).lexically_normal();
+    if (error_code
+        || !fs::is_directory(absolute, error_code)
+        || error_code
+        || !inside_root(root, absolute)) {
+        return std::unexpected(failure(
+            ErrorCode::invalid_correction,
+            requested,
+            "discovery excluded directory must be an existing directory strictly inside the project root"));
+    }
+    return absolute;
+}
+
+[[nodiscard]] std::expected<fs::path, Error> normalize_source_correction(
+    const fs::path& requested,
+    const fs::path& root,
+    const std::string_view description) {
+    std::error_code error_code;
+    fs::path absolute = fs::absolute(requested, error_code).lexically_normal();
+    if (error_code
+        || !fs::is_regular_file(absolute, error_code)
+        || error_code
+        || !source_extension(absolute)
+        || !inside_root(root, absolute)) {
+        return std::unexpected(failure(
+            ErrorCode::invalid_correction,
+            requested,
+            std::string{description}
+                + " must be an existing ordinary C++ source inside the project root"));
+    }
+    return absolute;
+}
+
 } // namespace
 
 std::expected<Result, Error>
@@ -349,6 +391,75 @@ SourceDiscovery::discover(const Request& request) {
             ErrorCode::invalid_entry,
             request.entry,
             "source discovery entry must be an ordinary C++ source inside the project root"));
+    }
+
+    std::vector<fs::path> excluded_directories;
+    std::unordered_set<std::string> excluded_directory_keys;
+    excluded_directories.reserve(request.excluded_directories.size());
+    for (const auto& requested : request.excluded_directories) {
+        auto directory = normalize_directory_correction(requested, root);
+        if (!directory) return std::unexpected(directory.error());
+        if (same_or_inside(*directory, entry)) {
+            return std::unexpected(failure(
+                ErrorCode::invalid_correction,
+                *directory,
+                "discovery excluded directory must not contain the entry translation unit"));
+        }
+        if (excluded_directory_keys.insert(path_key(*directory)).second) {
+            excluded_directories.push_back(std::move(*directory));
+        }
+    }
+
+    std::unordered_set<std::string> excluded_source_keys;
+    for (const auto& requested : request.excluded_sources) {
+        auto source = normalize_source_correction(requested, root, "discovery excluded source");
+        if (!source) return std::unexpected(source.error());
+        if (*source == entry) {
+            return std::unexpected(failure(
+                ErrorCode::invalid_correction,
+                *source,
+                "discovery excluded source must not be the entry translation unit"));
+        }
+        excluded_source_keys.insert(path_key(*source));
+    }
+
+    std::vector<fs::path> extra_sources;
+    std::unordered_set<std::string> extra_source_keys;
+    for (const auto& requested : request.extra_sources) {
+        auto source = normalize_source_correction(requested, root, "discovery extra source");
+        if (!source) return std::unexpected(source.error());
+        const std::string key = path_key(*source);
+        if (excluded_source_keys.contains(key)) {
+            return std::unexpected(failure(
+                ErrorCode::invalid_correction,
+                *source,
+                "the same source cannot be both extra and excluded"));
+        }
+        for (const auto& directory : excluded_directories) {
+            if (same_or_inside(directory, *source)) {
+                return std::unexpected(failure(
+                    ErrorCode::invalid_correction,
+                    *source,
+                    "discovery extra source must not be inside an excluded directory"));
+            }
+        }
+        if (*source != entry && extra_source_keys.insert(key).second) {
+            auto text = read_text(*source);
+            if (!text) {
+                return std::unexpected(failure(
+                    ErrorCode::invalid_correction,
+                    *source,
+                    text.error()));
+            }
+            const std::string comment_free = strip_comments_preserve_literals(*text);
+            if (contains_main(comment_free)) {
+                return std::unexpected(failure(
+                    ErrorCode::invalid_correction,
+                    *source,
+                    "discovery extra source must not define another main()"));
+            }
+            extra_sources.push_back(std::move(*source));
+        }
     }
 
     Result result;
@@ -376,7 +487,9 @@ SourceDiscovery::discover(const Request& request) {
         }
         const fs::directory_entry& item = *iterator;
         if (item.is_directory(error_code)) {
-            if (!error_code && excluded_directory(item.path())) {
+            const bool configured_excluded = !error_code
+                && excluded_directory_keys.contains(path_key(item.path()));
+            if (!error_code && (default_excluded_directory(item.path()) || configured_excluded)) {
                 iterator.disable_recursion_pending();
             }
             error_code.clear();
@@ -486,7 +599,9 @@ SourceDiscovery::discover(const Request& request) {
             const bool second_main = next != entry_index
                 && files[next].kind == FileKind::source
                 && files[next].defines_main;
-            if (!second_main) {
+            const bool excluded_source = files[next].kind == FileKind::source
+                && excluded_source_keys.contains(path_key(files[next].path));
+            if (!second_main && !excluded_source) {
                 queue.push_back(next);
             }
         }
@@ -499,7 +614,21 @@ SourceDiscovery::discover(const Request& request) {
         if (files[index].path != entry && files[index].defines_main) {
             continue;
         }
+        if (excluded_source_keys.contains(path_key(files[index].path))) {
+            continue;
+        }
         result.sources.push_back(files[index].path);
+    }
+
+    for (const auto& source : extra_sources) {
+        const std::string key = path_key(source);
+        const auto duplicate = std::find_if(
+            result.sources.begin(),
+            result.sources.end(),
+            [&](const fs::path& existing) { return path_key(existing) == key; });
+        if (duplicate == result.sources.end()) {
+            result.sources.push_back(source);
+        }
     }
 
     std::sort(
@@ -522,4 +651,4 @@ SourceDiscovery::discover(const Request& request) {
     return result;
 }
 
-} // namespace mqb
+} // namespace mqb::discovery

--- a/cpp/discovery/tests/CMakeLists.txt
+++ b/cpp/discovery/tests/CMakeLists.txt
@@ -1,14 +1,22 @@
 add_executable(mqb_source_discovery_tests
     source_discovery_tests.cpp
 )
-
 target_link_libraries(mqb_source_discovery_tests PRIVATE mqb_discovery)
 target_compile_features(mqb_source_discovery_tests PRIVATE cxx_std_23)
 
-if(MSVC)
-    target_compile_options(mqb_source_discovery_tests PRIVATE /W4 /permissive-)
-else()
-    target_compile_options(mqb_source_discovery_tests PRIVATE -Wall -Wextra -Wpedantic)
-endif()
+add_executable(mqb_source_discovery_corrections_tests
+    source_discovery_corrections_tests.cpp
+)
+target_link_libraries(mqb_source_discovery_corrections_tests PRIVATE mqb_discovery)
+target_compile_features(mqb_source_discovery_corrections_tests PRIVATE cxx_std_23)
+
+foreach(target IN ITEMS mqb_source_discovery_tests mqb_source_discovery_corrections_tests)
+    if(MSVC)
+        target_compile_options(${target} PRIVATE /W4 /permissive-)
+    else()
+        target_compile_options(${target} PRIVATE -Wall -Wextra -Wpedantic)
+    endif()
+endforeach()
 
 add_test(NAME mqb.discovery.source_graph COMMAND mqb_source_discovery_tests)
+add_test(NAME mqb.discovery.corrections COMMAND mqb_source_discovery_corrections_tests)

--- a/cpp/discovery/tests/source_discovery_corrections_tests.cpp
+++ b/cpp/discovery/tests/source_discovery_corrections_tests.cpp
@@ -1,0 +1,149 @@
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <vector>
+
+#include "mqb/discovery/SourceDiscovery.hpp"
+
+namespace {
+namespace fs = std::filesystem;
+int failures = 0;
+
+void expect(bool condition, std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+void write_text(const fs::path& path, std::string_view text) {
+    fs::create_directories(path.parent_path());
+    std::ofstream stream{path, std::ios::binary | std::ios::trunc};
+    stream << text;
+}
+bool contains(const std::vector<fs::path>& sources, const fs::path& source) {
+    for (const auto& candidate : sources) {
+        if (candidate.lexically_normal() == source.lexically_normal()) return true;
+    }
+    return false;
+}
+struct TempTree {
+    fs::path root;
+    ~TempTree() {
+        std::error_code ignored;
+        fs::remove_all(root, ignored);
+    }
+};
+} // namespace
+
+int main() {
+    const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
+    TempTree tree{
+        .root = fs::temp_directory_path() / ("mqb_discovery_corrections_" + std::to_string(unique)),
+    };
+    fs::create_directories(tree.root);
+
+    const fs::path main_cpp = tree.root / "main.cpp";
+    const fs::path prod_hpp = tree.root / "prod.hpp";
+    const fs::path prod_cpp = tree.root / "prod.cpp";
+    const fs::path legacy_hpp = tree.root / "legacy.hpp";
+    const fs::path legacy_cpp = tree.root / "legacy.cpp";
+    const fs::path private_hpp = tree.root / "private.hpp";
+    const fs::path private_cpp = tree.root / "private.cpp";
+    const fs::path extra_cpp = tree.root / "manual.cpp";
+    const fs::path tests_dir = tree.root / "tests";
+    const fs::path test_cpp = tests_dir / "test_helper.cpp";
+
+    write_text(main_cpp,
+        "#include \"prod.hpp\"\n"
+        "#include \"legacy.hpp\"\n"
+        "int main() { return prod() + legacy(); }\n");
+    write_text(prod_hpp, "#pragma once\nint prod();\n");
+    write_text(prod_cpp, "#include \"prod.hpp\"\nint prod() { return 1; }\n");
+    write_text(legacy_hpp, "#pragma once\nint legacy();\n");
+    write_text(legacy_cpp,
+        "#include \"legacy.hpp\"\n"
+        "#include \"private.hpp\"\n"
+        "int legacy() { return private_value(); }\n");
+    write_text(private_hpp, "#pragma once\nint private_value();\n");
+    write_text(private_cpp, "#include \"private.hpp\"\nint private_value() { return 9; }\n");
+    write_text(extra_cpp, "int manually_added() { return 7; }\n");
+    write_text(test_cpp,
+        "#include \"../prod.hpp\"\n"
+        "int test_helper() { return prod(); }\n");
+
+    const mqb::discovery::Request request{
+        .project_root = tree.root,
+        .entry = main_cpp,
+        .include_directories = {},
+        .excluded_directories = {tests_dir},
+        .extra_sources = {extra_cpp},
+        .excluded_sources = {legacy_cpp},
+    };
+    auto discovered = mqb::discovery::SourceDiscovery::discover(request);
+    expect(discovered.has_value(), "configured discovery should succeed");
+    if (discovered) {
+        expect(discovered->sources.size() == 3,
+               "configured discovery should select entry, production TU, and exact extra TU");
+        expect(!discovered->sources.empty() && discovered->sources.front() == main_cpp,
+               "entry should remain first after configured corrections");
+        expect(contains(discovered->sources, prod_cpp),
+               "production source connected through header should remain selected");
+        expect(contains(discovered->sources, extra_cpp),
+               "disconnected exact extra source should be selected");
+        expect(!contains(discovered->sources, legacy_cpp),
+               "exact excluded source should not be selected");
+        expect(!contains(discovered->sources, private_cpp),
+               "excluded source should be a traversal barrier to its private subgraph");
+        expect(!contains(discovered->sources, test_cpp),
+               "configured excluded directory should be pruned before graph construction");
+    }
+
+    auto entry_excluded = mqb::discovery::SourceDiscovery::discover({
+        .project_root = tree.root,
+        .entry = main_cpp,
+        .include_directories = {},
+        .excluded_directories = {},
+        .extra_sources = {},
+        .excluded_sources = {main_cpp},
+    });
+    expect(!entry_excluded
+               && entry_excluded.error().code == mqb::discovery::ErrorCode::invalid_correction,
+           "entry source must not be excludable");
+
+    const fs::path second_main = tree.root / "manual_main.cpp";
+    write_text(second_main, "int main() { return 1; }\n");
+    auto extra_main = mqb::discovery::SourceDiscovery::discover({
+        .project_root = tree.root,
+        .entry = main_cpp,
+        .include_directories = {},
+        .excluded_directories = {},
+        .extra_sources = {second_main},
+        .excluded_sources = {},
+    });
+    expect(!extra_main
+               && extra_main.error().code == mqb::discovery::ErrorCode::invalid_correction,
+           "explicit extra source defining another main must be rejected");
+
+    auto conflicting = mqb::discovery::SourceDiscovery::discover({
+        .project_root = tree.root,
+        .entry = main_cpp,
+        .include_directories = {},
+        .excluded_directories = {},
+        .extra_sources = {extra_cpp},
+        .excluded_sources = {extra_cpp},
+    });
+    expect(!conflicting
+               && conflicting.error().code == mqb::discovery::ErrorCode::invalid_correction,
+           "same exact source cannot be both extra and excluded");
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+    std::cout << "mqb_source_discovery_corrections_tests passed\n";
+    return 0;
+}

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -130,12 +130,17 @@ if(WIN32)
         target_link_libraries(mqb_cli_e2e_tests PRIVATE mqb_msvc mqb_platform_windows)
         target_compile_features(mqb_cli_e2e_tests PRIVATE cxx_std_23)
 
+        add_executable(mqb_project_config_e2e_tests mqb_project_config_e2e_tests.cpp)
+        target_link_libraries(mqb_project_config_e2e_tests PRIVATE mqb_msvc mqb_platform_windows)
+        target_compile_features(mqb_project_config_e2e_tests PRIVATE cxx_std_23)
+
         list(APPEND MQB_TEST_TARGETS
             mqb_msvc_visual_studio_tests
             mqb_msvc_compile_integration_tests
             mqb_msvc_link_integration_tests
             mqb_msvc_incremental_loop_tests
             mqb_cli_e2e_tests
+            mqb_project_config_e2e_tests
         )
     endif()
 endif()
@@ -182,6 +187,10 @@ if(WIN32)
         add_test(
             NAME mqb.cli.target_e2e
             COMMAND mqb_cli_e2e_tests $<TARGET_FILE:mqb>
+        )
+        add_test(
+            NAME mqb.cli.project_config_e2e
+            COMMAND mqb_project_config_e2e_tests $<TARGET_FILE:mqb>
         )
     endif()
 endif()

--- a/cpp/tests/cli_argument_tests.cpp
+++ b/cpp/tests/cli_argument_tests.cpp
@@ -37,6 +37,11 @@ int main() {
                    "single source should be preserved in ordered source list");
             expect(parsed->discover_sources,
                    "single-source smart discovery should be enabled by default");
+            expect(!parsed->discovery_override,
+                   "default discovery policy must not masquerade as an explicit CLI override");
+            expect(!parsed->configuration_override && !parsed->architecture_override
+                       && !parsed->standard_override,
+                   "built-in parser defaults must not masquerade as explicit CLI scalar overrides");
             expect(!parsed->build.output_name.has_value(),
                    "output name should remain unset by default");
             expect(!parsed->build.run_after_build,
@@ -61,6 +66,21 @@ int main() {
         auto parsed = mqb::cli::parse_arguments(arguments);
         expect(parsed.has_value() && !parsed->discover_sources,
                "--no-discover should disable single-source smart discovery");
+        if (parsed) {
+            expect(parsed->discovery_override.has_value() && !*parsed->discovery_override,
+                   "--no-discover must be recorded as an explicit false project override");
+        }
+    }
+
+    {
+        const std::vector arguments{"main.cpp"sv, "--discover"sv};
+        auto parsed = mqb::cli::parse_arguments(arguments);
+        expect(parsed.has_value() && parsed->discover_sources,
+               "--discover should explicitly enable smart discovery");
+        if (parsed) {
+            expect(parsed->discovery_override.has_value() && *parsed->discovery_override,
+                   "--discover must be recorded as an explicit true project override");
+        }
     }
 
     {
@@ -108,6 +128,8 @@ int main() {
             }
             expect(parsed->discover_sources,
                    "parser keeps discovery policy enabled; main treats multi-source sets as explicit");
+            expect(!parsed->discovery_override,
+                   "multi-source parsing must not create a discovery override unless requested");
             expect(parsed->build.output_name.has_value()
                        && *parsed->build.output_name == "product",
                    "output name should be parsed");
@@ -137,10 +159,16 @@ int main() {
             }
             expect(parsed->build.configuration == mqb::BuildConfiguration::release,
                    "release flag should override default");
+            expect(parsed->configuration_override == mqb::BuildConfiguration::release,
+                   "release flag must be recorded as an explicit project override");
             expect(parsed->build.architecture == mqb::Architecture::x86,
                    "x86 flag should be parsed");
+            expect(parsed->architecture_override == mqb::Architecture::x86,
+                   "x86 flag must be recorded as an explicit project override");
             expect(parsed->build.standard == mqb::CppStandard::latest,
                    "latest standard should be parsed");
+            expect(parsed->standard_override == mqb::CppStandard::latest,
+                   "--std must be recorded as an explicit project override");
             expect(parsed->toolchain_preference == mqb::msvc::ToolchainPreference::portable,
                    "portable toolchain preference should be parsed");
             expect(parsed->portable_roots.size() == 1,
@@ -150,6 +178,26 @@ int main() {
             expect(parsed->defines.size() == 1 && parsed->defines.front() == "VALUE=42",
                    "separate define value should be collected");
             expect(parsed->verbose, "verbose flag should be parsed");
+        }
+    }
+
+    {
+        const std::vector arguments{
+            "main.cpp"sv,
+            "--debug"sv,
+            "--x64"sv,
+            "--std"sv,
+            "20"sv,
+        };
+        auto parsed = mqb::cli::parse_arguments(arguments);
+        expect(parsed.has_value(), "explicit built-in-valued options should parse");
+        if (parsed) {
+            expect(parsed->configuration_override == mqb::BuildConfiguration::debug,
+                   "explicit --debug must override a possible release project config");
+            expect(parsed->architecture_override == mqb::Architecture::x64,
+                   "explicit --x64 must override a possible x86 project config");
+            expect(parsed->standard_override == mqb::CppStandard::cpp20,
+                   "explicit --std 20 must override project standard");
         }
     }
 
@@ -180,6 +228,8 @@ int main() {
         if (parsed) {
             expect(parsed->discover_sources,
                    "discovery parsing must stop at --");
+            expect(!parsed->discovery_override,
+                   "option-looking child argv must not create a project override");
             expect(parsed->build.run_arguments.size() == 1
                        && parsed->build.run_arguments.front() == "--no-discover",
                    "option-looking argv after -- must be preserved verbatim");

--- a/cpp/tests/mqb_project_config_e2e_tests.cpp
+++ b/cpp/tests/mqb_project_config_e2e_tests.cpp
@@ -1,0 +1,340 @@
+#include <chrono>
+#include <expected>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <vector>
+
+#include "mqb/core/BuildTypes.hpp"
+#include "mqb/msvc/MsvcToolchainLocator.hpp"
+#include "mqb/platform/windows/WindowsProcessRunner.hpp"
+#include "mqb/process/Process.hpp"
+
+namespace {
+namespace fs = std::filesystem;
+int failures = 0;
+
+void expect(bool condition, std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+[[nodiscard]] std::string path_text(const fs::path& path) {
+    const auto bytes = path.generic_u8string();
+    return std::string{reinterpret_cast<const char*>(bytes.data()), bytes.size()};
+}
+
+void write_text(const fs::path& path, std::string_view text) {
+    fs::create_directories(path.parent_path());
+    std::ofstream stream{path, std::ios::binary | std::ios::trunc};
+    stream << text;
+}
+
+void dump_failure(const mqb::process::ProcessResult& result) {
+    std::cerr << "exit: " << result.exit_code << '\n'
+              << "stdout:\n" << result.stdout_text << '\n'
+              << "stderr:\n" << result.stderr_text << '\n';
+}
+
+[[nodiscard]] bool contains_line(std::string_view output, std::string_view expected) {
+    std::size_t begin = 0;
+    while (begin <= output.size()) {
+        const std::size_t newline = output.find('\n', begin);
+        const std::size_t end = newline == std::string_view::npos ? output.size() : newline;
+        std::string_view line = output.substr(begin, end - begin);
+        if (!line.empty() && line.back() == '\r') line.remove_suffix(1);
+        if (line == expected) return true;
+        if (newline == std::string_view::npos) break;
+        begin = newline + 1;
+    }
+    return false;
+}
+
+struct TempTree {
+    fs::path root;
+    ~TempTree() {
+        std::error_code ignored;
+        fs::remove_all(root, ignored);
+    }
+};
+
+[[nodiscard]] std::expected<void, std::string> build_static_library(
+    mqb::platform::windows::WindowsProcessRunner& runner,
+    const mqb::msvc::MsvcToolchain& toolchain,
+    const fs::path& project_root,
+    const fs::path& library_directory) {
+    fs::create_directories(library_directory);
+    const fs::path source = library_directory / "math_library.cpp";
+    const fs::path object = library_directory / "math_library.obj";
+    const fs::path library = library_directory / "math.lib";
+    write_text(source, "int library_value() { return 100; }\n");
+
+    mqb::process::ProcessSpec compile;
+    compile.executable = toolchain.identity.compiler;
+    compile.arguments = {
+        "/nologo", "/c", "/Zl",
+        "/Fo:" + path_text(object),
+        path_text(source),
+    };
+    compile.working_directory = project_root;
+    compile.environment = toolchain.environment;
+    compile.inherit_environment = true;
+    compile.capture_stdout = true;
+    compile.capture_stderr = true;
+    auto compiled = runner.run(compile);
+    if (!compiled) return std::unexpected("failed to launch cl.exe: " + compiled.error().message);
+    if (compiled->exit_code != 0) {
+        dump_failure(*compiled);
+        return std::unexpected("cl.exe failed while building config E2E library");
+    }
+
+    mqb::process::ProcessSpec archive;
+    archive.executable = toolchain.librarian;
+    archive.arguments = {"/NOLOGO", "/OUT:" + path_text(library), path_text(object)};
+    archive.working_directory = project_root;
+    archive.environment = toolchain.environment;
+    archive.inherit_environment = true;
+    archive.capture_stdout = true;
+    archive.capture_stderr = true;
+    auto archived = runner.run(archive);
+    if (!archived) return std::unexpected("failed to launch lib.exe: " + archived.error().message);
+    if (archived->exit_code != 0) {
+        dump_failure(*archived);
+        return std::unexpected("lib.exe failed while building config E2E library");
+    }
+    if (!fs::is_regular_file(library)) return std::unexpected("math.lib was not produced");
+    return {};
+}
+
+[[nodiscard]] std::expected<mqb::process::ProcessResult, std::string> run_mqb(
+    mqb::platform::windows::WindowsProcessRunner& runner,
+    const fs::path& mqb,
+    const fs::path& working_directory,
+    const std::vector<std::string>& extra_arguments) {
+    mqb::process::ProcessSpec spec;
+    spec.executable = mqb;
+    spec.arguments = {"../../main.cpp", "--env", "vs", "--discover"};
+    spec.arguments.insert(spec.arguments.end(), extra_arguments.begin(), extra_arguments.end());
+    spec.working_directory = working_directory;
+    spec.capture_stdout = true;
+    spec.capture_stderr = true;
+    auto result = runner.run(spec);
+    if (!result) return std::unexpected("failed to launch mqb: " + result.error().message);
+    return std::move(*result);
+}
+
+[[nodiscard]] std::expected<mqb::process::ProcessResult, std::string> run_executable(
+    mqb::platform::windows::WindowsProcessRunner& runner,
+    const fs::path& executable,
+    const fs::path& project_root) {
+    mqb::process::ProcessSpec spec;
+    spec.executable = executable;
+    spec.working_directory = project_root;
+    spec.capture_stdout = true;
+    spec.capture_stderr = true;
+    auto result = runner.run(spec);
+    if (!result) return std::unexpected("failed to launch generated executable: " + result.error().message);
+    return std::move(*result);
+}
+
+[[nodiscard]] std::string config_text(int config_value) {
+    return std::string{R"json({
+  "version": 1,
+  "build": {
+    "configuration": "release",
+    "standard": "23",
+    "output": "config_product",
+    "defines": ["CONFIG_VALUE=)json"}
+        + std::to_string(config_value)
+        + R"json("],
+    "include_dirs": ["include"],
+    "library_dirs": ["vendor libs"],
+    "libraries": ["math"]
+  },
+  "discovery": {
+    "enabled": false,
+    "exclude_dirs": ["tests"],
+    "extra_sources": ["manual.cpp"],
+    "exclude_sources": ["legacy.cpp"]
+  }
+})json";
+}
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    if (argc != 2) {
+        std::cerr << "usage: mqb_project_config_e2e_tests <mqb-executable>\n";
+        return 2;
+    }
+
+    const fs::path mqb_executable{argv[1]};
+    const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
+    TempTree tree{
+        .root = fs::temp_directory_path() / ("mqb_project_config_e2e_" + std::to_string(unique)),
+    };
+    const fs::path nested_working_directory = tree.root / "nested" / "work";
+    const fs::path include_dir = tree.root / "include";
+    const fs::path library_dir = tree.root / "vendor libs";
+    fs::create_directories(nested_working_directory);
+
+    mqb::platform::windows::WindowsProcessRunner runner;
+    mqb::msvc::MsvcToolchainLocator locator{runner};
+    mqb::msvc::DiscoveryOptions discovery;
+    discovery.target_architecture = mqb::Architecture::x64;
+    discovery.host_architecture = mqb::Architecture::x64;
+    discovery.preference = mqb::msvc::ToolchainPreference::visual_studio;
+    auto toolchain = locator.discover(discovery);
+    expect(toolchain.has_value(), "VS2026 toolchain should be discoverable for config E2E");
+    if (!toolchain) {
+        std::cerr << toolchain.error().message << '\n';
+        return 1;
+    }
+    auto library = build_static_library(runner, *toolchain, tree.root, library_dir);
+    expect(library.has_value(), "static library fixture should build");
+    if (!library) {
+        std::cerr << library.error() << '\n';
+        return 1;
+    }
+
+    write_text(include_dir / "value.hpp", "#pragma once\nint value();\n");
+    write_text(tree.root / "src" / "value.cpp",
+               "#include \"value.hpp\"\nint value() { return 1; }\n");
+    write_text(tree.root / "legacy.hpp", "#pragma once\nint legacy();\n");
+    write_text(tree.root / "private.hpp", "#pragma once\nint private_value();\n");
+    write_text(tree.root / "legacy.cpp",
+               "#include \"legacy.hpp\"\n#include \"private.hpp\"\nint legacy() { return private_value(); }\n");
+    write_text(tree.root / "private.cpp",
+               "#include \"private.hpp\"\nint private_value() { return 50; }\n");
+    write_text(tree.root / "manual.cpp", "int manual_value() { return 3; }\n");
+    write_text(tree.root / "tests" / "test_helper.cpp",
+               "#include \"value.hpp\"\nint test_helper() { return value(); }\n");
+    write_text(tree.root / "main.cpp", R"cpp(#include <cstdio>
+#include "value.hpp"
+#include "legacy.hpp"
+#ifndef CONFIG_VALUE
+#error CONFIG_VALUE must come from mqb.json
+#endif
+#ifndef CLI_VALUE
+#define CLI_VALUE 0
+#endif
+int manual_value();
+int library_value();
+int main() {
+#ifdef _DEBUG
+    constexpr int debug_bonus = 1000;
+#else
+    constexpr int debug_bonus = 0;
+#endif
+    std::printf("config-e2e=%d\n", value() + manual_value() + library_value() + CONFIG_VALUE + CLI_VALUE + debug_bonus);
+    return 0;
+}
+)cpp");
+    write_text(tree.root / "mqb.json", config_text(5));
+
+    auto cold = run_mqb(runner, mqb_executable, nested_working_directory, {"--verbose"});
+    expect(cold.has_value(), "config-driven cold invocation should launch");
+    if (cold) {
+        if (cold->exit_code != 0) dump_failure(*cold);
+        expect(cold->exit_code == 0, "config-driven cold build should succeed");
+        expect(cold->stdout_text.find("[discover] 3 translation units") != std::string::npos,
+               "CLI --discover should override config discovery.enabled=false");
+        expect(cold->stdout_text.find("config:  ") != std::string::npos,
+               "verbose output should report the loaded project config");
+        expect(cold->stdout_text.find("[link] config_product.exe") != std::string::npos,
+               "config output name should drive target identity");
+    }
+
+    const fs::path config_exe = tree.root / ".mqb" / "bin" / "config_product.exe";
+    expect(fs::is_regular_file(config_exe),
+           "config-root artifact layout should be used even when invoked from nested directory");
+    expect(fs::is_regular_file(tree.root / ".mqb" / "obj" / "main.cpp.obj"),
+           "entry object should be rooted at config project root");
+    expect(fs::is_regular_file(tree.root / ".mqb" / "obj" / "src" / "value.cpp.obj"),
+           "include-connected source should be discovered from config root");
+    expect(fs::is_regular_file(tree.root / ".mqb" / "obj" / "manual.cpp.obj"),
+           "config extra_sources should add disconnected TU");
+    expect(!fs::exists(tree.root / ".mqb" / "obj" / "legacy.cpp.obj"),
+           "config exclude_sources should remove exact TU");
+    expect(!fs::exists(tree.root / ".mqb" / "obj" / "private.cpp.obj"),
+           "excluded source should block traversal into private subgraph");
+    expect(!fs::exists(tree.root / ".mqb" / "obj" / "tests" / "test_helper.cpp.obj"),
+           "config exclude_dirs should prune test subtree");
+
+    auto cold_run = run_executable(runner, config_exe, tree.root);
+    expect(cold_run.has_value() && cold_run->exit_code == 0,
+           "config-built executable should run successfully");
+    if (cold_run) {
+        expect(cold_run->stdout_text.find("config-e2e=109") != std::string::npos,
+               "config define/include/library settings should affect executable behavior");
+    }
+
+    auto warm = run_mqb(runner, mqb_executable, nested_working_directory, {});
+    expect(warm.has_value(), "warm config invocation should launch");
+    if (warm) {
+        if (warm->exit_code != 0) dump_failure(*warm);
+        expect(warm->exit_code == 0, "warm config build should succeed");
+        expect(contains_line(warm->stdout_text, "[up-to-date] main.cpp"),
+               "warm config build should reuse entry TU");
+        expect(contains_line(warm->stdout_text, "[up-to-date] src/value.cpp"),
+               "warm config build should reuse discovered TU");
+        expect(contains_line(warm->stdout_text, "[up-to-date] manual.cpp"),
+               "warm config build should reuse config extra TU");
+        expect(contains_line(warm->stdout_text, "[up-to-date] config_product.exe"),
+               "warm config build should reuse linked target");
+    }
+
+    write_text(tree.root / "mqb.json", config_text(6));
+    auto config_changed = run_mqb(runner, mqb_executable, nested_working_directory, {});
+    expect(config_changed.has_value(), "config-only change invocation should launch");
+    if (config_changed) {
+        if (config_changed->exit_code != 0) dump_failure(*config_changed);
+        expect(config_changed->exit_code == 0, "config-only changed build should succeed");
+        expect(config_changed->stdout_text.find("compiler options changed") != std::string::npos,
+               "config define change should invalidate compile recipe without source edits");
+        expect(config_changed->stdout_text.find("[link] config_product.exe") != std::string::npos,
+               "fresh compiles from config change should force relink");
+    }
+    auto config_changed_run = run_executable(runner, config_exe, tree.root);
+    if (config_changed_run) {
+        expect(config_changed_run->stdout_text.find("config-e2e=110") != std::string::npos,
+               "config-only define change should alter executable behavior");
+    } else {
+        expect(false, "config-changed executable should launch");
+    }
+
+    auto cli_override = run_mqb(
+        runner,
+        mqb_executable,
+        nested_working_directory,
+        {"--debug", "-DCLI_VALUE=10", "-o", "cli_product"});
+    expect(cli_override.has_value(), "CLI override invocation should launch");
+    if (cli_override) {
+        if (cli_override->exit_code != 0) dump_failure(*cli_override);
+        expect(cli_override->exit_code == 0, "CLI override build should succeed");
+        expect(cli_override->stdout_text.find("compiler options changed") != std::string::npos,
+               "CLI --debug should override config release and invalidate compile recipe");
+        expect(cli_override->stdout_text.find("[link] cli_product.exe") != std::string::npos,
+               "CLI output name should override config output name");
+    }
+    const fs::path cli_exe = tree.root / ".mqb" / "bin" / "cli_product.exe";
+    auto cli_run = run_executable(runner, cli_exe, tree.root);
+    expect(cli_run.has_value() && cli_run->exit_code == 0,
+           "CLI-override executable should launch");
+    if (cli_run) {
+        expect(cli_run->stdout_text.find("config-e2e=1120") != std::string::npos,
+               "CLI debug/define overrides should win while retaining config include/library inputs");
+    }
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+    std::cout << "mqb_project_config_e2e_tests passed\n";
+    return 0;
+}

--- a/docs/CPP_V2_ARCHITECTURE.md
+++ b/docs/CPP_V2_ARCHITECTURE.md
@@ -5,7 +5,7 @@ This document defines the architecture for migrating MSVC Quick Build from the P
 ## Goals
 
 - Keep the PowerShell implementation as the behavioral reference until parity is proven.
-- Separate build policy from compiler/linker/process execution.
+- Separate source selection, build policy, compiler/linker execution, and process execution.
 - Keep MSVC-specific spellings out of the core model.
 - Make compile and link cache invalidation explainable and regression-testable.
 - Treat paths and argv as structured data rather than shell command strings.
@@ -15,6 +15,13 @@ This document defines the architecture for migrating MSVC Quick Build from the P
 
 ```text
 CLI (mqb.exe)
+    |
+    +--> Project Config (mqb_config)
+    |      mqb.json locator/parser
+    |      CLI > config > defaults resolver
+    |
+    +--> Source Discovery (mqb_discovery)
+    |      ordinary C++ candidate-TU selection
     |
     v
 Target orchestration
@@ -26,12 +33,13 @@ Core                  MSVC backend
   BuildRequest           MsvcToolchainLocator
   Artifact / TU          MsvcCompiler
   ProjectArtifactLayout  MsvcCompileExecutor
-  BuildSignature         MsvcLinker
-  CompileCache           /sourceDependencies reader
-  LinkCache                    |
-  DependencyGraph              v
-  BuildPlanner           Process abstraction
-    |                     ProcessSpec { executable, argv, cwd, env }
+  BuildSignature         MsvcLibraryResolver
+  CompileCache           MsvcLinker
+  LinkCache              /sourceDependencies reader
+  DependencyGraph              |
+  BuildPlanner                 v
+    |                    Process abstraction
+    |                    ProcessSpec { executable, argv, cwd, env }
     |                          |
     +--------------------------+
                                v
@@ -51,6 +59,51 @@ Core                  MSVC backend
 7. **A fresh compile is an explicit relink signal.** Linking must not depend solely on filesystem timestamp granularity.
 8. **Source identity is not a basename.** Project artifacts preserve relative source identity; external sources receive a stable hashed namespace, and duplicate object mappings are rejected before execution.
 9. **Run-time argv is not build identity.** `--run` and arguments after `--` are execution state only; changing them must not invalidate compile or link caches.
+10. **Discovery is not dependency freshness.** Smart discovery chooses candidate translation units; MSVC `/sourceDependencies` remains the authority for header freshness.
+11. **Configuration is typed policy, not shell text.** `mqb.json` decodes into optional typed overrides before MSVC arguments are produced.
+
+## Project configuration
+
+`mqb_config` owns the versioned `mqb.json` contract. The CLI searches upward from the invocation directory for the nearest `mqb.json`.
+
+Path semantics are intentionally split:
+
+```text
+CLI relative path --------> invocation directory
+mqb.json relative path ---> directory containing mqb.json
+artifact project root ----> directory containing mqb.json (when present)
+```
+
+Scalar option precedence is:
+
+```text
+built-in defaults
+    <- mqb.json fields that are present
+        <- explicitly supplied CLI scalar options
+```
+
+The CLI parser therefore tracks whether `--debug`, `--release`, `--x86`, `--x64`, `--std`, `--discover`, and `--no-discover` were actually supplied. Parser defaults must never accidentally override project configuration.
+
+List-like build inputs are additive and deterministic: project-config entries appear first, then CLI entries. This currently applies to defines, include directories, library directories, and libraries.
+
+The v1 schema and examples are documented in `docs/MQB_CONFIG.md`. Unknown fields, duplicate JSON keys, wrong field types, malformed JSON, and unsupported schema versions are rejected instead of guessed.
+
+## Smart ordinary-C++ discovery
+
+With one positional source, MQB smart-discovers the connected ordinary-C++ target by default. Multiple positional sources remain an explicit ordered source set. `--no-discover` disables discovery; `--discover` explicitly enables it and can override project configuration.
+
+Discovery uses:
+
+- quoted `#include "..."` connectivity;
+- configured include directories;
+- same-basename ownership such as `foo.hpp <-> foo.cpp/.cc/.cxx`;
+- deterministic traversal from the entry TU;
+- built-in directory exclusions (`.mqb`, `.git`, `.vs`, `build`, `out`, `cmake-build-*`);
+- project-config `exclude_dirs`, `extra_sources`, and `exclude_sources` exact-path corrections.
+
+A reachable non-entry source defining `main(...)` is a traversal barrier, not merely a final-result filter. An explicitly excluded source is also a traversal barrier, so a test/tool TU cannot bridge the graph into a private subgraph. Configured excluded directories are pruned before graph construction. Explicit extra sources may add disconnected ordinary TUs but may not define another `main()`.
+
+Discovery output only selects TUs. Incremental header invalidation continues to use compiler-emitted `/sourceDependencies` metadata.
 
 ## Compile identity and cache freshness
 
@@ -66,46 +119,47 @@ artifact placement -----------> ProjectArtifactLayout
 
 `CompileCacheFile` persists compile metadata in a versioned binary format. Missing metadata is a normal cold-cache condition; corrupt/truncated/unsupported metadata is rejected and conservatively rebuilt.
 
+A config-only change that alters effective compiler options therefore changes compile identity even when no source timestamp changes.
+
 ## Link identity and cache freshness
 
 Linking has its own state machine rather than piggybacking on object timestamps.
 
 ```text
 ordered object inputs --------+
+resolved library identities --+
 link.exe identity ------------+
 link options -----------------+--> BuildSignature::for_link
 output identity --------------+
 
-output/object freshness ----------> LinkCacheValidator
-fresh compile --------------------> force_relink / explicit rebuild
+output/object/library freshness ---> LinkCacheValidator
+fresh compile ---------------------> force_relink
 ```
 
-`LinkerIdentity` stamps `link.exe` independently from `cl.exe`, so a linker update can invalidate only link state. `LinkCacheValidator` distinguishes link-input changes, linker-option changes, toolchain changes, missing output, and explicit relink.
+`LinkerIdentity` stamps `link.exe` independently from `cl.exe`, so a linker update can invalidate only link state.
 
-`LinkCacheFile` uses a separate versioned cache format. Broken link metadata can only cause a safe relink; it must never permit reuse of a stale executable.
+User-requested libraries are resolved deterministically to exact `.lib` files before invoking `link.exe`. Link cache v2 persists the resolved library inputs, so updating a `.lib` can trigger compile-0/link-1 invalidation. Library names/search paths are recipe state; the resolved files themselves are freshness inputs.
 
-When user-facing library support is added, resolved library-file freshness must join the link input state. Library names and search paths in the signature alone are not sufficient to detect an updated `.lib` file.
+Current boundary: explicitly requested libraries are tracked precisely. Indirect `/DEFAULTLIB` dependencies embedded in objects or libraries are still resolved by `link.exe` and are not claimed as fully tracked transitive link inputs.
 
 ## Project artifact layout
 
-The current explicit-target CLI uses the process working directory as the project root. Sources inside that root preserve their relative path; sources outside it are isolated under `.external/<stable-path-hash>/`.
+Without `mqb.json`, the invocation directory is the project root. With `mqb.json`, its directory becomes the project root even when MQB is launched from a nested directory.
 
-For example:
+Sources inside the root preserve relative identity; sources outside it are isolated under `.external/<stable-path-hash>/`.
 
 ```text
 project/
+  mqb.json
   main.cpp
   src/foo.cpp
-  tests/foo.cpp
   .mqb/
     obj/
       main.cpp.obj
       src/foo.cpp.obj
-      tests/foo.cpp.obj
     deps/
       main.cpp.json
       src/foo.cpp.json
-      tests/foo.cpp.json
     cache/
       compile/...
       link/main.linkcache
@@ -113,7 +167,7 @@ project/
       main.exe
 ```
 
-This prevents `src/foo.cpp`, `tests/foo.cpp`, `foo.cpp`, and `foo.cxx` from aliasing one object/cache artifact.
+This prevents same-basename sources in different directories from aliasing one object/cache artifact.
 
 ## Dependency graph and planner
 
@@ -137,6 +191,7 @@ LinkPlanItem
     +-- reusable cache ------> no action
     +-- stale cache ---------> LinkAction
                                   ordered object inputs
+                                  ordered resolved libraries
                                   executable output
                                   typed relink reasons
 ```
@@ -144,8 +199,6 @@ LinkPlanItem
 Executors therefore receive actions rather than policy decisions.
 
 ## Orchestration
-
-The application-facing coordinators compose existing policy/backend pieces without owning their algorithms.
 
 ### Incremental compile
 
@@ -162,8 +215,9 @@ CompileCacheFile
 ### Incremental link
 
 ```text
+requested libraries -> MsvcLibraryResolver -> exact .lib inputs
 LinkCacheFile
-      -> output/object snapshots
+      -> output/object/library snapshots
       -> LinkCacheValidator
       -> BuildPlanner::plan_link
       -> MsvcLinker
@@ -181,7 +235,7 @@ ordered source requests
       -> one target executable
 ```
 
-`MsvcIncrementalTargetCoordinator` currently schedules translation units sequentially. This is deliberate: correctness and stable target semantics are established before parallel scheduling is introduced. Parallel compilation can later replace the scheduling strategy without moving compiler/linker policy into the CLI.
+`MsvcIncrementalTargetCoordinator` still schedules translation units sequentially. Parallel compilation is the next execution-policy milestone; it must not change cache identity, artifact routing, diagnostics ordering, or failure semantics.
 
 Ordinary cache-load/save failures are surfaced as warnings and conservatively rebuild/relink. Compiler/linker execution failures are build errors.
 
@@ -189,58 +243,58 @@ Ordinary cache-load/save failures are surfaced as warnings and conservatively re
 
 `mqb_process` defines a platform-neutral `ProcessSpec` with executable, argv, working directory, structured environment overrides, inheritance choice, and stdout/stderr capture controls.
 
-`mqb_platform_windows` isolates Windows command-line quoting and the real `CreateProcessW` runner. Tests cover complex argv round-trips, explicit/inherited Unicode environment blocks, separate stdout/stderr capture, non-zero child exit codes, native launch errors, and concurrent draining of large output streams.
+`mqb_platform_windows` isolates Windows command-line quoting and the real `CreateProcessW` runner. Tests cover complex argv round-trips, Unicode environment blocks, separate stdout/stderr capture, non-zero child exit codes, native launch errors, and concurrent draining of large output streams.
 
-The CLI also uses the same structured process boundary for `--run`. Arguments after `--` are preserved as distinct argv elements, including whitespace-containing strings, option-looking strings, and empty arguments. MQB propagates the child exit code exactly; a failure to launch the child remains an MQB error. Captured CRLF is normalized before forwarding through Windows text streams so nested process output does not become `\r\r\n`; lone carriage returns are preserved.
+`--run` uses the same structured process boundary. Arguments after `--` remain distinct argv elements, including whitespace-containing strings, option-looking strings, and empty arguments. Run mode and child argv do not participate in build signatures.
 
-The current runner uses RAII for process/thread/pipe handles. Before final cutover, handle inheritance should be hardened further with `STARTUPINFOEXW` + `PROC_THREAD_ATTRIBUTE_HANDLE_LIST`.
+Captured CRLF is normalized before forwarding through Windows text streams so nested output does not become `\r\r\n`; lone carriage returns are preserved.
+
+Before final cutover, handle inheritance should be hardened further with `STARTUPINFOEXW` + `PROC_THREAD_ATTRIBUTE_HANDLE_LIST`.
 
 ## MSVC toolchain boundary
 
-`MsvcToolchainLocator` preserves the two environment tracks from the PowerShell reference:
+`MsvcToolchainLocator` preserves automatic, forced Visual Studio, and forced portable tracks. The Visual Studio track uses `vswhere`/fallback discovery and isolated `vcvarsall.bat` environment capture. The portable track resolves VC Tools and Windows Kit layout without mutating MQB's own process environment.
 
-```text
-automatic
-   |
-   +-- first existing portable_msvc root --> portable layout discovery
-   |
-   +-- otherwise --------------------------> Visual Studio discovery
-
-forced portable --> portable only
-forced VS -------> Visual Studio only
-```
-
-The portable track resolves VC Tools and Windows Kit layout without launching a subprocess. The Visual Studio track uses `vswhere`/fallback discovery and captures `vcvarsall.bat` output through an isolated UTF-16 environment dump. The captured environment is returned as structured overrides rather than mutating MQB's own process environment.
-
-GitHub CI enables installed-MSVC integration tests explicitly; local tests keep those tests opt-in so a portable-only development machine is not forced to have a registered Visual Studio installation.
+GitHub CI enables installed-MSVC integration tests explicitly; local tests keep them opt-in.
 
 ## Current CLI milestone
 
-`mqb.exe` supports an **explicit ordered set of ordinary C++ translation units** (`.cpp`, `.cc`, `.cxx`), target naming, and structured post-build execution:
+Examples:
 
 ```powershell
+# One entry: smart discovery
+mqb main.cpp
+
+# Explicit source set
 mqb main.cpp src/utils.cpp a/helper.cpp b/helper.cpp -o product
-mqb main.cpp src/utils.cpp -o product --run -- "hello world" --child-option ""
+
+# Exact static library request
+mqb main.cpp -L "vendor libs" -l math
+
+# Structured run argv
+mqb main.cpp --run -- "hello world" --child-option ""
 ```
 
-The first source supplies the default target name when `-o/--output` is omitted. Every source is incrementally validated independently; only stale TUs compile, and all resulting objects feed one independently cached link action. `-o/--output` selects a validated target filename under `.mqb/bin/`; it is not an arbitrary escape path.
+When an `mqb.json` is found, effective build/discovery options are resolved before toolchain discovery and artifact planning.
 
-`--run` executes the resulting target through `ProcessSpec`/`CreateProcessW`, not through a shell. The `--` sentinel ends MQB option parsing and passes every remaining argv element to the child verbatim. Run mode and child argv do not participate in build signatures, so changing only execution arguments reuses warm compile/link state.
+The real VS2026 suite now verifies, among other cases:
 
-The real VS2026 E2E suite verifies:
+- single-entry smart discovery plus same-basename artifact isolation;
+- second-entry traversal barriers and project discovery corrections;
+- warm compile/link reuse;
+- private-header partial rebuild through `/sourceDependencies`;
+- Debug/Release recipe invalidation without source edits;
+- exact static-library resolution and library-only relink;
+- custom output names and independent link-cache identities;
+- structured `--run` argv and child exit propagation;
+- upward `mqb.json` lookup from a nested working directory;
+- config-relative include/library paths and config-root artifact placement;
+- config-only define changes invalidating compile recipes;
+- explicit CLI scalar overrides winning over project config while config list inputs remain available.
 
-- cold multi-TU compile + link + executable launch;
-- warm build with zero compiler and linker actions;
-- same-basename sources in different directories have distinct artifacts;
-- a header private to one TU rebuilds only that TU;
-- any rebuilt TU explicitly forces relink;
-- the resulting executable behavior changes after the partial rebuild;
-- Debug -> Release invalidates compile and link recipes without source edits;
-- custom target naming produces independent executable/link-cache paths;
-- warm `--run` preserves spaced, option-looking, and empty child argv elements;
-- a non-zero child process exit code is propagated exactly.
+The current VS2026 PR suite contains 32 registered CTest cases, including real target and project-config E2E tests.
 
-Not yet exposed in the C++ CLI: automatic source discovery, user libraries/library paths, project config files, and C++ Modules. Translation-unit scheduling is still sequential.
+Not yet implemented in the C++ V2 path: parallel TU scheduling and C++ Modules/P1689/IFC handling. PowerShell/C++ behavioral parity and final cutover also remain future gates.
 
 ## Migration sequence
 
@@ -249,13 +303,16 @@ Not yet exposed in the C++ CLI: automatic source discovery, user libraries/libra
 3. **Process abstraction** — typed process spec, Windows quoting, Win32 runner. ✅
 4. **MSVC toolchain backend** — portable discovery plus `vswhere/vcvarsall` environment capture. ✅
 5. **Ordinary single TU** — typed compiler arguments, `/sourceDependencies`, cache persistence, real incremental CLI. ✅
-6. **Link state** — independent linker identity/signature/cache/planning/backend/orchestration and executable production. ✅
-7. **Explicit multi-TU target** — project artifact layout, ordered source set, per-TU incremental compile, single incremental link. ✅
+6. **Link state** — independent linker identity/signature/cache/planning/backend/orchestration. ✅
+7. **Explicit multi-TU target** — collision-free layout, per-TU incremental compile, one independently cached link. ✅
 8. **Target UX** — `-o/--output`, `--run`, structured `--` argv passthrough, child exit propagation. ✅
-9. **Target discovery and libraries** — resolved library freshness, library search paths, project config, smart source discovery, then parallel compile scheduling.
-10. **Modules** — P1689 `/scanDependencies`, module graph, IFC/object artifacts, `import std`.
-11. **Parity** — run PowerShell and C++ against the same E2E fixtures.
-12. **Cutover** — make `mqb.exe` primary only after parity tests pass.
+9. **Explicit libraries** — exact resolution, link-cache v2, `.lib` freshness, `-L/-l`. ✅
+10. **Smart source discovery** — single-entry graph selection, secondary-entry barriers, corrections. ✅
+11. **Project config v1** — upward `mqb.json`, typed schema, path semantics, CLI precedence, config E2E. ✅
+12. **Parallel ordinary-TU scheduling** — bounded concurrency with deterministic reporting/failure semantics.
+13. **Modules** — P1689 `/scanDependencies`, module graph, IFC/object artifacts, `import std`.
+14. **Parity** — run PowerShell and C++ against the same E2E fixtures.
+15. **Cutover** — make `mqb.exe` primary only after parity tests pass.
 
 ## Local build
 

--- a/docs/MQB_CONFIG.md
+++ b/docs/MQB_CONFIG.md
@@ -1,0 +1,171 @@
+# `mqb.json` Project Configuration v1
+
+`mqb.json` is the C++ V2 project configuration file for MSVC Quick Build.
+
+MQB searches upward from the directory where it is invoked and uses the nearest `mqb.json`. The directory containing that file becomes the project root and the root of `.mqb/` artifacts.
+
+## Minimal file
+
+```json
+{
+  "version": 1
+}
+```
+
+`version` is required. Version 1 uses strict JSON: comments, trailing commas, duplicate keys, unknown schema fields, and incorrect field types are rejected.
+
+## Full example
+
+```json
+{
+  "version": 1,
+  "build": {
+    "configuration": "release",
+    "architecture": "x64",
+    "standard": "23",
+    "output": "game",
+    "defines": [
+      "GAME_BUILD=1"
+    ],
+    "include_dirs": [
+      "include",
+      "third_party/include"
+    ],
+    "library_dirs": [
+      "third_party/lib"
+    ],
+    "libraries": [
+      "math",
+      "codec.lib"
+    ]
+  },
+  "discovery": {
+    "enabled": true,
+    "exclude_dirs": [
+      "tests",
+      "tools"
+    ],
+    "extra_sources": [
+      "src/manual_adapter.cpp"
+    ],
+    "exclude_sources": [
+      "src/legacy.cpp"
+    ]
+  }
+}
+```
+
+## Build fields
+
+| Field | Type | Values / meaning |
+|---|---|---|
+| `configuration` | string | `debug` or `release` |
+| `architecture` | string | `x86` or `x64` |
+| `standard` | string | `20`, `23`, or `latest` (`c++20`, `c++23`, `c++latest` are also accepted) |
+| `output` | string | target name under `.mqb/bin/` |
+| `defines` | string array | preprocessor definitions, without `/D` |
+| `include_dirs` | string array | include search directories |
+| `library_dirs` | string array | library search directories |
+| `libraries` | string array | requested libraries; `.lib` is optional for ordinary names |
+
+All path-valued config entries are resolved relative to the directory containing `mqb.json`, not the shell's current working directory.
+
+## Discovery fields
+
+| Field | Type | Meaning |
+|---|---|---|
+| `enabled` | boolean | enable or disable single-entry smart source discovery |
+| `exclude_dirs` | string array | exact project directories to prune before discovery graph construction |
+| `extra_sources` | string array | exact ordinary C++ TUs to add even when disconnected from the entry graph |
+| `exclude_sources` | string array | exact ordinary C++ TUs to exclude and treat as traversal barriers |
+
+Version 1 intentionally uses exact paths rather than a glob language. This keeps correction semantics deterministic while the discovery model is still being stabilized.
+
+An `extra_sources` entry may not define another `main()`. The entry TU itself may not be excluded. A source may not appear in both `extra_sources` and `exclude_sources`.
+
+Built-in directory exclusions such as `.mqb`, `.git`, `.vs`, `build`, `out`, and `cmake-build-*` remain active in addition to configured exclusions.
+
+## Precedence
+
+For scalar options:
+
+```text
+explicit CLI option > mqb.json > built-in default
+```
+
+Examples:
+
+```powershell
+# mqb.json says release; this build is debug.
+mqb main.cpp --debug
+
+# mqb.json disables discovery; this explicitly turns it back on.
+mqb main.cpp --discover
+
+# mqb.json output is ignored for this invocation.
+mqb main.cpp -o scratch
+```
+
+MQB tracks whether scalar CLI options were explicitly supplied, so parser defaults do not overwrite project configuration.
+
+List-like options are additive rather than replacing the config list. The effective order is:
+
+```text
+mqb.json entries, then CLI entries
+```
+
+This applies to defines, include directories, library directories, and libraries. For example, `-I local` adds a CLI include directory after the project's `include_dirs` entries.
+
+## Path bases
+
+There are two intentional relative-path bases:
+
+```text
+CLI relative paths     -> invocation directory
+mqb.json relative paths -> mqb.json directory
+```
+
+This makes nested-directory invocation predictable. For example, with:
+
+```text
+project/
+  mqb.json
+  main.cpp
+  include/
+  nested/work/
+```
+
+running from `project/nested/work`:
+
+```powershell
+mqb ../../main.cpp
+```
+
+still loads `project/mqb.json`, places artifacts under `project/.mqb/`, and interprets config `"include_dirs": ["include"]` as `project/include`.
+
+## Cache behavior
+
+The config file timestamp itself is not a special global rebuild trigger. Instead, the effective typed build options produced from the file participate in the existing compile/link signatures.
+
+For example, changing only:
+
+```json
+"defines": ["VALUE=1"]
+```
+
+to:
+
+```json
+"defines": ["VALUE=2"]
+```
+
+changes compiler recipe identity and recompiles the affected TUs even if no source file timestamp changed.
+
+Likewise, library names/search paths affect link recipe identity, while the exact resolved `.lib` files are separately tracked as link freshness inputs.
+
+## Current boundaries
+
+- Project configuration does not yet define C++ Module/IFC policy; Modules are a later milestone.
+- Parallel translation-unit scheduling is not yet part of v1 config.
+- `exclude_dirs`, `extra_sources`, and `exclude_sources` are exact paths, not globs.
+- Explicit user libraries are freshness-tracked; indirect `/DEFAULTLIB` transitive dependencies are not yet claimed as fully tracked.


### PR DESCRIPTION
Completes Project Config v1 for the C++23 MQB path.

Core configuration layer:
- new `mqb_config` library, independent from MSVC/process execution
- strict versioned JSON schema (`version: 1`)
- duplicate keys, unknown fields, malformed JSON, wrong types/enums, and unsupported versions fail explicitly
- Unicode `\uXXXX` and surrogate-pair decoding
- upward search for the nearest `mqb.json`
- all config path fields resolve relative to the config file directory
- scalar config fields remain optional overrides rather than receiving parser defaults

Precedence model:
- scalar values: explicit CLI > `mqb.json` > built-in defaults
- CLI parser tracks explicit `--debug/--release`, `--x86/--x64`, `--std`, `--discover/--no-discover`
- list inputs are additive in deterministic order: config entries, then CLI entries
- applies to defines, include directories, library directories, and libraries

Project-root/path semantics:
- CLI relative paths resolve from the invocation directory
- config relative paths resolve from the directory containing `mqb.json`
- when a config exists, its directory becomes the artifact project root even if MQB is invoked from a nested directory

Discovery corrections:
- `exclude_dirs` prunes exact project directories before graph construction
- `exclude_sources` removes exact ordinary TUs and makes them traversal barriers
- `extra_sources` adds exact disconnected ordinary TUs
- entry cannot be excluded; extra sources cannot define another `main()`; extra/excluded conflicts fail explicitly
- secondary-main traversal barriers remain intact
- `/sourceDependencies` remains the only authority for incremental header freshness

Real VS2026 E2E:
- invokes MQB two directories below the project root with only `../../main.cpp`
- upward-loads `mqb.json`
- config supplies Release, output name, define, include path, library path/library, and discovery corrections
- real `cl.exe + lib.exe` builds `math.lib`
- CLI `--discover` overrides config `discovery.enabled=false`
- verifies artifacts are rooted under the config directory
- proves `extra_sources`, `exclude_sources`, and `exclude_dirs` affect actual object production
- proves a warm config build is compile/link clean
- changes only a config define and proves compiler recipe invalidation + relink without source edits
- uses CLI `--debug -D... -o ...` and executable behavior to prove CLI scalar/additive-list precedence while retaining config include/library inputs

CTest registration was also corrected so test-bearing subdirectories are added after `enable_testing()`. The validated functional checkpoint runs 32/32 tests, including `mqb.discovery.source_graph`, `mqb.discovery.corrections`, `mqb.config.project_config`, `mqb.config.project_options`, the existing real target E2E, and the new real project-config E2E.

Documentation:
- `docs/CPP_V2_ARCHITECTURE.md` is synchronized with libraries, smart discovery, secondary-entry barriers, and Project Config v1
- `docs/MQB_CONFIG.md` defines the v1 schema, precedence, path bases, correction semantics, and cache behavior
- `mqb --help` now explains automatic config lookup and precedence

Known non-blocking cleanup after this milestone: replace the deprecated C++20 `std::filesystem::u8path` use in the config parser/test and decide whether to accept UTF-8 BOM input. Neither affects the validated strict UTF-8 JSON path in this PR.