### PR TITLE
feat: add bounded parallel TU scheduling

### DIFF
--- a/cpp/apps/mqb/Cli.cpp
+++ b/cpp/apps/mqb/Cli.cpp
@@ -1,10 +1,13 @@
 #include "Cli.hpp"
 
+#include <charconv>
+#include <cstddef>
 #include <expected>
 #include <filesystem>
 #include <span>
 #include <string>
 #include <string_view>
+#include <system_error>
 #include <utility>
 
 namespace mqb::cli {
@@ -37,6 +40,20 @@ parse_standard(const std::string_view value) {
     return std::unexpected(error(
         "unsupported C++ standard '" + std::string{value}
         + "' (expected 20, 23, or latest)"));
+}
+
+[[nodiscard]] std::expected<std::size_t, Error>
+parse_jobs(const std::string_view value) {
+    std::size_t jobs = 0;
+    const char* const begin = value.data();
+    const char* const end = value.data() + value.size();
+    const auto [parsed_end, parse_error] = std::from_chars(begin, end, jobs);
+    if (parse_error != std::errc{} || parsed_end != end || jobs == 0) {
+        return std::unexpected(error(
+            "invalid compile job count '" + std::string{value}
+            + "' (expected a positive integer)"));
+    }
+    return jobs;
 }
 
 [[nodiscard]] std::expected<msvc::ToolchainPreference, Error>
@@ -106,6 +123,28 @@ parse_arguments(const std::span<const std::string_view> arguments) {
         }
         if (argument == "--run") {
             options.build.run_after_build = true;
+            continue;
+        }
+        if (argument == "-j" || argument == "--jobs") {
+            auto value = require_value(arguments, index, argument);
+            if (!value) return std::unexpected(value.error());
+            auto jobs = parse_jobs(*value);
+            if (!jobs) return std::unexpected(jobs.error());
+            options.jobs = *jobs;
+            continue;
+        }
+        if (argument.starts_with("--jobs=")) {
+            auto value = long_equals_value(argument, "--jobs=");
+            if (!value) return std::unexpected(value.error());
+            auto jobs = parse_jobs(*value);
+            if (!jobs) return std::unexpected(jobs.error());
+            options.jobs = *jobs;
+            continue;
+        }
+        if (argument.starts_with("-j") && argument.size() > 2) {
+            auto jobs = parse_jobs(argument.substr(2));
+            if (!jobs) return std::unexpected(jobs.error());
+            options.jobs = *jobs;
             continue;
         }
         if (argument == "-o" || argument == "--output") {
@@ -256,6 +295,7 @@ Options:
   --release                Explicitly select Release compile/link preset
   --std <20|23|latest>     Explicitly select C++ language standard
   --x86 | --x64            Explicitly select target architecture
+  -j, --jobs <N>           Maximum concurrent TU compiles (default: hardware concurrency)
   -o, --output <name>      Set target executable name under .mqb/bin/
   --run                    Run the executable after a successful build
   -I <dir>, -I<dir>        Add an include directory
@@ -270,6 +310,7 @@ Options:
   -h, --help               Show this help
   --                       Pass all remaining argv elements to the program
 
+Compile job count is execution policy only; changing -j does not invalidate build caches.
 Discovery is source selection only. Incremental header freshness continues to use
 MSVC /sourceDependencies metadata.
 

--- a/cpp/apps/mqb/Cli.hpp
+++ b/cpp/apps/mqb/Cli.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <expected>
 #include <filesystem>
 #include <optional>
@@ -25,6 +26,7 @@ struct Options {
     msvc::ToolchainPreference toolchain_preference{msvc::ToolchainPreference::automatic};
     std::vector<std::filesystem::path> portable_roots;
     std::optional<bool> discovery_override;
+    std::optional<std::size_t> jobs;
     bool discover_sources{true};
     bool verbose{false};
     bool show_help{false};

--- a/cpp/apps/mqb/main.cpp
+++ b/cpp/apps/mqb/main.cpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <string_view>
 #include <system_error>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -403,6 +404,15 @@ int main(const int argc, char* argv[]) {
     }
     options.build.sources = sources;
 
+    const unsigned int hardware_threads = std::thread::hardware_concurrency();
+    const std::size_t requested_compile_jobs = options.jobs.value_or(
+        hardware_threads == 0
+            ? std::size_t{1}
+            : static_cast<std::size_t>(hardware_threads));
+    const std::size_t compile_jobs = std::max<std::size_t>(
+        1,
+        std::min(requested_compile_jobs, sources.size()));
+
     auto layout = mqb::ProjectArtifactLayout::create(project_root);
     if (!layout) {
         std::cerr << "error: " << layout.error().message << '\n';
@@ -475,7 +485,9 @@ int main(const int argc, char* argv[]) {
         if (project_config) {
             std::cout << "  config:  " << path_text(project_config->file) << '\n';
         }
-        std::cout << "  cl:      " << path_text(toolchain->identity.compiler) << '\n'
+        std::cout << "  jobs:    " << compile_jobs
+                  << (options.jobs ? "" : " (auto)") << '\n'
+                  << "  cl:      " << path_text(toolchain->identity.compiler) << '\n'
                   << "  link:    " << path_text(toolchain->linker) << '\n';
         for (const auto& source : target_sources) {
             std::cout << "  source:  " << path_text(display_source(project_root, source.source)) << '\n'
@@ -509,6 +521,7 @@ int main(const int argc, char* argv[]) {
         .compiler_options = std::move(compiler_options),
         .link_options = std::move(link_options),
         .working_directory = project_root,
+        .max_parallel_compiles = compile_jobs,
     };
 
     auto result = target_coordinator.run(request);

--- a/cpp/backends/msvc/src/MsvcCompiler.cpp
+++ b/cpp/backends/msvc/src/MsvcCompiler.cpp
@@ -41,18 +41,21 @@ namespace fs = std::filesystem;
 void append_configuration_arguments(
     std::vector<std::string>& arguments,
     const BuildConfiguration configuration) {
+    // /Z7 keeps compiler debug information inside each object instead of
+    // writing a shared compiler PDB. This makes each TU artifact self-contained
+    // and removes cross-process PDB write contention during parallel builds.
     switch (configuration) {
     case BuildConfiguration::debug:
         arguments.emplace_back("/Od");
         arguments.emplace_back("/MDd");
-        arguments.emplace_back("/Zi");
+        arguments.emplace_back("/Z7");
         arguments.emplace_back("/D_DEBUG");
         break;
     case BuildConfiguration::release:
         arguments.emplace_back("/O2");
         arguments.emplace_back("/Oi");
         arguments.emplace_back("/MD");
-        arguments.emplace_back("/Zi");
+        arguments.emplace_back("/Z7");
         arguments.emplace_back("/DNDEBUG");
         break;
     }

--- a/cpp/core/src/BuildSignature.cpp
+++ b/cpp/core/src/BuildSignature.cpp
@@ -105,7 +105,7 @@ BuildSignature BuildSignature::for_compile(
     const ToolchainIdentity& toolchain,
     const CompilerOptions& options) {
     StableHasher hasher;
-    hasher.add_string("mqb.compile.signature.v1");
+    hasher.add_string("mqb.compile.signature.v2");
 
     // Dependencies and output paths are deliberately excluded. Dependency
     // freshness is validated separately, while output locations are artifact

--- a/cpp/orchestration/CMakeLists.txt
+++ b/cpp/orchestration/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(mqb_orchestration STATIC
+    src/BoundedWorkScheduler.cpp
     src/MsvcIncrementalCompileCoordinator.cpp
     src/MsvcIncrementalLinkCoordinator.cpp
     src/MsvcIncrementalTargetCoordinator.cpp

--- a/cpp/orchestration/include/mqb/orchestration/BoundedWorkScheduler.hpp
+++ b/cpp/orchestration/include/mqb/orchestration/BoundedWorkScheduler.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <cstddef>
+#include <expected>
+#include <functional>
+#include <string>
+
+namespace mqb::orchestration {
+
+enum class BoundedWorkErrorCode {
+    invalid_worker_count,
+    callback_threw,
+};
+
+struct BoundedWorkError {
+    BoundedWorkErrorCode code{BoundedWorkErrorCode::invalid_worker_count};
+    std::string message;
+};
+
+struct BoundedWorkSummary {
+    std::size_t worker_count{};
+    std::size_t started_count{};
+    bool stop_requested{false};
+    bool stopped_before_all_items{false};
+};
+
+class BoundedWorkScheduler {
+public:
+    // Work indices are assigned monotonically. Returning false requests that no
+    // new indices be assigned; already assigned callbacks are allowed to finish.
+    // The call returns only after every worker has joined.
+    [[nodiscard]] static std::expected<BoundedWorkSummary, BoundedWorkError>
+    run(
+        std::size_t item_count,
+        std::size_t max_workers,
+        const std::function<bool(std::size_t)>& work);
+};
+
+} // namespace mqb::orchestration

--- a/cpp/orchestration/include/mqb/orchestration/MsvcIncrementalTargetCoordinator.hpp
+++ b/cpp/orchestration/include/mqb/orchestration/MsvcIncrementalTargetCoordinator.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <expected>
 #include <filesystem>
 #include <optional>
@@ -25,6 +26,7 @@ struct IncrementalTargetRequest {
     CompilerOptions compiler_options;
     LinkOptions link_options;
     std::filesystem::path working_directory;
+    std::size_t max_parallel_compiles{1};
 };
 
 struct TargetCompileResult {
@@ -34,8 +36,12 @@ struct TargetCompileResult {
 
 enum class IncrementalTargetErrorCode {
     no_sources,
+    invalid_parallelism,
     duplicate_source,
     duplicate_object,
+    duplicate_dependencies,
+    duplicate_compile_cache,
+    scheduling_failed,
     compile_failed,
     link_failed,
 };

--- a/cpp/orchestration/src/BoundedWorkScheduler.cpp
+++ b/cpp/orchestration/src/BoundedWorkScheduler.cpp
@@ -44,6 +44,14 @@ BoundedWorkScheduler::run(
     std::atomic<bool> stop_requested{false};
     std::atomic<bool> callback_threw{false};
 
+    // Quench future dispatch before publishing the stop flag. A worker that
+    // already observed stop_requested == false but has not claimed an index yet
+    // will receive item_count (or greater) and exit without starting new work.
+    const auto request_stop = [&] {
+        next_index.exchange(item_count, std::memory_order_acq_rel);
+        stop_requested.store(true, std::memory_order_release);
+    };
+
     std::vector<std::thread> workers;
     workers.reserve(worker_count);
     for (std::size_t worker_index = 0; worker_index < worker_count; ++worker_index) {
@@ -57,11 +65,11 @@ BoundedWorkScheduler::run(
                 started_count.fetch_add(1, std::memory_order_relaxed);
                 try {
                     if (!work(index)) {
-                        stop_requested.store(true, std::memory_order_release);
+                        request_stop();
                     }
                 } catch (...) {
                     callback_threw.store(true, std::memory_order_release);
-                    stop_requested.store(true, std::memory_order_release);
+                    request_stop();
                 }
             }
         });

--- a/cpp/orchestration/src/BoundedWorkScheduler.cpp
+++ b/cpp/orchestration/src/BoundedWorkScheduler.cpp
@@ -1,0 +1,89 @@
+#include "mqb/orchestration/BoundedWorkScheduler.hpp"
+
+#include <algorithm>
+#include <atomic>
+#include <cstddef>
+#include <expected>
+#include <functional>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace mqb::orchestration {
+namespace {
+
+[[nodiscard]] BoundedWorkError failure(
+    const BoundedWorkErrorCode code,
+    std::string message) {
+    return BoundedWorkError{
+        .code = code,
+        .message = std::move(message),
+    };
+}
+
+} // namespace
+
+std::expected<BoundedWorkSummary, BoundedWorkError>
+BoundedWorkScheduler::run(
+    const std::size_t item_count,
+    const std::size_t max_workers,
+    const std::function<bool(std::size_t)>& work) {
+    if (max_workers == 0) {
+        return std::unexpected(failure(
+            BoundedWorkErrorCode::invalid_worker_count,
+            "bounded work scheduler requires at least one worker"));
+    }
+
+    if (item_count == 0) {
+        return BoundedWorkSummary{};
+    }
+
+    const std::size_t worker_count = std::min(item_count, max_workers);
+    std::atomic<std::size_t> next_index{0};
+    std::atomic<std::size_t> started_count{0};
+    std::atomic<bool> stop_requested{false};
+    std::atomic<bool> callback_threw{false};
+
+    std::vector<std::thread> workers;
+    workers.reserve(worker_count);
+    for (std::size_t worker_index = 0; worker_index < worker_count; ++worker_index) {
+        workers.emplace_back([&] {
+            while (!stop_requested.load(std::memory_order_acquire)) {
+                const std::size_t index = next_index.fetch_add(1, std::memory_order_relaxed);
+                if (index >= item_count) {
+                    return;
+                }
+
+                started_count.fetch_add(1, std::memory_order_relaxed);
+                try {
+                    if (!work(index)) {
+                        stop_requested.store(true, std::memory_order_release);
+                    }
+                } catch (...) {
+                    callback_threw.store(true, std::memory_order_release);
+                    stop_requested.store(true, std::memory_order_release);
+                }
+            }
+        });
+    }
+
+    for (auto& worker : workers) {
+        worker.join();
+    }
+
+    if (callback_threw.load(std::memory_order_acquire)) {
+        return std::unexpected(failure(
+            BoundedWorkErrorCode::callback_threw,
+            "bounded work callback threw an exception"));
+    }
+
+    const std::size_t started = started_count.load(std::memory_order_relaxed);
+    return BoundedWorkSummary{
+        .worker_count = worker_count,
+        .started_count = started,
+        .stop_requested = stop_requested.load(std::memory_order_acquire),
+        .stopped_before_all_items = started < item_count,
+    };
+}
+
+} // namespace mqb::orchestration

--- a/cpp/orchestration/src/MsvcIncrementalTargetCoordinator.cpp
+++ b/cpp/orchestration/src/MsvcIncrementalTargetCoordinator.cpp
@@ -4,12 +4,14 @@
 #include <cctype>
 #include <expected>
 #include <filesystem>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
 
 #include "mqb/core/Artifact.hpp"
 #include "mqb/core/TranslationUnit.hpp"
+#include "mqb/orchestration/BoundedWorkScheduler.hpp"
 
 namespace mqb::orchestration {
 namespace {
@@ -37,6 +39,37 @@ namespace fs = std::filesystem;
     };
 }
 
+[[nodiscard]] bool insert_unique(
+    std::vector<std::string>& seen,
+    const fs::path& path) {
+    const std::string key = windows_path_key(path);
+    if (std::find(seen.begin(), seen.end(), key) != seen.end()) {
+        return false;
+    }
+    seen.push_back(key);
+    return true;
+}
+
+[[nodiscard]] IncrementalCompileRequest compile_request_for(
+    const TargetSourceRequest& source,
+    const CompilerOptions& options) {
+    TranslationUnit unit;
+    unit.source = source.source;
+    unit.kind = TranslationUnitKind::source;
+    unit.outputs.push_back(Artifact{
+        .path = source.artifacts.object,
+        .kind = ArtifactKind::object,
+    });
+
+    return IncrementalCompileRequest{
+        .unit = std::move(unit),
+        .options = options,
+        .cache_file = source.artifacts.compile_cache,
+        .source_dependencies_file = source.artifacts.dependencies,
+        .working_directory = source.source.parent_path(),
+    };
+}
+
 } // namespace
 
 std::expected<IncrementalTargetResult, IncrementalTargetError>
@@ -46,30 +79,81 @@ MsvcIncrementalTargetCoordinator::run(const IncrementalTargetRequest& request) c
             IncrementalTargetErrorCode::no_sources,
             "target build requires at least one source file"));
     }
+    if (request.max_parallel_compiles == 0) {
+        return std::unexpected(failure(
+            IncrementalTargetErrorCode::invalid_parallelism,
+            "target compile parallelism must be at least one"));
+    }
 
     std::vector<std::string> seen_sources;
     std::vector<std::string> seen_objects;
+    std::vector<std::string> seen_dependencies;
+    std::vector<std::string> seen_compile_caches;
     seen_sources.reserve(request.sources.size());
     seen_objects.reserve(request.sources.size());
+    seen_dependencies.reserve(request.sources.size());
+    seen_compile_caches.reserve(request.sources.size());
 
     for (const auto& source : request.sources) {
-        const std::string source_key = windows_path_key(source.source);
-        if (std::find(seen_sources.begin(), seen_sources.end(), source_key) != seen_sources.end()) {
+        if (!insert_unique(seen_sources, source.source)) {
             return std::unexpected(failure(
                 IncrementalTargetErrorCode::duplicate_source,
                 "target build contains the same source more than once",
                 source.source));
         }
-        seen_sources.push_back(source_key);
-
-        const std::string object_key = windows_path_key(source.artifacts.object);
-        if (std::find(seen_objects.begin(), seen_objects.end(), object_key) != seen_objects.end()) {
+        if (!insert_unique(seen_objects, source.artifacts.object)) {
             return std::unexpected(failure(
                 IncrementalTargetErrorCode::duplicate_object,
                 "two translation units map to the same object artifact",
                 source.source));
         }
-        seen_objects.push_back(object_key);
+        if (!insert_unique(seen_dependencies, source.artifacts.dependencies)) {
+            return std::unexpected(failure(
+                IncrementalTargetErrorCode::duplicate_dependencies,
+                "two translation units map to the same dependency metadata artifact",
+                source.source));
+        }
+        if (!insert_unique(seen_compile_caches, source.artifacts.compile_cache)) {
+            return std::unexpected(failure(
+                IncrementalTargetErrorCode::duplicate_compile_cache,
+                "two translation units map to the same compile cache artifact",
+                source.source));
+        }
+    }
+
+    using CompileAttempt = std::expected<IncrementalCompileResult, IncrementalCompileError>;
+    std::vector<std::optional<CompileAttempt>> attempts(request.sources.size());
+
+    const auto scheduled = BoundedWorkScheduler::run(
+        request.sources.size(),
+        request.max_parallel_compiles,
+        [&](const std::size_t index) {
+            const auto& source = request.sources[index];
+            auto compile_request = compile_request_for(source, request.compiler_options);
+            attempts[index].emplace(compile_coordinator_.run(compile_request));
+            return attempts[index]->has_value();
+        });
+    if (!scheduled) {
+        return std::unexpected(failure(
+            IncrementalTargetErrorCode::scheduling_failed,
+            "target compile scheduler failed: " + scheduled.error().message));
+    }
+
+    // Work indices are assigned monotonically. After all workers join, scanning
+    // in source order therefore selects the lowest-index compile failure even if
+    // several in-flight compiles failed concurrently.
+    for (std::size_t index = 0; index < attempts.size(); ++index) {
+        if (!attempts[index]) {
+            continue;
+        }
+        if (!attempts[index]->has_value()) {
+            IncrementalTargetError error = failure(
+                IncrementalTargetErrorCode::compile_failed,
+                "translation unit compilation failed",
+                request.sources[index].source);
+            error.compile_error = attempts[index]->error();
+            return std::unexpected(std::move(error));
+        }
     }
 
     IncrementalTargetResult result;
@@ -77,39 +161,21 @@ MsvcIncrementalTargetCoordinator::run(const IncrementalTargetRequest& request) c
     std::vector<fs::path> objects;
     objects.reserve(request.sources.size());
 
-    for (const auto& source : request.sources) {
-        TranslationUnit unit;
-        unit.source = source.source;
-        unit.kind = TranslationUnitKind::source;
-        unit.outputs.push_back(Artifact{
-            .path = source.artifacts.object,
-            .kind = ArtifactKind::object,
-        });
-
-        IncrementalCompileRequest compile_request{
-            .unit = std::move(unit),
-            .options = request.compiler_options,
-            .cache_file = source.artifacts.compile_cache,
-            .source_dependencies_file = source.artifacts.dependencies,
-            .working_directory = source.source.parent_path(),
-        };
-
-        auto compiled = compile_coordinator_.run(compile_request);
-        if (!compiled) {
-            IncrementalTargetError error = failure(
-                IncrementalTargetErrorCode::compile_failed,
-                "translation unit compilation failed",
-                source.source);
-            error.compile_error = compiled.error();
-            return std::unexpected(std::move(error));
+    for (std::size_t index = 0; index < request.sources.size(); ++index) {
+        if (!attempts[index]) {
+            return std::unexpected(failure(
+                IncrementalTargetErrorCode::scheduling_failed,
+                "target compile scheduler stopped without a recorded compile failure",
+                request.sources[index].source));
         }
 
-        result.any_compiled = result.any_compiled || compiled->compiled;
+        auto compiled = std::move(attempts[index]->value());
+        result.any_compiled = result.any_compiled || compiled.compiled;
         result.compiles.push_back(TargetCompileResult{
-            .source = source.source,
-            .result = std::move(*compiled),
+            .source = request.sources[index].source,
+            .result = std::move(compiled),
         });
-        objects.push_back(source.artifacts.object);
+        objects.push_back(request.sources[index].artifacts.object);
     }
 
     IncrementalLinkRequest link_request{

--- a/cpp/orchestration/tests/CMakeLists.txt
+++ b/cpp/orchestration/tests/CMakeLists.txt
@@ -25,14 +25,24 @@ target_compile_features(mqb_orchestration_incremental_link_tests PRIVATE cxx_std
 add_executable(mqb_bounded_work_scheduler_tests
     bounded_work_scheduler_tests.cpp
 )
-
 target_link_libraries(mqb_bounded_work_scheduler_tests PRIVATE mqb_orchestration)
 target_compile_features(mqb_bounded_work_scheduler_tests PRIVATE cxx_std_23)
+
+add_executable(mqb_incremental_target_coordinator_tests
+    incremental_target_coordinator_tests.cpp
+)
+target_link_libraries(mqb_incremental_target_coordinator_tests
+    PRIVATE
+        mqb_orchestration
+        mqb_msvc
+)
+target_compile_features(mqb_incremental_target_coordinator_tests PRIVATE cxx_std_23)
 
 foreach(test_target IN ITEMS
     mqb_orchestration_incremental_tests
     mqb_orchestration_incremental_link_tests
     mqb_bounded_work_scheduler_tests
+    mqb_incremental_target_coordinator_tests
 )
     if(MSVC)
         target_compile_options(${test_target} PRIVATE /W4 /permissive-)
@@ -54,4 +64,9 @@ add_test(
 add_test(
     NAME mqb.orchestration.bounded_work_scheduler
     COMMAND mqb_bounded_work_scheduler_tests
+)
+
+add_test(
+    NAME mqb.orchestration.incremental_target
+    COMMAND mqb_incremental_target_coordinator_tests
 )

--- a/cpp/orchestration/tests/CMakeLists.txt
+++ b/cpp/orchestration/tests/CMakeLists.txt
@@ -22,9 +22,17 @@ target_link_libraries(mqb_orchestration_incremental_link_tests
 
 target_compile_features(mqb_orchestration_incremental_link_tests PRIVATE cxx_std_23)
 
+add_executable(mqb_bounded_work_scheduler_tests
+    bounded_work_scheduler_tests.cpp
+)
+
+target_link_libraries(mqb_bounded_work_scheduler_tests PRIVATE mqb_orchestration)
+target_compile_features(mqb_bounded_work_scheduler_tests PRIVATE cxx_std_23)
+
 foreach(test_target IN ITEMS
     mqb_orchestration_incremental_tests
     mqb_orchestration_incremental_link_tests
+    mqb_bounded_work_scheduler_tests
 )
     if(MSVC)
         target_compile_options(${test_target} PRIVATE /W4 /permissive-)
@@ -41,4 +49,9 @@ add_test(
 add_test(
     NAME mqb.orchestration.incremental_link
     COMMAND mqb_orchestration_incremental_link_tests
+)
+
+add_test(
+    NAME mqb.orchestration.bounded_work_scheduler
+    COMMAND mqb_bounded_work_scheduler_tests
 )

--- a/cpp/orchestration/tests/bounded_work_scheduler_tests.cpp
+++ b/cpp/orchestration/tests/bounded_work_scheduler_tests.cpp
@@ -1,0 +1,179 @@
+#include <atomic>
+#include <barrier>
+#include <cstddef>
+#include <iostream>
+#include <mutex>
+#include <stdexcept>
+#include <string_view>
+#include <vector>
+
+#include "mqb/orchestration/BoundedWorkScheduler.hpp"
+
+namespace {
+
+int failures = 0;
+
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+void update_max(std::atomic<int>& maximum, const int value) {
+    int observed = maximum.load(std::memory_order_relaxed);
+    while (observed < value
+           && !maximum.compare_exchange_weak(
+               observed,
+               value,
+               std::memory_order_relaxed,
+               std::memory_order_relaxed)) {
+    }
+}
+
+} // namespace
+
+int main() {
+    using mqb::orchestration::BoundedWorkErrorCode;
+    using mqb::orchestration::BoundedWorkScheduler;
+
+    {
+        const auto invalid = BoundedWorkScheduler::run(4, 0, [](std::size_t) { return true; });
+        expect(!invalid, "zero workers should be rejected");
+        if (!invalid) {
+            expect(invalid.error().code == BoundedWorkErrorCode::invalid_worker_count,
+                   "zero workers should report invalid_worker_count");
+        }
+    }
+
+    {
+        const auto empty = BoundedWorkScheduler::run(0, 4, [](std::size_t) { return true; });
+        expect(empty.has_value(), "zero work items should be a successful no-op");
+        if (empty) {
+            expect(empty->worker_count == 0 && empty->started_count == 0,
+                   "zero work items should not create worker threads");
+        }
+    }
+
+    {
+        std::vector<std::size_t> order;
+        const auto sequential = BoundedWorkScheduler::run(
+            6,
+            1,
+            [&](const std::size_t index) {
+                order.push_back(index);
+                return true;
+            });
+        expect(sequential.has_value(), "single-worker scheduling should succeed");
+        if (sequential) {
+            expect(sequential->worker_count == 1 && sequential->started_count == 6,
+                   "single-worker scheduling should process every item");
+            expect(!sequential->stop_requested && !sequential->stopped_before_all_items,
+                   "successful single-worker scheduling should not report early stop");
+        }
+        expect(order == std::vector<std::size_t>({0, 1, 2, 3, 4, 5}),
+               "single-worker scheduling should preserve monotonic index order");
+    }
+
+    {
+        constexpr std::size_t concurrent_workers = 3;
+        std::barrier gate{static_cast<std::ptrdiff_t>(concurrent_workers)};
+        std::atomic<int> active{0};
+        std::atomic<int> maximum_active{0};
+        std::vector<std::atomic<bool>> seen(5);
+        for (auto& value : seen) value.store(false, std::memory_order_relaxed);
+
+        const auto concurrent = BoundedWorkScheduler::run(
+            seen.size(),
+            concurrent_workers,
+            [&](const std::size_t index) {
+                seen[index].store(true, std::memory_order_relaxed);
+                const int now_active = active.fetch_add(1, std::memory_order_relaxed) + 1;
+                update_max(maximum_active, now_active);
+                if (index < concurrent_workers) {
+                    gate.arrive_and_wait();
+                }
+                active.fetch_sub(1, std::memory_order_relaxed);
+                return true;
+            });
+
+        expect(concurrent.has_value(), "multi-worker scheduling should succeed");
+        if (concurrent) {
+            expect(concurrent->worker_count == concurrent_workers,
+                   "scheduler should respect the requested worker bound");
+            expect(concurrent->started_count == seen.size(),
+                   "successful concurrent scheduling should start every item");
+        }
+        expect(maximum_active.load(std::memory_order_relaxed) == 3,
+               "three workers should be observably active at the same time");
+        for (std::size_t index = 0; index < seen.size(); ++index) {
+            expect(seen[index].load(std::memory_order_relaxed),
+                   "every successful work index should run exactly once");
+        }
+    }
+
+    {
+        constexpr std::size_t worker_count = 3;
+        std::barrier first_wave{static_cast<std::ptrdiff_t>(worker_count)};
+        std::vector<std::atomic<int>> calls(20);
+        for (auto& value : calls) value.store(0, std::memory_order_relaxed);
+        std::atomic<int> finished{0};
+
+        const auto stopped = BoundedWorkScheduler::run(
+            calls.size(),
+            worker_count,
+            [&](const std::size_t index) {
+                calls[index].fetch_add(1, std::memory_order_relaxed);
+                if (index < worker_count) {
+                    first_wave.arrive_and_wait();
+                }
+                finished.fetch_add(1, std::memory_order_relaxed);
+                return index != 2;
+            });
+
+        expect(stopped.has_value(), "callback-requested stop should not be a scheduler error");
+        if (stopped) {
+            expect(stopped->stop_requested,
+                   "false callback result should record a stop request");
+            expect(stopped->started_count >= 3,
+                   "the complete first wave must be joined after a failure");
+            expect(stopped->started_count < calls.size(),
+                   "stop request should prevent at least some new work from starting");
+            expect(stopped->stopped_before_all_items,
+                   "summary should report that not every item started");
+            expect(finished.load(std::memory_order_relaxed)
+                       == static_cast<int>(stopped->started_count),
+                   "scheduler must join every callback that it started");
+        }
+        expect(calls[0].load(std::memory_order_relaxed) == 1
+                   && calls[1].load(std::memory_order_relaxed) == 1
+                   && calls[2].load(std::memory_order_relaxed) == 1,
+               "monotonic assignment must not skip lower indices before a failing index");
+        for (const auto& call_count : calls) {
+            expect(call_count.load(std::memory_order_relaxed) <= 1,
+                   "each work index must be assigned at most once");
+        }
+    }
+
+    {
+        const auto threw = BoundedWorkScheduler::run(
+            4,
+            2,
+            [](const std::size_t index) -> bool {
+                if (index == 0) throw std::runtime_error{"scheduler-test"};
+                return true;
+            });
+        expect(!threw, "callback exception should become a scheduler error");
+        if (!threw) {
+            expect(threw.error().code == BoundedWorkErrorCode::callback_threw,
+                   "callback exception should report callback_threw");
+        }
+    }
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+    std::cout << "mqb_bounded_work_scheduler_tests passed\n";
+    return 0;
+}

--- a/cpp/orchestration/tests/bounded_work_scheduler_tests.cpp
+++ b/cpp/orchestration/tests/bounded_work_scheduler_tests.cpp
@@ -2,7 +2,6 @@
 #include <barrier>
 #include <cstddef>
 #include <iostream>
-#include <mutex>
 #include <stdexcept>
 #include <string_view>
 #include <vector>
@@ -76,6 +75,27 @@ int main() {
     }
 
     {
+        std::vector<std::size_t> order;
+        const auto stopped = BoundedWorkScheduler::run(
+            6,
+            1,
+            [&](const std::size_t index) {
+                order.push_back(index);
+                return index != 2;
+            });
+
+        expect(stopped.has_value(), "single-worker callback stop should be a successful schedule");
+        if (stopped) {
+            expect(stopped->worker_count == 1 && stopped->started_count == 3,
+                   "single-worker stop should deterministically truncate later dispatch");
+            expect(stopped->stop_requested && stopped->stopped_before_all_items,
+                   "single-worker stop should report an early stop");
+        }
+        expect(order == std::vector<std::size_t>({0, 1, 2}),
+               "single-worker stop should not dispatch an index after the failing item");
+    }
+
+    {
         constexpr std::size_t concurrent_workers = 3;
         std::barrier gate{static_cast<std::ptrdiff_t>(concurrent_workers)};
         std::atomic<int> active{0};
@@ -133,14 +153,14 @@ int main() {
 
         expect(stopped.has_value(), "callback-requested stop should not be a scheduler error");
         if (stopped) {
+            expect(stopped->worker_count == worker_count,
+                   "stop path should preserve the requested worker bound");
             expect(stopped->stop_requested,
                    "false callback result should record a stop request");
-            expect(stopped->started_count >= 3,
+            expect(stopped->started_count >= worker_count,
                    "the complete first wave must be joined after a failure");
-            expect(stopped->started_count < calls.size(),
-                   "stop request should prevent at least some new work from starting");
-            expect(stopped->stopped_before_all_items,
-                   "summary should report that not every item started");
+            expect(stopped->stopped_before_all_items == (stopped->started_count < calls.size()),
+                   "early-stop summary should match the actual number of started items");
             expect(finished.load(std::memory_order_relaxed)
                        == static_cast<int>(stopped->started_count),
                    "scheduler must join every callback that it started");

--- a/cpp/orchestration/tests/incremental_target_coordinator_tests.cpp
+++ b/cpp/orchestration/tests/incremental_target_coordinator_tests.cpp
@@ -1,0 +1,407 @@
+#include <algorithm>
+#include <atomic>
+#include <barrier>
+#include <chrono>
+#include <cstddef>
+#include <expected>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <mutex>
+#include <set>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <vector>
+
+#include "mqb/core/BuildTypes.hpp"
+#include "mqb/core/CompilerOptions.hpp"
+#include "mqb/core/LinkOptions.hpp"
+#include "mqb/msvc/MsvcCompileExecutor.hpp"
+#include "mqb/msvc/MsvcLinker.hpp"
+#include "mqb/msvc/MsvcToolchainLocator.hpp"
+#include "mqb/orchestration/MsvcIncrementalCompileCoordinator.hpp"
+#include "mqb/orchestration/MsvcIncrementalLinkCoordinator.hpp"
+#include "mqb/orchestration/MsvcIncrementalTargetCoordinator.hpp"
+#include "mqb/process/Process.hpp"
+
+namespace {
+
+namespace fs = std::filesystem;
+int failures = 0;
+
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+void write_text(const fs::path& path, const std::string_view text) {
+    fs::create_directories(path.parent_path());
+    std::ofstream stream{path, std::ios::binary | std::ios::trunc};
+    stream << text;
+}
+
+[[nodiscard]] std::string path_to_utf8(const fs::path& path) {
+    const auto bytes = path.lexically_normal().generic_u8string();
+    return std::string{
+        reinterpret_cast<const char*>(bytes.data()),
+        bytes.size()};
+}
+
+[[nodiscard]] fs::path utf8_path(const std::string_view value) {
+    std::u8string bytes;
+    bytes.assign(
+        reinterpret_cast<const char8_t*>(value.data()),
+        reinterpret_cast<const char8_t*>(value.data() + value.size()));
+    return fs::path{bytes}.lexically_normal();
+}
+
+[[nodiscard]] std::string json_escape(const std::string_view value) {
+    std::string result;
+    for (const char ch : value) {
+        switch (ch) {
+        case '\\': result += "\\\\"; break;
+        case '"': result += "\\\""; break;
+        case '\n': result += "\\n"; break;
+        case '\r': result += "\\r"; break;
+        case '\t': result += "\\t"; break;
+        default: result.push_back(ch); break;
+        }
+    }
+    return result;
+}
+
+void update_max(std::atomic<int>& maximum, const int value) {
+    int observed = maximum.load(std::memory_order_relaxed);
+    while (observed < value
+           && !maximum.compare_exchange_weak(
+               observed,
+               value,
+               std::memory_order_relaxed,
+               std::memory_order_relaxed)) {
+    }
+}
+
+class TemporaryDirectory {
+public:
+    TemporaryDirectory() {
+        const auto tick = std::chrono::steady_clock::now().time_since_epoch().count();
+        path_ = fs::temp_directory_path()
+            / ("mqb-target-parallel-test-" + std::to_string(tick));
+        fs::create_directories(path_);
+    }
+    ~TemporaryDirectory() {
+        std::error_code ignored;
+        fs::remove_all(path_, ignored);
+    }
+    [[nodiscard]] const fs::path& path() const noexcept { return path_; }
+
+private:
+    fs::path path_;
+};
+
+class TargetToolRunner final : public mqb::process::ProcessRunner {
+public:
+    TargetToolRunner(fs::path compiler, fs::path linker, const std::size_t synchronized_wave)
+        : compiler_(std::move(compiler)),
+          linker_(std::move(linker)),
+          synchronized_wave_(synchronized_wave),
+          wave_gate_(static_cast<std::ptrdiff_t>(synchronized_wave)) {}
+
+    void fail_sources(std::set<std::string> names) {
+        std::scoped_lock lock{mutex_};
+        fail_source_names_ = std::move(names);
+    }
+
+    [[nodiscard]] int compile_calls() const noexcept {
+        return compile_calls_.load(std::memory_order_relaxed);
+    }
+    [[nodiscard]] int link_calls() const noexcept {
+        return link_calls_.load(std::memory_order_relaxed);
+    }
+    [[nodiscard]] int maximum_active_compiles() const noexcept {
+        return maximum_active_.load(std::memory_order_relaxed);
+    }
+
+    std::expected<mqb::process::ProcessResult, mqb::process::ProcessError>
+    run(const mqb::process::ProcessSpec& spec) override {
+        if (spec.executable.lexically_normal() == compiler_.lexically_normal()) {
+            return compile(spec);
+        }
+        if (spec.executable.lexically_normal() == linker_.lexically_normal()) {
+            return link(spec);
+        }
+        return std::unexpected(mqb::process::ProcessError{
+            .code = mqb::process::ProcessErrorCode::launch_failed,
+            .message = "unexpected fake tool executable",
+        });
+    }
+
+private:
+    std::expected<mqb::process::ProcessResult, mqb::process::ProcessError>
+    compile(const mqb::process::ProcessSpec& spec) {
+        fs::path object;
+        fs::path dependencies;
+        fs::path source;
+        for (std::size_t index = 0; index < spec.arguments.size(); ++index) {
+            const std::string& argument = spec.arguments[index];
+            if (argument.starts_with("/Fo")) {
+                object = utf8_path(std::string_view{argument}.substr(3));
+            } else if (argument == "/sourceDependencies" && index + 1 < spec.arguments.size()) {
+                dependencies = utf8_path(spec.arguments[index + 1]);
+            }
+        }
+        if (!spec.arguments.empty()) {
+            source = utf8_path(spec.arguments.back());
+        }
+
+        const int call_index = phase_compile_calls_.fetch_add(1, std::memory_order_relaxed);
+        compile_calls_.fetch_add(1, std::memory_order_relaxed);
+        const int active = active_compiles_.fetch_add(1, std::memory_order_relaxed) + 1;
+        update_max(maximum_active_, active);
+        if (static_cast<std::size_t>(call_index) < synchronized_wave_) {
+            wave_gate_.arrive_and_wait();
+        }
+
+        bool should_fail = false;
+        {
+            std::scoped_lock lock{mutex_};
+            should_fail = fail_source_names_.contains(source.filename().string());
+        }
+
+        if (!should_fail) {
+            write_text(object, "parallel fake object");
+            const std::string json =
+                "{\"Data\":{\"Source\":\""
+                + json_escape(path_to_utf8(source))
+                + "\",\"Includes\":[]}}";
+            write_text(dependencies, json);
+        }
+        active_compiles_.fetch_sub(1, std::memory_order_relaxed);
+
+        if (should_fail) {
+            return mqb::process::ProcessResult{
+                .exit_code = 2,
+                .stderr_text = "simulated parallel compile failure: " + source.filename().string(),
+            };
+        }
+        return mqb::process::ProcessResult{
+            .exit_code = 0,
+            .stdout_text = "simulated parallel compile success",
+        };
+    }
+
+    std::expected<mqb::process::ProcessResult, mqb::process::ProcessError>
+    link(const mqb::process::ProcessSpec& spec) {
+        link_calls_.fetch_add(1, std::memory_order_relaxed);
+        fs::path output;
+        for (const auto& argument : spec.arguments) {
+            if (argument.starts_with("/OUT:")) {
+                output = utf8_path(std::string_view{argument}.substr(5));
+            }
+        }
+        write_text(output, "parallel fake executable");
+        return mqb::process::ProcessResult{
+            .exit_code = 0,
+            .stdout_text = "simulated link success",
+        };
+    }
+
+    fs::path compiler_;
+    fs::path linker_;
+    std::size_t synchronized_wave_{};
+    std::barrier<> wave_gate_;
+    std::atomic<int> phase_compile_calls_{0};
+    std::atomic<int> compile_calls_{0};
+    std::atomic<int> link_calls_{0};
+    std::atomic<int> active_compiles_{0};
+    std::atomic<int> maximum_active_{0};
+    mutable std::mutex mutex_;
+    std::set<std::string> fail_source_names_;
+};
+
+[[nodiscard]] mqb::orchestration::TargetSourceRequest make_source(
+    const fs::path& root,
+    const std::string& name) {
+    const fs::path source = root / "src" / name;
+    write_text(source, "int value_" + name + " = 1;\n");
+    return mqb::orchestration::TargetSourceRequest{
+        .source = source,
+        .artifacts = mqb::SourceArtifacts{
+            .object = root / ".mqb" / "obj" / (name + ".obj"),
+            .dependencies = root / ".mqb" / "deps" / (name + ".json"),
+            .compile_cache = root / ".mqb" / "cache" / "compile" / (name + ".cache"),
+        },
+    };
+}
+
+} // namespace
+
+int main() {
+    TemporaryDirectory fixture;
+    const fs::path compiler = fixture.path() / "tools" / "cl.exe";
+    const fs::path linker_path = fixture.path() / "tools" / "link.exe";
+    write_text(compiler, "fake compiler identity");
+    write_text(linker_path, "fake linker identity");
+
+    mqb::msvc::MsvcToolchain toolchain{
+        .identity = mqb::ToolchainIdentity{
+            .compiler = compiler,
+            .version = "19.50.parallel-test",
+            .binary_stamp = "parallel-test-stamp",
+        },
+        .linker = linker_path,
+        .librarian = fixture.path() / "tools" / "lib.exe",
+        .vc_tools_root = fixture.path() / "tools",
+        .source = mqb::msvc::ToolchainSource::visual_studio,
+    };
+
+    std::vector<mqb::orchestration::TargetSourceRequest> sources;
+    sources.push_back(make_source(fixture.path(), "a.cpp"));
+    sources.push_back(make_source(fixture.path(), "b.cpp"));
+    sources.push_back(make_source(fixture.path(), "c.cpp"));
+    sources.push_back(make_source(fixture.path(), "d.cpp"));
+
+    mqb::CompilerOptions compiler_options;
+    compiler_options.configuration = mqb::BuildConfiguration::debug;
+    compiler_options.architecture = mqb::Architecture::x64;
+    compiler_options.standard = mqb::CppStandard::cpp23;
+
+    mqb::LinkOptions link_options;
+    link_options.configuration = mqb::BuildConfiguration::debug;
+    link_options.architecture = mqb::Architecture::x64;
+    link_options.subsystem = mqb::LinkSubsystem::console;
+
+    TargetToolRunner runner{compiler, linker_path, 3};
+    mqb::msvc::MsvcCompileExecutor compile_executor{toolchain, runner};
+    mqb::orchestration::MsvcIncrementalCompileCoordinator compile_coordinator{
+        toolchain, compile_executor};
+    mqb::msvc::MsvcLinker linker{toolchain, runner};
+    mqb::orchestration::MsvcIncrementalLinkCoordinator link_coordinator{toolchain, linker};
+    mqb::orchestration::MsvcIncrementalTargetCoordinator target_coordinator{
+        compile_coordinator, link_coordinator};
+
+    const mqb::orchestration::IncrementalTargetRequest request{
+        .sources = sources,
+        .target = mqb::TargetArtifacts{
+            .executable = fixture.path() / ".mqb" / "bin" / "parallel.exe",
+            .link_cache = fixture.path() / ".mqb" / "cache" / "link" / "parallel.cache",
+        },
+        .compiler_options = compiler_options,
+        .link_options = link_options,
+        .working_directory = fixture.path(),
+        .max_parallel_compiles = 3,
+    };
+
+    const auto cold = target_coordinator.run(request);
+    expect(cold.has_value(), "cold parallel target build should succeed");
+    if (cold) {
+        expect(cold->compiles.size() == sources.size(),
+               "parallel target result should retain one compile result per source");
+        for (std::size_t index = 0; index < sources.size() && index < cold->compiles.size(); ++index) {
+            expect(cold->compiles[index].source == sources[index].source,
+                   "parallel compile results should remain in original source order");
+        }
+        expect(cold->any_compiled,
+               "cold target should report that at least one TU compiled");
+        expect(cold->link.linked,
+               "cold parallel target should link after all compiles succeed");
+    }
+    expect(runner.maximum_active_compiles() == 3,
+           "target coordinator should execute three compile requests concurrently");
+    expect(runner.compile_calls() == 4,
+           "cold target should compile every source exactly once");
+    expect(runner.link_calls() == 1,
+           "cold target should link exactly once");
+
+    const auto warm = target_coordinator.run(request);
+    expect(warm.has_value(), "warm parallel target validation should succeed");
+    if (warm) {
+        expect(!warm->any_compiled,
+               "warm target should report no compile execution");
+        expect(!warm->link.linked,
+               "warm target should reuse link state");
+        expect(warm->compiles.size() == sources.size(),
+               "warm target should still report every TU in source order");
+    }
+    expect(runner.compile_calls() == 4,
+           "warm target should not invoke the compiler runner");
+    expect(runner.link_calls() == 1,
+           "warm target should not invoke the linker runner");
+
+    {
+        auto invalid = request;
+        invalid.max_parallel_compiles = 0;
+        const auto rejected = target_coordinator.run(invalid);
+        expect(!rejected
+                   && rejected.error().code
+                       == mqb::orchestration::IncrementalTargetErrorCode::invalid_parallelism,
+               "zero parallelism should fail before scheduling work");
+    }
+
+    {
+        auto duplicate = request;
+        duplicate.sources[1].artifacts.dependencies = duplicate.sources[0].artifacts.dependencies;
+        const int calls_before = runner.compile_calls();
+        const auto rejected = target_coordinator.run(duplicate);
+        expect(!rejected
+                   && rejected.error().code
+                       == mqb::orchestration::IncrementalTargetErrorCode::duplicate_dependencies,
+               "duplicate dependency metadata output should be rejected before workers start");
+        expect(runner.compile_calls() == calls_before,
+               "duplicate dependency metadata should not launch any compiler work");
+    }
+
+    {
+        auto duplicate = request;
+        duplicate.sources[1].artifacts.compile_cache = duplicate.sources[0].artifacts.compile_cache;
+        const int calls_before = runner.compile_calls();
+        const auto rejected = target_coordinator.run(duplicate);
+        expect(!rejected
+                   && rejected.error().code
+                       == mqb::orchestration::IncrementalTargetErrorCode::duplicate_compile_cache,
+               "duplicate compile cache output should be rejected before workers start");
+        expect(runner.compile_calls() == calls_before,
+               "duplicate compile cache should not launch any compiler work");
+    }
+
+    // Remove compile/link state so the next run is a true concurrent failure wave.
+    std::error_code ignored;
+    fs::remove_all(fixture.path() / ".mqb", ignored);
+
+    TargetToolRunner failing_runner{compiler, linker_path, 3};
+    failing_runner.fail_sources({"b.cpp", "c.cpp"});
+    mqb::msvc::MsvcCompileExecutor failing_executor{toolchain, failing_runner};
+    mqb::orchestration::MsvcIncrementalCompileCoordinator failing_compile_coordinator{
+        toolchain, failing_executor};
+    mqb::msvc::MsvcLinker failing_linker{toolchain, failing_runner};
+    mqb::orchestration::MsvcIncrementalLinkCoordinator failing_link_coordinator{
+        toolchain, failing_linker};
+    mqb::orchestration::MsvcIncrementalTargetCoordinator failing_target_coordinator{
+        failing_compile_coordinator, failing_link_coordinator};
+
+    const auto failed = failing_target_coordinator.run(request);
+    expect(!failed, "parallel compile failure should fail the target");
+    if (!failed) {
+        expect(failed.error().code
+                   == mqb::orchestration::IncrementalTargetErrorCode::compile_failed,
+               "parallel compile failure should report compile_failed");
+        expect(failed.error().source == sources[1].source,
+               "concurrent failures should deterministically report the lowest source index");
+        expect(failed.error().compile_error.has_value(),
+               "target failure should retain the selected compile error");
+    }
+    expect(failing_runner.maximum_active_compiles() == 3,
+           "failure wave should still prove three concurrent in-flight compiles");
+    expect(failing_runner.link_calls() == 0,
+           "target must not link when any parallel compile fails");
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+    std::cout << "mqb_incremental_target_coordinator_tests passed\n";
+    return 0;
+}

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -134,6 +134,10 @@ if(WIN32)
         target_link_libraries(mqb_project_config_e2e_tests PRIVATE mqb_msvc mqb_platform_windows)
         target_compile_features(mqb_project_config_e2e_tests PRIVATE cxx_std_23)
 
+        add_executable(mqb_parallel_cli_e2e_tests mqb_parallel_cli_e2e_tests.cpp)
+        target_link_libraries(mqb_parallel_cli_e2e_tests PRIVATE mqb_platform_windows)
+        target_compile_features(mqb_parallel_cli_e2e_tests PRIVATE cxx_std_23)
+
         list(APPEND MQB_TEST_TARGETS
             mqb_msvc_visual_studio_tests
             mqb_msvc_compile_integration_tests
@@ -141,6 +145,7 @@ if(WIN32)
             mqb_msvc_incremental_loop_tests
             mqb_cli_e2e_tests
             mqb_project_config_e2e_tests
+            mqb_parallel_cli_e2e_tests
         )
     endif()
 endif()
@@ -191,6 +196,10 @@ if(WIN32)
         add_test(
             NAME mqb.cli.project_config_e2e
             COMMAND mqb_project_config_e2e_tests $<TARGET_FILE:mqb>
+        )
+        add_test(
+            NAME mqb.cli.parallel_e2e
+            COMMAND mqb_parallel_cli_e2e_tests $<TARGET_FILE:mqb>
         )
     endif()
 endif()

--- a/cpp/tests/cli_argument_tests.cpp
+++ b/cpp/tests/cli_argument_tests.cpp
@@ -42,6 +42,8 @@ int main() {
             expect(!parsed->configuration_override && !parsed->architecture_override
                        && !parsed->standard_override,
                    "built-in parser defaults must not masquerade as explicit CLI scalar overrides");
+            expect(!parsed->jobs,
+                   "compile job count should remain unset so main can choose hardware concurrency");
             expect(!parsed->build.output_name.has_value(),
                    "output name should remain unset by default");
             expect(!parsed->build.run_after_build,
@@ -92,6 +94,7 @@ int main() {
             "--std"sv,
             "latest"sv,
             "--x86"sv,
+            "-j4"sv,
             "--output"sv,
             "product"sv,
             "--run"sv,
@@ -130,6 +133,8 @@ int main() {
                    "parser keeps discovery policy enabled; main treats multi-source sets as explicit");
             expect(!parsed->discovery_override,
                    "multi-source parsing must not create a discovery override unless requested");
+            expect(parsed->jobs.has_value() && *parsed->jobs == 4,
+                   "attached -j form should preserve explicit compile job count");
             expect(parsed->build.output_name.has_value()
                        && *parsed->build.output_name == "product",
                    "output name should be parsed");
@@ -188,6 +193,8 @@ int main() {
             "--x64"sv,
             "--std"sv,
             "20"sv,
+            "--jobs"sv,
+            "2"sv,
         };
         auto parsed = mqb::cli::parse_arguments(arguments);
         expect(parsed.has_value(), "explicit built-in-valued options should parse");
@@ -198,6 +205,8 @@ int main() {
                    "explicit --x64 must override a possible x86 project config");
             expect(parsed->standard_override == mqb::CppStandard::cpp20,
                    "explicit --std 20 must override project standard");
+            expect(parsed->jobs.has_value() && *parsed->jobs == 2,
+                   "separate --jobs value should parse");
         }
     }
 
@@ -205,6 +214,7 @@ int main() {
         const std::vector arguments{
             "main.cpp"sv,
             "--output=demo"sv,
+            "--jobs=3"sv,
             "--lib-path=vendor"sv,
             "--lib=foo"sv,
         };
@@ -213,6 +223,8 @@ int main() {
         if (parsed) {
             expect(parsed->build.output_name.has_value() && *parsed->build.output_name == "demo",
                    "attached long output value should be preserved");
+            expect(parsed->jobs.has_value() && *parsed->jobs == 3,
+                   "attached long jobs value should be preserved");
             expect(parsed->library_directories.size() == 1
                        && parsed->library_directories.front() == "vendor",
                    "attached long library path should be preserved");
@@ -222,17 +234,15 @@ int main() {
     }
 
     {
-        const std::vector arguments{"main.cpp"sv, "--run"sv, "--"sv, "--no-discover"sv};
+        const std::vector arguments{"main.cpp"sv, "--run"sv, "--"sv, "--jobs=9"sv};
         auto parsed = mqb::cli::parse_arguments(arguments);
         expect(parsed.has_value(), "options after -- should become program arguments");
         if (parsed) {
-            expect(parsed->discover_sources,
-                   "discovery parsing must stop at --");
-            expect(!parsed->discovery_override,
-                   "option-looking child argv must not create a project override");
+            expect(!parsed->jobs,
+                   "option-looking child argv must not create compile job policy");
             expect(parsed->build.run_arguments.size() == 1
-                       && parsed->build.run_arguments.front() == "--no-discover",
-                   "option-looking argv after -- must be preserved verbatim");
+                       && parsed->build.run_arguments.front() == "--jobs=9",
+                   "job-looking argv after -- must be preserved verbatim");
         }
     }
 
@@ -246,6 +256,24 @@ int main() {
         const std::vector arguments{"main.cpp"sv, "-o"sv};
         auto parsed = mqb::cli::parse_arguments(arguments);
         expect(!parsed, "missing output value should be rejected");
+    }
+
+    {
+        const std::vector arguments{"main.cpp"sv, "--jobs"sv};
+        auto parsed = mqb::cli::parse_arguments(arguments);
+        expect(!parsed, "missing compile job count should be rejected");
+    }
+
+    {
+        const std::vector arguments{"main.cpp"sv, "-j0"sv};
+        auto parsed = mqb::cli::parse_arguments(arguments);
+        expect(!parsed, "zero compile job count should be rejected");
+    }
+
+    {
+        const std::vector arguments{"main.cpp"sv, "--jobs=abc"sv};
+        auto parsed = mqb::cli::parse_arguments(arguments);
+        expect(!parsed, "non-numeric compile job count should be rejected");
     }
 
     {

--- a/cpp/tests/mqb_parallel_cli_e2e_tests.cpp
+++ b/cpp/tests/mqb_parallel_cli_e2e_tests.cpp
@@ -1,0 +1,197 @@
+#include <chrono>
+#include <expected>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <vector>
+
+#include "mqb/platform/windows/WindowsProcessRunner.hpp"
+#include "mqb/process/Process.hpp"
+
+namespace {
+
+namespace fs = std::filesystem;
+int failures = 0;
+
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+void write_text(const fs::path& path, const std::string_view text) {
+    fs::create_directories(path.parent_path());
+    std::ofstream stream{path, std::ios::binary | std::ios::trunc};
+    stream << text;
+}
+
+void dump_failure(const mqb::process::ProcessResult& result) {
+    std::cerr << "exit: " << result.exit_code << '\n'
+              << "stdout:\n" << result.stdout_text << '\n'
+              << "stderr:\n" << result.stderr_text << '\n';
+}
+
+[[nodiscard]] bool contains_line(std::string_view output, std::string_view expected) {
+    std::size_t begin = 0;
+    while (begin <= output.size()) {
+        const std::size_t newline = output.find('\n', begin);
+        const std::size_t end = newline == std::string_view::npos ? output.size() : newline;
+        std::string_view line = output.substr(begin, end - begin);
+        if (!line.empty() && line.back() == '\r') line.remove_suffix(1);
+        if (line == expected) return true;
+        if (newline == std::string_view::npos) break;
+        begin = newline + 1;
+    }
+    return false;
+}
+
+struct TempTree {
+    fs::path root;
+    ~TempTree() {
+        std::error_code ignored;
+        fs::remove_all(root, ignored);
+    }
+};
+
+[[nodiscard]] std::expected<mqb::process::ProcessResult, std::string> run_mqb(
+    mqb::platform::windows::WindowsProcessRunner& runner,
+    const fs::path& mqb,
+    const fs::path& root,
+    const std::string& jobs) {
+    mqb::process::ProcessSpec spec;
+    spec.executable = mqb;
+    spec.arguments = {
+        "main.cpp",
+        "a.cpp",
+        "b.cpp",
+        "c.cpp",
+        "--env",
+        "vs",
+        "--jobs",
+        jobs,
+        "--verbose",
+        "-o",
+        "parallel",
+    };
+    spec.working_directory = root;
+    spec.capture_stdout = true;
+    spec.capture_stderr = true;
+    auto result = runner.run(spec);
+    if (!result) return std::unexpected("failed to launch mqb: " + result.error().message);
+    return std::move(*result);
+}
+
+[[nodiscard]] std::expected<mqb::process::ProcessResult, std::string> run_executable(
+    mqb::platform::windows::WindowsProcessRunner& runner,
+    const fs::path& executable,
+    const fs::path& root) {
+    mqb::process::ProcessSpec spec;
+    spec.executable = executable;
+    spec.working_directory = root;
+    spec.capture_stdout = true;
+    spec.capture_stderr = true;
+    auto result = runner.run(spec);
+    if (!result) return std::unexpected("failed to launch built executable: " + result.error().message);
+    return std::move(*result);
+}
+
+} // namespace
+
+int main(const int argc, char* argv[]) {
+    if (argc != 2) {
+        std::cerr << "usage: mqb_parallel_cli_e2e_tests <mqb-executable>\n";
+        return 2;
+    }
+
+    const fs::path mqb_executable{argv[1]};
+    const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
+    TempTree tree{
+        .root = fs::temp_directory_path() / ("mqb_parallel_cli_e2e_" + std::to_string(unique)),
+    };
+    fs::create_directories(tree.root);
+
+    write_text(tree.root / "main.cpp", R"cpp(#include <cstdio>
+int a();
+int b();
+int c();
+int main() {
+    std::printf("parallel=%d\n", 1 + a() + b() + c());
+    return 0;
+}
+)cpp");
+    write_text(tree.root / "a.cpp", "int a() { return 2; }\n");
+    write_text(tree.root / "b.cpp", "int b() { return 3; }\n");
+    write_text(tree.root / "c.cpp", "int c() { return 4; }\n");
+
+    mqb::platform::windows::WindowsProcessRunner runner;
+
+    auto cold = run_mqb(runner, mqb_executable, tree.root, "4");
+    expect(cold.has_value(), "cold real parallel MQB invocation should launch");
+    if (cold) {
+        if (cold->exit_code != 0) dump_failure(*cold);
+        expect(cold->exit_code == 0,
+               "cold same-directory four-TU parallel build should succeed");
+        expect(cold->stdout_text.find("  jobs:    4") != std::string::npos,
+               "verbose target output should report four active compile jobs");
+        expect(cold->stdout_text.find("[compile] main.cpp") != std::string::npos,
+               "cold parallel build should compile main.cpp");
+        expect(cold->stdout_text.find("[compile] a.cpp") != std::string::npos,
+               "cold parallel build should compile a.cpp");
+        expect(cold->stdout_text.find("[compile] b.cpp") != std::string::npos,
+               "cold parallel build should compile b.cpp");
+        expect(cold->stdout_text.find("[compile] c.cpp") != std::string::npos,
+               "cold parallel build should compile c.cpp");
+        expect(cold->stdout_text.find("[link] parallel.exe") != std::string::npos,
+               "cold parallel build should link after all four TUs finish");
+    }
+
+    const fs::path executable = tree.root / ".mqb" / "bin" / "parallel.exe";
+    expect(fs::is_regular_file(executable),
+           "parallel target executable should be produced");
+    auto cold_run = run_executable(runner, executable, tree.root);
+    expect(cold_run.has_value() && cold_run->exit_code == 0,
+           "parallel-built executable should launch");
+    if (cold_run) {
+        expect(cold_run->stdout_text.find("parallel=10") != std::string::npos,
+               "parallel-built executable should contain every TU contribution");
+    }
+
+    auto warm = run_mqb(runner, mqb_executable, tree.root, "1");
+    expect(warm.has_value(), "warm sequential-policy MQB invocation should launch");
+    if (warm) {
+        if (warm->exit_code != 0) dump_failure(*warm);
+        expect(warm->exit_code == 0,
+               "warm build should succeed after changing only compile job count");
+        expect(warm->stdout_text.find("  jobs:    1") != std::string::npos,
+               "verbose target output should report explicit sequential job policy");
+        expect(contains_line(warm->stdout_text, "[up-to-date] main.cpp"),
+               "changing -j must not invalidate main.cpp compile cache");
+        expect(contains_line(warm->stdout_text, "[up-to-date] a.cpp"),
+               "changing -j must not invalidate a.cpp compile cache");
+        expect(contains_line(warm->stdout_text, "[up-to-date] b.cpp"),
+               "changing -j must not invalidate b.cpp compile cache");
+        expect(contains_line(warm->stdout_text, "[up-to-date] c.cpp"),
+               "changing -j must not invalidate c.cpp compile cache");
+        expect(contains_line(warm->stdout_text, "[up-to-date] parallel.exe"),
+               "changing -j must not invalidate link cache");
+    }
+
+    auto warm_run = run_executable(runner, executable, tree.root);
+    expect(warm_run.has_value() && warm_run->exit_code == 0,
+           "warm reused executable should still launch");
+    if (warm_run) {
+        expect(warm_run->stdout_text.find("parallel=10") != std::string::npos,
+               "warm reused executable behavior should remain unchanged");
+    }
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+    std::cout << "mqb_parallel_cli_e2e_tests passed\n";
+    return 0;
+}

--- a/cpp/tests/msvc_compiler_arguments_tests.cpp
+++ b/cpp/tests/msvc_compiler_arguments_tests.cpp
@@ -50,6 +50,10 @@ int main() {
         expect(contains(*result, "/utf-8"), "argv should use UTF-8 source/execution encoding");
         expect(contains(*result, "/Od"), "debug configuration should disable optimization");
         expect(contains(*result, "/MDd"), "debug configuration should select debug DLL CRT");
+        expect(contains(*result, "/Z7"),
+               "debug compilation should keep debug information inside the object for parallel safety");
+        expect(!contains(*result, "/Zi"),
+               "debug compilation must not emit a shared compiler PDB recipe");
         expect(contains(*result, "/D_DEBUG"), "debug configuration should define _DEBUG");
         expect(contains(*result, "/std:c++23preview"),
                "C++23 should map to MSVC's current C++23 preview switch");
@@ -94,6 +98,10 @@ int main() {
     if (release_result) {
         expect(contains(*release_result, "/O2"), "release configuration should optimize");
         expect(contains(*release_result, "/MD"), "release configuration should select release DLL CRT");
+        expect(contains(*release_result, "/Z7"),
+               "release compilation should also avoid a shared compiler PDB");
+        expect(!contains(*release_result, "/Zi"),
+               "release compilation must not emit a shared compiler PDB recipe");
         expect(contains(*release_result, "/DNDEBUG"), "release configuration should define NDEBUG");
         expect(contains(*release_result, "/std:c++latest"), "latest standard should map correctly");
         expect(!contains(*release_result, "/sourceDependencies"),

--- a/docs/CPP_V2_ARCHITECTURE.md
+++ b/docs/CPP_V2_ARCHITECTURE.md
@@ -25,7 +25,7 @@ CLI (mqb.exe)
     |
     v
 Target orchestration
-  N x compile coordinator -> collect objects -> one link coordinator
+  bounded parallel N x compile coordinator -> ordered results -> one link coordinator
     |
     +--------------------+
     v                    v
@@ -61,6 +61,7 @@ Core                  MSVC backend
 9. **Run-time argv is not build identity.** `--run` and arguments after `--` are execution state only; changing them must not invalidate compile or link caches.
 10. **Discovery is not dependency freshness.** Smart discovery chooses candidate translation units; MSVC `/sourceDependencies` remains the authority for header freshness.
 11. **Configuration is typed policy, not shell text.** `mqb.json` decodes into optional typed overrides before MSVC arguments are produced.
+12. **Compile parallelism is execution policy, not build identity.** `-j/--jobs` controls how many ordinary TUs may execute concurrently; changing it must not invalidate compile or link caches.
 
 ## Project configuration
 
@@ -120,6 +121,8 @@ artifact placement -----------> ProjectArtifactLayout
 `CompileCacheFile` persists compile metadata in a versioned binary format. Missing metadata is a normal cold-cache condition; corrupt/truncated/unsupported metadata is rejected and conservatively rebuilt.
 
 A config-only change that alters effective compiler options therefore changes compile identity even when no source timestamp changes.
+
+Ordinary Debug and Release compilation use MSVC `/Z7`, keeping compiler debug information inside each TU's object instead of sharing a compiler PDB between concurrent `cl.exe` processes. Final link debug information remains a linker concern. The compile signature recipe was version-bumped when this policy changed so old `/Zi` cache entries are conservatively rebuilt once.
 
 ## Link identity and cache freshness
 
@@ -228,14 +231,21 @@ LinkCacheFile
 
 ```text
 ordered source requests
-      -> compile each TU with IncrementalCompileCoordinator
-      -> collect collision-free object artifacts
-      -> any TU compiled? ---- yes ----> force_relink
+      -> preflight unique source/object/deps/cache artifacts
+      -> BoundedWorkScheduler(max_parallel_compiles)
+      -> parallel IncrementalCompileCoordinator per ordinary TU
+      -> join every in-flight compile
+      -> scan attempts in original source order
+      -> any compile failure? ---- yes ----> report lowest source index; never link
+      -> collect collision-free objects in original source order
+      -> any TU compiled? -------- yes ----> force_relink
       -> IncrementalLinkCoordinator
       -> one target executable
 ```
 
-`MsvcIncrementalTargetCoordinator` still schedules translation units sequentially. Parallel compilation is the next execution-policy milestone; it must not change cache identity, artifact routing, diagnostics ordering, or failure semantics.
+`MsvcIncrementalTargetCoordinator` performs bounded ordinary-TU compilation. `-j/--jobs` selects the maximum concurrency; if omitted, the CLI starts from hardware concurrency and clamps it to the selected TU count. `-j1` preserves the sequential execution mode for debugging. Parallelism does not participate in compile or link signatures.
+
+The scheduler assigns indices monotonically and at most once, joins all work that was already assigned, and publishes a stop request when a callback fails. Stop publication also quenches the dispatch counter so a worker that observed an older stop flag but had not yet claimed an index cannot start later work. Target results are reassembled in source order, and concurrent compile failures deterministically surface the lowest source index among recorded failures.
 
 Ordinary cache-load/save failures are surfaced as warnings and conservatively rebuild/relink. Compiler/linker execution failures are build errors.
 
@@ -243,13 +253,13 @@ Ordinary cache-load/save failures are surfaced as warnings and conservatively re
 
 `mqb_process` defines a platform-neutral `ProcessSpec` with executable, argv, working directory, structured environment overrides, inheritance choice, and stdout/stderr capture controls.
 
-`mqb_platform_windows` isolates Windows command-line quoting and the real `CreateProcessW` runner. Tests cover complex argv round-trips, Unicode environment blocks, separate stdout/stderr capture, non-zero child exit codes, native launch errors, and concurrent draining of large output streams.
+`mqb_platform_windows` isolates Windows command-line quoting and the real `CreateProcessW` runner. Tests cover complex argv round-trips, Unicode environment blocks, separate stdout/stderr capture, non-zero child exit codes, native launch errors, concurrent draining of large output streams, and concurrent use of one runner instance.
 
 `--run` uses the same structured process boundary. Arguments after `--` remain distinct argv elements, including whitespace-containing strings, option-looking strings, and empty arguments. Run mode and child argv do not participate in build signatures.
 
 Captured CRLF is normalized before forwarding through Windows text streams so nested output does not become `\r\r\n`; lone carriage returns are preserved.
 
-Before final cutover, handle inheritance should be hardened further with `STARTUPINFOEXW` + `PROC_THREAD_ATTRIBUTE_HANDLE_LIST`.
+Captured child processes use `STARTUPINFOEXW` with `PROC_THREAD_ATTRIBUTE_HANDLE_LIST`. Only that child's explicit stdin/stdout/stderr handles are inheritable through `CreateProcessW`; unrelated pipe handles from concurrent compiler launches are not exposed to sibling children. Non-capture launches continue to use no inherited handles.
 
 ## MSVC toolchain boundary
 
@@ -267,6 +277,12 @@ mqb main.cpp
 
 # Explicit source set
 mqb main.cpp src/utils.cpp a/helper.cpp b/helper.cpp -o product
+
+# Bound ordinary-TU compilation to four concurrent jobs
+mqb main.cpp --jobs 4
+
+# Force sequential compile scheduling without changing build identity
+mqb main.cpp -j1
 
 # Exact static library request
 mqb main.cpp -L "vendor libs" -l math
@@ -290,11 +306,14 @@ The real VS2026 suite now verifies, among other cases:
 - upward `mqb.json` lookup from a nested working directory;
 - config-relative include/library paths and config-root artifact placement;
 - config-only define changes invalidating compile recipes;
-- explicit CLI scalar overrides winning over project config while config list inputs remain available.
+- explicit CLI scalar overrides winning over project config while config list inputs remain available;
+- three-way bounded scheduler concurrency, stop/join semantics, and deterministic target failure selection;
+- same-directory four-TU real MSVC cold build with `-j4`;
+- warm reuse of those exact artifacts under `-j1`, proving job count is not build identity.
 
-The current VS2026 PR suite contains 32 registered CTest cases, including real target and project-config E2E tests.
+The current VS2026 PR suite contains 35 registered CTest cases, including real target, project-config, and parallel CLI E2E tests.
 
-Not yet implemented in the C++ V2 path: parallel TU scheduling and C++ Modules/P1689/IFC handling. PowerShell/C++ behavioral parity and final cutover also remain future gates.
+Not yet implemented in the C++ V2 path: C++ Modules/P1689/IFC handling. PowerShell/C++ behavioral parity and final cutover also remain future gates.
 
 ## Migration sequence
 
@@ -309,7 +328,7 @@ Not yet implemented in the C++ V2 path: parallel TU scheduling and C++ Modules/P
 9. **Explicit libraries** — exact resolution, link-cache v2, `.lib` freshness, `-L/-l`. ✅
 10. **Smart source discovery** — single-entry graph selection, secondary-entry barriers, corrections. ✅
 11. **Project config v1** — upward `mqb.json`, typed schema, path semantics, CLI precedence, config E2E. ✅
-12. **Parallel ordinary-TU scheduling** — bounded concurrency with deterministic reporting/failure semantics.
+12. **Parallel ordinary-TU scheduling** — bounded concurrency with deterministic reporting/failure semantics. ✅
 13. **Modules** — P1689 `/scanDependencies`, module graph, IFC/object artifacts, `import std`.
 14. **Parity** — run PowerShell and C++ against the same E2E fixtures.
 15. **Cutover** — make `mqb.exe` primary only after parity tests pass.


### PR DESCRIPTION
Completes the Parallel Ordinary-TU milestone for C++ V2.

Implemented:
- generic `BoundedWorkScheduler` with explicit worker bound, monotonic at-most-once index assignment, callback-stop handling, full worker joining, and exception containment
- dispatch quenching on stop so a worker that observed an older stop flag but has not claimed an index cannot start later work
- `MsvcIncrementalTargetCoordinator` bounded parallel compile scheduling
- source-order result reconstruction and deterministic lowest-source-index compile error reporting
- no-link-on-any-compile-failure semantics after all in-flight work joins
- preflight collision rejection for source, object, `/sourceDependencies` metadata, and compile-cache artifacts
- `-j/--jobs` CLI policy with hardware-concurrency default and `-j1` sequential debugging mode
- job count remains execution policy only and is excluded from compile/link cache identity
- MSVC compiler debug-info recipe changed from `/Zi` to `/Z7`, avoiding shared compiler-PDB writes between concurrent `cl.exe` processes; compile signature epoch bumped to v2
- real same-directory four-TU Visual Studio 2026 E2E: cold `-j4`, executable behavior check, then warm `-j1` with all compile and link artifacts reused

Concurrency prerequisites already present on main:
- `WindowsProcessRunner` uses `STARTUPINFOEXW + PROC_THREAD_ATTRIBUTE_HANDLE_LIST` for captured child processes, restricting inheritance to each child's own stdio handles
- collision-free per-TU object/dependency/cache artifact routing

Validation on head before the final documentation-only commit:
- Visual Studio 2026 Configure: pass
- Build: pass
- CTest: 35/35 pass
- `mqb.cli.parallel_e2e`: pass
- `mqb.orchestration.bounded_work_scheduler`: pass
- `mqb.orchestration.incremental_target`: pass

The final documentation commit synchronizes `docs/CPP_V2_ARCHITECTURE.md` with this implemented behavior. A final full CI run is required before merge.