### PR TITLE
fix: whitelist inherited handles before parallel builds

### DIFF
--- a/cpp/platform/windows/src/WindowsProcessRunner.cpp
+++ b/cpp/platform/windows/src/WindowsProcessRunner.cpp
@@ -11,6 +11,7 @@
 #include <expected>
 #include <filesystem>
 #include <optional>
+#include <span>
 #include <string>
 #include <string_view>
 #include <thread>
@@ -66,6 +67,50 @@ private:
     HANDLE handle_{nullptr};
 };
 
+class ProcThreadAttributeList {
+public:
+    ProcThreadAttributeList() = default;
+
+    ~ProcThreadAttributeList() {
+        reset();
+    }
+
+    ProcThreadAttributeList(const ProcThreadAttributeList&) = delete;
+    ProcThreadAttributeList& operator=(const ProcThreadAttributeList&) = delete;
+
+    ProcThreadAttributeList(ProcThreadAttributeList&& other) noexcept
+        : list_(std::exchange(other.list_, nullptr)) {}
+
+    ProcThreadAttributeList& operator=(ProcThreadAttributeList&& other) noexcept {
+        if (this != &other) {
+            reset();
+            list_ = std::exchange(other.list_, nullptr);
+        }
+        return *this;
+    }
+
+    [[nodiscard]] LPPROC_THREAD_ATTRIBUTE_LIST get() const noexcept {
+        return list_;
+    }
+
+    [[nodiscard]] static std::expected<ProcThreadAttributeList, ProcessError>
+    for_handle_list(const std::span<HANDLE> handles);
+
+private:
+    explicit ProcThreadAttributeList(LPPROC_THREAD_ATTRIBUTE_LIST list) noexcept
+        : list_(list) {}
+
+    void reset() noexcept {
+        if (list_ != nullptr) {
+            ::DeleteProcThreadAttributeList(list_);
+            ::HeapFree(::GetProcessHeap(), 0, list_);
+            list_ = nullptr;
+        }
+    }
+
+    LPPROC_THREAD_ATTRIBUTE_LIST list_{nullptr};
+};
+
 struct PipePair {
     UniqueHandle read;
     UniqueHandle write;
@@ -85,6 +130,59 @@ struct EnvironmentEntry {
         .native_code = native_code,
         .message = std::move(message),
     };
+}
+
+std::expected<ProcThreadAttributeList, ProcessError>
+ProcThreadAttributeList::for_handle_list(const std::span<HANDLE> handles) {
+    if (handles.empty()) {
+        return std::unexpected(error(
+            ProcessErrorCode::invalid_specification,
+            ERROR_INVALID_PARAMETER,
+            "inherited handle whitelist is empty"));
+    }
+
+    SIZE_T bytes = 0;
+    ::InitializeProcThreadAttributeList(nullptr, 1, 0, &bytes);
+    if (bytes == 0) {
+        return std::unexpected(error(
+            ProcessErrorCode::launch_failed,
+            ::GetLastError(),
+            "failed to size process attribute list"));
+    }
+
+    auto* raw = static_cast<LPPROC_THREAD_ATTRIBUTE_LIST>(
+        ::HeapAlloc(::GetProcessHeap(), 0, bytes));
+    if (raw == nullptr) {
+        return std::unexpected(error(
+            ProcessErrorCode::launch_failed,
+            ERROR_NOT_ENOUGH_MEMORY,
+            "failed to allocate process attribute list"));
+    }
+
+    if (!::InitializeProcThreadAttributeList(raw, 1, 0, &bytes)) {
+        const DWORD native_code = ::GetLastError();
+        ::HeapFree(::GetProcessHeap(), 0, raw);
+        return std::unexpected(error(
+            ProcessErrorCode::launch_failed,
+            native_code,
+            "InitializeProcThreadAttributeList failed"));
+    }
+
+    ProcThreadAttributeList result{raw};
+    if (!::UpdateProcThreadAttribute(
+            result.get(),
+            0,
+            PROC_THREAD_ATTRIBUTE_HANDLE_LIST,
+            handles.data(),
+            handles.size_bytes(),
+            nullptr,
+            nullptr)) {
+        return std::unexpected(error(
+            ProcessErrorCode::launch_failed,
+            ::GetLastError(),
+            "UpdateProcThreadAttribute failed for inherited handle whitelist"));
+    }
+    return result;
 }
 
 [[nodiscard]] bool contains_nul(const std::string_view value) noexcept {
@@ -423,12 +521,18 @@ WindowsProcessRunner::run(const process::ProcessSpec& spec) {
         stderr_pipe.emplace(std::move(*pipe));
     }
 
-    STARTUPINFOW startup{};
-    startup.cb = sizeof(startup);
+    STARTUPINFOW basic_startup{};
+    basic_startup.cb = sizeof(basic_startup);
+    STARTUPINFOEXW extended_startup{};
+    extended_startup.StartupInfo.cb = sizeof(extended_startup);
+    LPSTARTUPINFOW startup = &basic_startup;
 
     UniqueHandle child_stdin;
     UniqueHandle child_stdout;
     UniqueHandle child_stderr;
+    std::optional<ProcThreadAttributeList> attribute_list;
+    std::vector<HANDLE> inherited_handles;
+
     const bool use_explicit_standard_handles = spec.capture_stdout || spec.capture_stderr;
     if (use_explicit_standard_handles) {
         auto stdin_handle = inheritable_standard_handle(STD_INPUT_HANDLE, GENERIC_READ);
@@ -452,10 +556,25 @@ WindowsProcessRunner::run(const process::ProcessSpec& spec) {
             child_stderr = std::move(*stderr_handle);
         }
 
-        startup.dwFlags |= STARTF_USESTDHANDLES;
-        startup.hStdInput = child_stdin.get();
-        startup.hStdOutput = spec.capture_stdout ? stdout_pipe->write.get() : child_stdout.get();
-        startup.hStdError = spec.capture_stderr ? stderr_pipe->write.get() : child_stderr.get();
+        auto& startup_info = extended_startup.StartupInfo;
+        startup_info.dwFlags |= STARTF_USESTDHANDLES;
+        startup_info.hStdInput = child_stdin.get();
+        startup_info.hStdOutput = spec.capture_stdout ? stdout_pipe->write.get() : child_stdout.get();
+        startup_info.hStdError = spec.capture_stderr ? stderr_pipe->write.get() : child_stderr.get();
+
+        inherited_handles = {
+            startup_info.hStdInput,
+            startup_info.hStdOutput,
+            startup_info.hStdError,
+        };
+        auto attributes = ProcThreadAttributeList::for_handle_list(inherited_handles);
+        if (!attributes) {
+            return std::unexpected(attributes.error());
+        }
+        attribute_list.emplace(std::move(*attributes));
+        extended_startup.lpAttributeList = attribute_list->get();
+        creation_flags |= EXTENDED_STARTUPINFO_PRESENT;
+        startup = &extended_startup.StartupInfo;
     }
 
     PROCESS_INFORMATION process_info{};
@@ -468,7 +587,7 @@ WindowsProcessRunner::run(const process::ProcessSpec& spec) {
         creation_flags,
         environment_pointer,
         working_directory ? working_directory->c_str() : nullptr,
-        &startup,
+        startup,
         &process_info);
     if (!created) {
         return std::unexpected(error(

--- a/cpp/process/include/mqb/process/Process.hpp
+++ b/cpp/process/include/mqb/process/Process.hpp
@@ -47,6 +47,8 @@ class ProcessRunner {
 public:
     virtual ~ProcessRunner() = default;
 
+    // Orchestration may call run() concurrently on the same runner instance.
+    // Implementations must keep per-launch state isolated.
     [[nodiscard]] virtual std::expected<ProcessResult, ProcessError>
     run(const ProcessSpec& spec) = 0;
 };

--- a/cpp/tests/windows_process_runner_tests.cpp
+++ b/cpp/tests/windows_process_runner_tests.cpp
@@ -1,7 +1,10 @@
+#include <barrier>
 #include <filesystem>
+#include <future>
 #include <iostream>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "mqb/platform/windows/WindowsProcessRunner.hpp"
 #include "mqb/process/Process.hpp"
@@ -99,6 +102,52 @@ int main(const int argc, char** argv) {
                "large stdout payload should be captured completely");
         expect(flood_result->stderr_text.size() == payload_size,
                "large stderr payload should be captured completely");
+    }
+
+    {
+        constexpr int launch_count = 12;
+        std::barrier start_gate{launch_count};
+        std::vector<std::future<std::expected<mqb::process::ProcessResult, mqb::process::ProcessError>>>
+            launches;
+        launches.reserve(launch_count);
+
+        for (int index = 0; index < launch_count; ++index) {
+            launches.push_back(std::async(
+                std::launch::async,
+                [&runner, &start_gate, helper, index] {
+                    mqb::process::ProcessSpec concurrent;
+                    concurrent.executable = helper;
+                    concurrent.arguments = {"concurrent-" + std::to_string(index)};
+                    concurrent.environment = {
+                        mqb::process::EnvironmentVariable{
+                            "MQB_TEST_ENV",
+                            "env-" + std::to_string(index)},
+                    };
+                    start_gate.arrive_and_wait();
+                    return runner.run(concurrent);
+                }));
+        }
+
+        for (int index = 0; index < launch_count; ++index) {
+            auto concurrent = launches[static_cast<std::size_t>(index)].get();
+            expect(concurrent.has_value(),
+                   "same WindowsProcessRunner instance should support concurrent launches");
+            if (!concurrent) {
+                continue;
+            }
+            expect(concurrent->exit_code == 23,
+                   "concurrent child exit code should remain isolated");
+            expect(contains(
+                       concurrent->stdout_text,
+                       "ARG=[concurrent-" + std::to_string(index) + "]"),
+                   "concurrent stdout capture should belong to the correct child");
+            expect(contains(
+                       concurrent->stdout_text,
+                       "ENV=[env-" + std::to_string(index) + "]"),
+                   "concurrent environment blocks should remain isolated");
+            expect(contains(concurrent->stderr_text, "STDERR-MARKER"),
+                   "concurrent stderr capture should complete independently");
+        }
     }
 
     mqb::process::ProcessSpec empty_executable;


### PR DESCRIPTION
Hardens the Windows process boundary before enabling parallel translation-unit scheduling.

Why this is required:
- MQB captures child stdout/stderr using inheritable pipe write handles
- plain `CreateProcessW(..., bInheritHandles=TRUE, STARTUPINFOW, ...)` can inherit unrelated inheritable handles that happen to exist in the parent process
- that is unsafe for future concurrent compiler launches because one child can keep another launch's pipe handle alive

Implementation:
- use `STARTUPINFOEXW` when explicit standard handles are required
- build a `PROC_THREAD_ATTRIBUTE_HANDLE_LIST` containing exactly child stdin/stdout/stderr
- set `EXTENDED_STARTUPINFO_PRESENT`
- retain `bInheritHandles=TRUE` only for the explicit-handle path as required by the Win32 API
- keep the non-capture path on ordinary `STARTUPINFOW` with handle inheritance disabled
- manage the process attribute list with RAII (`DeleteProcThreadAttributeList` + `HeapFree`)
- existing argv, UTF-8 environment, working directory, split stdout/stderr, flood draining, exit-code, and error behavior are preserved

Contract/test hardening:
- `ProcessRunner::run` now explicitly documents that orchestration may call the same runner concurrently
- Windows runner test starts 12 launches through the same `WindowsProcessRunner` instance behind a barrier and verifies each child receives its own argv/environment/stdout/stderr
- existing large stdout/stderr flood test remains intact

This PR deliberately does not parallelize compilation yet. It establishes the process-launch correctness prerequisite first. After this is green and merged, bounded parallel TU scheduling can be implemented without relying on process-wide implicit handle inheritance.