### PR TITLE
feat: add P1689 incremental named-module pipeline

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -16,6 +16,7 @@ endif()
 
 add_subdirectory(core)
 add_subdirectory(process)
+add_subdirectory(json)
 add_subdirectory(config)
 add_subdirectory(discovery)
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -17,6 +17,7 @@ endif()
 add_subdirectory(core)
 add_subdirectory(process)
 add_subdirectory(json)
+add_subdirectory(modules)
 add_subdirectory(config)
 add_subdirectory(discovery)
 

--- a/cpp/backends/msvc/CMakeLists.txt
+++ b/cpp/backends/msvc/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(mqb_msvc STATIC
     src/MsvcCompiler.cpp
     src/MsvcLibraryResolver.cpp
     src/MsvcLinker.cpp
+    src/MsvcModuleDependencyScanner.cpp
     src/MsvcSourceDependenciesReader.cpp
     src/MsvcToolchainLocator.cpp
 )
@@ -15,6 +16,7 @@ target_include_directories(mqb_msvc
 target_link_libraries(mqb_msvc
     PUBLIC
         mqb_core
+        mqb_modules
         mqb_process
 )
 

--- a/cpp/backends/msvc/CMakeLists.txt
+++ b/cpp/backends/msvc/CMakeLists.txt
@@ -27,3 +27,7 @@ if(MSVC)
 else()
     target_compile_options(mqb_msvc PRIVATE -Wall -Wextra -Wpedantic)
 endif()
+
+if(MQB_BUILD_TESTS)
+    add_subdirectory(tests)
+endif()

--- a/cpp/backends/msvc/include/mqb/msvc/MsvcCompiler.hpp
+++ b/cpp/backends/msvc/include/mqb/msvc/MsvcCompiler.hpp
@@ -13,10 +13,7 @@
 
 namespace mqb::msvc {
 
-struct ModuleReference {
-    std::string logical_name;
-    std::filesystem::path interface_file;
-};
+using ModuleReference = mqb::ModuleReference;
 
 struct CompileInvocation {
     std::filesystem::path source;

--- a/cpp/backends/msvc/include/mqb/msvc/MsvcCompiler.hpp
+++ b/cpp/backends/msvc/include/mqb/msvc/MsvcCompiler.hpp
@@ -7,15 +7,24 @@
 #include <vector>
 
 #include "mqb/core/CompilerOptions.hpp"
+#include "mqb/core/TranslationUnit.hpp"
 #include "mqb/msvc/MsvcToolchainLocator.hpp"
 #include "mqb/process/Process.hpp"
 
 namespace mqb::msvc {
 
+struct ModuleReference {
+    std::string logical_name;
+    std::filesystem::path interface_file;
+};
+
 struct CompileInvocation {
     std::filesystem::path source;
     std::filesystem::path object;
     std::optional<std::filesystem::path> source_dependencies;
+    TranslationUnitKind kind{TranslationUnitKind::source};
+    std::optional<std::filesystem::path> module_interface_output;
+    std::vector<ModuleReference> module_references;
     CompilerOptions options;
     std::optional<std::filesystem::path> working_directory;
 };

--- a/cpp/backends/msvc/include/mqb/msvc/MsvcModuleDependencyScanner.hpp
+++ b/cpp/backends/msvc/include/mqb/msvc/MsvcModuleDependencyScanner.hpp
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <expected>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "mqb/core/CompilerOptions.hpp"
+#include "mqb/core/TranslationUnit.hpp"
+#include "mqb/modules/P1689.hpp"
+#include "mqb/msvc/MsvcToolchainLocator.hpp"
+#include "mqb/process/Process.hpp"
+
+namespace mqb::msvc {
+
+struct ModuleScanInvocation {
+    std::filesystem::path source;
+    std::filesystem::path output_file;
+    CompilerOptions options;
+    TranslationUnitKind kind{TranslationUnitKind::source};
+    std::optional<std::filesystem::path> working_directory;
+};
+
+struct ModuleScanResult {
+    process::ProcessResult process;
+    modules::P1689Document dependencies;
+};
+
+enum class ModuleScanErrorCode {
+    invalid_request,
+    output_prepare_failed,
+    stale_output_remove_failed,
+    process_failed,
+    scan_failed,
+    output_missing,
+    output_read_failed,
+    dependency_metadata_failed,
+};
+
+struct ModuleScanError {
+    ModuleScanErrorCode code{ModuleScanErrorCode::invalid_request};
+    std::string message;
+    std::optional<process::ProcessError> process_error;
+    std::optional<process::ProcessResult> process_result;
+    std::optional<modules::P1689Error> dependency_error;
+};
+
+class MsvcModuleDependencyScanner {
+public:
+    MsvcModuleDependencyScanner(
+        const MsvcToolchain& toolchain,
+        process::ProcessRunner& runner)
+        : toolchain_(toolchain), runner_(runner) {}
+
+    [[nodiscard]] static std::expected<std::vector<std::string>, ModuleScanError>
+    build_arguments(const ModuleScanInvocation& invocation);
+
+    [[nodiscard]] std::expected<ModuleScanResult, ModuleScanError>
+    scan(const ModuleScanInvocation& invocation) const;
+
+private:
+    const MsvcToolchain& toolchain_;
+    process::ProcessRunner& runner_;
+};
+
+} // namespace mqb::msvc

--- a/cpp/backends/msvc/src/MsvcCompileExecutor.cpp
+++ b/cpp/backends/msvc/src/MsvcCompileExecutor.cpp
@@ -1,10 +1,12 @@
 #include "mqb/msvc/MsvcCompileExecutor.hpp"
 
+#include <algorithm>
 #include <cstddef>
 #include <expected>
 #include <filesystem>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "mqb/core/Artifact.hpp"
 #include "mqb/core/BuildSignature.hpp"
@@ -23,21 +25,22 @@ namespace fs = std::filesystem;
     };
 }
 
-[[nodiscard]] const Artifact* find_single_object(
+[[nodiscard]] const Artifact* find_single_artifact(
     const TranslationUnit& unit,
-    std::size_t& object_count) noexcept {
-    const Artifact* object = nullptr;
-    object_count = 0;
+    const ArtifactKind kind,
+    std::size_t& count) noexcept {
+    const Artifact* found = nullptr;
+    count = 0;
     for (const auto& output : unit.outputs) {
-        if (output.kind != ArtifactKind::object) {
+        if (output.kind != kind) {
             continue;
         }
-        ++object_count;
-        if (object == nullptr) {
-            object = &output;
+        ++count;
+        if (found == nullptr) {
+            found = &output;
         }
     }
-    return object;
+    return found;
 }
 
 [[nodiscard]] bool same_existing_file(
@@ -46,6 +49,20 @@ namespace fs = std::filesystem;
     std::error_code error_code;
     const bool equivalent = fs::equivalent(left, right, error_code);
     return equivalent && !error_code;
+}
+
+[[nodiscard]] bool same_dependency_path(
+    const fs::path& left,
+    const fs::path& right) {
+    if (same_existing_file(left, right)) {
+        return true;
+    }
+    return left.lexically_normal() == right.lexically_normal();
+}
+
+[[nodiscard]] bool regular_file(const fs::path& path) {
+    std::error_code error_code;
+    return fs::is_regular_file(path, error_code) && !error_code;
 }
 
 } // namespace
@@ -60,10 +77,38 @@ MsvcCompileExecutor::execute(const CompileExecutionRequest& request) const {
     }
 
     std::size_t object_count = 0;
-    const Artifact* object = find_single_object(request.unit, object_count);
+    const Artifact* object = find_single_artifact(
+        request.unit,
+        ArtifactKind::object,
+        object_count);
     if (object == nullptr || object_count != 1 || object->path.empty()) {
         return std::unexpected(invalid_request(
             "translation unit must expose exactly one non-empty object artifact"));
+    }
+
+    std::size_t interface_count = 0;
+    const Artifact* module_interface = find_single_artifact(
+        request.unit,
+        ArtifactKind::module_interface,
+        interface_count);
+    if (request.unit.kind == TranslationUnitKind::module_interface) {
+        if (module_interface == nullptr
+            || interface_count != 1
+            || module_interface->path.empty()) {
+            return std::unexpected(invalid_request(
+                "module interface translation unit must expose exactly one non-empty IFC artifact"));
+        }
+    } else if (interface_count != 0) {
+        return std::unexpected(invalid_request(
+            "ordinary source translation unit must not expose an IFC output artifact"));
+    }
+
+    for (const auto& output : request.unit.outputs) {
+        if (output.kind != ArtifactKind::object
+            && output.kind != ArtifactKind::module_interface) {
+            return std::unexpected(invalid_request(
+                "compile translation unit contains a non-compile output artifact"));
+        }
     }
 
     MsvcCompiler compiler{toolchain_, runner_};
@@ -71,6 +116,11 @@ MsvcCompileExecutor::execute(const CompileExecutionRequest& request) const {
     invocation.source = request.unit.source;
     invocation.object = object->path;
     invocation.source_dependencies = request.source_dependencies_file;
+    invocation.kind = request.unit.kind;
+    if (module_interface != nullptr) {
+        invocation.module_interface_output = module_interface->path;
+    }
+    invocation.module_references = request.unit.module_references;
     invocation.options = request.options;
     invocation.working_directory = request.working_directory;
 
@@ -83,11 +133,16 @@ MsvcCompileExecutor::execute(const CompileExecutionRequest& request) const {
         });
     }
 
-    std::error_code output_error;
-    if (!fs::is_regular_file(object->path, output_error) || output_error) {
+    if (!regular_file(object->path)) {
         return std::unexpected(CompileExecutorError{
             .code = CompileExecutorErrorCode::output_missing,
             .message = "MSVC reported success but the planned object artifact is missing",
+        });
+    }
+    if (module_interface != nullptr && !regular_file(module_interface->path)) {
+        return std::unexpected(CompileExecutorError{
+            .code = CompileExecutorErrorCode::output_missing,
+            .message = "MSVC reported success but the planned IFC artifact is missing",
         });
     }
 
@@ -107,6 +162,19 @@ MsvcCompileExecutor::execute(const CompileExecutionRequest& request) const {
         });
     }
 
+    std::vector<fs::path> cache_dependencies = std::move(dependencies->includes);
+    for (const auto& reference : request.unit.module_references) {
+        const auto duplicate = std::find_if(
+            cache_dependencies.begin(),
+            cache_dependencies.end(),
+            [&reference](const fs::path& dependency) {
+                return same_dependency_path(dependency, reference.interface_file);
+            });
+        if (duplicate == cache_dependencies.end()) {
+            cache_dependencies.push_back(reference.interface_file.lexically_normal());
+        }
+    }
+
     CompileCacheEntry cache_entry{
         .source = request.unit.source,
         .kind = request.unit.kind,
@@ -116,7 +184,7 @@ MsvcCompileExecutor::execute(const CompileExecutionRequest& request) const {
             toolchain_.identity,
             request.options),
         .object = *object,
-        .dependencies = std::move(dependencies->includes),
+        .dependencies = std::move(cache_dependencies),
     };
 
     return CompileExecutionResult{

--- a/cpp/backends/msvc/src/MsvcCompiler.cpp
+++ b/cpp/backends/msvc/src/MsvcCompiler.cpp
@@ -4,6 +4,7 @@
 #include <filesystem>
 #include <string>
 #include <string_view>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -80,6 +81,38 @@ void append_configuration_arguments(
     return {};
 }
 
+[[nodiscard]] std::expected<void, CompilerError> validate_module_contract(
+    const CompileInvocation& invocation) {
+    if (invocation.kind == TranslationUnitKind::module_interface) {
+        if (!invocation.module_interface_output
+            || invocation.module_interface_output->empty()) {
+            return std::unexpected(invalid_request(
+                "module interface compilation requires a non-empty IFC output path"));
+        }
+    } else if (invocation.module_interface_output) {
+        return std::unexpected(invalid_request(
+            "ordinary source compilation must not request an IFC output"));
+    }
+
+    std::unordered_set<std::string> logical_names;
+    logical_names.reserve(invocation.module_references.size());
+    for (const auto& reference : invocation.module_references) {
+        if (reference.logical_name.empty()) {
+            return std::unexpected(invalid_request(
+                "module reference logical name must not be empty"));
+        }
+        if (reference.interface_file.empty()) {
+            return std::unexpected(invalid_request(
+                "module reference IFC path must not be empty"));
+        }
+        if (!logical_names.emplace(reference.logical_name).second) {
+            return std::unexpected(invalid_request(
+                "duplicate module reference logical name '" + reference.logical_name + "'"));
+        }
+    }
+    return {};
+}
+
 } // namespace
 
 std::expected<std::vector<std::string>, CompilerError>
@@ -93,13 +126,18 @@ MsvcCompiler::build_arguments(const CompileInvocation& invocation) {
     if (invocation.source_dependencies && invocation.source_dependencies->empty()) {
         return std::unexpected(invalid_request("sourceDependencies output path is empty"));
     }
+    auto module_contract = validate_module_contract(invocation);
+    if (!module_contract) {
+        return std::unexpected(module_contract.error());
+    }
 
     std::vector<std::string> arguments;
     arguments.reserve(
-        16
+        20
         + invocation.options.defines.size()
         + invocation.options.include_directories.size()
-        + invocation.options.additional_arguments.size());
+        + invocation.options.additional_arguments.size()
+        + (invocation.module_references.size() * 2));
 
     arguments.emplace_back("/nologo");
     arguments.emplace_back("/c");
@@ -135,13 +173,29 @@ MsvcCompiler::build_arguments(const CompileInvocation& invocation) {
         arguments.push_back(argument);
     }
 
+    // Module inputs and structured outputs are emitted after raw additional
+    // arguments so the BuildPlan remains authoritative over semantic routing.
+    if (invocation.kind == TranslationUnitKind::module_interface) {
+        arguments.emplace_back("/interface");
+        arguments.emplace_back("/TP");
+    }
+
+    for (const auto& reference : invocation.module_references) {
+        arguments.emplace_back("/reference");
+        arguments.push_back(
+            reference.logical_name + "=" + path_to_utf8(reference.interface_file));
+    }
+
+    if (invocation.module_interface_output) {
+        arguments.emplace_back("/ifcOutput");
+        arguments.push_back(path_to_utf8(*invocation.module_interface_output));
+    }
+
     if (invocation.source_dependencies) {
         arguments.emplace_back("/sourceDependencies");
         arguments.push_back(path_to_utf8(*invocation.source_dependencies));
     }
 
-    // Structured artifact routing is appended after raw additional arguments so
-    // a raw /Fo cannot silently redirect the object away from the BuildPlan.
     arguments.push_back("/Fo" + path_to_utf8(invocation.object));
     arguments.push_back(path_to_utf8(invocation.source));
     return arguments;
@@ -164,6 +218,14 @@ MsvcCompiler::compile(const CompileInvocation& invocation) const {
             "sourceDependencies");
         if (!prepared_dependencies) {
             return std::unexpected(prepared_dependencies.error());
+        }
+    }
+    if (invocation.module_interface_output) {
+        auto prepared_interface = prepare_parent_directory(
+            *invocation.module_interface_output,
+            "module interface");
+        if (!prepared_interface) {
+            return std::unexpected(prepared_interface.error());
         }
     }
 

--- a/cpp/backends/msvc/src/MsvcModuleDependencyScanner.cpp
+++ b/cpp/backends/msvc/src/MsvcModuleDependencyScanner.cpp
@@ -1,0 +1,239 @@
+#include "mqb/msvc/MsvcModuleDependencyScanner.hpp"
+
+#include <fstream>
+#include <iterator>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace mqb::msvc {
+namespace {
+
+namespace fs = std::filesystem;
+
+[[nodiscard]] ModuleScanError failure(
+    const ModuleScanErrorCode code,
+    std::string message) {
+    return ModuleScanError{
+        .code = code,
+        .message = std::move(message),
+    };
+}
+
+[[nodiscard]] std::string path_to_utf8(const fs::path& path) {
+    const auto bytes = path.generic_u8string();
+    return std::string{
+        reinterpret_cast<const char*>(bytes.data()),
+        bytes.size()};
+}
+
+[[nodiscard]] std::string standard_argument(const CppStandard standard) {
+    switch (standard) {
+    case CppStandard::cpp20:
+        return "/std:c++20";
+    case CppStandard::cpp23:
+        return "/std:c++23preview";
+    case CppStandard::latest:
+        return "/std:c++latest";
+    }
+    return "/std:c++23preview";
+}
+
+void append_configuration_macro(
+    std::vector<std::string>& arguments,
+    const BuildConfiguration configuration) {
+    switch (configuration) {
+    case BuildConfiguration::debug:
+        arguments.emplace_back("/D_DEBUG");
+        break;
+    case BuildConfiguration::release:
+        arguments.emplace_back("/DNDEBUG");
+        break;
+    }
+}
+
+[[nodiscard]] std::expected<void, ModuleScanError> prepare_output(
+    const fs::path& output) {
+    const fs::path parent = output.parent_path();
+    if (!parent.empty()) {
+        std::error_code create_error;
+        fs::create_directories(parent, create_error);
+        if (create_error) {
+            return std::unexpected(failure(
+                ModuleScanErrorCode::output_prepare_failed,
+                "failed to prepare module dependency output directory"));
+        }
+    }
+
+    std::error_code remove_error;
+    fs::remove(output, remove_error);
+    if (remove_error) {
+        return std::unexpected(failure(
+            ModuleScanErrorCode::stale_output_remove_failed,
+            "failed to remove stale module dependency output"));
+    }
+    return {};
+}
+
+[[nodiscard]] std::expected<std::string, ModuleScanError> read_text_file(
+    const fs::path& path) {
+    std::ifstream input(path, std::ios::binary);
+    if (!input) {
+        return std::unexpected(failure(
+            ModuleScanErrorCode::output_read_failed,
+            "failed to open module dependency output"));
+    }
+
+    std::string text{
+        std::istreambuf_iterator<char>{input},
+        std::istreambuf_iterator<char>{}};
+    if (input.bad()) {
+        return std::unexpected(failure(
+            ModuleScanErrorCode::output_read_failed,
+            "failed while reading module dependency output"));
+    }
+    return text;
+}
+
+} // namespace
+
+std::expected<std::vector<std::string>, ModuleScanError>
+MsvcModuleDependencyScanner::build_arguments(const ModuleScanInvocation& invocation) {
+    if (invocation.source.empty()) {
+        return std::unexpected(failure(
+            ModuleScanErrorCode::invalid_request,
+            "module scan source path is empty"));
+    }
+    if (invocation.output_file.empty()) {
+        return std::unexpected(failure(
+            ModuleScanErrorCode::invalid_request,
+            "module scan output path is empty"));
+    }
+
+    std::vector<std::string> arguments;
+    arguments.reserve(
+        12
+        + invocation.options.defines.size()
+        + invocation.options.include_directories.size()
+        + invocation.options.additional_arguments.size());
+
+    arguments.emplace_back("/nologo");
+    arguments.emplace_back("/utf-8");
+    arguments.emplace_back("/permissive-");
+    arguments.emplace_back("/Zc:preprocessor");
+    arguments.emplace_back("/diagnostics:column");
+    append_configuration_macro(arguments, invocation.options.configuration);
+    arguments.push_back(standard_argument(invocation.options.standard));
+
+    for (const auto& define : invocation.options.defines) {
+        if (define.empty()) {
+            return std::unexpected(failure(
+                ModuleScanErrorCode::invalid_request,
+                "compiler define must not be empty"));
+        }
+        arguments.push_back("/D" + define);
+    }
+
+    for (const auto& include_directory : invocation.options.include_directories) {
+        if (include_directory.empty()) {
+            return std::unexpected(failure(
+                ModuleScanErrorCode::invalid_request,
+                "include directory must not be empty"));
+        }
+        arguments.push_back("/I" + path_to_utf8(include_directory));
+    }
+
+    for (const auto& argument : invocation.options.additional_arguments) {
+        if (argument.empty()) {
+            return std::unexpected(failure(
+                ModuleScanErrorCode::invalid_request,
+                "additional compiler argument must not be empty"));
+        }
+        arguments.push_back(argument);
+    }
+
+    if (invocation.kind == TranslationUnitKind::module_interface) {
+        arguments.emplace_back("/interface");
+        arguments.emplace_back("/TP");
+    }
+
+    // Keep structured scan routing after raw additional arguments so a caller
+    // cannot silently redirect dependency metadata away from the BuildPlan.
+    arguments.emplace_back("/scanDependencies");
+    arguments.push_back(path_to_utf8(invocation.output_file));
+    arguments.push_back(path_to_utf8(invocation.source));
+    return arguments;
+}
+
+std::expected<ModuleScanResult, ModuleScanError>
+MsvcModuleDependencyScanner::scan(const ModuleScanInvocation& invocation) const {
+    auto arguments = build_arguments(invocation);
+    if (!arguments) {
+        return std::unexpected(arguments.error());
+    }
+
+    auto prepared = prepare_output(invocation.output_file);
+    if (!prepared) {
+        return std::unexpected(prepared.error());
+    }
+
+    process::ProcessSpec spec;
+    spec.executable = toolchain_.identity.compiler;
+    spec.arguments = std::move(*arguments);
+    spec.working_directory = invocation.working_directory;
+    spec.environment = toolchain_.environment;
+    spec.inherit_environment = true;
+    spec.capture_stdout = true;
+    spec.capture_stderr = true;
+
+    auto result = runner_.run(spec);
+    if (!result) {
+        ModuleScanError error = failure(
+            ModuleScanErrorCode::process_failed,
+            "failed to launch MSVC module dependency scan");
+        error.process_error = result.error();
+        return std::unexpected(std::move(error));
+    }
+
+    if (result->exit_code != 0) {
+        ModuleScanError error = failure(
+            ModuleScanErrorCode::scan_failed,
+            "MSVC module dependency scan returned a non-zero exit code");
+        error.process_result = std::move(*result);
+        return std::unexpected(std::move(error));
+    }
+
+    std::error_code exists_error;
+    const bool exists = fs::is_regular_file(invocation.output_file, exists_error);
+    if (exists_error || !exists) {
+        ModuleScanError error = failure(
+            ModuleScanErrorCode::output_missing,
+            "MSVC module dependency scan did not produce the requested JSON file");
+        error.process_result = std::move(*result);
+        return std::unexpected(std::move(error));
+    }
+
+    auto text = read_text_file(invocation.output_file);
+    if (!text) {
+        auto error = text.error();
+        error.process_result = std::move(*result);
+        return std::unexpected(std::move(error));
+    }
+
+    auto dependencies = modules::P1689Parser::parse(*text);
+    if (!dependencies) {
+        ModuleScanError error = failure(
+            ModuleScanErrorCode::dependency_metadata_failed,
+            "failed to parse MSVC P1689 module dependency metadata");
+        error.process_result = std::move(*result);
+        error.dependency_error = dependencies.error();
+        return std::unexpected(std::move(error));
+    }
+
+    return ModuleScanResult{
+        .process = std::move(*result),
+        .dependencies = std::move(*dependencies),
+    };
+}
+
+} // namespace mqb::msvc

--- a/cpp/backends/msvc/tests/CMakeLists.txt
+++ b/cpp/backends/msvc/tests/CMakeLists.txt
@@ -24,14 +24,31 @@ if(MQB_ENABLE_INSTALLED_MSVC_TESTS)
     )
     target_compile_features(mqb_msvc_module_scanner_integration_tests PRIVATE cxx_std_23)
 
+    add_executable(mqb_msvc_module_compile_integration_tests
+        module_compile_integration_tests.cpp
+    )
+    target_link_libraries(
+        mqb_msvc_module_compile_integration_tests
+        PRIVATE
+            mqb_msvc
+            mqb_platform_windows
+    )
+    target_compile_features(mqb_msvc_module_compile_integration_tests PRIVATE cxx_std_23)
+
     if(MSVC)
         target_compile_options(mqb_msvc_module_scanner_integration_tests PRIVATE /W4 /permissive-)
+        target_compile_options(mqb_msvc_module_compile_integration_tests PRIVATE /W4 /permissive-)
     else()
         target_compile_options(mqb_msvc_module_scanner_integration_tests PRIVATE -Wall -Wextra -Wpedantic)
+        target_compile_options(mqb_msvc_module_compile_integration_tests PRIVATE -Wall -Wextra -Wpedantic)
     endif()
 
     add_test(
         NAME mqb.msvc.module_scanner_integration
         COMMAND mqb_msvc_module_scanner_integration_tests
+    )
+    add_test(
+        NAME mqb.msvc.module_compile_integration
+        COMMAND mqb_msvc_module_compile_integration_tests
     )
 endif()

--- a/cpp/backends/msvc/tests/CMakeLists.txt
+++ b/cpp/backends/msvc/tests/CMakeLists.txt
@@ -1,0 +1,37 @@
+add_executable(mqb_msvc_module_scanner_tests
+    module_dependency_scanner_tests.cpp
+)
+target_link_libraries(mqb_msvc_module_scanner_tests PRIVATE mqb_msvc)
+target_compile_features(mqb_msvc_module_scanner_tests PRIVATE cxx_std_23)
+
+if(MSVC)
+    target_compile_options(mqb_msvc_module_scanner_tests PRIVATE /W4 /permissive-)
+else()
+    target_compile_options(mqb_msvc_module_scanner_tests PRIVATE -Wall -Wextra -Wpedantic)
+endif()
+
+add_test(NAME mqb.msvc.module_scanner COMMAND mqb_msvc_module_scanner_tests)
+
+if(MQB_ENABLE_INSTALLED_MSVC_TESTS)
+    add_executable(mqb_msvc_module_scanner_integration_tests
+        module_dependency_scanner_integration_tests.cpp
+    )
+    target_link_libraries(
+        mqb_msvc_module_scanner_integration_tests
+        PRIVATE
+            mqb_msvc
+            mqb_platform_windows
+    )
+    target_compile_features(mqb_msvc_module_scanner_integration_tests PRIVATE cxx_std_23)
+
+    if(MSVC)
+        target_compile_options(mqb_msvc_module_scanner_integration_tests PRIVATE /W4 /permissive-)
+    else()
+        target_compile_options(mqb_msvc_module_scanner_integration_tests PRIVATE -Wall -Wextra -Wpedantic)
+    endif()
+
+    add_test(
+        NAME mqb.msvc.module_scanner_integration
+        COMMAND mqb_msvc_module_scanner_integration_tests
+    )
+endif()

--- a/cpp/backends/msvc/tests/module_compile_integration_tests.cpp
+++ b/cpp/backends/msvc/tests/module_compile_integration_tests.cpp
@@ -1,0 +1,177 @@
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <string_view>
+
+#include "mqb/core/ProjectArtifactLayout.hpp"
+#include "mqb/core/TranslationUnit.hpp"
+#include "mqb/msvc/MsvcCompiler.hpp"
+#include "mqb/msvc/MsvcToolchainLocator.hpp"
+#include "mqb/platform/windows/WindowsProcessRunner.hpp"
+
+namespace {
+
+namespace fs = std::filesystem;
+
+int failures = 0;
+
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+[[nodiscard]] fs::path make_temp_root() {
+    const auto stamp = std::chrono::steady_clock::now().time_since_epoch().count();
+    return fs::temp_directory_path() / ("mqb_module_compile_vs_" + std::to_string(stamp));
+}
+
+void print_compile_error(const mqb::msvc::CompilerError& error) {
+    std::cerr << "compile error: " << error.message << '\n';
+    if (error.process_error) {
+        std::cerr << "process error: " << error.process_error->message
+                  << " native=" << error.process_error->native_code << '\n';
+    }
+    if (error.process_result) {
+        std::cerr << "exit=" << error.process_result->exit_code << '\n';
+        std::cerr << error.process_result->stdout_text;
+        std::cerr << error.process_result->stderr_text;
+    }
+}
+
+} // namespace
+
+int main() {
+    using mqb::Architecture;
+    using mqb::CppStandard;
+    using mqb::ProjectArtifactLayout;
+    using mqb::TranslationUnitKind;
+    using mqb::msvc::CompileInvocation;
+    using mqb::msvc::DiscoveryOptions;
+    using mqb::msvc::ModuleReference;
+    using mqb::msvc::MsvcCompiler;
+    using mqb::msvc::MsvcToolchainLocator;
+    using mqb::msvc::ToolchainPreference;
+
+    mqb::platform::windows::WindowsProcessRunner runner;
+    MsvcToolchainLocator locator{runner};
+
+    DiscoveryOptions discovery;
+    discovery.preference = ToolchainPreference::visual_studio;
+    discovery.target_architecture = Architecture::x64;
+    discovery.host_architecture = Architecture::x64;
+
+    auto toolchain = locator.discover(discovery);
+    expect(toolchain.has_value(), "Visual Studio toolchain should be available for module compile E2E");
+    if (!toolchain) {
+        std::cerr << "toolchain error: " << toolchain.error().message << '\n';
+        return 1;
+    }
+
+    const fs::path root = make_temp_root();
+    const fs::path module_source = root / "modules" / "math.ixx";
+    const fs::path consumer_source = root / "src" / "consumer.cpp";
+    fs::create_directories(module_source.parent_path());
+    fs::create_directories(consumer_source.parent_path());
+
+    {
+        std::ofstream source(module_source, std::ios::binary | std::ios::trunc);
+        source << "export module math;\n"
+                  "export int add(int a, int b) { return a + b; }\n";
+    }
+    {
+        std::ofstream source(consumer_source, std::ios::binary | std::ios::trunc);
+        source << "import math;\n"
+                  "int use_math() { return add(2, 3); }\n";
+    }
+
+    auto layout = ProjectArtifactLayout::create(root);
+    expect(layout.has_value(), "temporary project should create artifact layout");
+    if (!layout) return 1;
+
+    auto module_artifacts = layout->for_source(module_source);
+    auto consumer_artifacts = layout->for_source(consumer_source);
+    expect(module_artifacts.has_value() && consumer_artifacts.has_value(),
+           "module and consumer should receive planned artifacts");
+    if (!module_artifacts || !consumer_artifacts) return 1;
+
+    MsvcCompiler compiler{*toolchain, runner};
+
+    CompileInvocation module;
+    module.source = module_source;
+    module.object = module_artifacts->object;
+    module.source_dependencies = module_artifacts->dependencies;
+    module.kind = TranslationUnitKind::module_interface;
+    module.module_interface_output = module_artifacts->module_interface;
+    module.working_directory = root;
+    module.options.standard = CppStandard::latest;
+
+    auto module_result = compiler.compile(module);
+    expect(module_result.has_value(), "real MSVC should compile a named module interface to planned IFC");
+    if (!module_result) {
+        print_compile_error(module_result.error());
+    }
+
+    expect(fs::is_regular_file(module_artifacts->object),
+           "module interface compilation should produce the planned object");
+    expect(fs::is_regular_file(module_artifacts->module_interface),
+           "module interface compilation should produce the planned IFC");
+    expect(fs::is_regular_file(module_artifacts->dependencies),
+           "module interface compilation should still emit sourceDependencies metadata");
+
+    CompileInvocation consumer;
+    consumer.source = consumer_source;
+    consumer.object = consumer_artifacts->object;
+    consumer.source_dependencies = consumer_artifacts->dependencies;
+    consumer.kind = TranslationUnitKind::source;
+    consumer.module_references = {
+        ModuleReference{
+            .logical_name = "math",
+            .interface_file = module_artifacts->module_interface,
+        },
+    };
+    consumer.working_directory = root;
+    consumer.options.standard = CppStandard::latest;
+
+    auto consumer_result = compiler.compile(consumer);
+    expect(consumer_result.has_value(),
+           "real MSVC consumer should compile using an explicit logical-name to IFC reference");
+    if (!consumer_result) {
+        print_compile_error(consumer_result.error());
+    }
+
+    expect(fs::is_regular_file(consumer_artifacts->object),
+           "module consumer should produce the planned object");
+    expect(fs::is_regular_file(consumer_artifacts->dependencies),
+           "module consumer should still emit sourceDependencies metadata");
+
+    std::size_t ifc_count = 0;
+    fs::path discovered_ifc;
+    std::error_code walk_error;
+    for (fs::recursive_directory_iterator it(root, walk_error), end;
+         it != end && !walk_error;
+         it.increment(walk_error)) {
+        if (!it->is_regular_file()) continue;
+        if (it->path().extension() == ".ifc") {
+            ++ifc_count;
+            discovered_ifc = it->path();
+        }
+    }
+    expect(!walk_error, "temporary module project should be traversable after compilation");
+    expect(ifc_count == 1 && discovered_ifc == module_artifacts->module_interface,
+           "MSVC should emit exactly the explicitly planned IFC rather than a default-path side artifact");
+
+    std::error_code cleanup_error;
+    fs::remove_all(root, cleanup_error);
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+
+    std::cout << "mqb_msvc_module_compile_integration_tests passed\n";
+    return 0;
+}

--- a/cpp/backends/msvc/tests/module_dependency_scanner_integration_tests.cpp
+++ b/cpp/backends/msvc/tests/module_dependency_scanner_integration_tests.cpp
@@ -1,0 +1,179 @@
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <string_view>
+
+#include "mqb/msvc/MsvcModuleDependencyScanner.hpp"
+#include "mqb/msvc/MsvcToolchainLocator.hpp"
+#include "mqb/platform/windows/WindowsProcessRunner.hpp"
+
+namespace {
+
+namespace fs = std::filesystem;
+
+int failures = 0;
+
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+[[nodiscard]] fs::path make_temp_root() {
+    const auto stamp = std::chrono::steady_clock::now().time_since_epoch().count();
+    return fs::temp_directory_path() / ("mqb_module_scanner_vs_" + std::to_string(stamp));
+}
+
+[[nodiscard]] bool has_named_provide(
+    const mqb::modules::P1689Document& document,
+    const std::string_view logical_name) {
+    for (const auto& rule : document.rules) {
+        for (const auto& provided : rule.provided_modules) {
+            if (provided.logical_name == logical_name) return true;
+        }
+    }
+    return false;
+}
+
+[[nodiscard]] bool has_named_requirement(
+    const mqb::modules::P1689Document& document,
+    const std::string_view logical_name) {
+    for (const auto& rule : document.rules) {
+        for (const auto& required : rule.required_modules) {
+            if (required.logical_name == logical_name
+                && required.lookup_method == mqb::modules::LookupMethod::by_name) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+void print_scan_error(const mqb::msvc::ModuleScanError& error) {
+    std::cerr << "module scan error: " << error.message << '\n';
+    if (error.process_error) {
+        std::cerr << "process error: " << error.process_error->message
+                  << " native=" << error.process_error->native_code << '\n';
+    }
+    if (error.process_result) {
+        std::cerr << "exit=" << error.process_result->exit_code << '\n';
+        std::cerr << error.process_result->stdout_text;
+        std::cerr << error.process_result->stderr_text;
+    }
+    if (error.dependency_error) {
+        std::cerr << "P1689 error " << error.dependency_error->line << ':'
+                  << error.dependency_error->column << ' '
+                  << error.dependency_error->message << '\n';
+    }
+}
+
+} // namespace
+
+int main() {
+    using mqb::Architecture;
+    using mqb::CppStandard;
+    using mqb::TranslationUnitKind;
+    using mqb::msvc::DiscoveryOptions;
+    using mqb::msvc::ModuleScanInvocation;
+    using mqb::msvc::MsvcModuleDependencyScanner;
+    using mqb::msvc::MsvcToolchainLocator;
+    using mqb::msvc::ToolchainPreference;
+
+    mqb::platform::windows::WindowsProcessRunner runner;
+    MsvcToolchainLocator locator{runner};
+
+    DiscoveryOptions discovery;
+    discovery.preference = ToolchainPreference::visual_studio;
+    discovery.target_architecture = Architecture::x64;
+    discovery.host_architecture = Architecture::x64;
+
+    auto toolchain = locator.discover(discovery);
+    expect(toolchain.has_value(), "Visual Studio toolchain should be available for module scan E2E");
+    if (!toolchain) {
+        std::cerr << "toolchain error: " << toolchain.error().message << '\n';
+        return 1;
+    }
+
+    const fs::path root = make_temp_root();
+    const fs::path scan_dir = root / "scan";
+    const fs::path module_source = root / "math.ixx";
+    const fs::path consumer_source = root / "consumer.cpp";
+    const fs::path module_scan = scan_dir / "math.json";
+    const fs::path consumer_scan = scan_dir / "consumer.json";
+
+    fs::create_directories(root);
+    {
+        std::ofstream source(module_source, std::ios::binary | std::ios::trunc);
+        source << "export module math;\n"
+                  "export int add(int a, int b) { return a + b; }\n";
+    }
+    {
+        std::ofstream source(consumer_source, std::ios::binary | std::ios::trunc);
+        source << "import math;\n"
+                  "int use_math() { return add(2, 3); }\n";
+    }
+
+    MsvcModuleDependencyScanner scanner{*toolchain, runner};
+
+    ModuleScanInvocation module_invocation;
+    module_invocation.source = module_source;
+    module_invocation.output_file = module_scan;
+    module_invocation.kind = TranslationUnitKind::module_interface;
+    module_invocation.working_directory = root;
+    module_invocation.options.standard = CppStandard::latest;
+
+    auto module_result = scanner.scan(module_invocation);
+    expect(module_result.has_value(), "real MSVC scan should accept a named module interface");
+    if (!module_result) {
+        print_scan_error(module_result.error());
+    } else {
+        expect(has_named_provide(module_result->dependencies, "math"),
+               "module-interface scan should provide logical module 'math'");
+    }
+
+    ModuleScanInvocation consumer_invocation;
+    consumer_invocation.source = consumer_source;
+    consumer_invocation.output_file = consumer_scan;
+    consumer_invocation.kind = TranslationUnitKind::source;
+    consumer_invocation.working_directory = root;
+    consumer_invocation.options.standard = CppStandard::latest;
+
+    auto consumer_result = scanner.scan(consumer_invocation);
+    expect(consumer_result.has_value(), "real MSVC scan should accept a consumer before IFC exists");
+    if (!consumer_result) {
+        print_scan_error(consumer_result.error());
+    } else {
+        expect(has_named_requirement(consumer_result->dependencies, "math"),
+               "consumer scan should require logical module 'math' by name");
+    }
+
+    expect(fs::is_regular_file(module_scan) && fs::is_regular_file(consumer_scan),
+           "scan phase should emit the requested P1689 JSON files");
+
+    bool found_compiled_artifact = false;
+    std::error_code walk_error;
+    for (fs::recursive_directory_iterator it(root, walk_error), end; it != end && !walk_error; it.increment(walk_error)) {
+        if (!it->is_regular_file()) continue;
+        const auto extension = it->path().extension().string();
+        if (extension == ".obj" || extension == ".ifc") {
+            found_compiled_artifact = true;
+            std::cerr << "unexpected compiled artifact from scan: " << it->path().string() << '\n';
+        }
+    }
+    expect(!found_compiled_artifact,
+           "/scanDependencies topology scan should not create .obj or .ifc artifacts");
+
+    std::error_code cleanup_error;
+    fs::remove_all(root, cleanup_error);
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+
+    std::cout << "mqb_msvc_module_scanner_integration_tests passed\n";
+    return 0;
+}

--- a/cpp/backends/msvc/tests/module_dependency_scanner_tests.cpp
+++ b/cpp/backends/msvc/tests/module_dependency_scanner_tests.cpp
@@ -1,0 +1,226 @@
+#include <algorithm>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "mqb/msvc/MsvcModuleDependencyScanner.hpp"
+
+namespace {
+
+namespace fs = std::filesystem;
+
+int failures = 0;
+
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+[[nodiscard]] bool contains(
+    const std::vector<std::string>& arguments,
+    const std::string_view value) {
+    return std::find(arguments.begin(), arguments.end(), value) != arguments.end();
+}
+
+[[nodiscard]] fs::path make_temp_root() {
+    const auto stamp = std::chrono::steady_clock::now().time_since_epoch().count();
+    return fs::temp_directory_path() / ("mqb_module_scanner_unit_" + std::to_string(stamp));
+}
+
+class FakeRunner final : public mqb::process::ProcessRunner {
+public:
+    enum class Mode {
+        valid,
+        malformed,
+        no_output,
+        nonzero_exit,
+    };
+
+    Mode mode{Mode::valid};
+    mqb::process::ProcessSpec last_spec;
+    int calls{};
+
+    [[nodiscard]] std::expected<mqb::process::ProcessResult, mqb::process::ProcessError>
+    run(const mqb::process::ProcessSpec& spec) override {
+        ++calls;
+        last_spec = spec;
+
+        fs::path output;
+        for (std::size_t index = 0; index + 1 < spec.arguments.size(); ++index) {
+            if (spec.arguments[index] == "/scanDependencies") {
+                output = fs::path{spec.arguments[index + 1]};
+                break;
+            }
+        }
+
+        if (mode == Mode::nonzero_exit) {
+            return mqb::process::ProcessResult{
+                .exit_code = 2,
+                .stderr_text = "synthetic scan failure",
+            };
+        }
+
+        if (mode != Mode::no_output && !output.empty()) {
+            fs::create_directories(output.parent_path());
+            std::ofstream stream(output, std::ios::binary | std::ios::trunc);
+            if (mode == Mode::malformed) {
+                stream << "{\"version\":1,]";
+            } else {
+                stream << R"json({
+  "version": 1,
+  "revision": 0,
+  "rules": [ {
+    "primary-output": "module.obj",
+    "provides": [ { "logical-name": "demo" } ]
+  } ]
+})json";
+            }
+        }
+
+        return mqb::process::ProcessResult{
+            .exit_code = 0,
+            .stdout_text = "scan-ok",
+        };
+    }
+};
+
+} // namespace
+
+int main() {
+    using mqb::BuildConfiguration;
+    using mqb::CppStandard;
+    using mqb::TranslationUnitKind;
+    using mqb::msvc::ModuleScanErrorCode;
+    using mqb::msvc::ModuleScanInvocation;
+    using mqb::msvc::MsvcModuleDependencyScanner;
+    using mqb::msvc::MsvcToolchain;
+
+    {
+        ModuleScanInvocation invocation;
+        invocation.source = "src/module.cppm";
+        invocation.output_file = "scan/module.json";
+        invocation.kind = TranslationUnitKind::module_interface;
+        invocation.options.configuration = BuildConfiguration::release;
+        invocation.options.standard = CppStandard::cpp20;
+        invocation.options.defines = {"FEATURE=1"};
+        invocation.options.include_directories = {"include dir"};
+        invocation.options.additional_arguments = {"/FIforced.hpp"};
+
+        auto arguments = MsvcModuleDependencyScanner::build_arguments(invocation);
+        expect(arguments.has_value(), "valid scan invocation should build argv");
+        if (arguments) {
+            expect(contains(*arguments, "/std:c++20"), "scan should carry the language standard");
+            expect(contains(*arguments, "/DNDEBUG"), "release scan should carry NDEBUG");
+            expect(contains(*arguments, "/DFEATURE=1"), "scan should carry user defines");
+            expect(contains(*arguments, "/Iinclude dir"), "scan should carry include directories");
+            expect(contains(*arguments, "/FIforced.hpp"), "scan should preserve additional arguments");
+            expect(contains(*arguments, "/interface") && contains(*arguments, "/TP"),
+                   "explicit module-interface scans should use /interface with /TP");
+            expect(!contains(*arguments, "/c"), "scan must not request object compilation");
+            expect(!contains(*arguments, "/Z7"), "scan must not carry compiler debug artifact state");
+            expect(!contains(*arguments, "/sourceDependencies"),
+                   "scanDependencies and sourceDependencies are separate phases");
+            expect(arguments->size() >= 3
+                       && (*arguments)[arguments->size() - 3] == "/scanDependencies"
+                       && (*arguments)[arguments->size() - 2] == "scan/module.json"
+                       && (*arguments).back() == "src/module.cppm",
+                   "structured scan routing should be appended at the end");
+        }
+    }
+
+    const fs::path root = make_temp_root();
+    const fs::path output = root / "scan" / "module.json";
+    const fs::path source = root / "module.ixx";
+    fs::create_directories(root);
+    {
+        std::ofstream stream(source);
+        stream << "export module demo;\n";
+    }
+
+    MsvcToolchain toolchain;
+    toolchain.identity.compiler = "fake-cl.exe";
+    FakeRunner runner;
+    MsvcModuleDependencyScanner scanner{toolchain, runner};
+
+    ModuleScanInvocation invocation;
+    invocation.source = source;
+    invocation.output_file = output;
+    invocation.kind = TranslationUnitKind::module_interface;
+    invocation.working_directory = root;
+
+    {
+        fs::create_directories(output.parent_path());
+        std::ofstream stale(output, std::ios::binary | std::ios::trunc);
+        stale << "stale metadata that must not survive";
+        stale.close();
+
+        runner.mode = FakeRunner::Mode::valid;
+        auto scanned = scanner.scan(invocation);
+        expect(scanned.has_value(), "valid fake scan should parse P1689 output");
+        if (scanned) {
+            expect(scanned->dependencies.rules.size() == 1,
+                   "scan should return the parsed P1689 rule");
+            expect(scanned->dependencies.rules[0].provided_modules.size() == 1
+                       && scanned->dependencies.rules[0].provided_modules[0].logical_name == "demo",
+                   "scan should expose provided module identity");
+        }
+        expect(runner.calls == 1, "scanner should launch exactly one process per invocation");
+        expect(runner.last_spec.executable == toolchain.identity.compiler,
+               "scanner should launch the discovered compiler");
+        expect(runner.last_spec.working_directory == root,
+               "scanner should preserve the requested working directory");
+    }
+
+    {
+        runner.mode = FakeRunner::Mode::malformed;
+        auto malformed = scanner.scan(invocation);
+        expect(!malformed
+                   && malformed.error().code == ModuleScanErrorCode::dependency_metadata_failed
+                   && malformed.error().dependency_error.has_value(),
+               "malformed P1689 should be a typed metadata error");
+    }
+
+    {
+        runner.mode = FakeRunner::Mode::no_output;
+        auto missing = scanner.scan(invocation);
+        expect(!missing && missing.error().code == ModuleScanErrorCode::output_missing,
+               "successful process without metadata should fail closed");
+    }
+
+    {
+        std::ofstream stale(output, std::ios::binary | std::ios::trunc);
+        stale << R"json({"version":1,"rules":[{}]})json";
+        stale.close();
+        runner.mode = FakeRunner::Mode::nonzero_exit;
+        auto failed = scanner.scan(invocation);
+        expect(!failed && failed.error().code == ModuleScanErrorCode::scan_failed,
+               "non-zero cl.exe exit should be a scan failure");
+        expect(!fs::exists(output),
+               "stale metadata must be removed before a failing scan launches");
+    }
+
+    {
+        ModuleScanInvocation invalid = invocation;
+        invalid.options.defines = {""};
+        auto arguments = MsvcModuleDependencyScanner::build_arguments(invalid);
+        expect(!arguments && arguments.error().code == ModuleScanErrorCode::invalid_request,
+               "empty defines should be rejected before launching cl.exe");
+    }
+
+    std::error_code cleanup_error;
+    fs::remove_all(root, cleanup_error);
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+
+    std::cout << "mqb_msvc_module_scanner_tests passed\n";
+    return 0;
+}

--- a/cpp/core/include/mqb/core/CompileCache.hpp
+++ b/cpp/core/include/mqb/core/CompileCache.hpp
@@ -40,7 +40,7 @@ public:
         const CompilerOptions& current_options,
         const std::optional<CompileCacheEntry>& cached_entry,
         const FileSnapshot& source_snapshot,
-        const FileSnapshot& object_snapshot,
+        std::span<const FileSnapshot> output_snapshots,
         std::span<const FileSnapshot> dependency_snapshots);
 };
 

--- a/cpp/core/include/mqb/core/ProjectArtifactLayout.hpp
+++ b/cpp/core/include/mqb/core/ProjectArtifactLayout.hpp
@@ -10,6 +10,8 @@ namespace mqb {
 struct SourceArtifacts {
     std::filesystem::path object;
     std::filesystem::path dependencies;
+    std::filesystem::path module_dependencies;
+    std::filesystem::path module_interface;
     std::filesystem::path compile_cache;
 };
 

--- a/cpp/core/include/mqb/core/TranslationUnit.hpp
+++ b/cpp/core/include/mqb/core/TranslationUnit.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <filesystem>
+#include <string>
 #include <vector>
 
 #include "mqb/core/Artifact.hpp"
@@ -12,10 +13,16 @@ enum class TranslationUnitKind {
     module_interface,
 };
 
+struct ModuleReference {
+    std::string logical_name;
+    std::filesystem::path interface_file;
+};
+
 struct TranslationUnit {
     std::filesystem::path source;
     TranslationUnitKind kind{TranslationUnitKind::source};
     std::vector<std::filesystem::path> dependencies;
+    std::vector<ModuleReference> module_references;
     std::vector<Artifact> outputs;
 };
 

--- a/cpp/core/src/BuildSignature.cpp
+++ b/cpp/core/src/BuildSignature.cpp
@@ -8,6 +8,8 @@
 #include <string_view>
 #include <type_traits>
 
+#include "mqb/core/Artifact.hpp"
+
 namespace mqb {
 namespace {
 
@@ -62,6 +64,29 @@ public:
         }
     }
 
+    void add_module_references(const std::vector<ModuleReference>& references) noexcept {
+        add_u64(static_cast<std::uint64_t>(references.size()));
+        for (const auto& reference : references) {
+            add_string(reference.logical_name);
+            add_path(reference.interface_file);
+        }
+    }
+
+    void add_module_outputs(const std::vector<Artifact>& outputs) noexcept {
+        std::uint64_t count = 0;
+        for (const auto& output : outputs) {
+            if (output.kind == ArtifactKind::module_interface) {
+                ++count;
+            }
+        }
+        add_u64(count);
+        for (const auto& output : outputs) {
+            if (output.kind == ArtifactKind::module_interface) {
+                add_path(output.path);
+            }
+        }
+    }
+
     [[nodiscard]] SignatureDigest finish() const noexcept {
         return SignatureDigest{
             .high = avalanche(primary_),
@@ -105,13 +130,17 @@ BuildSignature BuildSignature::for_compile(
     const ToolchainIdentity& toolchain,
     const CompilerOptions& options) {
     StableHasher hasher;
-    hasher.add_string("mqb.compile.signature.v2");
+    hasher.add_string("mqb.compile.signature.v3");
 
-    // Dependencies and output paths are deliberately excluded. Dependency
-    // freshness is validated separately, while output locations are artifact
-    // placement rather than compiler recipe identity.
+    // Header dependency membership remains freshness-only state. Ordinary
+    // object placement also remains outside recipe identity. Module references
+    // are different: their logical-name -> compiled-interface mapping affects
+    // import resolution, and a provider's planned interface-file output path is
+    // consumed semantically by downstream translation units.
     hasher.add_path(unit.source);
     hasher.add_enum(unit.kind);
+    hasher.add_module_references(unit.module_references);
+    hasher.add_module_outputs(unit.outputs);
 
     hasher.add_path(toolchain.compiler);
     hasher.add_string(toolchain.version);

--- a/cpp/core/src/CompileCache.cpp
+++ b/cpp/core/src/CompileCache.cpp
@@ -42,6 +42,18 @@ void add_reason(std::vector<BuildReason>& reasons, const BuildReason reason) {
     return it == snapshots.end() ? nullptr : &*it;
 }
 
+[[nodiscard]] const Artifact* find_artifact(
+    const TranslationUnit& unit,
+    const ArtifactKind kind) {
+    const auto it = std::find_if(
+        unit.outputs.begin(),
+        unit.outputs.end(),
+        [kind](const Artifact& artifact) {
+            return artifact.kind == kind;
+        });
+    return it == unit.outputs.end() ? nullptr : &*it;
+}
+
 } // namespace
 
 CompileCacheValidation CompileCacheValidator::validate(
@@ -50,15 +62,27 @@ CompileCacheValidation CompileCacheValidator::validate(
     const CompilerOptions& current_options,
     const std::optional<CompileCacheEntry>& cached_entry,
     const FileSnapshot& source_snapshot,
-    const FileSnapshot& object_snapshot,
+    const std::span<const FileSnapshot> output_snapshots,
     const std::span<const FileSnapshot> dependency_snapshots) {
     CompileCacheValidation result;
 
+    const Artifact* current_object = find_artifact(current_unit, ArtifactKind::object);
+    const FileSnapshot* object_snapshot = current_object == nullptr
+        ? nullptr
+        : find_snapshot(output_snapshots, current_object->path);
+
+    const auto validate_outputs = [&] {
+        for (const auto& output : current_unit.outputs) {
+            const auto* snapshot = find_snapshot(output_snapshots, output.path);
+            if (snapshot == nullptr || !snapshot->exists) {
+                add_reason(result.reasons, BuildReason::missing_output);
+            }
+        }
+    };
+
     if (!cached_entry) {
         add_reason(result.reasons, BuildReason::missing_cache_entry);
-        if (!object_snapshot.exists) {
-            add_reason(result.reasons, BuildReason::missing_output);
-        }
+        validate_outputs();
         return result;
     }
 
@@ -82,13 +106,18 @@ CompileCacheValidation CompileCacheValidator::validate(
         add_reason(result.reasons, BuildReason::compiler_options_changed);
     }
 
-    if (!object_snapshot.exists) {
+    if (current_object == nullptr
+        || !same_path(cached.object.path, current_object->path)
+        || cached.object.kind != ArtifactKind::object) {
         add_reason(result.reasons, BuildReason::missing_output);
     }
+    validate_outputs();
 
     if (!source_snapshot.exists) {
         add_reason(result.reasons, BuildReason::source_changed);
-    } else if (object_snapshot.exists && source_snapshot.modified > object_snapshot.modified) {
+    } else if (object_snapshot != nullptr
+               && object_snapshot->exists
+               && source_snapshot.modified > object_snapshot->modified) {
         add_reason(result.reasons, BuildReason::source_changed);
     }
 
@@ -99,7 +128,9 @@ CompileCacheValidation CompileCacheValidator::validate(
             continue;
         }
 
-        if (object_snapshot.exists && snapshot->modified > object_snapshot.modified) {
+        if (object_snapshot != nullptr
+            && object_snapshot->exists
+            && snapshot->modified > object_snapshot->modified) {
             add_reason(result.reasons, BuildReason::dependency_changed);
         }
     }

--- a/cpp/core/src/ProjectArtifactLayout.cpp
+++ b/cpp/core/src/ProjectArtifactLayout.cpp
@@ -117,6 +117,8 @@ ProjectArtifactLayout::for_source(const fs::path& source) const {
     return SourceArtifacts{
         .object = append_suffix(artifact_root_ / "obj" / key, ".obj"),
         .dependencies = append_suffix(artifact_root_ / "deps" / key, ".json"),
+        .module_dependencies = append_suffix(artifact_root_ / "scan" / key, ".json"),
+        .module_interface = append_suffix(artifact_root_ / "ifc" / key, ".ifc"),
         .compile_cache = append_suffix(
             artifact_root_ / "cache" / "compile" / key,
             ".mqbcache"),

--- a/cpp/json/CMakeLists.txt
+++ b/cpp/json/CMakeLists.txt
@@ -1,0 +1,20 @@
+add_library(mqb_json STATIC
+    src/Json.cpp
+)
+
+target_include_directories(mqb_json
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+
+target_compile_features(mqb_json PUBLIC cxx_std_23)
+
+if(MSVC)
+    target_compile_options(mqb_json PRIVATE /W4 /permissive-)
+else()
+    target_compile_options(mqb_json PRIVATE -Wall -Wextra -Wpedantic)
+endif()
+
+if(MQB_BUILD_TESTS)
+    add_subdirectory(tests)
+endif()

--- a/cpp/json/include/mqb/json/Json.hpp
+++ b/cpp/json/include/mqb/json/Json.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <cstddef>
+#include <expected>
+#include <map>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace mqb::json {
+
+enum class Kind {
+    null_value,
+    boolean,
+    number,
+    string,
+    array,
+    object,
+};
+
+struct Value {
+    Kind kind{Kind::null_value};
+    std::size_t line{1};
+    std::size_t column{1};
+    bool boolean{};
+    std::string scalar;
+    std::vector<Value> array;
+    std::map<std::string, Value, std::less<>> object;
+};
+
+using Object = decltype(Value{}.object);
+
+struct Error {
+    std::size_t line{1};
+    std::size_t column{1};
+    std::string message;
+};
+
+[[nodiscard]] std::expected<Value, Error> parse(std::string_view text);
+
+} // namespace mqb::json

--- a/cpp/json/src/Json.cpp
+++ b/cpp/json/src/Json.cpp
@@ -1,0 +1,360 @@
+#include "mqb/json/Json.hpp"
+
+#include <cctype>
+#include <cstdint>
+#include <expected>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace mqb::json {
+namespace {
+
+class Parser {
+public:
+    explicit Parser(const std::string_view text) : text_(text) {}
+
+    [[nodiscard]] std::expected<Value, Error> parse_document() {
+        skip_ws();
+        auto value = parse_value();
+        if (!value) return std::unexpected(value.error());
+        skip_ws();
+        if (!eof()) {
+            return std::unexpected(error("unexpected characters after JSON value"));
+        }
+        return value;
+    }
+
+private:
+    [[nodiscard]] bool eof() const noexcept { return pos_ >= text_.size(); }
+    [[nodiscard]] char peek() const noexcept { return eof() ? '\0' : text_[pos_]; }
+
+    char take() {
+        const char ch = text_[pos_++];
+        if (ch == '\n') {
+            ++line_;
+            column_ = 1;
+        } else {
+            ++column_;
+        }
+        return ch;
+    }
+
+    void skip_ws() {
+        while (!eof()) {
+            const char ch = peek();
+            if (ch != ' ' && ch != '\t' && ch != '\r' && ch != '\n') break;
+            take();
+        }
+    }
+
+    [[nodiscard]] Error error(std::string message) const {
+        return Error{
+            .line = line_,
+            .column = column_,
+            .message = std::move(message),
+        };
+    }
+
+    [[nodiscard]] std::expected<Value, Error> parse_value() {
+        if (eof()) {
+            return std::unexpected(error("unexpected end of JSON input"));
+        }
+
+        const std::size_t start_line = line_;
+        const std::size_t start_column = column_;
+        switch (peek()) {
+        case '{':
+            return parse_object(start_line, start_column);
+        case '[':
+            return parse_array(start_line, start_column);
+        case '"': {
+            auto text = parse_string();
+            if (!text) return std::unexpected(text.error());
+            Value value;
+            value.kind = Kind::string;
+            value.line = start_line;
+            value.column = start_column;
+            value.scalar = std::move(*text);
+            return value;
+        }
+        case 't':
+            return parse_literal("true", Kind::boolean, true, start_line, start_column);
+        case 'f':
+            return parse_literal("false", Kind::boolean, false, start_line, start_column);
+        case 'n':
+            return parse_literal("null", Kind::null_value, false, start_line, start_column);
+        default:
+            if (peek() == '-' || std::isdigit(static_cast<unsigned char>(peek()))) {
+                return parse_number(start_line, start_column);
+            }
+            return std::unexpected(error("unexpected token in JSON input"));
+        }
+    }
+
+    [[nodiscard]] std::expected<Value, Error> parse_literal(
+        const std::string_view literal,
+        const Kind kind,
+        const bool boolean,
+        const std::size_t start_line,
+        const std::size_t start_column) {
+        for (const char expected : literal) {
+            if (eof() || take() != expected) {
+                return std::unexpected(error("invalid JSON literal"));
+            }
+        }
+
+        Value value;
+        value.kind = kind;
+        value.line = start_line;
+        value.column = start_column;
+        value.boolean = boolean;
+        return value;
+    }
+
+    [[nodiscard]] std::expected<Value, Error> parse_object(
+        const std::size_t start_line,
+        const std::size_t start_column) {
+        take();
+        Value value;
+        value.kind = Kind::object;
+        value.line = start_line;
+        value.column = start_column;
+        skip_ws();
+        if (!eof() && peek() == '}') {
+            take();
+            return value;
+        }
+
+        while (true) {
+            skip_ws();
+            if (eof() || peek() != '"') {
+                return std::unexpected(error("expected string key in JSON object"));
+            }
+            const std::size_t key_line = line_;
+            const std::size_t key_column = column_;
+            auto key = parse_string();
+            if (!key) return std::unexpected(key.error());
+
+            skip_ws();
+            if (eof() || take() != ':') {
+                return std::unexpected(error("expected ':' after JSON object key"));
+            }
+            skip_ws();
+
+            auto member = parse_value();
+            if (!member) return std::unexpected(member.error());
+            if (value.object.contains(*key)) {
+                return std::unexpected(Error{
+                    .line = key_line,
+                    .column = key_column,
+                    .message = "duplicate JSON object key '" + *key + "'",
+                });
+            }
+            value.object.emplace(std::move(*key), std::move(*member));
+
+            skip_ws();
+            if (eof()) {
+                return std::unexpected(error("unterminated JSON object"));
+            }
+            const char delimiter = take();
+            if (delimiter == '}') break;
+            if (delimiter != ',') {
+                return std::unexpected(error("expected ',' or '}' in JSON object"));
+            }
+        }
+        return value;
+    }
+
+    [[nodiscard]] std::expected<Value, Error> parse_array(
+        const std::size_t start_line,
+        const std::size_t start_column) {
+        take();
+        Value value;
+        value.kind = Kind::array;
+        value.line = start_line;
+        value.column = start_column;
+        skip_ws();
+        if (!eof() && peek() == ']') {
+            take();
+            return value;
+        }
+
+        while (true) {
+            skip_ws();
+            auto element = parse_value();
+            if (!element) return std::unexpected(element.error());
+            value.array.push_back(std::move(*element));
+
+            skip_ws();
+            if (eof()) {
+                return std::unexpected(error("unterminated JSON array"));
+            }
+            const char delimiter = take();
+            if (delimiter == ']') break;
+            if (delimiter != ',') {
+                return std::unexpected(error("expected ',' or ']' in JSON array"));
+            }
+        }
+        return value;
+    }
+
+    [[nodiscard]] static int hex(const char ch) noexcept {
+        if (ch >= '0' && ch <= '9') return ch - '0';
+        if (ch >= 'a' && ch <= 'f') return 10 + ch - 'a';
+        if (ch >= 'A' && ch <= 'F') return 10 + ch - 'A';
+        return -1;
+    }
+
+    [[nodiscard]] std::expected<std::uint32_t, Error> parse_hex_quad() {
+        std::uint32_t value = 0;
+        for (int i = 0; i < 4; ++i) {
+            if (eof()) {
+                return std::unexpected(error("incomplete Unicode escape"));
+            }
+            const int digit = hex(take());
+            if (digit < 0) {
+                return std::unexpected(error("invalid Unicode escape"));
+            }
+            value = (value << 4u) | static_cast<std::uint32_t>(digit);
+        }
+        return value;
+    }
+
+    static void append_utf8(std::string& out, const std::uint32_t cp) {
+        if (cp <= 0x7fu) {
+            out.push_back(static_cast<char>(cp));
+        } else if (cp <= 0x7ffu) {
+            out.push_back(static_cast<char>(0xc0u | (cp >> 6u)));
+            out.push_back(static_cast<char>(0x80u | (cp & 0x3fu)));
+        } else if (cp <= 0xffffu) {
+            out.push_back(static_cast<char>(0xe0u | (cp >> 12u)));
+            out.push_back(static_cast<char>(0x80u | ((cp >> 6u) & 0x3fu)));
+            out.push_back(static_cast<char>(0x80u | (cp & 0x3fu)));
+        } else {
+            out.push_back(static_cast<char>(0xf0u | (cp >> 18u)));
+            out.push_back(static_cast<char>(0x80u | ((cp >> 12u) & 0x3fu)));
+            out.push_back(static_cast<char>(0x80u | ((cp >> 6u) & 0x3fu)));
+            out.push_back(static_cast<char>(0x80u | (cp & 0x3fu)));
+        }
+    }
+
+    [[nodiscard]] std::expected<std::string, Error> parse_string() {
+        if (eof() || take() != '"') {
+            return std::unexpected(error("expected JSON string"));
+        }
+
+        std::string out;
+        while (!eof()) {
+            const unsigned char raw = static_cast<unsigned char>(take());
+            if (raw == '"') return out;
+            if (raw < 0x20u) {
+                return std::unexpected(error("unescaped control character in JSON string"));
+            }
+            if (raw != '\\') {
+                out.push_back(static_cast<char>(raw));
+                continue;
+            }
+
+            if (eof()) {
+                return std::unexpected(error("incomplete JSON string escape"));
+            }
+            switch (take()) {
+            case '"': out.push_back('"'); break;
+            case '\\': out.push_back('\\'); break;
+            case '/': out.push_back('/'); break;
+            case 'b': out.push_back('\b'); break;
+            case 'f': out.push_back('\f'); break;
+            case 'n': out.push_back('\n'); break;
+            case 'r': out.push_back('\r'); break;
+            case 't': out.push_back('\t'); break;
+            case 'u': {
+                auto first = parse_hex_quad();
+                if (!first) return std::unexpected(first.error());
+                std::uint32_t cp = *first;
+                if (cp >= 0xd800u && cp <= 0xdbffu) {
+                    if (eof() || take() != '\\' || eof() || take() != 'u') {
+                        return std::unexpected(error(
+                            "high surrogate must be followed by low surrogate"));
+                    }
+                    auto second = parse_hex_quad();
+                    if (!second) return std::unexpected(second.error());
+                    if (*second < 0xdc00u || *second > 0xdfffu) {
+                        return std::unexpected(error(
+                            "invalid low surrogate in Unicode escape"));
+                    }
+                    cp = 0x10000u
+                        + ((cp - 0xd800u) << 10u)
+                        + (*second - 0xdc00u);
+                } else if (cp >= 0xdc00u && cp <= 0xdfffu) {
+                    return std::unexpected(error(
+                        "unexpected low surrogate in Unicode escape"));
+                }
+                append_utf8(out, cp);
+                break;
+            }
+            default:
+                return std::unexpected(error("invalid JSON string escape"));
+            }
+        }
+        return std::unexpected(error("unterminated JSON string"));
+    }
+
+    [[nodiscard]] std::expected<Value, Error> parse_number(
+        const std::size_t start_line,
+        const std::size_t start_column) {
+        const std::size_t begin = pos_;
+        if (peek() == '-') take();
+        if (eof()) {
+            return std::unexpected(error("incomplete JSON number"));
+        }
+
+        if (peek() == '0') {
+            take();
+            if (!eof() && std::isdigit(static_cast<unsigned char>(peek()))) {
+                return std::unexpected(error("leading zero in JSON number"));
+            }
+        } else if (peek() >= '1' && peek() <= '9') {
+            while (!eof() && std::isdigit(static_cast<unsigned char>(peek()))) take();
+        } else {
+            return std::unexpected(error("invalid JSON number"));
+        }
+
+        if (!eof() && peek() == '.') {
+            take();
+            if (eof() || !std::isdigit(static_cast<unsigned char>(peek()))) {
+                return std::unexpected(error("JSON fraction requires digits"));
+            }
+            while (!eof() && std::isdigit(static_cast<unsigned char>(peek()))) take();
+        }
+
+        if (!eof() && (peek() == 'e' || peek() == 'E')) {
+            take();
+            if (!eof() && (peek() == '+' || peek() == '-')) take();
+            if (eof() || !std::isdigit(static_cast<unsigned char>(peek()))) {
+                return std::unexpected(error("JSON exponent requires digits"));
+            }
+            while (!eof() && std::isdigit(static_cast<unsigned char>(peek()))) take();
+        }
+
+        Value value;
+        value.kind = Kind::number;
+        value.line = start_line;
+        value.column = start_column;
+        value.scalar = std::string{text_.substr(begin, pos_ - begin)};
+        return value;
+    }
+
+    std::string_view text_;
+    std::size_t pos_{};
+    std::size_t line_{1};
+    std::size_t column_{1};
+};
+
+} // namespace
+
+std::expected<Value, Error> parse(const std::string_view text) {
+    return Parser{text}.parse_document();
+}
+
+} // namespace mqb::json

--- a/cpp/json/tests/CMakeLists.txt
+++ b/cpp/json/tests/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_executable(mqb_json_tests json_tests.cpp)
+target_link_libraries(mqb_json_tests PRIVATE mqb_json)
+target_compile_features(mqb_json_tests PRIVATE cxx_std_23)
+
+if(MSVC)
+    target_compile_options(mqb_json_tests PRIVATE /W4 /permissive-)
+else()
+    target_compile_options(mqb_json_tests PRIVATE -Wall -Wextra -Wpedantic)
+endif()
+
+add_test(NAME mqb.json.strict_parser COMMAND mqb_json_tests)

--- a/cpp/json/tests/json_tests.cpp
+++ b/cpp/json/tests/json_tests.cpp
@@ -1,0 +1,89 @@
+#include <iostream>
+#include <string_view>
+
+#include "mqb/json/Json.hpp"
+
+namespace {
+
+int failures = 0;
+
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+} // namespace
+
+int main() {
+    using mqb::json::Kind;
+
+    {
+        auto parsed = mqb::json::parse(R"json({
+  "version": 1,
+  "enabled": true,
+  "name": "M\\u002eCore",
+  "items": [null, -1.5e+2, "\u65e5\u672c", "\ud83d\ude80"]
+})json");
+        expect(parsed.has_value(), "valid nested JSON should parse");
+        if (parsed) {
+            expect(parsed->kind == Kind::object, "root should be object");
+            expect(parsed->object.at("version").scalar == "1", "integer spelling should be preserved");
+            expect(parsed->object.at("enabled").boolean, "boolean should be preserved");
+            expect(parsed->object.at("items").kind == Kind::array
+                       && parsed->object.at("items").array.size() == 4,
+                   "array contents should be preserved");
+            expect(parsed->object.at("items").array[2].scalar == "日本",
+                   "BMP Unicode escapes should decode as UTF-8");
+            expect(parsed->object.at("items").array[3].scalar == "🚀",
+                   "surrogate pair should decode as UTF-8");
+        }
+    }
+
+    {
+        auto duplicate = mqb::json::parse(R"json({"a": 1, "a": 2})json");
+        expect(!duplicate, "duplicate object keys should be rejected");
+        if (!duplicate) {
+            expect(duplicate.error().message.find("duplicate JSON object key") != std::string::npos,
+                   "duplicate-key error should be explicit");
+        }
+    }
+
+    {
+        auto invalid_number = mqb::json::parse(R"json({"n": 01})json");
+        expect(!invalid_number, "leading-zero JSON number should be rejected");
+    }
+
+    {
+        auto trailing = mqb::json::parse(R"json({"a": 1} trailing)json");
+        expect(!trailing, "trailing non-whitespace should be rejected");
+    }
+
+    {
+        auto bad_surrogate = mqb::json::parse(R"json("\ud83dX")json");
+        expect(!bad_surrogate, "unpaired high surrogate should be rejected");
+    }
+
+    {
+        auto control = mqb::json::parse(std::string_view{"\"line\nfeed\"", 11});
+        expect(!control, "raw control characters inside JSON strings should be rejected");
+    }
+
+    {
+        auto empty = mqb::json::parse("   \r\n\t");
+        expect(!empty, "whitespace-only input should be rejected");
+        if (!empty) {
+            expect(empty.error().line >= 1 && empty.error().column >= 1,
+                   "parse errors should carry source coordinates");
+        }
+    }
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+
+    std::cout << "mqb_json_tests passed\n";
+    return 0;
+}

--- a/cpp/modules/CMakeLists.txt
+++ b/cpp/modules/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(mqb_modules STATIC
+    src/ModuleDependencyGraph.cpp
     src/P1689.cpp
 )
 
@@ -9,6 +10,7 @@ target_include_directories(mqb_modules
 
 target_link_libraries(mqb_modules
     PUBLIC
+        mqb_core
         mqb_json
 )
 

--- a/cpp/modules/CMakeLists.txt
+++ b/cpp/modules/CMakeLists.txt
@@ -1,0 +1,25 @@
+add_library(mqb_modules STATIC
+    src/P1689.cpp
+)
+
+target_include_directories(mqb_modules
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+
+target_link_libraries(mqb_modules
+    PUBLIC
+        mqb_json
+)
+
+target_compile_features(mqb_modules PUBLIC cxx_std_23)
+
+if(MSVC)
+    target_compile_options(mqb_modules PRIVATE /W4 /permissive-)
+else()
+    target_compile_options(mqb_modules PRIVATE -Wall -Wextra -Wpedantic)
+endif()
+
+if(MQB_BUILD_TESTS)
+    add_subdirectory(tests)
+endif()

--- a/cpp/modules/include/mqb/modules/ModuleDependencyGraph.hpp
+++ b/cpp/modules/include/mqb/modules/ModuleDependencyGraph.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <expected>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "mqb/core/DependencyGraph.hpp"
+#include "mqb/modules/P1689.hpp"
+
+namespace mqb::modules {
+
+struct ScannedModuleUnit {
+    std::filesystem::path source;
+    P1689Rule rule;
+};
+
+enum class UnresolvedRequirementKind {
+    named_module,
+    header_unit,
+};
+
+struct UnresolvedModuleRequirement {
+    std::filesystem::path consumer_source;
+    RequiredModule requirement;
+    UnresolvedRequirementKind kind{UnresolvedRequirementKind::named_module};
+};
+
+struct ModuleDependencyPlan {
+    // Each inner vector may be compiled concurrently. Earlier levels must
+    // complete before later levels begin.
+    std::vector<std::vector<std::filesystem::path>> compile_levels;
+    std::vector<UnresolvedModuleRequirement> unresolved_requirements;
+};
+
+enum class ModuleGraphErrorCode {
+    empty_source,
+    duplicate_source,
+    duplicate_interface_provider,
+    ambiguous_named_provider,
+    dependency_cycle,
+};
+
+struct ModuleGraphError {
+    ModuleGraphErrorCode code{ModuleGraphErrorCode::empty_source};
+    std::filesystem::path source;
+    std::string logical_name;
+    std::string message;
+    std::optional<DependencyGraphError> graph_error;
+};
+
+class ModuleDependencyGraphBuilder {
+public:
+    [[nodiscard]] static std::expected<ModuleDependencyPlan, ModuleGraphError>
+    build(const std::vector<ScannedModuleUnit>& units);
+};
+
+} // namespace mqb::modules

--- a/cpp/modules/include/mqb/modules/ModuleDependencyGraph.hpp
+++ b/cpp/modules/include/mqb/modules/ModuleDependencyGraph.hpp
@@ -27,10 +27,20 @@ struct UnresolvedModuleRequirement {
     UnresolvedRequirementKind kind{UnresolvedRequirementKind::named_module};
 };
 
+struct ResolvedModuleDependency {
+    std::filesystem::path consumer_source;
+    std::filesystem::path provider_source;
+    std::string logical_name;
+};
+
 struct ModuleDependencyPlan {
     // Each inner vector may be compiled concurrently. Earlier levels must
     // complete before later levels begin.
     std::vector<std::vector<std::filesystem::path>> compile_levels;
+    // Named-module imports that were resolved to another source in this plan.
+    // Orchestration uses these exact edges both for /reference wiring and for
+    // downstream rebuild propagation; provider selection must not be repeated.
+    std::vector<ResolvedModuleDependency> resolved_dependencies;
     std::vector<UnresolvedModuleRequirement> unresolved_requirements;
 };
 

--- a/cpp/modules/include/mqb/modules/P1689.hpp
+++ b/cpp/modules/include/mqb/modules/P1689.hpp
@@ -36,8 +36,8 @@ struct P1689Rule {
     std::optional<std::filesystem::path> work_directory;
     std::optional<std::filesystem::path> primary_output;
     std::vector<std::filesystem::path> outputs;
-    std::vector<ProvidedModule> provides;
-    std::vector<RequiredModule> requires;
+    std::vector<ProvidedModule> provided_modules;
+    std::vector<RequiredModule> required_modules;
 };
 
 struct P1689Document {

--- a/cpp/modules/include/mqb/modules/P1689.hpp
+++ b/cpp/modules/include/mqb/modules/P1689.hpp
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <cstddef>
+#include <expected>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace mqb::modules {
+
+enum class LookupMethod {
+    by_name,
+    include_angle,
+    include_quote,
+};
+
+struct ProvidedModule {
+    std::string logical_name;
+    std::optional<std::filesystem::path> source_path;
+    std::optional<std::filesystem::path> compiled_module_path;
+    bool unique_on_source_path{false};
+    bool is_interface{true};
+};
+
+struct RequiredModule {
+    std::string logical_name;
+    std::optional<std::filesystem::path> source_path;
+    std::optional<std::filesystem::path> compiled_module_path;
+    bool unique_on_source_path{false};
+    LookupMethod lookup_method{LookupMethod::by_name};
+};
+
+struct P1689Rule {
+    std::optional<std::filesystem::path> work_directory;
+    std::optional<std::filesystem::path> primary_output;
+    std::vector<std::filesystem::path> outputs;
+    std::vector<ProvidedModule> provides;
+    std::vector<RequiredModule> requires;
+};
+
+struct P1689Document {
+    int version{1};
+    int revision{0};
+    std::vector<P1689Rule> rules;
+};
+
+enum class P1689ErrorCode {
+    parse_error,
+    schema_error,
+    unsupported_version,
+    unsupported_revision,
+};
+
+struct P1689Error {
+    P1689ErrorCode code{P1689ErrorCode::parse_error};
+    std::size_t line{1};
+    std::size_t column{1};
+    std::string message;
+};
+
+class P1689Parser {
+public:
+    [[nodiscard]] static std::expected<P1689Document, P1689Error>
+    parse(std::string_view text);
+};
+
+} // namespace mqb::modules

--- a/cpp/modules/src/ModuleDependencyGraph.cpp
+++ b/cpp/modules/src/ModuleDependencyGraph.cpp
@@ -153,9 +153,15 @@ ModuleDependencyGraphBuilder::build(const std::vector<ScannedModuleUnit>& units)
 
             if (provider->second == consumer_index) {
                 // A source may mention its own module identity in scan metadata.
-                // It does not create a useful build-order edge.
+                // It does not create a useful build-order edge or /reference.
                 continue;
             }
+
+            plan.resolved_dependencies.push_back(ResolvedModuleDependency{
+                .consumer_source = units[consumer_index].source,
+                .provider_source = units[provider->second].source,
+                .logical_name = required.logical_name,
+            });
 
             auto dependency = graph.add_dependency(
                 consumer_key,

--- a/cpp/modules/src/ModuleDependencyGraph.cpp
+++ b/cpp/modules/src/ModuleDependencyGraph.cpp
@@ -1,0 +1,199 @@
+#include "mqb/modules/ModuleDependencyGraph.hpp"
+
+#include <algorithm>
+#include <expected>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace mqb::modules {
+namespace {
+
+namespace fs = std::filesystem;
+
+[[nodiscard]] std::string path_key(const fs::path& path) {
+    const auto bytes = path.lexically_normal().generic_u8string();
+    return std::string{
+        reinterpret_cast<const char*>(bytes.data()),
+        bytes.size()};
+}
+
+[[nodiscard]] ModuleGraphError graph_failure(
+    const ModuleGraphErrorCode code,
+    std::string message,
+    fs::path source = {},
+    std::string logical_name = {}) {
+    return ModuleGraphError{
+        .code = code,
+        .source = std::move(source),
+        .logical_name = std::move(logical_name),
+        .message = std::move(message),
+    };
+}
+
+struct ProviderCandidate {
+    std::size_t unit_index{};
+    bool is_interface{true};
+};
+
+[[nodiscard]] std::expected<std::size_t, ModuleGraphError> select_provider(
+    const std::string& logical_name,
+    const std::vector<ProviderCandidate>& candidates,
+    const std::vector<ScannedModuleUnit>& units) {
+    std::vector<std::size_t> interface_candidates;
+    for (const auto& candidate : candidates) {
+        if (candidate.is_interface) {
+            interface_candidates.push_back(candidate.unit_index);
+        }
+    }
+
+    if (interface_candidates.size() > 1) {
+        return std::unexpected(graph_failure(
+            ModuleGraphErrorCode::duplicate_interface_provider,
+            "multiple module interface units provide logical module '" + logical_name + "'",
+            units[interface_candidates.front()].source,
+            logical_name));
+    }
+    if (interface_candidates.size() == 1) {
+        return interface_candidates.front();
+    }
+    if (candidates.size() == 1) {
+        return candidates.front().unit_index;
+    }
+
+    return std::unexpected(graph_failure(
+        ModuleGraphErrorCode::ambiguous_named_provider,
+        "multiple non-interface units provide logical module '" + logical_name
+            + "' without a unique interface provider",
+        units[candidates.front().unit_index].source,
+        logical_name));
+}
+
+} // namespace
+
+std::expected<ModuleDependencyPlan, ModuleGraphError>
+ModuleDependencyGraphBuilder::build(const std::vector<ScannedModuleUnit>& units) {
+    DependencyGraph graph;
+    std::unordered_map<std::string, std::size_t> unit_by_key;
+    unit_by_key.reserve(units.size());
+
+    for (std::size_t index = 0; index < units.size(); ++index) {
+        if (units[index].source.empty()) {
+            return std::unexpected(graph_failure(
+                ModuleGraphErrorCode::empty_source,
+                "module graph unit source path is empty"));
+        }
+        const std::string key = path_key(units[index].source);
+        if (unit_by_key.contains(key)) {
+            return std::unexpected(graph_failure(
+                ModuleGraphErrorCode::duplicate_source,
+                "module graph contains the same source more than once",
+                units[index].source));
+        }
+        unit_by_key.emplace(key, index);
+        auto added = graph.add_node(key);
+        if (!added) {
+            return std::unexpected(graph_failure(
+                ModuleGraphErrorCode::duplicate_source,
+                "module graph contains the same source more than once",
+                units[index].source));
+        }
+    }
+
+    std::unordered_map<std::string, std::vector<ProviderCandidate>> provider_candidates;
+    for (std::size_t index = 0; index < units.size(); ++index) {
+        for (const auto& provided : units[index].rule.provided_modules) {
+            if (provided.unique_on_source_path) {
+                // Header-unit identity is source-based and is retained as an
+                // unresolved typed requirement until header-unit compilation is
+                // implemented. It must not collide with the named-module map.
+                continue;
+            }
+            provider_candidates[provided.logical_name].push_back(ProviderCandidate{
+                .unit_index = index,
+                .is_interface = provided.is_interface,
+            });
+        }
+    }
+
+    std::unordered_map<std::string, std::size_t> provider_by_name;
+    provider_by_name.reserve(provider_candidates.size());
+    for (const auto& [logical_name, candidates] : provider_candidates) {
+        auto provider = select_provider(logical_name, candidates, units);
+        if (!provider) return std::unexpected(provider.error());
+        provider_by_name.emplace(logical_name, *provider);
+    }
+
+    ModuleDependencyPlan plan;
+    for (std::size_t consumer_index = 0; consumer_index < units.size(); ++consumer_index) {
+        const std::string consumer_key = path_key(units[consumer_index].source);
+        for (const auto& required : units[consumer_index].rule.required_modules) {
+            const bool header_unit = required.unique_on_source_path
+                || required.lookup_method != LookupMethod::by_name;
+            if (header_unit) {
+                plan.unresolved_requirements.push_back(UnresolvedModuleRequirement{
+                    .consumer_source = units[consumer_index].source,
+                    .requirement = required,
+                    .kind = UnresolvedRequirementKind::header_unit,
+                });
+                continue;
+            }
+
+            const auto provider = provider_by_name.find(required.logical_name);
+            if (provider == provider_by_name.end()) {
+                plan.unresolved_requirements.push_back(UnresolvedModuleRequirement{
+                    .consumer_source = units[consumer_index].source,
+                    .requirement = required,
+                    .kind = UnresolvedRequirementKind::named_module,
+                });
+                continue;
+            }
+
+            if (provider->second == consumer_index) {
+                // A source may mention its own module identity in scan metadata.
+                // It does not create a useful build-order edge.
+                continue;
+            }
+
+            auto dependency = graph.add_dependency(
+                consumer_key,
+                path_key(units[provider->second].source));
+            if (!dependency) {
+                ModuleGraphError error = graph_failure(
+                    ModuleGraphErrorCode::dependency_cycle,
+                    "failed to add module dependency edge",
+                    units[consumer_index].source,
+                    required.logical_name);
+                error.graph_error = dependency.error();
+                return std::unexpected(std::move(error));
+            }
+        }
+    }
+
+    auto levels = graph.topological_levels();
+    if (!levels) {
+        ModuleGraphError error = graph_failure(
+            ModuleGraphErrorCode::dependency_cycle,
+            "module dependency graph contains a cycle");
+        error.graph_error = levels.error();
+        return std::unexpected(std::move(error));
+    }
+
+    plan.compile_levels.reserve(levels->size());
+    for (const auto& level : *levels) {
+        auto& output_level = plan.compile_levels.emplace_back();
+        output_level.reserve(level.size());
+        for (const auto& key : level) {
+            const auto unit = unit_by_key.find(key);
+            if (unit != unit_by_key.end()) {
+                output_level.push_back(units[unit->second].source);
+            }
+        }
+    }
+
+    return plan;
+}
+
+} // namespace mqb::modules

--- a/cpp/modules/src/P1689.cpp
+++ b/cpp/modules/src/P1689.cpp
@@ -3,6 +3,7 @@
 #include <charconv>
 #include <expected>
 #include <filesystem>
+#include <initializer_list>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -309,21 +310,21 @@ struct CommonModuleFields {
     if (const auto it = (**object).find("provides"); it != (**object).end()) {
         auto array = require_array(it->second, "rule.provides");
         if (!array) return std::unexpected(array.error());
-        rule.provides.reserve((*array)->size());
+        rule.provided_modules.reserve((*array)->size());
         for (const auto& entry : **array) {
             auto provided = decode_provided(entry);
             if (!provided) return std::unexpected(provided.error());
-            rule.provides.push_back(std::move(*provided));
+            rule.provided_modules.push_back(std::move(*provided));
         }
     }
     if (const auto it = (**object).find("requires"); it != (**object).end()) {
         auto array = require_array(it->second, "rule.requires");
         if (!array) return std::unexpected(array.error());
-        rule.requires.reserve((*array)->size());
+        rule.required_modules.reserve((*array)->size());
         for (const auto& entry : **array) {
             auto required = decode_required(entry);
             if (!required) return std::unexpected(required.error());
-            rule.requires.push_back(std::move(*required));
+            rule.required_modules.push_back(std::move(*required));
         }
     }
     return rule;

--- a/cpp/modules/src/P1689.cpp
+++ b/cpp/modules/src/P1689.cpp
@@ -1,0 +1,403 @@
+#include "mqb/modules/P1689.hpp"
+
+#include <charconv>
+#include <expected>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+#include "mqb/json/Json.hpp"
+
+namespace mqb::modules {
+namespace {
+
+namespace fs = std::filesystem;
+using json::Kind;
+using json::Object;
+using json::Value;
+
+[[nodiscard]] P1689Error schema_error(
+    const Value& value,
+    std::string message) {
+    return P1689Error{
+        .code = P1689ErrorCode::schema_error,
+        .line = value.line,
+        .column = value.column,
+        .message = std::move(message),
+    };
+}
+
+[[nodiscard]] bool vendor_extension(const std::string_view key) noexcept {
+    return key.size() >= 3 && key.front() == '_'
+        && key.find('_', 1) != std::string_view::npos;
+}
+
+[[nodiscard]] bool allowed_key(
+    const std::string_view key,
+    const std::initializer_list<std::string_view> allowed) {
+    for (const auto candidate : allowed) {
+        if (key == candidate) return true;
+    }
+    return vendor_extension(key);
+}
+
+[[nodiscard]] std::expected<void, P1689Error> reject_unknown(
+    const Object& object,
+    const std::initializer_list<std::string_view> allowed,
+    const std::string_view scope) {
+    for (const auto& [key, value] : object) {
+        if (!allowed_key(key, allowed)) {
+            return std::unexpected(schema_error(
+                value,
+                "unknown P1689 " + std::string{scope} + " field '" + key + "'"));
+        }
+    }
+    return {};
+}
+
+[[nodiscard]] std::expected<const Object*, P1689Error> require_object(
+    const Value& value,
+    const std::string_view name) {
+    if (value.kind != Kind::object) {
+        return std::unexpected(schema_error(
+            value,
+            std::string{name} + " must be a JSON object"));
+    }
+    return &value.object;
+}
+
+[[nodiscard]] std::expected<const std::vector<Value>*, P1689Error> require_array(
+    const Value& value,
+    const std::string_view name) {
+    if (value.kind != Kind::array) {
+        return std::unexpected(schema_error(
+            value,
+            std::string{name} + " must be a JSON array"));
+    }
+    return &value.array;
+}
+
+[[nodiscard]] std::expected<std::string, P1689Error> require_string(
+    const Value& value,
+    const std::string_view name) {
+    if (value.kind != Kind::string) {
+        return std::unexpected(schema_error(
+            value,
+            std::string{name} + " must be a JSON string"));
+    }
+    if (value.scalar.empty()) {
+        return std::unexpected(schema_error(
+            value,
+            std::string{name} + " must not be empty"));
+    }
+    return value.scalar;
+}
+
+[[nodiscard]] std::expected<bool, P1689Error> require_bool(
+    const Value& value,
+    const std::string_view name) {
+    if (value.kind != Kind::boolean) {
+        return std::unexpected(schema_error(
+            value,
+            std::string{name} + " must be a JSON boolean"));
+    }
+    return value.boolean;
+}
+
+[[nodiscard]] std::expected<int, P1689Error> require_integer(
+    const Value& value,
+    const std::string_view name) {
+    if (value.kind != Kind::number) {
+        return std::unexpected(schema_error(
+            value,
+            std::string{name} + " must be a JSON integer"));
+    }
+
+    int result = 0;
+    const auto* begin = value.scalar.data();
+    const auto* end = begin + value.scalar.size();
+    const auto [parsed_end, error] = std::from_chars(begin, end, result);
+    if (error != std::errc{} || parsed_end != end) {
+        return std::unexpected(schema_error(
+            value,
+            std::string{name} + " must be a JSON integer"));
+    }
+    return result;
+}
+
+[[nodiscard]] fs::path utf8_path(const std::string& value) {
+    std::u8string bytes;
+    bytes.reserve(value.size());
+    for (const unsigned char byte : value) {
+        bytes.push_back(static_cast<char8_t>(byte));
+    }
+    return fs::path{bytes};
+}
+
+[[nodiscard]] std::expected<fs::path, P1689Error> require_path(
+    const Value& value,
+    const std::string_view name) {
+    auto text = require_string(value, name);
+    if (!text) return std::unexpected(text.error());
+    return utf8_path(*text);
+}
+
+[[nodiscard]] std::expected<std::vector<fs::path>, P1689Error> require_paths(
+    const Value& value,
+    const std::string_view name) {
+    auto array = require_array(value, name);
+    if (!array) return std::unexpected(array.error());
+
+    std::vector<fs::path> paths;
+    paths.reserve((*array)->size());
+    for (const auto& element : **array) {
+        auto path = require_path(element, name);
+        if (!path) return std::unexpected(path.error());
+        paths.push_back(std::move(*path));
+    }
+    return paths;
+}
+
+[[nodiscard]] std::expected<LookupMethod, P1689Error> decode_lookup_method(
+    const Value& value) {
+    auto text = require_string(value, "requires.lookup-method");
+    if (!text) return std::unexpected(text.error());
+    if (*text == "by-name") return LookupMethod::by_name;
+    if (*text == "include-angle") return LookupMethod::include_angle;
+    if (*text == "include-quote") return LookupMethod::include_quote;
+    return std::unexpected(schema_error(
+        value,
+        "requires.lookup-method must be 'by-name', 'include-angle', or 'include-quote'"));
+}
+
+struct CommonModuleFields {
+    std::string logical_name;
+    std::optional<fs::path> source_path;
+    std::optional<fs::path> compiled_module_path;
+    bool unique_on_source_path{false};
+};
+
+[[nodiscard]] std::expected<CommonModuleFields, P1689Error> decode_common_module(
+    const Object& object,
+    const Value& object_value,
+    const std::string_view scope) {
+    const auto logical = object.find("logical-name");
+    if (logical == object.end()) {
+        return std::unexpected(schema_error(
+            object_value,
+            std::string{scope} + " requires non-empty 'logical-name'"));
+    }
+
+    auto logical_name = require_string(logical->second, std::string{scope} + ".logical-name");
+    if (!logical_name) return std::unexpected(logical_name.error());
+
+    CommonModuleFields result;
+    result.logical_name = std::move(*logical_name);
+
+    if (const auto it = object.find("source-path"); it != object.end()) {
+        auto path = require_path(it->second, std::string{scope} + ".source-path");
+        if (!path) return std::unexpected(path.error());
+        result.source_path = std::move(*path);
+    }
+    if (const auto it = object.find("compiled-module-path"); it != object.end()) {
+        auto path = require_path(it->second, std::string{scope} + ".compiled-module-path");
+        if (!path) return std::unexpected(path.error());
+        result.compiled_module_path = std::move(*path);
+    }
+    if (const auto it = object.find("unique-on-source-path"); it != object.end()) {
+        auto unique = require_bool(it->second, std::string{scope} + ".unique-on-source-path");
+        if (!unique) return std::unexpected(unique.error());
+        result.unique_on_source_path = *unique;
+    }
+
+    if (result.unique_on_source_path && !result.source_path) {
+        return std::unexpected(schema_error(
+            object_value,
+            std::string{scope}
+                + " with unique-on-source-path=true requires non-empty 'source-path'"));
+    }
+    return result;
+}
+
+[[nodiscard]] std::expected<ProvidedModule, P1689Error> decode_provided(
+    const Value& value) {
+    auto object = require_object(value, "provides entry");
+    if (!object) return std::unexpected(object.error());
+    auto known = reject_unknown(
+        **object,
+        {"logical-name", "source-path", "compiled-module-path", "unique-on-source-path", "is-interface"},
+        "provides");
+    if (!known) return std::unexpected(known.error());
+
+    auto common = decode_common_module(**object, value, "provides");
+    if (!common) return std::unexpected(common.error());
+
+    bool is_interface = true;
+    if (const auto it = (**object).find("is-interface"); it != (**object).end()) {
+        auto parsed = require_bool(it->second, "provides.is-interface");
+        if (!parsed) return std::unexpected(parsed.error());
+        is_interface = *parsed;
+    }
+
+    return ProvidedModule{
+        .logical_name = std::move(common->logical_name),
+        .source_path = std::move(common->source_path),
+        .compiled_module_path = std::move(common->compiled_module_path),
+        .unique_on_source_path = common->unique_on_source_path,
+        .is_interface = is_interface,
+    };
+}
+
+[[nodiscard]] std::expected<RequiredModule, P1689Error> decode_required(
+    const Value& value) {
+    auto object = require_object(value, "requires entry");
+    if (!object) return std::unexpected(object.error());
+    auto known = reject_unknown(
+        **object,
+        {"logical-name", "source-path", "compiled-module-path", "unique-on-source-path", "lookup-method"},
+        "requires");
+    if (!known) return std::unexpected(known.error());
+
+    auto common = decode_common_module(**object, value, "requires");
+    if (!common) return std::unexpected(common.error());
+
+    LookupMethod lookup_method = LookupMethod::by_name;
+    if (const auto it = (**object).find("lookup-method"); it != (**object).end()) {
+        auto parsed = decode_lookup_method(it->second);
+        if (!parsed) return std::unexpected(parsed.error());
+        lookup_method = *parsed;
+    }
+
+    return RequiredModule{
+        .logical_name = std::move(common->logical_name),
+        .source_path = std::move(common->source_path),
+        .compiled_module_path = std::move(common->compiled_module_path),
+        .unique_on_source_path = common->unique_on_source_path,
+        .lookup_method = lookup_method,
+    };
+}
+
+[[nodiscard]] std::expected<P1689Rule, P1689Error> decode_rule(const Value& value) {
+    auto object = require_object(value, "P1689 rule");
+    if (!object) return std::unexpected(object.error());
+    auto known = reject_unknown(
+        **object,
+        {"work-directory", "primary-output", "outputs", "provides", "requires"},
+        "rule");
+    if (!known) return std::unexpected(known.error());
+
+    P1689Rule rule;
+    if (const auto it = (**object).find("work-directory"); it != (**object).end()) {
+        auto path = require_path(it->second, "rule.work-directory");
+        if (!path) return std::unexpected(path.error());
+        rule.work_directory = std::move(*path);
+    }
+    if (const auto it = (**object).find("primary-output"); it != (**object).end()) {
+        auto path = require_path(it->second, "rule.primary-output");
+        if (!path) return std::unexpected(path.error());
+        rule.primary_output = std::move(*path);
+    }
+    if (const auto it = (**object).find("outputs"); it != (**object).end()) {
+        auto paths = require_paths(it->second, "rule.outputs");
+        if (!paths) return std::unexpected(paths.error());
+        rule.outputs = std::move(*paths);
+    }
+    if (const auto it = (**object).find("provides"); it != (**object).end()) {
+        auto array = require_array(it->second, "rule.provides");
+        if (!array) return std::unexpected(array.error());
+        rule.provides.reserve((*array)->size());
+        for (const auto& entry : **array) {
+            auto provided = decode_provided(entry);
+            if (!provided) return std::unexpected(provided.error());
+            rule.provides.push_back(std::move(*provided));
+        }
+    }
+    if (const auto it = (**object).find("requires"); it != (**object).end()) {
+        auto array = require_array(it->second, "rule.requires");
+        if (!array) return std::unexpected(array.error());
+        rule.requires.reserve((*array)->size());
+        for (const auto& entry : **array) {
+            auto required = decode_required(entry);
+            if (!required) return std::unexpected(required.error());
+            rule.requires.push_back(std::move(*required));
+        }
+    }
+    return rule;
+}
+
+} // namespace
+
+std::expected<P1689Document, P1689Error>
+P1689Parser::parse(const std::string_view text) {
+    auto root = json::parse(text);
+    if (!root) {
+        return std::unexpected(P1689Error{
+            .code = P1689ErrorCode::parse_error,
+            .line = root.error().line,
+            .column = root.error().column,
+            .message = root.error().message,
+        });
+    }
+
+    auto object = require_object(*root, "P1689 root");
+    if (!object) return std::unexpected(object.error());
+    auto known = reject_unknown(**object, {"version", "revision", "rules"}, "root");
+    if (!known) return std::unexpected(known.error());
+
+    const auto version_it = (**object).find("version");
+    if (version_it == (**object).end()) {
+        return std::unexpected(schema_error(*root, "P1689 root requires integer field 'version'"));
+    }
+    auto version = require_integer(version_it->second, "version");
+    if (!version) return std::unexpected(version.error());
+    if (*version != 1) {
+        return std::unexpected(P1689Error{
+            .code = P1689ErrorCode::unsupported_version,
+            .line = version_it->second.line,
+            .column = version_it->second.column,
+            .message = "unsupported P1689 version " + std::to_string(*version) + " (expected 1)",
+        });
+    }
+
+    int revision = 0;
+    if (const auto revision_it = (**object).find("revision"); revision_it != (**object).end()) {
+        auto parsed = require_integer(revision_it->second, "revision");
+        if (!parsed) return std::unexpected(parsed.error());
+        revision = *parsed;
+        if (revision != 0) {
+            return std::unexpected(P1689Error{
+                .code = P1689ErrorCode::unsupported_revision,
+                .line = revision_it->second.line,
+                .column = revision_it->second.column,
+                .message = "unsupported P1689 revision " + std::to_string(revision) + " (expected 0)",
+            });
+        }
+    }
+
+    const auto rules_it = (**object).find("rules");
+    if (rules_it == (**object).end()) {
+        return std::unexpected(schema_error(*root, "P1689 root requires non-empty array field 'rules'"));
+    }
+    auto rules = require_array(rules_it->second, "rules");
+    if (!rules) return std::unexpected(rules.error());
+    if ((*rules)->empty()) {
+        return std::unexpected(schema_error(rules_it->second, "rules must contain at least one rule"));
+    }
+
+    P1689Document document;
+    document.version = *version;
+    document.revision = revision;
+    document.rules.reserve((*rules)->size());
+    for (const auto& rule_value : **rules) {
+        auto rule = decode_rule(rule_value);
+        if (!rule) return std::unexpected(rule.error());
+        document.rules.push_back(std::move(*rule));
+    }
+    return document;
+}
+
+} // namespace mqb::modules

--- a/cpp/modules/tests/CMakeLists.txt
+++ b/cpp/modules/tests/CMakeLists.txt
@@ -6,13 +6,22 @@ add_executable(mqb_module_dependency_graph_tests module_dependency_graph_tests.c
 target_link_libraries(mqb_module_dependency_graph_tests PRIVATE mqb_modules)
 target_compile_features(mqb_module_dependency_graph_tests PRIVATE cxx_std_23)
 
-if(MSVC)
-    target_compile_options(mqb_p1689_tests PRIVATE /W4 /permissive-)
-    target_compile_options(mqb_module_dependency_graph_tests PRIVATE /W4 /permissive-)
-else()
-    target_compile_options(mqb_p1689_tests PRIVATE -Wall -Wextra -Wpedantic)
-    target_compile_options(mqb_module_dependency_graph_tests PRIVATE -Wall -Wextra -Wpedantic)
-endif()
+add_executable(mqb_module_dependency_resolution_tests module_dependency_resolution_tests.cpp)
+target_link_libraries(mqb_module_dependency_resolution_tests PRIVATE mqb_modules)
+target_compile_features(mqb_module_dependency_resolution_tests PRIVATE cxx_std_23)
+
+foreach(test_target IN ITEMS
+    mqb_p1689_tests
+    mqb_module_dependency_graph_tests
+    mqb_module_dependency_resolution_tests
+)
+    if(MSVC)
+        target_compile_options(${test_target} PRIVATE /W4 /permissive-)
+    else()
+        target_compile_options(${test_target} PRIVATE -Wall -Wextra -Wpedantic)
+    endif()
+endforeach()
 
 add_test(NAME mqb.modules.p1689_parser COMMAND mqb_p1689_tests)
 add_test(NAME mqb.modules.dependency_graph COMMAND mqb_module_dependency_graph_tests)
+add_test(NAME mqb.modules.dependency_resolution COMMAND mqb_module_dependency_resolution_tests)

--- a/cpp/modules/tests/CMakeLists.txt
+++ b/cpp/modules/tests/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_executable(mqb_p1689_tests p1689_tests.cpp)
+target_link_libraries(mqb_p1689_tests PRIVATE mqb_modules)
+target_compile_features(mqb_p1689_tests PRIVATE cxx_std_23)
+
+if(MSVC)
+    target_compile_options(mqb_p1689_tests PRIVATE /W4 /permissive-)
+else()
+    target_compile_options(mqb_p1689_tests PRIVATE -Wall -Wextra -Wpedantic)
+endif()
+
+add_test(NAME mqb.modules.p1689_parser COMMAND mqb_p1689_tests)

--- a/cpp/modules/tests/CMakeLists.txt
+++ b/cpp/modules/tests/CMakeLists.txt
@@ -2,10 +2,17 @@ add_executable(mqb_p1689_tests p1689_tests.cpp)
 target_link_libraries(mqb_p1689_tests PRIVATE mqb_modules)
 target_compile_features(mqb_p1689_tests PRIVATE cxx_std_23)
 
+add_executable(mqb_module_dependency_graph_tests module_dependency_graph_tests.cpp)
+target_link_libraries(mqb_module_dependency_graph_tests PRIVATE mqb_modules)
+target_compile_features(mqb_module_dependency_graph_tests PRIVATE cxx_std_23)
+
 if(MSVC)
     target_compile_options(mqb_p1689_tests PRIVATE /W4 /permissive-)
+    target_compile_options(mqb_module_dependency_graph_tests PRIVATE /W4 /permissive-)
 else()
     target_compile_options(mqb_p1689_tests PRIVATE -Wall -Wextra -Wpedantic)
+    target_compile_options(mqb_module_dependency_graph_tests PRIVATE -Wall -Wextra -Wpedantic)
 endif()
 
 add_test(NAME mqb.modules.p1689_parser COMMAND mqb_p1689_tests)
+add_test(NAME mqb.modules.dependency_graph COMMAND mqb_module_dependency_graph_tests)

--- a/cpp/modules/tests/module_dependency_graph_tests.cpp
+++ b/cpp/modules/tests/module_dependency_graph_tests.cpp
@@ -1,0 +1,219 @@
+#include <filesystem>
+#include <iostream>
+#include <string_view>
+#include <vector>
+
+#include "mqb/modules/ModuleDependencyGraph.hpp"
+
+namespace {
+
+namespace fs = std::filesystem;
+
+int failures = 0;
+
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+[[nodiscard]] mqb::modules::ProvidedModule provide(
+    std::string name,
+    const bool is_interface = true) {
+    return mqb::modules::ProvidedModule{
+        .logical_name = std::move(name),
+        .is_interface = is_interface,
+    };
+}
+
+[[nodiscard]] mqb::modules::RequiredModule require_named(std::string name) {
+    return mqb::modules::RequiredModule{
+        .logical_name = std::move(name),
+    };
+}
+
+[[nodiscard]] mqb::modules::ScannedModuleUnit unit(
+    fs::path source,
+    std::vector<mqb::modules::ProvidedModule> provided = {},
+    std::vector<mqb::modules::RequiredModule> required = {}) {
+    mqb::modules::P1689Rule rule;
+    rule.provided_modules = std::move(provided);
+    rule.required_modules = std::move(required);
+    return mqb::modules::ScannedModuleUnit{
+        .source = std::move(source),
+        .rule = std::move(rule),
+    };
+}
+
+} // namespace
+
+int main() {
+    using mqb::modules::LookupMethod;
+    using mqb::modules::ModuleDependencyGraphBuilder;
+    using mqb::modules::ModuleGraphErrorCode;
+    using mqb::modules::UnresolvedRequirementKind;
+
+    {
+        const std::vector units{
+            unit("math.ixx", {provide("math")}),
+            unit("stats.ixx", {provide("stats")}, {require_named("math")}),
+            unit("app.cpp", {}, {require_named("stats"), require_named("std")}),
+        };
+
+        auto plan = ModuleDependencyGraphBuilder::build(units);
+        expect(plan.has_value(), "named module chain should build a dependency plan");
+        if (plan) {
+            expect(plan->compile_levels.size() == 3,
+                   "provider chain should form three compile levels");
+            if (plan->compile_levels.size() == 3) {
+                expect(plan->compile_levels[0] == std::vector<fs::path>{"math.ixx"},
+                       "math provider should compile first");
+                expect(plan->compile_levels[1] == std::vector<fs::path>{"stats.ixx"},
+                       "stats provider should compile after math");
+                expect(plan->compile_levels[2] == std::vector<fs::path>{"app.cpp"},
+                       "consumer should compile after stats");
+            }
+            expect(plan->unresolved_requirements.size() == 1
+                       && plan->unresolved_requirements[0].requirement.logical_name == "std"
+                       && plan->unresolved_requirements[0].kind == UnresolvedRequirementKind::named_module,
+                   "external named modules should remain typed unresolved requirements");
+        }
+    }
+
+    {
+        const std::vector units{
+            unit("A.ixx", {provide("A")}),
+            unit("B.ixx", {provide("B")}, {require_named("A")}),
+            unit("C.ixx", {provide("C")}, {require_named("A")}),
+            unit("D.cpp", {}, {require_named("B"), require_named("C")}),
+        };
+
+        auto plan = ModuleDependencyGraphBuilder::build(units);
+        expect(plan.has_value(), "diamond graph should build successfully");
+        if (plan && plan->compile_levels.size() == 3) {
+            expect(plan->compile_levels[0] == std::vector<fs::path>{"A.ixx"},
+                   "diamond root should be first level");
+            expect(plan->compile_levels[1]
+                       == std::vector<fs::path>({"B.ixx", "C.ixx"}),
+                   "independent consumers should share one deterministic compile level");
+            expect(plan->compile_levels[2] == std::vector<fs::path>{"D.cpp"},
+                   "diamond sink should compile last");
+        }
+    }
+
+    {
+        const std::vector units{
+            unit("M.ixx", {provide("M", true)}),
+            unit("M_impl.cpp", {provide("M", false)}, {require_named("M")}),
+            unit("consumer.cpp", {}, {require_named("M")}),
+        };
+
+        auto plan = ModuleDependencyGraphBuilder::build(units);
+        expect(plan.has_value(),
+               "one interface provider should disambiguate same-name non-interface units");
+        if (plan) {
+            expect(plan->compile_levels.size() == 2,
+                   "interface provider should precede implementation and consumer");
+            if (plan->compile_levels.size() == 2) {
+                expect(plan->compile_levels[0] == std::vector<fs::path>{"M.ixx"},
+                       "interface unit should be selected as import provider");
+                expect(plan->compile_levels[1]
+                           == std::vector<fs::path>({"M_impl.cpp", "consumer.cpp"}),
+                       "implementation and ordinary consumer may follow the interface together");
+            }
+        }
+    }
+
+    {
+        const std::vector units{
+            unit("part.cppm", {provide("M:part", false)}),
+            unit("consumer.cpp", {}, {require_named("M:part")}),
+        };
+        auto plan = ModuleDependencyGraphBuilder::build(units);
+        expect(plan.has_value() && plan->compile_levels.size() == 2,
+               "a unique non-interface partition provider should be usable for ordering");
+    }
+
+    {
+        mqb::modules::RequiredModule header;
+        header.logical_name = "header.hpp";
+        header.source_path = fs::path{"include/header.hpp"};
+        header.unique_on_source_path = true;
+        header.lookup_method = LookupMethod::include_quote;
+
+        const std::vector units{
+            unit("consumer.cpp", {}, {header}),
+        };
+        auto plan = ModuleDependencyGraphBuilder::build(units);
+        expect(plan.has_value(), "header-unit requirements should not corrupt named-module graphing");
+        if (plan) {
+            expect(plan->unresolved_requirements.size() == 1
+                       && plan->unresolved_requirements[0].kind == UnresolvedRequirementKind::header_unit,
+                   "header units should remain explicitly unresolved until that milestone exists");
+        }
+    }
+
+    {
+        const std::vector units{
+            unit("first.ixx", {provide("M", true)}),
+            unit("second.ixx", {provide("M", true)}),
+        };
+        auto duplicate = ModuleDependencyGraphBuilder::build(units);
+        expect(!duplicate
+                   && duplicate.error().code == ModuleGraphErrorCode::duplicate_interface_provider,
+               "multiple interface providers for one logical module should fail explicitly");
+    }
+
+    {
+        const std::vector units{
+            unit("one.cpp", {provide("M", false)}),
+            unit("two.cpp", {provide("M", false)}),
+        };
+        auto ambiguous = ModuleDependencyGraphBuilder::build(units);
+        expect(!ambiguous
+                   && ambiguous.error().code == ModuleGraphErrorCode::ambiguous_named_provider,
+               "multiple non-interface providers without an interface should be ambiguous");
+    }
+
+    {
+        const std::vector units{
+            unit("same.cpp", {provide("A")}),
+            unit("same.cpp", {provide("B")}),
+        };
+        auto duplicate = ModuleDependencyGraphBuilder::build(units);
+        expect(!duplicate && duplicate.error().code == ModuleGraphErrorCode::duplicate_source,
+               "duplicate source units should be rejected before graphing");
+    }
+
+    {
+        const std::vector units{
+            unit("A.ixx", {provide("A")}, {require_named("B")}),
+            unit("B.ixx", {provide("B")}, {require_named("A")}),
+        };
+        auto cycle = ModuleDependencyGraphBuilder::build(units);
+        expect(!cycle && cycle.error().code == ModuleGraphErrorCode::dependency_cycle,
+               "module import cycles should surface as dependency-cycle errors");
+        if (!cycle) {
+            expect(cycle.error().graph_error.has_value(),
+                   "cycle error should retain the underlying graph diagnostic");
+        }
+    }
+
+    {
+        const std::vector units{
+            unit({}, {provide("A")}),
+        };
+        auto empty = ModuleDependencyGraphBuilder::build(units);
+        expect(!empty && empty.error().code == ModuleGraphErrorCode::empty_source,
+               "empty scanned source identity should fail closed");
+    }
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+
+    std::cout << "mqb_module_dependency_graph_tests passed\n";
+    return 0;
+}

--- a/cpp/modules/tests/module_dependency_resolution_tests.cpp
+++ b/cpp/modules/tests/module_dependency_resolution_tests.cpp
@@ -1,0 +1,117 @@
+#include <algorithm>
+#include <filesystem>
+#include <iostream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "mqb/modules/ModuleDependencyGraph.hpp"
+
+namespace {
+
+namespace fs = std::filesystem;
+int failures = 0;
+
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+[[nodiscard]] mqb::modules::ProvidedModule provide(
+    std::string name,
+    const bool is_interface = true) {
+    return mqb::modules::ProvidedModule{
+        .logical_name = std::move(name),
+        .is_interface = is_interface,
+    };
+}
+
+[[nodiscard]] mqb::modules::RequiredModule require_named(std::string name) {
+    return mqb::modules::RequiredModule{
+        .logical_name = std::move(name),
+    };
+}
+
+[[nodiscard]] mqb::modules::ScannedModuleUnit unit(
+    fs::path source,
+    std::vector<mqb::modules::ProvidedModule> provided = {},
+    std::vector<mqb::modules::RequiredModule> required = {}) {
+    mqb::modules::P1689Rule rule;
+    rule.provided_modules = std::move(provided);
+    rule.required_modules = std::move(required);
+    return mqb::modules::ScannedModuleUnit{
+        .source = std::move(source),
+        .rule = std::move(rule),
+    };
+}
+
+[[nodiscard]] bool has_edge(
+    const mqb::modules::ModuleDependencyPlan& plan,
+    const fs::path& consumer,
+    const fs::path& provider,
+    const std::string_view logical_name) {
+    return std::any_of(
+        plan.resolved_dependencies.begin(),
+        plan.resolved_dependencies.end(),
+        [&](const mqb::modules::ResolvedModuleDependency& dependency) {
+            return dependency.consumer_source == consumer
+                && dependency.provider_source == provider
+                && dependency.logical_name == logical_name;
+        });
+}
+
+} // namespace
+
+int main() {
+    using mqb::modules::ModuleDependencyGraphBuilder;
+
+    {
+        const std::vector units{
+            unit("math.ixx", {provide("math")}),
+            unit("stats.ixx", {provide("stats")}, {require_named("math")}),
+            unit("app.cpp", {}, {require_named("stats"), require_named("std")}),
+        };
+
+        const auto plan = ModuleDependencyGraphBuilder::build(units);
+        expect(plan.has_value(), "named module chain should resolve providers");
+        if (plan) {
+            expect(plan->resolved_dependencies.size() == 2,
+                   "only internal named-module requirements should become resolved edges");
+            expect(has_edge(*plan, "stats.ixx", "math.ixx", "math"),
+                   "stats should retain the exact provider source selected for logical module math");
+            expect(has_edge(*plan, "app.cpp", "stats.ixx", "stats"),
+                   "app should retain the exact provider source selected for logical module stats");
+            expect(!has_edge(*plan, "app.cpp", {}, "std"),
+                   "unresolved external modules must not be fabricated as resolved edges");
+        }
+    }
+
+    {
+        const std::vector units{
+            unit("M.ixx", {provide("M", true)}),
+            unit("M_impl.cpp", {provide("M", false)}, {require_named("M")}),
+            unit("consumer.cpp", {}, {require_named("M")}),
+        };
+
+        const auto plan = ModuleDependencyGraphBuilder::build(units);
+        expect(plan.has_value(), "interface provider should disambiguate same-name module units");
+        if (plan) {
+            expect(has_edge(*plan, "M_impl.cpp", "M.ixx", "M"),
+                   "implementation unit should reference the selected interface provider");
+            expect(has_edge(*plan, "consumer.cpp", "M.ixx", "M"),
+                   "ordinary consumer should reference the selected interface provider");
+            expect(!has_edge(*plan, "consumer.cpp", "M_impl.cpp", "M"),
+                   "non-interface same-name unit must not leak into provider resolution");
+        }
+    }
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+
+    std::cout << "mqb_module_dependency_resolution_tests passed\n";
+    return 0;
+}

--- a/cpp/modules/tests/p1689_tests.cpp
+++ b/cpp/modules/tests/p1689_tests.cpp
@@ -64,19 +64,19 @@ int main() {
                    "version and revision should be preserved");
             expect(document->rules.size() == 2,
                    "all P1689 rules should be preserved");
-            expect(document->rules[0].provides.size() == 1
-                       && document->rules[0].provides[0].logical_name == "duplicate",
+            expect(document->rules[0].provided_modules.size() == 1
+                       && document->rules[0].provided_modules[0].logical_name == "duplicate",
                    "provided named module should decode");
-            expect(document->rules[0].provides[0].is_interface,
+            expect(document->rules[0].provided_modules[0].is_interface,
                    "provided module should default is-interface to true");
-            expect(document->rules[1].provides[0].logical_name == "another"
-                       && !document->rules[1].provides[0].is_interface,
+            expect(document->rules[1].provided_modules[0].logical_name == "another"
+                       && !document->rules[1].provided_modules[0].is_interface,
                    "explicit is-interface=false should decode");
-            expect(document->rules[1].requires[0].lookup_method == LookupMethod::by_name,
+            expect(document->rules[1].required_modules[0].lookup_method == LookupMethod::by_name,
                    "required named module should default lookup-method to by-name");
-            expect(document->rules[1].requires[1].lookup_method == LookupMethod::include_quote
-                       && document->rules[1].requires[1].unique_on_source_path
-                       && document->rules[1].requires[1].source_path.has_value(),
+            expect(document->rules[1].required_modules[1].lookup_method == LookupMethod::include_quote
+                       && document->rules[1].required_modules[1].unique_on_source_path
+                       && document->rules[1].required_modules[1].source_path.has_value(),
                    "header-unit lookup identity should decode");
         }
     }

--- a/cpp/modules/tests/p1689_tests.cpp
+++ b/cpp/modules/tests/p1689_tests.cpp
@@ -1,0 +1,172 @@
+#include <iostream>
+#include <string>
+#include <string_view>
+
+#include "mqb/modules/P1689.hpp"
+
+namespace {
+
+int failures = 0;
+
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+} // namespace
+
+int main() {
+    using mqb::modules::LookupMethod;
+    using mqb::modules::P1689ErrorCode;
+    using mqb::modules::P1689Parser;
+
+    {
+        auto document = P1689Parser::parse(R"json({
+  "version": 1,
+  "revision": 0,
+  "rules": [
+    {
+      "primary-output": "duplicate.obj",
+      "provides": [
+        { "logical-name": "duplicate" }
+      ]
+    },
+    {
+      "primary-output": "another.obj",
+      "outputs": ["another.module.json"],
+      "provides": [
+        {
+          "logical-name": "another",
+          "compiled-module-path": "ifc/another.ifc",
+          "is-interface": false
+        }
+      ],
+      "requires": [
+        { "logical-name": "duplicate" },
+        {
+          "logical-name": "header.hpp",
+          "source-path": "C:\\project\\header.hpp",
+          "unique-on-source-path": true,
+          "lookup-method": "include-quote"
+        }
+      ],
+      "_MSVC_future": { "ignored": true }
+    }
+  ],
+  "_VENDOR_document": 1
+})json");
+
+        expect(document.has_value(), "valid P1689R5 document should parse");
+        if (document) {
+            expect(document->version == 1 && document->revision == 0,
+                   "version and revision should be preserved");
+            expect(document->rules.size() == 2,
+                   "all P1689 rules should be preserved");
+            expect(document->rules[0].provides.size() == 1
+                       && document->rules[0].provides[0].logical_name == "duplicate",
+                   "provided named module should decode");
+            expect(document->rules[0].provides[0].is_interface,
+                   "provided module should default is-interface to true");
+            expect(document->rules[1].provides[0].logical_name == "another"
+                       && !document->rules[1].provides[0].is_interface,
+                   "explicit is-interface=false should decode");
+            expect(document->rules[1].requires[0].lookup_method == LookupMethod::by_name,
+                   "required named module should default lookup-method to by-name");
+            expect(document->rules[1].requires[1].lookup_method == LookupMethod::include_quote
+                       && document->rules[1].requires[1].unique_on_source_path
+                       && document->rules[1].requires[1].source_path.has_value(),
+                   "header-unit lookup identity should decode");
+        }
+    }
+
+    {
+        auto no_revision = P1689Parser::parse(R"json({
+  "version": 1,
+  "rules": [ { "requires": [ { "logical-name": "std" } ] } ]
+})json");
+        expect(no_revision.has_value() && no_revision->revision == 0,
+               "omitted revision should default to zero");
+    }
+
+    {
+        auto unknown = P1689Parser::parse(R"json({
+  "version": 1,
+  "rules": [ { "mystery": true } ]
+})json");
+        expect(!unknown && unknown.error().code == P1689ErrorCode::schema_error,
+               "unknown non-vendor fields should be rejected");
+    }
+
+    {
+        auto missing_name = P1689Parser::parse(R"json({
+  "version": 1,
+  "rules": [ { "provides": [ { "is-interface": true } ] } ]
+})json");
+        expect(!missing_name && missing_name.error().code == P1689ErrorCode::schema_error,
+               "module descriptions must require logical-name");
+    }
+
+    {
+        auto missing_source = P1689Parser::parse(R"json({
+  "version": 1,
+  "rules": [ {
+    "requires": [ {
+      "logical-name": "header.hpp",
+      "unique-on-source-path": true
+    } ]
+  } ]
+})json");
+        expect(!missing_source && missing_source.error().code == P1689ErrorCode::schema_error,
+               "source-unique module identities must provide source-path");
+    }
+
+    {
+        auto bad_lookup = P1689Parser::parse(R"json({
+  "version": 1,
+  "rules": [ { "requires": [ {
+    "logical-name": "M",
+    "lookup-method": "magic"
+  } ] } ]
+})json");
+        expect(!bad_lookup && bad_lookup.error().code == P1689ErrorCode::schema_error,
+               "unknown lookup methods should be rejected");
+    }
+
+    {
+        auto bad_version = P1689Parser::parse(R"json({"version":2,"rules":[{}]})json");
+        expect(!bad_version && bad_version.error().code == P1689ErrorCode::unsupported_version,
+               "future semantic versions should fail explicitly");
+    }
+
+    {
+        auto bad_revision = P1689Parser::parse(R"json({"version":1,"revision":1,"rules":[{}]})json");
+        expect(!bad_revision && bad_revision.error().code == P1689ErrorCode::unsupported_revision,
+               "unsupported revisions should fail explicitly");
+    }
+
+    {
+        auto empty_rules = P1689Parser::parse(R"json({"version":1,"rules":[]})json");
+        expect(!empty_rules && empty_rules.error().code == P1689ErrorCode::schema_error,
+               "P1689 rules must be non-empty");
+    }
+
+    {
+        auto malformed = P1689Parser::parse("{\"version\":1,]");
+        expect(!malformed && malformed.error().code == P1689ErrorCode::parse_error,
+               "malformed JSON should remain a parse error");
+        if (!malformed) {
+            expect(malformed.error().line >= 1 && malformed.error().column >= 1,
+                   "P1689 parse errors should retain JSON coordinates");
+        }
+    }
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+
+    std::cout << "mqb_p1689_tests passed\n";
+    return 0;
+}

--- a/cpp/orchestration/CMakeLists.txt
+++ b/cpp/orchestration/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(mqb_orchestration STATIC
     src/MsvcIncrementalLinkCoordinator.cpp
     src/MsvcIncrementalTargetCoordinator.cpp
     src/MsvcModuleCompileCoordinator.cpp
+    src/MsvcModuleTargetCoordinator.cpp
 )
 
 target_include_directories(mqb_orchestration

--- a/cpp/orchestration/CMakeLists.txt
+++ b/cpp/orchestration/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(mqb_orchestration STATIC
     src/MsvcIncrementalCompileCoordinator.cpp
     src/MsvcIncrementalLinkCoordinator.cpp
     src/MsvcIncrementalTargetCoordinator.cpp
+    src/MsvcModuleCompileCoordinator.cpp
 )
 
 target_include_directories(mqb_orchestration
@@ -13,6 +14,7 @@ target_include_directories(mqb_orchestration
 target_link_libraries(mqb_orchestration
     PUBLIC
         mqb_core
+        mqb_modules
         mqb_msvc
         mqb_process
 )

--- a/cpp/orchestration/include/mqb/orchestration/MsvcIncrementalCompileCoordinator.hpp
+++ b/cpp/orchestration/include/mqb/orchestration/MsvcIncrementalCompileCoordinator.hpp
@@ -24,6 +24,7 @@ struct IncrementalCompileRequest {
     std::filesystem::path cache_file;
     std::filesystem::path source_dependencies_file;
     std::optional<std::filesystem::path> working_directory;
+    bool force_rebuild{false};
 };
 
 enum class IncrementalCompileWarningCode {

--- a/cpp/orchestration/include/mqb/orchestration/MsvcModuleCompileCoordinator.hpp
+++ b/cpp/orchestration/include/mqb/orchestration/MsvcModuleCompileCoordinator.hpp
@@ -38,6 +38,8 @@ enum class ModuleCompileErrorCode {
     no_sources,
     invalid_parallelism,
     duplicate_source,
+    invalid_artifact,
+    artifact_collision,
     plan_source_missing,
     plan_source_duplicate,
     plan_source_unlisted,
@@ -52,6 +54,7 @@ struct ModuleCompileError {
     ModuleCompileErrorCode code{ModuleCompileErrorCode::no_sources};
     std::string message;
     std::filesystem::path source;
+    std::filesystem::path artifact;
     std::filesystem::path provider_source;
     std::string logical_name;
     std::optional<IncrementalCompileError> compile_error;

--- a/cpp/orchestration/include/mqb/orchestration/MsvcModuleCompileCoordinator.hpp
+++ b/cpp/orchestration/include/mqb/orchestration/MsvcModuleCompileCoordinator.hpp
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <cstddef>
+#include <expected>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "mqb/core/CompilerOptions.hpp"
+#include "mqb/core/ProjectArtifactLayout.hpp"
+#include "mqb/core/TranslationUnit.hpp"
+#include "mqb/modules/ModuleDependencyGraph.hpp"
+#include "mqb/orchestration/MsvcIncrementalCompileCoordinator.hpp"
+
+namespace mqb::orchestration {
+
+struct ModuleCompileSourceRequest {
+    std::filesystem::path source;
+    SourceArtifacts artifacts;
+    TranslationUnitKind kind{TranslationUnitKind::source};
+};
+
+struct ModuleCompileWaveRequest {
+    std::vector<ModuleCompileSourceRequest> sources;
+    modules::ModuleDependencyPlan plan;
+    CompilerOptions compiler_options;
+    std::filesystem::path working_directory;
+    std::size_t max_parallel_compiles{1};
+};
+
+struct ModuleCompileResult {
+    std::filesystem::path source;
+    IncrementalCompileResult result;
+};
+
+enum class ModuleCompileErrorCode {
+    no_sources,
+    invalid_parallelism,
+    duplicate_source,
+    plan_source_missing,
+    plan_source_duplicate,
+    plan_source_unlisted,
+    unresolved_requirement,
+    invalid_provider,
+    duplicate_reference,
+    scheduling_failed,
+    compile_failed,
+};
+
+struct ModuleCompileError {
+    ModuleCompileErrorCode code{ModuleCompileErrorCode::no_sources};
+    std::string message;
+    std::filesystem::path source;
+    std::filesystem::path provider_source;
+    std::string logical_name;
+    std::optional<IncrementalCompileError> compile_error;
+};
+
+struct ModuleCompileWaveResult {
+    // Results are returned in request.sources order, independent of graph level
+    // order and worker completion order.
+    std::vector<ModuleCompileResult> compiles;
+    bool any_compiled{false};
+};
+
+class MsvcModuleCompileCoordinator {
+public:
+    explicit MsvcModuleCompileCoordinator(
+        MsvcIncrementalCompileCoordinator& compile_coordinator)
+        : compile_coordinator_(compile_coordinator) {}
+
+    [[nodiscard]] std::expected<ModuleCompileWaveResult, ModuleCompileError>
+    run(const ModuleCompileWaveRequest& request) const;
+
+private:
+    MsvcIncrementalCompileCoordinator& compile_coordinator_;
+};
+
+} // namespace mqb::orchestration

--- a/cpp/orchestration/include/mqb/orchestration/MsvcModuleTargetCoordinator.hpp
+++ b/cpp/orchestration/include/mqb/orchestration/MsvcModuleTargetCoordinator.hpp
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <cstddef>
+#include <expected>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "mqb/core/CompilerOptions.hpp"
+#include "mqb/core/LinkOptions.hpp"
+#include "mqb/core/ProjectArtifactLayout.hpp"
+#include "mqb/modules/ModuleDependencyGraph.hpp"
+#include "mqb/msvc/MsvcModuleDependencyScanner.hpp"
+#include "mqb/orchestration/MsvcIncrementalLinkCoordinator.hpp"
+#include "mqb/orchestration/MsvcModuleCompileCoordinator.hpp"
+
+namespace mqb::orchestration {
+
+struct IncrementalModuleTargetRequest {
+    std::vector<ModuleCompileSourceRequest> sources;
+    TargetArtifacts target;
+    CompilerOptions compiler_options;
+    LinkOptions link_options;
+    std::filesystem::path working_directory;
+    std::size_t max_parallel_scans{1};
+    std::size_t max_parallel_compiles{1};
+};
+
+struct ModuleTargetScanResult {
+    std::filesystem::path source;
+    msvc::ModuleScanResult result;
+};
+
+enum class IncrementalModuleTargetErrorCode {
+    no_sources,
+    invalid_parallelism,
+    duplicate_source,
+    duplicate_scan_output,
+    scheduling_failed,
+    scan_failed,
+    invalid_scan_result,
+    graph_failed,
+    compile_failed,
+    link_failed,
+};
+
+struct IncrementalModuleTargetError {
+    IncrementalModuleTargetErrorCode code{IncrementalModuleTargetErrorCode::no_sources};
+    std::string message;
+    std::filesystem::path source;
+    std::optional<msvc::ModuleScanError> scan_error;
+    std::optional<modules::ModuleGraphError> graph_error;
+    std::optional<ModuleCompileError> compile_error;
+    std::optional<IncrementalLinkError> link_error;
+};
+
+struct IncrementalModuleTargetResult {
+    // Scan and compile results both preserve request.sources ordering.
+    std::vector<ModuleTargetScanResult> scans;
+    modules::ModuleDependencyPlan plan;
+    ModuleCompileWaveResult compiles;
+    IncrementalLinkResult link;
+};
+
+class MsvcModuleTargetCoordinator {
+public:
+    MsvcModuleTargetCoordinator(
+        msvc::MsvcModuleDependencyScanner& scanner,
+        MsvcModuleCompileCoordinator& compile_coordinator,
+        MsvcIncrementalLinkCoordinator& link_coordinator)
+        : scanner_(scanner),
+          compile_coordinator_(compile_coordinator),
+          link_coordinator_(link_coordinator) {}
+
+    [[nodiscard]] std::expected<IncrementalModuleTargetResult, IncrementalModuleTargetError>
+    run(const IncrementalModuleTargetRequest& request) const;
+
+private:
+    msvc::MsvcModuleDependencyScanner& scanner_;
+    MsvcModuleCompileCoordinator& compile_coordinator_;
+    MsvcIncrementalLinkCoordinator& link_coordinator_;
+};
+
+} // namespace mqb::orchestration

--- a/cpp/orchestration/include/mqb/orchestration/MsvcModuleTargetCoordinator.hpp
+++ b/cpp/orchestration/include/mqb/orchestration/MsvcModuleTargetCoordinator.hpp
@@ -36,7 +36,8 @@ enum class IncrementalModuleTargetErrorCode {
     no_sources,
     invalid_parallelism,
     duplicate_source,
-    duplicate_scan_output,
+    invalid_artifact,
+    artifact_collision,
     scheduling_failed,
     scan_failed,
     invalid_scan_result,
@@ -49,6 +50,7 @@ struct IncrementalModuleTargetError {
     IncrementalModuleTargetErrorCode code{IncrementalModuleTargetErrorCode::no_sources};
     std::string message;
     std::filesystem::path source;
+    std::filesystem::path artifact;
     std::optional<msvc::ModuleScanError> scan_error;
     std::optional<modules::ModuleGraphError> graph_error;
     std::optional<ModuleCompileError> compile_error;

--- a/cpp/orchestration/src/MsvcIncrementalCompileCoordinator.cpp
+++ b/cpp/orchestration/src/MsvcIncrementalCompileCoordinator.cpp
@@ -1,5 +1,6 @@
 #include "mqb/orchestration/MsvcIncrementalCompileCoordinator.hpp"
 
+#include <algorithm>
 #include <array>
 #include <expected>
 #include <filesystem>
@@ -95,6 +96,14 @@ void append_warning(
     }
 }
 
+void add_reason_once(
+    std::vector<BuildReason>& reasons,
+    const BuildReason reason) {
+    if (std::find(reasons.begin(), reasons.end(), reason) == reasons.end()) {
+        reasons.push_back(reason);
+    }
+}
+
 } // namespace
 
 std::expected<IncrementalCompileResult, IncrementalCompileError>
@@ -142,6 +151,10 @@ MsvcIncrementalCompileCoordinator::run(const IncrementalCompileRequest& request)
         source_snapshot.snapshot,
         output_snapshots,
         dependency_snapshots);
+
+    if (request.force_rebuild) {
+        add_reason_once(result.validation.reasons, BuildReason::explicit_rebuild);
+    }
 
     const std::array<CompilePlanItem, 1> items{
         CompilePlanItem{

--- a/cpp/orchestration/src/MsvcIncrementalCompileCoordinator.cpp
+++ b/cpp/orchestration/src/MsvcIncrementalCompileCoordinator.cpp
@@ -9,7 +9,6 @@
 #include <utility>
 #include <vector>
 
-#include "mqb/core/Artifact.hpp"
 #include "mqb/core/BuildPlanner.hpp"
 #include "mqb/core/CompileCache.hpp"
 #include "mqb/core/CompileCacheFile.hpp"
@@ -88,15 +87,6 @@ struct SnapshotResult {
     };
 }
 
-[[nodiscard]] fs::path first_object_path(const TranslationUnit& unit) {
-    for (const auto& output : unit.outputs) {
-        if (output.kind == ArtifactKind::object) {
-            return output.path;
-        }
-    }
-    return {};
-}
-
 void append_warning(
     std::vector<IncrementalCompileWarning>& warnings,
     std::optional<IncrementalCompileWarning> warning) {
@@ -126,8 +116,13 @@ MsvcIncrementalCompileCoordinator::run(const IncrementalCompileRequest& request)
     auto source_snapshot = snapshot_file(request.unit.source);
     append_warning(result.warnings, std::move(source_snapshot.warning));
 
-    auto object_snapshot = snapshot_file(first_object_path(request.unit));
-    append_warning(result.warnings, std::move(object_snapshot.warning));
+    std::vector<FileSnapshot> output_snapshots;
+    output_snapshots.reserve(request.unit.outputs.size());
+    for (const auto& output : request.unit.outputs) {
+        auto output_snapshot = snapshot_file(output.path);
+        append_warning(result.warnings, std::move(output_snapshot.warning));
+        output_snapshots.push_back(std::move(output_snapshot.snapshot));
+    }
 
     std::vector<FileSnapshot> dependency_snapshots;
     if (cached_entry) {
@@ -145,7 +140,7 @@ MsvcIncrementalCompileCoordinator::run(const IncrementalCompileRequest& request)
         request.options,
         cached_entry,
         source_snapshot.snapshot,
-        object_snapshot.snapshot,
+        output_snapshots,
         dependency_snapshots);
 
     const std::array<CompilePlanItem, 1> items{

--- a/cpp/orchestration/src/MsvcModuleCompileCoordinator.cpp
+++ b/cpp/orchestration/src/MsvcModuleCompileCoordinator.cpp
@@ -1,0 +1,270 @@
+#include "mqb/orchestration/MsvcModuleCompileCoordinator.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <expected>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "mqb/core/Artifact.hpp"
+#include "mqb/core/TranslationUnit.hpp"
+#include "mqb/orchestration/BoundedWorkScheduler.hpp"
+
+namespace mqb::orchestration {
+namespace {
+
+namespace fs = std::filesystem;
+
+[[nodiscard]] std::string windows_path_key(const fs::path& path) {
+    std::string value = path.lexically_normal().generic_string();
+    std::transform(
+        value.begin(),
+        value.end(),
+        value.begin(),
+        [](const unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+    return value;
+}
+
+[[nodiscard]] ModuleCompileError failure(
+    const ModuleCompileErrorCode code,
+    std::string message,
+    fs::path source = {},
+    fs::path provider_source = {},
+    std::string logical_name = {}) {
+    return ModuleCompileError{
+        .code = code,
+        .message = std::move(message),
+        .source = std::move(source),
+        .provider_source = std::move(provider_source),
+        .logical_name = std::move(logical_name),
+    };
+}
+
+[[nodiscard]] IncrementalCompileRequest compile_request_for(
+    const ModuleCompileSourceRequest& source,
+    const CompilerOptions& options,
+    const std::vector<ModuleReference>& references,
+    const bool force_rebuild,
+    const fs::path& working_directory) {
+    TranslationUnit unit;
+    unit.source = source.source;
+    unit.kind = source.kind;
+    unit.module_references = references;
+    unit.outputs.push_back(Artifact{
+        .path = source.artifacts.object,
+        .kind = ArtifactKind::object,
+    });
+    if (source.kind == TranslationUnitKind::module_interface) {
+        unit.outputs.push_back(Artifact{
+            .path = source.artifacts.module_interface,
+            .kind = ArtifactKind::module_interface,
+        });
+    }
+
+    return IncrementalCompileRequest{
+        .unit = std::move(unit),
+        .options = options,
+        .cache_file = source.artifacts.compile_cache,
+        .source_dependencies_file = source.artifacts.dependencies,
+        .working_directory = working_directory.empty()
+            ? std::optional<fs::path>{source.source.parent_path()}
+            : std::optional<fs::path>{working_directory},
+        .force_rebuild = force_rebuild,
+    };
+}
+
+} // namespace
+
+std::expected<ModuleCompileWaveResult, ModuleCompileError>
+MsvcModuleCompileCoordinator::run(const ModuleCompileWaveRequest& request) const {
+    if (request.sources.empty()) {
+        return std::unexpected(failure(
+            ModuleCompileErrorCode::no_sources,
+            "module compile wave requires at least one source"));
+    }
+    if (request.max_parallel_compiles == 0) {
+        return std::unexpected(failure(
+            ModuleCompileErrorCode::invalid_parallelism,
+            "module compile parallelism must be at least one"));
+    }
+    if (!request.plan.unresolved_requirements.empty()) {
+        const auto& unresolved = request.plan.unresolved_requirements.front();
+        return std::unexpected(failure(
+            ModuleCompileErrorCode::unresolved_requirement,
+            "module compile wave contains a requirement that this milestone cannot yet satisfy",
+            unresolved.consumer_source,
+            {},
+            unresolved.requirement.logical_name));
+    }
+
+    std::unordered_map<std::string, std::size_t> source_by_key;
+    source_by_key.reserve(request.sources.size());
+    for (std::size_t index = 0; index < request.sources.size(); ++index) {
+        const std::string key = windows_path_key(request.sources[index].source);
+        if (!source_by_key.emplace(key, index).second) {
+            return std::unexpected(failure(
+                ModuleCompileErrorCode::duplicate_source,
+                "module compile request contains the same source more than once",
+                request.sources[index].source));
+        }
+    }
+
+    std::vector<std::size_t> plan_occurrences(request.sources.size(), 0);
+    std::vector<std::vector<std::size_t>> level_indices;
+    level_indices.reserve(request.plan.compile_levels.size());
+    for (const auto& level : request.plan.compile_levels) {
+        auto& indices = level_indices.emplace_back();
+        indices.reserve(level.size());
+        for (const auto& source : level) {
+            const auto found = source_by_key.find(windows_path_key(source));
+            if (found == source_by_key.end()) {
+                return std::unexpected(failure(
+                    ModuleCompileErrorCode::plan_source_missing,
+                    "module dependency plan references a source absent from the compile request",
+                    source));
+            }
+            if (++plan_occurrences[found->second] != 1) {
+                return std::unexpected(failure(
+                    ModuleCompileErrorCode::plan_source_duplicate,
+                    "module dependency plan schedules a source more than once",
+                    source));
+            }
+            indices.push_back(found->second);
+        }
+    }
+    for (std::size_t index = 0; index < plan_occurrences.size(); ++index) {
+        if (plan_occurrences[index] == 0) {
+            return std::unexpected(failure(
+                ModuleCompileErrorCode::plan_source_unlisted,
+                "module compile source is missing from dependency-plan compile levels",
+                request.sources[index].source));
+        }
+    }
+
+    std::vector<std::vector<ModuleReference>> references(request.sources.size());
+    std::vector<std::vector<std::size_t>> provider_indices(request.sources.size());
+    for (const auto& dependency : request.plan.resolved_dependencies) {
+        const auto consumer = source_by_key.find(windows_path_key(dependency.consumer_source));
+        const auto provider = source_by_key.find(windows_path_key(dependency.provider_source));
+        if (consumer == source_by_key.end() || provider == source_by_key.end()) {
+            return std::unexpected(failure(
+                ModuleCompileErrorCode::plan_source_missing,
+                "resolved module dependency references a source absent from the compile request",
+                dependency.consumer_source,
+                dependency.provider_source,
+                dependency.logical_name));
+        }
+
+        const auto& provider_request = request.sources[provider->second];
+        if (provider_request.kind != TranslationUnitKind::module_interface
+            || provider_request.artifacts.module_interface.empty()) {
+            return std::unexpected(failure(
+                ModuleCompileErrorCode::invalid_provider,
+                "resolved named-module provider cannot produce an IFC artifact",
+                dependency.consumer_source,
+                dependency.provider_source,
+                dependency.logical_name));
+        }
+
+        auto& consumer_references = references[consumer->second];
+        const auto duplicate = std::find_if(
+            consumer_references.begin(),
+            consumer_references.end(),
+            [&dependency](const ModuleReference& reference) {
+                return reference.logical_name == dependency.logical_name;
+            });
+        if (duplicate != consumer_references.end()) {
+            return std::unexpected(failure(
+                ModuleCompileErrorCode::duplicate_reference,
+                "module dependency plan resolves the same logical name more than once for one consumer",
+                dependency.consumer_source,
+                dependency.provider_source,
+                dependency.logical_name));
+        }
+
+        consumer_references.push_back(ModuleReference{
+            .logical_name = dependency.logical_name,
+            .interface_file = provider_request.artifacts.module_interface,
+        });
+        provider_indices[consumer->second].push_back(provider->second);
+    }
+
+    using CompileAttempt = std::expected<IncrementalCompileResult, IncrementalCompileError>;
+    std::vector<std::optional<CompileAttempt>> attempts(request.sources.size());
+    std::vector<bool> compiled_this_run(request.sources.size(), false);
+
+    for (const auto& level : level_indices) {
+        const auto scheduled = BoundedWorkScheduler::run(
+            level.size(),
+            request.max_parallel_compiles,
+            [&](const std::size_t level_index) {
+                const std::size_t source_index = level[level_index];
+                bool force_rebuild = false;
+                for (const auto provider_index : provider_indices[source_index]) {
+                    force_rebuild = force_rebuild || compiled_this_run[provider_index];
+                }
+
+                auto compile_request = compile_request_for(
+                    request.sources[source_index],
+                    request.compiler_options,
+                    references[source_index],
+                    force_rebuild,
+                    request.working_directory);
+                attempts[source_index].emplace(compile_coordinator_.run(compile_request));
+                return attempts[source_index]->has_value();
+            });
+        if (!scheduled) {
+            return std::unexpected(failure(
+                ModuleCompileErrorCode::scheduling_failed,
+                "module compile scheduler failed: " + scheduled.error().message));
+        }
+
+        for (const auto source_index : level) {
+            if (!attempts[source_index]) {
+                continue;
+            }
+            if (!attempts[source_index]->has_value()) {
+                ModuleCompileError error = failure(
+                    ModuleCompileErrorCode::compile_failed,
+                    "module translation unit compilation failed",
+                    request.sources[source_index].source);
+                error.compile_error = attempts[source_index]->error();
+                return std::unexpected(std::move(error));
+            }
+        }
+
+        for (const auto source_index : level) {
+            if (!attempts[source_index]) {
+                return std::unexpected(failure(
+                    ModuleCompileErrorCode::scheduling_failed,
+                    "module scheduler stopped without a recorded compile failure",
+                    request.sources[source_index].source));
+            }
+            compiled_this_run[source_index] = attempts[source_index]->value().compiled;
+        }
+    }
+
+    ModuleCompileWaveResult result;
+    result.compiles.reserve(request.sources.size());
+    for (std::size_t index = 0; index < request.sources.size(); ++index) {
+        if (!attempts[index] || !attempts[index]->has_value()) {
+            return std::unexpected(failure(
+                ModuleCompileErrorCode::scheduling_failed,
+                "module compile result is missing after all dependency levels completed",
+                request.sources[index].source));
+        }
+        auto compiled = std::move(attempts[index]->value());
+        result.any_compiled = result.any_compiled || compiled.compiled;
+        result.compiles.push_back(ModuleCompileResult{
+            .source = request.sources[index].source,
+            .result = std::move(compiled),
+        });
+    }
+    return result;
+}
+
+} // namespace mqb::orchestration

--- a/cpp/orchestration/src/MsvcModuleCompileCoordinator.cpp
+++ b/cpp/orchestration/src/MsvcModuleCompileCoordinator.cpp
@@ -7,6 +7,7 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -42,6 +43,42 @@ namespace fs = std::filesystem;
         .provider_source = std::move(provider_source),
         .logical_name = std::move(logical_name),
     };
+}
+
+[[nodiscard]] ModuleCompileError artifact_failure(
+    const ModuleCompileErrorCode code,
+    std::string message,
+    const fs::path& source,
+    const fs::path& artifact) {
+    return ModuleCompileError{
+        .code = code,
+        .message = std::move(message),
+        .source = source,
+        .artifact = artifact,
+    };
+}
+
+[[nodiscard]] std::optional<ModuleCompileError> claim_artifact(
+    std::unordered_set<std::string>& claimed,
+    const fs::path& source,
+    const fs::path& artifact,
+    const std::string_view role) {
+    if (artifact.empty()) {
+        return artifact_failure(
+            ModuleCompileErrorCode::invalid_artifact,
+            "module compile " + std::string{role} + " artifact path is empty",
+            source,
+            artifact);
+    }
+    if (!claimed.emplace(windows_path_key(artifact)).second) {
+        return artifact_failure(
+            ModuleCompileErrorCode::artifact_collision,
+            "module compile " + std::string{role}
+                + " artifact collides with another planned writable artifact",
+            source,
+            artifact);
+    }
+    return std::nullopt;
 }
 
 [[nodiscard]] IncrementalCompileRequest compile_request_for(
@@ -103,13 +140,45 @@ MsvcModuleCompileCoordinator::run(const ModuleCompileWaveRequest& request) const
 
     std::unordered_map<std::string, std::size_t> source_by_key;
     source_by_key.reserve(request.sources.size());
+    std::unordered_set<std::string> claimed_artifacts;
+    claimed_artifacts.reserve(request.sources.size() * 4u);
+
     for (std::size_t index = 0; index < request.sources.size(); ++index) {
-        const std::string key = windows_path_key(request.sources[index].source);
+        const auto& source = request.sources[index];
+        const std::string key = windows_path_key(source.source);
         if (!source_by_key.emplace(key, index).second) {
             return std::unexpected(failure(
                 ModuleCompileErrorCode::duplicate_source,
                 "module compile request contains the same source more than once",
-                request.sources[index].source));
+                source.source));
+        }
+
+        if (auto error = claim_artifact(
+                claimed_artifacts, source.source, source.artifacts.object, "object")) {
+            return std::unexpected(std::move(*error));
+        }
+        if (auto error = claim_artifact(
+                claimed_artifacts,
+                source.source,
+                source.artifacts.dependencies,
+                "source-dependency metadata")) {
+            return std::unexpected(std::move(*error));
+        }
+        if (auto error = claim_artifact(
+                claimed_artifacts,
+                source.source,
+                source.artifacts.compile_cache,
+                "compile-cache metadata")) {
+            return std::unexpected(std::move(*error));
+        }
+        if (source.kind == TranslationUnitKind::module_interface) {
+            if (auto error = claim_artifact(
+                    claimed_artifacts,
+                    source.source,
+                    source.artifacts.module_interface,
+                    "IFC")) {
+                return std::unexpected(std::move(*error));
+            }
         }
     }
 

--- a/cpp/orchestration/src/MsvcModuleTargetCoordinator.cpp
+++ b/cpp/orchestration/src/MsvcModuleTargetCoordinator.cpp
@@ -6,6 +6,7 @@
 #include <filesystem>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -40,6 +41,42 @@ namespace fs = std::filesystem;
     };
 }
 
+[[nodiscard]] IncrementalModuleTargetError artifact_failure(
+    const IncrementalModuleTargetErrorCode code,
+    std::string message,
+    const fs::path& source,
+    const fs::path& artifact) {
+    return IncrementalModuleTargetError{
+        .code = code,
+        .message = std::move(message),
+        .source = source,
+        .artifact = artifact,
+    };
+}
+
+[[nodiscard]] std::optional<IncrementalModuleTargetError> claim_artifact(
+    std::unordered_set<std::string>& claimed,
+    const fs::path& source,
+    const fs::path& artifact,
+    const std::string_view role) {
+    if (artifact.empty()) {
+        return artifact_failure(
+            IncrementalModuleTargetErrorCode::invalid_artifact,
+            "module target " + std::string{role} + " artifact path is empty",
+            source,
+            artifact);
+    }
+    if (!claimed.emplace(windows_path_key(artifact)).second) {
+        return artifact_failure(
+            IncrementalModuleTargetErrorCode::artifact_collision,
+            "module target " + std::string{role}
+                + " artifact collides with another planned writable artifact",
+            source,
+            artifact);
+    }
+    return std::nullopt;
+}
+
 [[nodiscard]] std::optional<fs::path> working_directory_for(
     const fs::path& requested,
     const fs::path& source) {
@@ -68,23 +105,67 @@ MsvcModuleTargetCoordinator::run(const IncrementalModuleTargetRequest& request) 
     }
 
     std::unordered_set<std::string> seen_sources;
-    std::unordered_set<std::string> seen_scan_outputs;
+    std::unordered_set<std::string> claimed_artifacts;
     seen_sources.reserve(request.sources.size());
-    seen_scan_outputs.reserve(request.sources.size());
+    claimed_artifacts.reserve(request.sources.size() * 5u + 2u);
+
     for (const auto& source : request.sources) {
+        if (source.source.empty()) {
+            return std::unexpected(failure(
+                IncrementalModuleTargetErrorCode::duplicate_source,
+                "module target source path is empty",
+                source.source));
+        }
         if (!seen_sources.emplace(windows_path_key(source.source)).second) {
             return std::unexpected(failure(
                 IncrementalModuleTargetErrorCode::duplicate_source,
                 "module target contains the same source more than once",
                 source.source));
         }
-        if (!seen_scan_outputs.emplace(
-                windows_path_key(source.artifacts.module_dependencies)).second) {
-            return std::unexpected(failure(
-                IncrementalModuleTargetErrorCode::duplicate_scan_output,
-                "two module target sources map to the same scan metadata output",
-                source.source));
+
+        if (auto error = claim_artifact(
+                claimed_artifacts, source.source, source.artifacts.object, "object")) {
+            return std::unexpected(std::move(*error));
         }
+        if (auto error = claim_artifact(
+                claimed_artifacts,
+                source.source,
+                source.artifacts.dependencies,
+                "source-dependency metadata")) {
+            return std::unexpected(std::move(*error));
+        }
+        if (auto error = claim_artifact(
+                claimed_artifacts,
+                source.source,
+                source.artifacts.module_dependencies,
+                "module-scan metadata")) {
+            return std::unexpected(std::move(*error));
+        }
+        if (auto error = claim_artifact(
+                claimed_artifacts,
+                source.source,
+                source.artifacts.compile_cache,
+                "compile-cache metadata")) {
+            return std::unexpected(std::move(*error));
+        }
+        if (source.kind == TranslationUnitKind::module_interface) {
+            if (auto error = claim_artifact(
+                    claimed_artifacts,
+                    source.source,
+                    source.artifacts.module_interface,
+                    "IFC")) {
+                return std::unexpected(std::move(*error));
+            }
+        }
+    }
+
+    if (auto error = claim_artifact(
+            claimed_artifacts, {}, request.target.executable, "executable")) {
+        return std::unexpected(std::move(*error));
+    }
+    if (auto error = claim_artifact(
+            claimed_artifacts, {}, request.target.link_cache, "link-cache metadata")) {
+        return std::unexpected(std::move(*error));
     }
 
     using ScanAttempt = std::expected<msvc::ModuleScanResult, msvc::ModuleScanError>;

--- a/cpp/orchestration/src/MsvcModuleTargetCoordinator.cpp
+++ b/cpp/orchestration/src/MsvcModuleTargetCoordinator.cpp
@@ -1,0 +1,219 @@
+#include "mqb/orchestration/MsvcModuleTargetCoordinator.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <expected>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "mqb/modules/ModuleDependencyGraph.hpp"
+#include "mqb/msvc/MsvcModuleDependencyScanner.hpp"
+#include "mqb/orchestration/BoundedWorkScheduler.hpp"
+
+namespace mqb::orchestration {
+namespace {
+
+namespace fs = std::filesystem;
+
+[[nodiscard]] std::string windows_path_key(const fs::path& path) {
+    std::string value = path.lexically_normal().generic_string();
+    std::transform(
+        value.begin(),
+        value.end(),
+        value.begin(),
+        [](const unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+    return value;
+}
+
+[[nodiscard]] IncrementalModuleTargetError failure(
+    const IncrementalModuleTargetErrorCode code,
+    std::string message,
+    fs::path source = {}) {
+    return IncrementalModuleTargetError{
+        .code = code,
+        .message = std::move(message),
+        .source = std::move(source),
+    };
+}
+
+[[nodiscard]] std::optional<fs::path> working_directory_for(
+    const fs::path& requested,
+    const fs::path& source) {
+    if (!requested.empty()) {
+        return requested;
+    }
+    if (!source.parent_path().empty()) {
+        return source.parent_path();
+    }
+    return std::nullopt;
+}
+
+} // namespace
+
+std::expected<IncrementalModuleTargetResult, IncrementalModuleTargetError>
+MsvcModuleTargetCoordinator::run(const IncrementalModuleTargetRequest& request) const {
+    if (request.sources.empty()) {
+        return std::unexpected(failure(
+            IncrementalModuleTargetErrorCode::no_sources,
+            "module target requires at least one source"));
+    }
+    if (request.max_parallel_scans == 0 || request.max_parallel_compiles == 0) {
+        return std::unexpected(failure(
+            IncrementalModuleTargetErrorCode::invalid_parallelism,
+            "module target scan and compile parallelism must both be at least one"));
+    }
+
+    std::unordered_set<std::string> seen_sources;
+    std::unordered_set<std::string> seen_scan_outputs;
+    seen_sources.reserve(request.sources.size());
+    seen_scan_outputs.reserve(request.sources.size());
+    for (const auto& source : request.sources) {
+        if (!seen_sources.emplace(windows_path_key(source.source)).second) {
+            return std::unexpected(failure(
+                IncrementalModuleTargetErrorCode::duplicate_source,
+                "module target contains the same source more than once",
+                source.source));
+        }
+        if (!seen_scan_outputs.emplace(
+                windows_path_key(source.artifacts.module_dependencies)).second) {
+            return std::unexpected(failure(
+                IncrementalModuleTargetErrorCode::duplicate_scan_output,
+                "two module target sources map to the same scan metadata output",
+                source.source));
+        }
+    }
+
+    using ScanAttempt = std::expected<msvc::ModuleScanResult, msvc::ModuleScanError>;
+    std::vector<std::optional<ScanAttempt>> attempts(request.sources.size());
+
+    const auto scheduled = BoundedWorkScheduler::run(
+        request.sources.size(),
+        request.max_parallel_scans,
+        [&](const std::size_t index) {
+            const auto& source = request.sources[index];
+            msvc::ModuleScanInvocation invocation{
+                .source = source.source,
+                .output_file = source.artifacts.module_dependencies,
+                .options = request.compiler_options,
+                .kind = source.kind,
+                .working_directory = working_directory_for(
+                    request.working_directory,
+                    source.source),
+            };
+            attempts[index].emplace(scanner_.scan(invocation));
+            return attempts[index]->has_value();
+        });
+    if (!scheduled) {
+        return std::unexpected(failure(
+            IncrementalModuleTargetErrorCode::scheduling_failed,
+            "module scan scheduler failed: " + scheduled.error().message));
+    }
+
+    // After all scan workers join, report the lowest request-index failure so
+    // diagnostics do not depend on which concurrent process completed first.
+    for (std::size_t index = 0; index < attempts.size(); ++index) {
+        if (!attempts[index]) {
+            continue;
+        }
+        if (!attempts[index]->has_value()) {
+            IncrementalModuleTargetError error = failure(
+                IncrementalModuleTargetErrorCode::scan_failed,
+                "module dependency scan failed",
+                request.sources[index].source);
+            error.scan_error = attempts[index]->error();
+            return std::unexpected(std::move(error));
+        }
+    }
+
+    IncrementalModuleTargetResult result;
+    result.scans.reserve(request.sources.size());
+    std::vector<modules::ScannedModuleUnit> scanned_units;
+    scanned_units.reserve(request.sources.size());
+
+    for (std::size_t index = 0; index < request.sources.size(); ++index) {
+        if (!attempts[index]) {
+            return std::unexpected(failure(
+                IncrementalModuleTargetErrorCode::scheduling_failed,
+                "module scan scheduler stopped without a recorded scan failure",
+                request.sources[index].source));
+        }
+
+        auto scan = std::move(attempts[index]->value());
+        if (scan.dependencies.rules.size() != 1) {
+            return std::unexpected(failure(
+                IncrementalModuleTargetErrorCode::invalid_scan_result,
+                "one-source module scan must produce exactly one P1689 rule",
+                request.sources[index].source));
+        }
+
+        scanned_units.push_back(modules::ScannedModuleUnit{
+            .source = request.sources[index].source,
+            .rule = scan.dependencies.rules.front(),
+        });
+        result.scans.push_back(ModuleTargetScanResult{
+            .source = request.sources[index].source,
+            .result = std::move(scan),
+        });
+    }
+
+    auto plan = modules::ModuleDependencyGraphBuilder::build(scanned_units);
+    if (!plan) {
+        IncrementalModuleTargetError error = failure(
+            IncrementalModuleTargetErrorCode::graph_failed,
+            "failed to build module dependency graph");
+        error.graph_error = plan.error();
+        return std::unexpected(std::move(error));
+    }
+    result.plan = *plan;
+
+    ModuleCompileWaveRequest compile_request{
+        .sources = request.sources,
+        .plan = result.plan,
+        .compiler_options = request.compiler_options,
+        .working_directory = request.working_directory,
+        .max_parallel_compiles = request.max_parallel_compiles,
+    };
+    auto compiled = compile_coordinator_.run(compile_request);
+    if (!compiled) {
+        IncrementalModuleTargetError error = failure(
+            IncrementalModuleTargetErrorCode::compile_failed,
+            "module target compile waves failed",
+            compiled.error().source);
+        error.compile_error = compiled.error();
+        return std::unexpected(std::move(error));
+    }
+    result.compiles = std::move(*compiled);
+
+    std::vector<fs::path> objects;
+    objects.reserve(request.sources.size());
+    for (const auto& source : request.sources) {
+        objects.push_back(source.artifacts.object);
+    }
+
+    IncrementalLinkRequest link_request{
+        .objects = std::move(objects),
+        .output = request.target.executable,
+        .options = request.link_options,
+        .cache_file = request.target.link_cache,
+        .working_directory = request.working_directory.empty()
+            ? std::nullopt
+            : std::optional<fs::path>{request.working_directory},
+        .force_relink = result.compiles.any_compiled,
+    };
+    auto linked = link_coordinator_.run(link_request);
+    if (!linked) {
+        IncrementalModuleTargetError error = failure(
+            IncrementalModuleTargetErrorCode::link_failed,
+            "module target link failed");
+        error.link_error = linked.error();
+        return std::unexpected(std::move(error));
+    }
+    result.link = std::move(*linked);
+    return result;
+}
+
+} // namespace mqb::orchestration

--- a/cpp/orchestration/tests/CMakeLists.txt
+++ b/cpp/orchestration/tests/CMakeLists.txt
@@ -49,12 +49,24 @@ target_link_libraries(mqb_module_compile_coordinator_tests
 )
 target_compile_features(mqb_module_compile_coordinator_tests PRIVATE cxx_std_23)
 
+add_executable(mqb_module_target_coordinator_tests
+    module_target_coordinator_tests.cpp
+)
+target_link_libraries(mqb_module_target_coordinator_tests
+    PRIVATE
+        mqb_orchestration
+        mqb_modules
+        mqb_msvc
+)
+target_compile_features(mqb_module_target_coordinator_tests PRIVATE cxx_std_23)
+
 foreach(test_target IN ITEMS
     mqb_orchestration_incremental_tests
     mqb_orchestration_incremental_link_tests
     mqb_bounded_work_scheduler_tests
     mqb_incremental_target_coordinator_tests
     mqb_module_compile_coordinator_tests
+    mqb_module_target_coordinator_tests
 )
     if(MSVC)
         target_compile_options(${test_target} PRIVATE /W4 /permissive-)
@@ -86,4 +98,9 @@ add_test(
 add_test(
     NAME mqb.orchestration.module_compile_wave
     COMMAND mqb_module_compile_coordinator_tests
+)
+
+add_test(
+    NAME mqb.orchestration.module_target
+    COMMAND mqb_module_target_coordinator_tests
 )

--- a/cpp/orchestration/tests/CMakeLists.txt
+++ b/cpp/orchestration/tests/CMakeLists.txt
@@ -104,3 +104,25 @@ add_test(
     NAME mqb.orchestration.module_target
     COMMAND mqb_module_target_coordinator_tests
 )
+
+if(MQB_ENABLE_INSTALLED_MSVC_TESTS)
+    add_executable(mqb_module_target_integration_tests
+        module_target_integration_tests.cpp
+    )
+    target_link_libraries(mqb_module_target_integration_tests
+        PRIVATE
+            mqb_orchestration
+            mqb_msvc
+            mqb_platform_windows
+    )
+    target_compile_features(mqb_module_target_integration_tests PRIVATE cxx_std_23)
+    if(MSVC)
+        target_compile_options(mqb_module_target_integration_tests PRIVATE /W4 /permissive-)
+    else()
+        target_compile_options(mqb_module_target_integration_tests PRIVATE -Wall -Wextra -Wpedantic)
+    endif()
+    add_test(
+        NAME mqb.orchestration.module_target_integration
+        COMMAND mqb_module_target_integration_tests
+    )
+endif()

--- a/cpp/orchestration/tests/CMakeLists.txt
+++ b/cpp/orchestration/tests/CMakeLists.txt
@@ -60,6 +60,16 @@ target_link_libraries(mqb_module_target_coordinator_tests
 )
 target_compile_features(mqb_module_target_coordinator_tests PRIVATE cxx_std_23)
 
+add_executable(mqb_module_target_validation_tests
+    module_target_validation_tests.cpp
+)
+target_link_libraries(mqb_module_target_validation_tests
+    PRIVATE
+        mqb_orchestration
+        mqb_msvc
+)
+target_compile_features(mqb_module_target_validation_tests PRIVATE cxx_std_23)
+
 foreach(test_target IN ITEMS
     mqb_orchestration_incremental_tests
     mqb_orchestration_incremental_link_tests
@@ -67,6 +77,7 @@ foreach(test_target IN ITEMS
     mqb_incremental_target_coordinator_tests
     mqb_module_compile_coordinator_tests
     mqb_module_target_coordinator_tests
+    mqb_module_target_validation_tests
 )
     if(MSVC)
         target_compile_options(${test_target} PRIVATE /W4 /permissive-)
@@ -103,6 +114,11 @@ add_test(
 add_test(
     NAME mqb.orchestration.module_target
     COMMAND mqb_module_target_coordinator_tests
+)
+
+add_test(
+    NAME mqb.orchestration.module_target_validation
+    COMMAND mqb_module_target_validation_tests
 )
 
 if(MQB_ENABLE_INSTALLED_MSVC_TESTS)

--- a/cpp/orchestration/tests/CMakeLists.txt
+++ b/cpp/orchestration/tests/CMakeLists.txt
@@ -38,11 +38,23 @@ target_link_libraries(mqb_incremental_target_coordinator_tests
 )
 target_compile_features(mqb_incremental_target_coordinator_tests PRIVATE cxx_std_23)
 
+add_executable(mqb_module_compile_coordinator_tests
+    module_compile_coordinator_tests.cpp
+)
+target_link_libraries(mqb_module_compile_coordinator_tests
+    PRIVATE
+        mqb_orchestration
+        mqb_modules
+        mqb_msvc
+)
+target_compile_features(mqb_module_compile_coordinator_tests PRIVATE cxx_std_23)
+
 foreach(test_target IN ITEMS
     mqb_orchestration_incremental_tests
     mqb_orchestration_incremental_link_tests
     mqb_bounded_work_scheduler_tests
     mqb_incremental_target_coordinator_tests
+    mqb_module_compile_coordinator_tests
 )
     if(MSVC)
         target_compile_options(${test_target} PRIVATE /W4 /permissive-)
@@ -69,4 +81,9 @@ add_test(
 add_test(
     NAME mqb.orchestration.incremental_target
     COMMAND mqb_incremental_target_coordinator_tests
+)
+
+add_test(
+    NAME mqb.orchestration.module_compile_wave
+    COMMAND mqb_module_compile_coordinator_tests
 )

--- a/cpp/orchestration/tests/incremental_compile_coordinator_tests.cpp
+++ b/cpp/orchestration/tests/incremental_compile_coordinator_tests.cpp
@@ -219,6 +219,37 @@ int main() {
     expect(runner.calls == 1,
            "warm cache hit should not invoke the compiler again");
 
+    auto forced_request = request;
+    forced_request.force_rebuild = true;
+    const auto forced = coordinator.run(forced_request);
+    expect(forced.has_value(), "explicit rebuild request should compile successfully");
+    if (forced) {
+        expect(forced->compiled,
+               "explicit rebuild should execute even when the cache was otherwise reusable");
+        expect(forced->plan.actions.size() == 1,
+               "explicit rebuild should produce exactly one compile action");
+        expect(has_reason(forced->validation, mqb::BuildReason::explicit_rebuild),
+               "explicit rebuild should be visible as explicit_rebuild");
+        expect(!has_reason(forced->validation, mqb::BuildReason::compiler_options_changed),
+               "explicit rebuild must not masquerade as a compile-signature change");
+    }
+    expect(runner.calls == 2,
+           "explicit rebuild should invoke the compiler exactly once");
+
+    const auto warm_after_force = coordinator.run(request);
+    expect(warm_after_force.has_value(),
+           "ordinary warm check after an explicit rebuild should succeed");
+    if (warm_after_force) {
+        expect(!warm_after_force->compiled,
+               "explicit rebuild must not poison the following ordinary cache hit");
+        expect(warm_after_force->validation.reusable(),
+               "cache should be reusable immediately after a successful explicit rebuild");
+        expect(!has_reason(warm_after_force->validation, mqb::BuildReason::explicit_rebuild),
+               "explicit rebuild reason must be request-local rather than persisted");
+    }
+    expect(runner.calls == 2,
+           "post-force ordinary warm hit should not invoke the compiler");
+
     write_text(cache_file, "not an MQB cache file");
     const auto corrupt = coordinator.run(request);
     expect(corrupt.has_value(),
@@ -233,7 +264,7 @@ int main() {
                    mqb::orchestration::IncrementalCompileWarningCode::cache_load_failed),
                "corrupt metadata should remain visible as a cache_load_failed warning");
     }
-    expect(runner.calls == 2,
+    expect(runner.calls == 3,
            "corrupt metadata should invoke the compiler exactly once more");
 
     auto release_request = request;
@@ -248,7 +279,7 @@ int main() {
                    mqb::BuildReason::compiler_options_changed),
                "configuration transition should report compiler_options_changed");
     }
-    expect(runner.calls == 3,
+    expect(runner.calls == 4,
            "configuration transition should invoke the compiler once");
 
     std::error_code ignored;
@@ -264,7 +295,7 @@ int main() {
         expect(failed.error().compile_error.has_value(),
                "coordinator should preserve the backend compile error");
     }
-    expect(runner.calls == 4,
+    expect(runner.calls == 5,
            "failed cold rebuild should still correspond to one compiler launch");
 
     if (failures != 0) {

--- a/cpp/orchestration/tests/module_compile_coordinator_tests.cpp
+++ b/cpp/orchestration/tests/module_compile_coordinator_tests.cpp
@@ -1,0 +1,351 @@
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <expected>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <mutex>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "mqb/core/BuildTypes.hpp"
+#include "mqb/core/ProjectArtifactLayout.hpp"
+#include "mqb/modules/ModuleDependencyGraph.hpp"
+#include "mqb/msvc/MsvcCompileExecutor.hpp"
+#include "mqb/msvc/MsvcToolchainLocator.hpp"
+#include "mqb/orchestration/MsvcIncrementalCompileCoordinator.hpp"
+#include "mqb/orchestration/MsvcModuleCompileCoordinator.hpp"
+#include "mqb/process/Process.hpp"
+
+namespace {
+
+namespace fs = std::filesystem;
+int failures = 0;
+
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+class TemporaryDirectory {
+public:
+    TemporaryDirectory() {
+        const auto tick = std::chrono::steady_clock::now().time_since_epoch().count();
+        path_ = fs::temp_directory_path() / ("mqb-module-wave-test-" + std::to_string(tick));
+        fs::create_directories(path_);
+    }
+
+    ~TemporaryDirectory() {
+        std::error_code ignored;
+        fs::remove_all(path_, ignored);
+    }
+
+    [[nodiscard]] const fs::path& path() const noexcept { return path_; }
+
+private:
+    fs::path path_;
+};
+
+void write_text(const fs::path& path, const std::string_view text) {
+    fs::create_directories(path.parent_path());
+    std::ofstream file{path, std::ios::binary | std::ios::trunc};
+    file.write(text.data(), static_cast<std::streamsize>(text.size()));
+}
+
+[[nodiscard]] std::string path_to_utf8(const fs::path& path) {
+    const auto bytes = path.lexically_normal().generic_u8string();
+    return std::string{
+        reinterpret_cast<const char*>(bytes.data()),
+        bytes.size()};
+}
+
+[[nodiscard]] std::string json_escape(const std::string_view value) {
+    std::string escaped;
+    for (const char ch : value) {
+        switch (ch) {
+        case '\\': escaped += "\\\\"; break;
+        case '"': escaped += "\\\""; break;
+        case '\n': escaped += "\\n"; break;
+        case '\r': escaped += "\\r"; break;
+        case '\t': escaped += "\\t"; break;
+        default: escaped.push_back(ch); break;
+        }
+    }
+    return escaped;
+}
+
+struct RecordedCompile {
+    fs::path source;
+    std::vector<std::string> arguments;
+};
+
+class CompilerLikeRunner final : public mqb::process::ProcessRunner {
+public:
+    std::expected<mqb::process::ProcessResult, mqb::process::ProcessError>
+    run(const mqb::process::ProcessSpec& spec) override {
+        fs::path source;
+        fs::path object;
+        fs::path dependencies;
+        fs::path interface_file;
+
+        for (std::size_t index = 0; index < spec.arguments.size(); ++index) {
+            const auto& argument = spec.arguments[index];
+            if (argument.starts_with("/Fo")) {
+                object = fs::path{argument.substr(3)};
+            } else if (argument == "/sourceDependencies" && index + 1 < spec.arguments.size()) {
+                dependencies = fs::path{spec.arguments[++index]};
+            } else if (argument == "/ifcOutput" && index + 1 < spec.arguments.size()) {
+                interface_file = fs::path{spec.arguments[++index]};
+            }
+        }
+        if (!spec.arguments.empty()) {
+            source = fs::path{spec.arguments.back()};
+        }
+
+        write_text(object, "fake object");
+        if (!interface_file.empty()) {
+            write_text(interface_file, "fake ifc");
+        }
+        const std::string json =
+            "{\"Data\":{\"Source\":\""
+            + json_escape(path_to_utf8(source))
+            + "\",\"Includes\":[]}}";
+        write_text(dependencies, json);
+
+        {
+            std::scoped_lock lock{mutex_};
+            records_.push_back(RecordedCompile{
+                .source = source.lexically_normal(),
+                .arguments = spec.arguments,
+            });
+        }
+        ++calls_;
+
+        return mqb::process::ProcessResult{
+            .exit_code = 0,
+            .stdout_text = "fake cl.exe success",
+        };
+    }
+
+    [[nodiscard]] int calls() const noexcept { return calls_.load(); }
+
+    [[nodiscard]] std::vector<RecordedCompile> records() const {
+        std::scoped_lock lock{mutex_};
+        return records_;
+    }
+
+private:
+    std::atomic<int> calls_{0};
+    mutable std::mutex mutex_;
+    std::vector<RecordedCompile> records_;
+};
+
+[[nodiscard]] const mqb::orchestration::ModuleCompileResult* find_result(
+    const mqb::orchestration::ModuleCompileWaveResult& result,
+    const fs::path& source) {
+    const auto found = std::find_if(
+        result.compiles.begin(),
+        result.compiles.end(),
+        [&source](const mqb::orchestration::ModuleCompileResult& item) {
+            return item.source.lexically_normal() == source.lexically_normal();
+        });
+    return found == result.compiles.end() ? nullptr : &*found;
+}
+
+[[nodiscard]] bool has_reason(
+    const mqb::orchestration::ModuleCompileResult& result,
+    const mqb::BuildReason reason) {
+    return std::find(
+               result.result.validation.reasons.begin(),
+               result.result.validation.reasons.end(),
+               reason)
+        != result.result.validation.reasons.end();
+}
+
+[[nodiscard]] bool has_reference_argument(
+    const std::vector<RecordedCompile>& records,
+    const fs::path& source,
+    const std::string_view logical_name,
+    const fs::path& interface_file) {
+    for (const auto& record : records) {
+        if (record.source != source.lexically_normal()) continue;
+        const std::string expected = std::string{logical_name} + "=" + path_to_utf8(interface_file);
+        for (std::size_t index = 0; index + 1 < record.arguments.size(); ++index) {
+            if (record.arguments[index] == "/reference"
+                && record.arguments[index + 1] == expected) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+} // namespace
+
+int main() {
+    TemporaryDirectory fixture;
+    const fs::path root = fixture.path();
+    const fs::path a_source = root / "modules" / "A.ixx";
+    const fs::path b_source = root / "modules" / "B.ixx";
+    const fs::path consumer_source = root / "src" / "consumer.cpp";
+    write_text(a_source, "export module A;\n");
+    write_text(b_source, "export module B;\n");
+    write_text(consumer_source, "import A; import B;\n");
+
+    auto layout = mqb::ProjectArtifactLayout::create(root);
+    expect(layout.has_value(), "temporary module project should create an artifact layout");
+    if (!layout) return 1;
+
+    auto a_artifacts = layout->for_source(a_source);
+    auto b_artifacts = layout->for_source(b_source);
+    auto consumer_artifacts = layout->for_source(consumer_source);
+    expect(a_artifacts && b_artifacts && consumer_artifacts,
+           "all module-wave sources should receive unique artifacts");
+    if (!a_artifacts || !b_artifacts || !consumer_artifacts) return 1;
+
+    mqb::msvc::MsvcToolchain toolchain{
+        .identity = mqb::ToolchainIdentity{
+            .compiler = "C:/fake/cl.exe",
+            .version = "19.51.test",
+            .binary_stamp = "fake-stamp",
+        },
+        .linker = "C:/fake/link.exe",
+        .librarian = "C:/fake/lib.exe",
+        .vc_tools_root = "C:/fake",
+        .source = mqb::msvc::ToolchainSource::visual_studio,
+    };
+
+    CompilerLikeRunner runner;
+    mqb::msvc::MsvcCompileExecutor executor{toolchain, runner};
+    mqb::orchestration::MsvcIncrementalCompileCoordinator incremental{
+        toolchain,
+        executor};
+    mqb::orchestration::MsvcModuleCompileCoordinator modules{incremental};
+
+    mqb::modules::ModuleDependencyPlan plan;
+    plan.compile_levels = {
+        {a_source, b_source},
+        {consumer_source},
+    };
+    plan.resolved_dependencies = {
+        mqb::modules::ResolvedModuleDependency{
+            .consumer_source = consumer_source,
+            .provider_source = a_source,
+            .logical_name = "A",
+        },
+        mqb::modules::ResolvedModuleDependency{
+            .consumer_source = consumer_source,
+            .provider_source = b_source,
+            .logical_name = "B",
+        },
+    };
+
+    mqb::CompilerOptions options;
+    options.standard = mqb::CppStandard::latest;
+
+    mqb::orchestration::ModuleCompileWaveRequest request;
+    // Deliberately differ from plan order: result order must remain request order.
+    request.sources = {
+        mqb::orchestration::ModuleCompileSourceRequest{
+            .source = consumer_source,
+            .artifacts = *consumer_artifacts,
+            .kind = mqb::TranslationUnitKind::source,
+        },
+        mqb::orchestration::ModuleCompileSourceRequest{
+            .source = a_source,
+            .artifacts = *a_artifacts,
+            .kind = mqb::TranslationUnitKind::module_interface,
+        },
+        mqb::orchestration::ModuleCompileSourceRequest{
+            .source = b_source,
+            .artifacts = *b_artifacts,
+            .kind = mqb::TranslationUnitKind::module_interface,
+        },
+    };
+    request.plan = plan;
+    request.compiler_options = options;
+    request.working_directory = root;
+    request.max_parallel_compiles = 2;
+
+    const auto cold = modules.run(request);
+    expect(cold.has_value(), "cold module wave should compile successfully");
+    if (!cold) return 1;
+    expect(cold->compiles.size() == 3,
+           "cold module wave should return one result per requested source");
+    expect(cold->compiles[0].source == consumer_source
+               && cold->compiles[1].source == a_source
+               && cold->compiles[2].source == b_source,
+           "module wave result order should follow request source order");
+    expect(cold->any_compiled, "cold module wave should report compiled work");
+    expect(runner.calls() == 3, "cold module wave should launch exactly three compiles");
+    expect(fs::is_regular_file(a_artifacts->module_interface)
+               && fs::is_regular_file(b_artifacts->module_interface),
+           "cold module wave should produce both provider IFC artifacts");
+
+    const auto cold_records = runner.records();
+    expect(has_reference_argument(
+               cold_records, consumer_source, "A", a_artifacts->module_interface),
+           "consumer compile should receive resolved /reference A=<planned IFC>");
+    expect(has_reference_argument(
+               cold_records, consumer_source, "B", b_artifacts->module_interface),
+           "consumer compile should receive resolved /reference B=<planned IFC>");
+
+    const auto warm = modules.run(request);
+    expect(warm.has_value(), "warm module wave should validate successfully");
+    if (!warm) return 1;
+    expect(!warm->any_compiled, "unchanged warm module wave should be a complete cache hit");
+    expect(runner.calls() == 3, "warm module wave should launch no compiler processes");
+
+    std::error_code remove_error;
+    fs::remove(a_artifacts->module_interface, remove_error);
+    expect(!remove_error, "test should be able to remove one provider IFC");
+
+    const auto repaired = modules.run(request);
+    expect(repaired.has_value(), "missing provider IFC should be repaired successfully");
+    if (!repaired) return 1;
+    expect(repaired->any_compiled, "missing provider IFC should trigger compile work");
+    expect(runner.calls() == 5,
+           "missing A.ifc should rebuild only A and its consumer, leaving B cached");
+
+    const auto* repaired_a = find_result(*repaired, a_source);
+    const auto* repaired_b = find_result(*repaired, b_source);
+    const auto* repaired_consumer = find_result(*repaired, consumer_source);
+    expect(repaired_a != nullptr && repaired_a->result.compiled,
+           "provider with missing IFC should recompile");
+    expect(repaired_b != nullptr && !repaired_b->result.compiled,
+           "unaffected provider in the same dependency level should remain cached");
+    expect(repaired_consumer != nullptr && repaired_consumer->result.compiled,
+           "consumer should rebuild after one provider recompiles");
+    if (repaired_consumer) {
+        expect(has_reason(*repaired_consumer, mqb::BuildReason::explicit_rebuild),
+               "downstream provider rebuild should propagate as explicit_rebuild");
+    }
+
+    auto unsupported = request;
+    unsupported.plan.unresolved_requirements.push_back(
+        mqb::modules::UnresolvedModuleRequirement{
+            .consumer_source = consumer_source,
+            .requirement = mqb::modules::RequiredModule{.logical_name = "external"},
+            .kind = mqb::modules::UnresolvedRequirementKind::named_module,
+        });
+    const int calls_before_unsupported = runner.calls();
+    const auto unresolved = modules.run(unsupported);
+    expect(!unresolved
+               && unresolved.error().code
+                   == mqb::orchestration::ModuleCompileErrorCode::unresolved_requirement,
+           "unsupported unresolved requirements should fail closed before compilation");
+    expect(runner.calls() == calls_before_unsupported,
+           "unresolved requirement rejection should not launch the compiler");
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+
+    std::cout << "mqb_module_compile_coordinator_tests passed\n";
+    return 0;
+}

--- a/cpp/orchestration/tests/module_target_coordinator_tests.cpp
+++ b/cpp/orchestration/tests/module_target_coordinator_tests.cpp
@@ -1,0 +1,309 @@
+#include <atomic>
+#include <chrono>
+#include <expected>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <mutex>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "mqb/core/ProjectArtifactLayout.hpp"
+#include "mqb/msvc/MsvcCompileExecutor.hpp"
+#include "mqb/msvc/MsvcLinker.hpp"
+#include "mqb/msvc/MsvcModuleDependencyScanner.hpp"
+#include "mqb/orchestration/MsvcIncrementalCompileCoordinator.hpp"
+#include "mqb/orchestration/MsvcIncrementalLinkCoordinator.hpp"
+#include "mqb/orchestration/MsvcModuleCompileCoordinator.hpp"
+#include "mqb/orchestration/MsvcModuleTargetCoordinator.hpp"
+#include "mqb/process/Process.hpp"
+
+namespace {
+
+namespace fs = std::filesystem;
+int failures = 0;
+
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+class TemporaryDirectory {
+public:
+    TemporaryDirectory() {
+        const auto tick = std::chrono::steady_clock::now().time_since_epoch().count();
+        path_ = fs::temp_directory_path() / ("mqb-module-target-test-" + std::to_string(tick));
+        fs::create_directories(path_);
+    }
+
+    ~TemporaryDirectory() {
+        std::error_code ignored;
+        fs::remove_all(path_, ignored);
+    }
+
+    [[nodiscard]] const fs::path& path() const noexcept { return path_; }
+
+private:
+    fs::path path_;
+};
+
+void write_text(const fs::path& path, const std::string_view text) {
+    fs::create_directories(path.parent_path());
+    std::ofstream file{path, std::ios::binary | std::ios::trunc};
+    file.write(text.data(), static_cast<std::streamsize>(text.size()));
+}
+
+[[nodiscard]] std::string path_to_utf8(const fs::path& path) {
+    const auto bytes = path.lexically_normal().generic_u8string();
+    return std::string{
+        reinterpret_cast<const char*>(bytes.data()),
+        bytes.size()};
+}
+
+[[nodiscard]] std::string json_escape(const std::string_view value) {
+    std::string escaped;
+    for (const char ch : value) {
+        switch (ch) {
+        case '\\': escaped += "\\\\"; break;
+        case '"': escaped += "\\\""; break;
+        case '\n': escaped += "\\n"; break;
+        case '\r': escaped += "\\r"; break;
+        case '\t': escaped += "\\t"; break;
+        default: escaped.push_back(ch); break;
+        }
+    }
+    return escaped;
+}
+
+class ToolchainLikeRunner final : public mqb::process::ProcessRunner {
+public:
+    fs::path linker;
+    std::atomic<int> scan_calls{0};
+    std::atomic<int> compile_calls{0};
+    std::atomic<int> link_calls{0};
+    std::atomic<bool> emit_two_scan_rules{false};
+
+    std::expected<mqb::process::ProcessResult, mqb::process::ProcessError>
+    run(const mqb::process::ProcessSpec& spec) override {
+        if (spec.executable == linker) {
+            return run_link(spec);
+        }
+        for (const auto& argument : spec.arguments) {
+            if (argument == "/scanDependencies") {
+                return run_scan(spec);
+            }
+        }
+        return run_compile(spec);
+    }
+
+private:
+    std::expected<mqb::process::ProcessResult, mqb::process::ProcessError>
+    run_scan(const mqb::process::ProcessSpec& spec) {
+        ++scan_calls;
+        fs::path output;
+        fs::path source;
+        for (std::size_t index = 0; index < spec.arguments.size(); ++index) {
+            if (spec.arguments[index] == "/scanDependencies"
+                && index + 1 < spec.arguments.size()) {
+                output = fs::path{spec.arguments[index + 1]};
+            }
+        }
+        if (!spec.arguments.empty()) {
+            source = fs::path{spec.arguments.back()};
+        }
+
+        const bool module_interface = source.extension() == ".ixx";
+        std::string rule = module_interface
+            ? R"json({"provides":[{"logical-name":"math"}]})json"
+            : R"json({"requires":[{"logical-name":"math"}]})json";
+        std::string json = "{\"version\":1,\"revision\":0,\"rules\":[" + rule;
+        if (emit_two_scan_rules.load()) {
+            json += ",{}";
+        }
+        json += "]}";
+        write_text(output, json);
+        return mqb::process::ProcessResult{.exit_code = 0};
+    }
+
+    std::expected<mqb::process::ProcessResult, mqb::process::ProcessError>
+    run_compile(const mqb::process::ProcessSpec& spec) {
+        ++compile_calls;
+        fs::path source;
+        fs::path object;
+        fs::path dependencies;
+        fs::path interface_file;
+        for (std::size_t index = 0; index < spec.arguments.size(); ++index) {
+            const auto& argument = spec.arguments[index];
+            if (argument.starts_with("/Fo")) {
+                object = fs::path{argument.substr(3)};
+            } else if (argument == "/sourceDependencies" && index + 1 < spec.arguments.size()) {
+                dependencies = fs::path{spec.arguments[++index]};
+            } else if (argument == "/ifcOutput" && index + 1 < spec.arguments.size()) {
+                interface_file = fs::path{spec.arguments[++index]};
+            }
+        }
+        if (!spec.arguments.empty()) {
+            source = fs::path{spec.arguments.back()};
+        }
+
+        write_text(object, "fake object");
+        if (!interface_file.empty()) {
+            write_text(interface_file, "fake ifc");
+        }
+        const std::string metadata =
+            "{\"Data\":{\"Source\":\""
+            + json_escape(path_to_utf8(source))
+            + "\",\"Includes\":[]}}";
+        write_text(dependencies, metadata);
+        return mqb::process::ProcessResult{.exit_code = 0};
+    }
+
+    std::expected<mqb::process::ProcessResult, mqb::process::ProcessError>
+    run_link(const mqb::process::ProcessSpec& spec) {
+        ++link_calls;
+        fs::path output;
+        for (const auto& argument : spec.arguments) {
+            constexpr std::string_view prefix = "/OUT:";
+            if (argument.starts_with(prefix)) {
+                output = fs::path{argument.substr(prefix.size())};
+                break;
+            }
+        }
+        write_text(output, "fake executable");
+        return mqb::process::ProcessResult{.exit_code = 0};
+    }
+};
+
+} // namespace
+
+int main() {
+    TemporaryDirectory fixture;
+    const fs::path root = fixture.path();
+    const fs::path module_source = root / "modules" / "math.ixx";
+    const fs::path consumer_source = root / "src" / "main.cpp";
+    write_text(module_source, "export module math;\n");
+    write_text(consumer_source, "import math;\nint main() { return 0; }\n");
+
+    auto layout = mqb::ProjectArtifactLayout::create(root);
+    expect(layout.has_value(), "module target fixture should create artifact layout");
+    if (!layout) return 1;
+    auto module_artifacts = layout->for_source(module_source);
+    auto consumer_artifacts = layout->for_source(consumer_source);
+    auto target_artifacts = layout->for_target("module-app");
+    expect(module_artifacts && consumer_artifacts && target_artifacts,
+           "module target fixture should map all source and target artifacts");
+    if (!module_artifacts || !consumer_artifacts || !target_artifacts) return 1;
+
+    const fs::path fake_compiler = root / "toolchain" / "cl.exe";
+    const fs::path fake_linker = root / "toolchain" / "link.exe";
+    const fs::path fake_librarian = root / "toolchain" / "lib.exe";
+    write_text(fake_compiler, "fake compiler binary");
+    write_text(fake_linker, "fake linker binary");
+    write_text(fake_librarian, "fake librarian binary");
+
+    mqb::msvc::MsvcToolchain toolchain{
+        .identity = mqb::ToolchainIdentity{
+            .compiler = fake_compiler,
+            .version = "19.51.test",
+            .binary_stamp = "fake-compiler-stamp",
+        },
+        .linker = fake_linker,
+        .librarian = fake_librarian,
+        .vc_tools_root = fake_compiler.parent_path(),
+        .source = mqb::msvc::ToolchainSource::visual_studio,
+    };
+
+    ToolchainLikeRunner runner;
+    runner.linker = fake_linker;
+    mqb::msvc::MsvcModuleDependencyScanner scanner{toolchain, runner};
+    mqb::msvc::MsvcCompileExecutor executor{toolchain, runner};
+    mqb::orchestration::MsvcIncrementalCompileCoordinator incremental_compile{
+        toolchain,
+        executor};
+    mqb::orchestration::MsvcModuleCompileCoordinator module_compile{incremental_compile};
+    mqb::msvc::MsvcLinker linker{toolchain, runner};
+    mqb::orchestration::MsvcIncrementalLinkCoordinator incremental_link{toolchain, linker};
+    mqb::orchestration::MsvcModuleTargetCoordinator target{
+        scanner,
+        module_compile,
+        incremental_link};
+
+    mqb::orchestration::IncrementalModuleTargetRequest request;
+    request.sources = {
+        mqb::orchestration::ModuleCompileSourceRequest{
+            .source = consumer_source,
+            .artifacts = *consumer_artifacts,
+            .kind = mqb::TranslationUnitKind::source,
+        },
+        mqb::orchestration::ModuleCompileSourceRequest{
+            .source = module_source,
+            .artifacts = *module_artifacts,
+            .kind = mqb::TranslationUnitKind::module_interface,
+        },
+    };
+    request.target = *target_artifacts;
+    request.compiler_options.standard = mqb::CppStandard::latest;
+    request.link_options.architecture = mqb::Architecture::x64;
+    request.link_options.subsystem = mqb::LinkSubsystem::console;
+    request.working_directory = root;
+    request.max_parallel_scans = 2;
+    request.max_parallel_compiles = 2;
+
+    const auto cold = target.run(request);
+    expect(cold.has_value(), "cold module target should scan, graph, compile and link successfully");
+    if (!cold) return 1;
+    expect(cold->scans.size() == 2
+               && cold->scans[0].source == consumer_source
+               && cold->scans[1].source == module_source,
+           "module target scan results should preserve request source order");
+    expect(cold->plan.compile_levels.size() == 2,
+           "scanned provider and consumer should form two compile levels");
+    expect(cold->plan.resolved_dependencies.size() == 1
+               && cold->plan.resolved_dependencies.front().logical_name == "math"
+               && cold->plan.resolved_dependencies.front().provider_source == module_source
+               && cold->plan.resolved_dependencies.front().consumer_source == consumer_source,
+           "module target should retain graph-selected math provider mapping");
+    expect(cold->compiles.any_compiled,
+           "cold module target should report compile work");
+    expect(cold->link.linked,
+           "cold module target should execute the link action");
+    expect(runner.scan_calls.load() == 2
+               && runner.compile_calls.load() == 2
+               && runner.link_calls.load() == 1,
+           "cold module target should run two scans, two compiles and one link");
+
+    const auto warm = target.run(request);
+    expect(warm.has_value(), "warm module target should validate successfully");
+    if (!warm) return 1;
+    expect(!warm->compiles.any_compiled,
+           "warm module target should reuse both compile caches");
+    expect(!warm->link.linked,
+           "warm module target should reuse link cache");
+    expect(runner.scan_calls.load() == 4,
+           "topology scanning is intentionally repeated on the warm target build");
+    expect(runner.compile_calls.load() == 2 && runner.link_calls.load() == 1,
+           "warm module target should run zero compiles and zero links");
+
+    runner.emit_two_scan_rules = true;
+    const int compile_calls_before_invalid_scan = runner.compile_calls.load();
+    const int link_calls_before_invalid_scan = runner.link_calls.load();
+    const auto invalid = target.run(request);
+    expect(!invalid
+               && invalid.error().code
+                   == mqb::orchestration::IncrementalModuleTargetErrorCode::invalid_scan_result,
+           "multi-rule output from a one-source scan should fail closed");
+    expect(runner.compile_calls.load() == compile_calls_before_invalid_scan
+               && runner.link_calls.load() == link_calls_before_invalid_scan,
+           "invalid scan cardinality should stop before compile and link");
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+
+    std::cout << "mqb_module_target_coordinator_tests passed\n";
+    return 0;
+}

--- a/cpp/orchestration/tests/module_target_integration_tests.cpp
+++ b/cpp/orchestration/tests/module_target_integration_tests.cpp
@@ -1,0 +1,388 @@
+#include <algorithm>
+#include <chrono>
+#include <expected>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <string_view>
+
+#include "mqb/core/BuildTypes.hpp"
+#include "mqb/core/ProjectArtifactLayout.hpp"
+#include "mqb/msvc/MsvcCompileExecutor.hpp"
+#include "mqb/msvc/MsvcLinker.hpp"
+#include "mqb/msvc/MsvcModuleDependencyScanner.hpp"
+#include "mqb/msvc/MsvcToolchainLocator.hpp"
+#include "mqb/orchestration/MsvcIncrementalCompileCoordinator.hpp"
+#include "mqb/orchestration/MsvcIncrementalLinkCoordinator.hpp"
+#include "mqb/orchestration/MsvcModuleCompileCoordinator.hpp"
+#include "mqb/orchestration/MsvcModuleTargetCoordinator.hpp"
+#include "mqb/platform/windows/WindowsProcessRunner.hpp"
+
+namespace {
+
+namespace fs = std::filesystem;
+int failures = 0;
+
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+class TemporaryDirectory {
+public:
+    TemporaryDirectory() {
+        const auto tick = std::chrono::steady_clock::now().time_since_epoch().count();
+        path_ = fs::temp_directory_path()
+            / ("mqb-module-target-vs-" + std::to_string(tick));
+        fs::create_directories(path_);
+    }
+
+    ~TemporaryDirectory() {
+        std::error_code ignored;
+        fs::remove_all(path_, ignored);
+    }
+
+    [[nodiscard]] const fs::path& path() const noexcept { return path_; }
+
+private:
+    fs::path path_;
+};
+
+void write_text(const fs::path& path, const std::string_view text) {
+    fs::create_directories(path.parent_path());
+    std::ofstream file{path, std::ios::binary | std::ios::trunc};
+    file.write(text.data(), static_cast<std::streamsize>(text.size()));
+}
+
+[[nodiscard]] const mqb::orchestration::ModuleCompileResult* find_compile(
+    const mqb::orchestration::IncrementalModuleTargetResult& result,
+    const fs::path& source) {
+    const auto found = std::find_if(
+        result.compiles.compiles.begin(),
+        result.compiles.compiles.end(),
+        [&source](const mqb::orchestration::ModuleCompileResult& item) {
+            return item.source.lexically_normal() == source.lexically_normal();
+        });
+    return found == result.compiles.compiles.end() ? nullptr : &*found;
+}
+
+[[nodiscard]] bool has_reason(
+    const mqb::orchestration::ModuleCompileResult& result,
+    const mqb::BuildReason reason) {
+    return std::find(
+               result.result.validation.reasons.begin(),
+               result.result.validation.reasons.end(),
+               reason)
+        != result.result.validation.reasons.end();
+}
+
+void print_target_error(const mqb::orchestration::IncrementalModuleTargetError& error) {
+    std::cerr << "module target error: " << error.message << '\n';
+    if (!error.source.empty()) {
+        std::cerr << "source: " << error.source.string() << '\n';
+    }
+    if (error.scan_error) {
+        std::cerr << "scan error: " << error.scan_error->message << '\n';
+        if (error.scan_error->process_result) {
+            std::cerr << error.scan_error->process_result->stdout_text;
+            std::cerr << error.scan_error->process_result->stderr_text;
+        }
+    }
+    if (error.graph_error) {
+        std::cerr << "graph error: " << error.graph_error->message << '\n';
+    }
+    if (error.compile_error) {
+        std::cerr << "compile wave error: " << error.compile_error->message << '\n';
+        if (error.compile_error->compile_error
+            && error.compile_error->compile_error->compile_error
+            && error.compile_error->compile_error->compile_error->compiler_error
+            && error.compile_error->compile_error->compile_error->compiler_error->process_result) {
+            const auto& process = *error.compile_error->compile_error
+                ->compile_error->compiler_error->process_result;
+            std::cerr << process.stdout_text;
+            std::cerr << process.stderr_text;
+        }
+    }
+    if (error.link_error) {
+        std::cerr << "link error: " << error.link_error->message << '\n';
+        if (error.link_error->linker_error
+            && error.link_error->linker_error->process_result) {
+            std::cerr << error.link_error->linker_error->process_result->stdout_text;
+            std::cerr << error.link_error->linker_error->process_result->stderr_text;
+        }
+    }
+}
+
+[[nodiscard]] bool run_executable(
+    mqb::platform::windows::WindowsProcessRunner& runner,
+    const fs::path& executable,
+    const fs::path& working_directory) {
+    mqb::process::ProcessSpec run;
+    run.executable = executable;
+    run.working_directory = working_directory;
+    run.capture_stdout = true;
+    run.capture_stderr = true;
+    auto executed = runner.run(run);
+    expect(executed.has_value(), "linked module executable should launch");
+    if (!executed) {
+        std::cerr << "launch error: " << executed.error().message << '\n';
+        return false;
+    }
+    expect(executed->exit_code == 0,
+           "linked module executable should observe imported module behavior and return zero");
+    if (executed->exit_code != 0) {
+        std::cerr << executed->stdout_text << executed->stderr_text;
+        return false;
+    }
+    return true;
+}
+
+[[nodiscard]] bool expect_compile_state(
+    const mqb::orchestration::IncrementalModuleTargetResult& result,
+    const fs::path& module_source,
+    const fs::path& consumer_source,
+    const bool module_compiled,
+    const bool consumer_compiled,
+    const bool linked,
+    const std::string_view description) {
+    const auto* module = find_compile(result, module_source);
+    const auto* consumer = find_compile(result, consumer_source);
+    expect(module != nullptr && consumer != nullptr,
+           "module target result should contain provider and consumer compile states");
+    if (module == nullptr || consumer == nullptr) return false;
+
+    expect(module->result.compiled == module_compiled,
+           std::string{description} + ": provider compile state should match expectation");
+    expect(consumer->result.compiled == consumer_compiled,
+           std::string{description} + ": consumer compile state should match expectation");
+    expect(result.link.linked == linked,
+           std::string{description} + ": link state should match expectation");
+    return module->result.compiled == module_compiled
+        && consumer->result.compiled == consumer_compiled
+        && result.link.linked == linked;
+}
+
+} // namespace
+
+int main() {
+    mqb::platform::windows::WindowsProcessRunner runner;
+    mqb::msvc::MsvcToolchainLocator locator{runner};
+    mqb::msvc::DiscoveryOptions discovery;
+    discovery.preference = mqb::msvc::ToolchainPreference::visual_studio;
+    discovery.target_architecture = mqb::Architecture::x64;
+    discovery.host_architecture = mqb::Architecture::x64;
+
+    auto toolchain = locator.discover(discovery);
+    expect(toolchain.has_value(),
+           "installed Visual Studio toolchain should be available for module target E2E");
+    if (!toolchain) {
+        std::cerr << "toolchain error: " << toolchain.error().message << '\n';
+        return 1;
+    }
+
+    TemporaryDirectory fixture;
+    const fs::path root = fixture.path();
+    const fs::path module_source = root / "modules" / "math.ixx";
+    const fs::path consumer_source = root / "src" / "main.cpp";
+    write_text(
+        module_source,
+        "export module math;\n"
+        "export int add(int a, int b) { return a + b; }\n");
+    write_text(
+        consumer_source,
+        "import math;\n"
+        "int main() { return add(2, 3) == 5 ? 0 : 1; }\n");
+
+    auto layout = mqb::ProjectArtifactLayout::create(root);
+    expect(layout.has_value(), "module target E2E should create project artifact layout");
+    if (!layout) return 1;
+    auto module_artifacts = layout->for_source(module_source);
+    auto consumer_artifacts = layout->for_source(consumer_source);
+    auto target_artifacts = layout->for_target("module-e2e");
+    expect(module_artifacts && consumer_artifacts && target_artifacts,
+           "module target E2E should map all artifacts");
+    if (!module_artifacts || !consumer_artifacts || !target_artifacts) return 1;
+
+    mqb::msvc::MsvcModuleDependencyScanner scanner{*toolchain, runner};
+    mqb::msvc::MsvcCompileExecutor executor{*toolchain, runner};
+    mqb::orchestration::MsvcIncrementalCompileCoordinator incremental_compile{
+        *toolchain,
+        executor};
+    mqb::orchestration::MsvcModuleCompileCoordinator module_compile{incremental_compile};
+    mqb::msvc::MsvcLinker linker{*toolchain, runner};
+    mqb::orchestration::MsvcIncrementalLinkCoordinator incremental_link{*toolchain, linker};
+    mqb::orchestration::MsvcModuleTargetCoordinator target{
+        scanner,
+        module_compile,
+        incremental_link};
+
+    mqb::orchestration::IncrementalModuleTargetRequest request;
+    // Consumer first intentionally proves scan/result order is independent of
+    // provider-before-consumer compile order discovered from P1689.
+    request.sources = {
+        mqb::orchestration::ModuleCompileSourceRequest{
+            .source = consumer_source,
+            .artifacts = *consumer_artifacts,
+            .kind = mqb::TranslationUnitKind::source,
+        },
+        mqb::orchestration::ModuleCompileSourceRequest{
+            .source = module_source,
+            .artifacts = *module_artifacts,
+            .kind = mqb::TranslationUnitKind::module_interface,
+        },
+    };
+    request.target = *target_artifacts;
+    request.compiler_options.configuration = mqb::BuildConfiguration::debug;
+    request.compiler_options.architecture = mqb::Architecture::x64;
+    request.compiler_options.standard = mqb::CppStandard::latest;
+    request.link_options.configuration = mqb::BuildConfiguration::debug;
+    request.link_options.architecture = mqb::Architecture::x64;
+    request.link_options.subsystem = mqb::LinkSubsystem::console;
+    request.working_directory = root;
+    request.max_parallel_scans = 2;
+    request.max_parallel_compiles = 2;
+
+    // 1. Cold: scan -> graph -> provider -> consumer -> link.
+    auto cold = target.run(request);
+    expect(cold.has_value(), "cold real module target should build successfully");
+    if (!cold) {
+        print_target_error(cold.error());
+        return 1;
+    }
+    expect(cold->plan.resolved_dependencies.size() == 1
+               && cold->plan.resolved_dependencies.front().logical_name == "math"
+               && cold->plan.resolved_dependencies.front().provider_source == module_source
+               && cold->plan.resolved_dependencies.front().consumer_source == consumer_source,
+           "real P1689 scan should resolve consumer import math to math.ixx");
+    expect_compile_state(
+        *cold, module_source, consumer_source, true, true, true, "cold build");
+    expect(fs::is_regular_file(module_artifacts->module_interface),
+           "cold module target should produce planned IFC");
+    if (!run_executable(runner, target_artifacts->executable, root)) return 1;
+
+    // 2. Warm: scans may repeat, but compile and link must both be complete hits.
+    auto warm = target.run(request);
+    expect(warm.has_value(), "warm real module target should validate successfully");
+    if (!warm) {
+        print_target_error(warm.error());
+        return 1;
+    }
+    expect_compile_state(
+        *warm, module_source, consumer_source, false, false, false, "warm build");
+    if (!run_executable(runner, target_artifacts->executable, root)) return 1;
+
+    // 3. Provider source mutation: make source.mtime deterministically newer
+    // than its current object so invalidation is independent of clock granularity.
+    std::error_code time_error;
+    const auto old_object_time = fs::last_write_time(module_artifacts->object, time_error);
+    expect(!time_error, "provider object timestamp should be readable before source mutation");
+    write_text(
+        module_source,
+        "export module math;\n"
+        "export int add(int a, int b) { return (a + b); }\n");
+    time_error.clear();
+    fs::last_write_time(
+        module_source,
+        old_object_time + std::chrono::seconds{2},
+        time_error);
+    expect(!time_error,
+           "provider source timestamp should be made deterministically newer than cached object");
+
+    auto provider_changed = target.run(request);
+    expect(provider_changed.has_value(),
+           "provider source mutation should rebuild real module target successfully");
+    if (!provider_changed) {
+        print_target_error(provider_changed.error());
+        return 1;
+    }
+    expect_compile_state(
+        *provider_changed,
+        module_source,
+        consumer_source,
+        true,
+        true,
+        true,
+        "provider source mutation");
+    const auto* changed_consumer = find_compile(*provider_changed, consumer_source);
+    if (changed_consumer) {
+        expect(has_reason(*changed_consumer, mqb::BuildReason::explicit_rebuild),
+               "consumer rebuild after provider mutation should use explicit downstream propagation");
+    }
+    if (!run_executable(runner, target_artifacts->executable, root)) return 1;
+
+    // The mutation deliberately pushed source time into the future. Normalize
+    // it behind the rebuilt object and prove the target becomes warm again
+    // before testing IFC-only loss, so the next invalidation has one cause.
+    time_error.clear();
+    const auto rebuilt_object_time = fs::last_write_time(module_artifacts->object, time_error);
+    expect(!time_error, "rebuilt provider object timestamp should be readable");
+    time_error.clear();
+    fs::last_write_time(
+        module_source,
+        rebuilt_object_time - std::chrono::seconds{1},
+        time_error);
+    expect(!time_error, "provider source timestamp should normalize behind rebuilt object");
+
+    auto stable_again = target.run(request);
+    expect(stable_again.has_value(), "target should become warm again after timestamp normalization");
+    if (!stable_again) {
+        print_target_error(stable_again.error());
+        return 1;
+    }
+    expect_compile_state(
+        *stable_again,
+        module_source,
+        consumer_source,
+        false,
+        false,
+        false,
+        "post-mutation warm build");
+
+    // 4. IFC-only loss: object and source remain untouched. Provider must
+    // rebuild because a planned output is missing; consumer must rebuild via
+    // the same explicit downstream propagation, then link must refresh.
+    std::error_code remove_error;
+    const bool removed = fs::remove(module_artifacts->module_interface, remove_error);
+    expect(!remove_error && removed,
+           "test should remove exactly the planned provider IFC artifact");
+
+    auto missing_ifc = target.run(request);
+    expect(missing_ifc.has_value(),
+           "missing provider IFC should repair the real module target successfully");
+    if (!missing_ifc) {
+        print_target_error(missing_ifc.error());
+        return 1;
+    }
+    expect_compile_state(
+        *missing_ifc,
+        module_source,
+        consumer_source,
+        true,
+        true,
+        true,
+        "missing IFC repair");
+    const auto* repaired_provider = find_compile(*missing_ifc, module_source);
+    const auto* repaired_consumer = find_compile(*missing_ifc, consumer_source);
+    if (repaired_provider) {
+        expect(has_reason(*repaired_provider, mqb::BuildReason::missing_output),
+               "provider with deleted IFC should report missing_output");
+    }
+    if (repaired_consumer) {
+        expect(has_reason(*repaired_consumer, mqb::BuildReason::explicit_rebuild),
+               "consumer after IFC repair should report explicit_rebuild");
+    }
+    expect(fs::is_regular_file(module_artifacts->module_interface),
+           "IFC repair should recreate the planned provider IFC");
+    if (!run_executable(runner, target_artifacts->executable, root)) return 1;
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+
+    std::cout << "mqb_module_target_integration_tests passed\n";
+    return 0;
+}

--- a/cpp/orchestration/tests/module_target_integration_tests.cpp
+++ b/cpp/orchestration/tests/module_target_integration_tests.cpp
@@ -257,8 +257,10 @@ int main() {
                && cold->plan.resolved_dependencies.front().provider_source == module_source
                && cold->plan.resolved_dependencies.front().consumer_source == consumer_source,
            "real P1689 scan should resolve consumer import math to math.ixx");
-    expect_compile_state(
-        *cold, module_source, consumer_source, true, true, true, "cold build");
+    if (!expect_compile_state(
+            *cold, module_source, consumer_source, true, true, true, "cold build")) {
+        return 1;
+    }
     expect(fs::is_regular_file(module_artifacts->module_interface),
            "cold module target should produce planned IFC");
     if (!run_executable(runner, target_artifacts->executable, root)) return 1;
@@ -270,8 +272,10 @@ int main() {
         print_target_error(warm.error());
         return 1;
     }
-    expect_compile_state(
-        *warm, module_source, consumer_source, false, false, false, "warm build");
+    if (!expect_compile_state(
+            *warm, module_source, consumer_source, false, false, false, "warm build")) {
+        return 1;
+    }
     if (!run_executable(runner, target_artifacts->executable, root)) return 1;
 
     // 3. Provider source mutation: make source.mtime deterministically newer
@@ -298,14 +302,16 @@ int main() {
         print_target_error(provider_changed.error());
         return 1;
     }
-    expect_compile_state(
-        *provider_changed,
-        module_source,
-        consumer_source,
-        true,
-        true,
-        true,
-        "provider source mutation");
+    if (!expect_compile_state(
+            *provider_changed,
+            module_source,
+            consumer_source,
+            true,
+            true,
+            true,
+            "provider source mutation")) {
+        return 1;
+    }
     const auto* changed_consumer = find_compile(*provider_changed, consumer_source);
     if (changed_consumer) {
         expect(has_reason(*changed_consumer, mqb::BuildReason::explicit_rebuild),
@@ -332,14 +338,16 @@ int main() {
         print_target_error(stable_again.error());
         return 1;
     }
-    expect_compile_state(
-        *stable_again,
-        module_source,
-        consumer_source,
-        false,
-        false,
-        false,
-        "post-mutation warm build");
+    if (!expect_compile_state(
+            *stable_again,
+            module_source,
+            consumer_source,
+            false,
+            false,
+            false,
+            "post-mutation warm build")) {
+        return 1;
+    }
 
     // 4. IFC-only loss: object and source remain untouched. Provider must
     // rebuild because a planned output is missing; consumer must rebuild via
@@ -356,14 +364,16 @@ int main() {
         print_target_error(missing_ifc.error());
         return 1;
     }
-    expect_compile_state(
-        *missing_ifc,
-        module_source,
-        consumer_source,
-        true,
-        true,
-        true,
-        "missing IFC repair");
+    if (!expect_compile_state(
+            *missing_ifc,
+            module_source,
+            consumer_source,
+            true,
+            true,
+            true,
+            "missing IFC repair")) {
+        return 1;
+    }
     const auto* repaired_provider = find_compile(*missing_ifc, module_source);
     const auto* repaired_consumer = find_compile(*missing_ifc, consumer_source);
     if (repaired_provider) {

--- a/cpp/orchestration/tests/module_target_validation_tests.cpp
+++ b/cpp/orchestration/tests/module_target_validation_tests.cpp
@@ -1,0 +1,163 @@
+#include <expected>
+#include <filesystem>
+#include <iostream>
+#include <string_view>
+
+#include "mqb/core/ProjectArtifactLayout.hpp"
+#include "mqb/msvc/MsvcCompileExecutor.hpp"
+#include "mqb/msvc/MsvcLinker.hpp"
+#include "mqb/msvc/MsvcModuleDependencyScanner.hpp"
+#include "mqb/orchestration/MsvcIncrementalCompileCoordinator.hpp"
+#include "mqb/orchestration/MsvcIncrementalLinkCoordinator.hpp"
+#include "mqb/orchestration/MsvcModuleCompileCoordinator.hpp"
+#include "mqb/orchestration/MsvcModuleTargetCoordinator.hpp"
+#include "mqb/process/Process.hpp"
+
+namespace {
+
+namespace fs = std::filesystem;
+int failures = 0;
+
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+class FailIfCalledRunner final : public mqb::process::ProcessRunner {
+public:
+    std::expected<mqb::process::ProcessResult, mqb::process::ProcessError>
+    run(const mqb::process::ProcessSpec&) override {
+        ++calls;
+        return mqb::process::ProcessResult{.exit_code = 0};
+    }
+
+    int calls{};
+};
+
+[[nodiscard]] mqb::orchestration::IncrementalModuleTargetRequest make_request() {
+    mqb::orchestration::IncrementalModuleTargetRequest request;
+    request.sources = {
+        mqb::orchestration::ModuleCompileSourceRequest{
+            .source = "C:/project/modules/A.ixx",
+            .artifacts = mqb::SourceArtifacts{
+                .object = "C:/project/.mqb/obj/A.obj",
+                .dependencies = "C:/project/.mqb/deps/A.json",
+                .module_dependencies = "C:/project/.mqb/scan/A.json",
+                .module_interface = "C:/project/.mqb/ifc/A.ifc",
+                .compile_cache = "C:/project/.mqb/cache/A.mqbcache",
+            },
+            .kind = mqb::TranslationUnitKind::module_interface,
+        },
+        mqb::orchestration::ModuleCompileSourceRequest{
+            .source = "C:/project/src/main.cpp",
+            .artifacts = mqb::SourceArtifacts{
+                .object = "C:/project/.mqb/obj/main.obj",
+                .dependencies = "C:/project/.mqb/deps/main.json",
+                .module_dependencies = "C:/project/.mqb/scan/main.json",
+                .module_interface = "C:/project/.mqb/ifc/main.ifc",
+                .compile_cache = "C:/project/.mqb/cache/main.mqbcache",
+            },
+            .kind = mqb::TranslationUnitKind::source,
+        },
+    };
+    request.target = mqb::TargetArtifacts{
+        .executable = "C:/project/.mqb/bin/app.exe",
+        .link_cache = "C:/project/.mqb/cache/link/app.linkcache",
+    };
+    request.max_parallel_scans = 2;
+    request.max_parallel_compiles = 2;
+    return request;
+}
+
+} // namespace
+
+int main() {
+    FailIfCalledRunner runner;
+    const mqb::msvc::MsvcToolchain toolchain{
+        .identity = mqb::ToolchainIdentity{
+            .compiler = "C:/fake/cl.exe",
+            .version = "19.51.test",
+            .binary_stamp = "fake",
+        },
+        .linker = "C:/fake/link.exe",
+        .librarian = "C:/fake/lib.exe",
+        .vc_tools_root = "C:/fake",
+        .source = mqb::msvc::ToolchainSource::visual_studio,
+    };
+
+    mqb::msvc::MsvcModuleDependencyScanner scanner{toolchain, runner};
+    mqb::msvc::MsvcCompileExecutor executor{toolchain, runner};
+    mqb::orchestration::MsvcIncrementalCompileCoordinator incremental_compile{
+        toolchain,
+        executor};
+    mqb::orchestration::MsvcModuleCompileCoordinator module_compile{incremental_compile};
+    mqb::msvc::MsvcLinker linker{toolchain, runner};
+    mqb::orchestration::MsvcIncrementalLinkCoordinator incremental_link{toolchain, linker};
+    mqb::orchestration::MsvcModuleTargetCoordinator target{
+        scanner,
+        module_compile,
+        incremental_link};
+
+    {
+        auto request = make_request();
+        const fs::path shared_object = request.sources[0].artifacts.object;
+        request.sources[1].artifacts.object = shared_object;
+
+        const auto result = target.run(request);
+        expect(!result,
+               "two sources sharing one object artifact should be rejected");
+        if (!result) {
+            expect(result.error().code
+                       == mqb::orchestration::IncrementalModuleTargetErrorCode::artifact_collision,
+                   "shared object path should report artifact_collision");
+            expect(result.error().artifact == shared_object,
+                   "artifact_collision should identify the conflicting writable path");
+        }
+        expect(runner.calls == 0,
+               "artifact collision must fail before scan, compile, or link process execution");
+    }
+
+    {
+        auto request = make_request();
+        request.sources[0].artifacts.dependencies.clear();
+
+        const auto result = target.run(request);
+        expect(!result,
+               "empty source-dependency metadata path should be rejected");
+        if (!result) {
+            expect(result.error().code
+                       == mqb::orchestration::IncrementalModuleTargetErrorCode::invalid_artifact,
+                   "empty writable artifact should report invalid_artifact");
+            expect(result.error().source == request.sources[0].source,
+                   "invalid source artifact should preserve source diagnostics");
+        }
+        expect(runner.calls == 0,
+               "invalid artifact must fail before any external process execution");
+    }
+
+    {
+        auto request = make_request();
+        request.target.executable = request.sources[1].artifacts.compile_cache;
+
+        const auto result = target.run(request);
+        expect(!result,
+               "target executable colliding with compile metadata should be rejected");
+        if (!result) {
+            expect(result.error().code
+                       == mqb::orchestration::IncrementalModuleTargetErrorCode::artifact_collision,
+                   "cross-role source/target collision should report artifact_collision");
+        }
+        expect(runner.calls == 0,
+               "cross-role artifact collision must fail before process execution");
+    }
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+
+    std::cout << "mqb_module_target_validation_tests passed\n";
+    return 0;
+}

--- a/cpp/tests/build_signature_tests.cpp
+++ b/cpp/tests/build_signature_tests.cpp
@@ -108,8 +108,48 @@ int main() {
 
     auto module_unit = unit;
     module_unit.kind = mqb::TranslationUnitKind::module_interface;
-    expect(mqb::BuildSignature::for_compile(module_unit, toolchain, options) != baseline,
-           "translation-unit kind should participate in the signature");
+    module_unit.outputs.push_back(mqb::Artifact{
+        .path = "build/ifc/main.ifc",
+        .kind = mqb::ArtifactKind::module_interface,
+    });
+    const auto module_baseline = mqb::BuildSignature::for_compile(module_unit, toolchain, options);
+    expect(module_baseline != baseline,
+           "translation-unit kind and module output state should participate in the signature");
+
+    auto moved_ifc = module_unit;
+    moved_ifc.outputs.back().path = "another-ifc/main.ifc";
+    expect(mqb::BuildSignature::for_compile(moved_ifc, toolchain, options) != module_baseline,
+           "planned compiled-module output path should participate in provider identity");
+
+    auto consumer = unit;
+    consumer.module_references = {
+        mqb::ModuleReference{.logical_name = "math", .interface_file = "ifc/math.ifc"},
+    };
+    const auto consumer_baseline = mqb::BuildSignature::for_compile(consumer, toolchain, options);
+    expect(consumer_baseline != baseline,
+           "module references should participate in consumer recipe identity");
+
+    auto renamed_reference = consumer;
+    renamed_reference.module_references[0].logical_name = "math2";
+    expect(mqb::BuildSignature::for_compile(renamed_reference, toolchain, options)
+               != consumer_baseline,
+           "module logical-name mapping should participate in consumer identity");
+
+    auto moved_reference = consumer;
+    moved_reference.module_references[0].interface_file = "ifc/other-math.ifc";
+    expect(mqb::BuildSignature::for_compile(moved_reference, toolchain, options)
+               != consumer_baseline,
+           "referenced IFC path should participate in consumer identity");
+
+    auto reordered_references = consumer;
+    reordered_references.module_references.push_back(
+        mqb::ModuleReference{.logical_name = "stats", .interface_file = "ifc/stats.ifc"});
+    const auto two_references = mqb::BuildSignature::for_compile(
+        reordered_references, toolchain, options);
+    std::swap(reordered_references.module_references[0], reordered_references.module_references[1]);
+    expect(mqb::BuildSignature::for_compile(reordered_references, toolchain, options)
+               != two_references,
+           "ordered module-reference routing should be stable build identity");
 
     auto dependency_only_change = unit;
     dependency_only_change.dependencies.emplace_back("include/transitive.hpp");
@@ -119,7 +159,7 @@ int main() {
     auto output_only_change = unit;
     output_only_change.outputs.front().path = std::filesystem::path{"another-cache/main.obj"};
     expect(mqb::BuildSignature::for_compile(output_only_change, toolchain, options) == baseline,
-           "artifact placement should not change compiler recipe identity");
+           "ordinary object placement should not change compiler recipe identity");
 
     if (failures != 0) {
         std::cerr << failures << " test(s) failed\n";

--- a/cpp/tests/compile_cache_tests.cpp
+++ b/cpp/tests/compile_cache_tests.cpp
@@ -69,12 +69,18 @@ mqb::CompileCacheEntry make_entry(
     const mqb::TranslationUnit& unit,
     const mqb::ToolchainIdentity& toolchain,
     const mqb::CompilerOptions& options) {
+    const auto object = std::find_if(
+        unit.outputs.begin(),
+        unit.outputs.end(),
+        [](const mqb::Artifact& artifact) {
+            return artifact.kind == mqb::ArtifactKind::object;
+        });
     return mqb::CompileCacheEntry{
         .source = unit.source,
         .kind = unit.kind,
         .toolchain = toolchain,
         .signature = mqb::BuildSignature::for_compile(unit, toolchain, options),
-        .object = unit.outputs.front(),
+        .object = object == unit.outputs.end() ? mqb::Artifact{} : *object,
         .dependencies = {
             std::filesystem::path{"include/app.hpp"},
             std::filesystem::path{"include/config.hpp"},
@@ -100,33 +106,34 @@ int main() {
         .exists = true,
         .modified = time_at(30),
     };
+    const std::vector<mqb::FileSnapshot> outputs{object};
     const std::vector<mqb::FileSnapshot> dependencies{
         mqb::FileSnapshot{.path = "include/app.hpp", .exists = true, .modified = time_at(20)},
         mqb::FileSnapshot{.path = "include/config.hpp", .exists = true, .modified = time_at(25)},
     };
 
     const auto fresh = mqb::CompileCacheValidator::validate(
-        unit, toolchain, options, entry, source, object, dependencies);
+        unit, toolchain, options, entry, source, outputs, dependencies);
     expect(fresh.reusable(), "unchanged recipe and older dependencies should reuse the object");
     expect(fresh.reasons.empty(), "reusable cache entry should not invent rebuild reasons");
 
     const auto no_entry = mqb::CompileCacheValidator::validate(
-        unit, toolchain, options, std::nullopt, source, object, dependencies);
+        unit, toolchain, options, std::nullopt, source, outputs, dependencies);
     expect(!no_entry.reusable(), "missing cache metadata should force a rebuild");
     expect(has_reason(no_entry, mqb::BuildReason::missing_cache_entry),
            "missing cache metadata should be explainable");
 
-    auto missing_object = object;
-    missing_object.exists = false;
+    auto missing_outputs = outputs;
+    missing_outputs[0].exists = false;
     const auto missing_output = mqb::CompileCacheValidator::validate(
-        unit, toolchain, options, entry, source, missing_object, dependencies);
+        unit, toolchain, options, entry, source, missing_outputs, dependencies);
     expect(has_reason(missing_output, mqb::BuildReason::missing_output),
            "missing object artifact should force a rebuild");
 
     auto newer_source = source;
     newer_source.modified = time_at(40);
     const auto source_changed = mqb::CompileCacheValidator::validate(
-        unit, toolchain, options, entry, newer_source, object, dependencies);
+        unit, toolchain, options, entry, newer_source, outputs, dependencies);
     expect(has_reason(source_changed, mqb::BuildReason::source_changed),
            "source newer than object should invalidate the cache");
 
@@ -134,7 +141,7 @@ int main() {
     newer_dependencies[0].modified = time_at(50);
     newer_dependencies[1].modified = time_at(60);
     const auto dependency_changed = mqb::CompileCacheValidator::validate(
-        unit, toolchain, options, entry, source, object, newer_dependencies);
+        unit, toolchain, options, entry, source, outputs, newer_dependencies);
     expect(has_reason(dependency_changed, mqb::BuildReason::dependency_changed),
            "newer cached dependency should invalidate the object");
     expect(std::count(
@@ -146,20 +153,20 @@ int main() {
     auto missing_dependency = dependencies;
     missing_dependency[0].exists = false;
     const auto dependency_missing = mqb::CompileCacheValidator::validate(
-        unit, toolchain, options, entry, source, object, missing_dependency);
+        unit, toolchain, options, entry, source, outputs, missing_dependency);
     expect(has_reason(dependency_missing, mqb::BuildReason::dependency_changed),
            "deleted cached dependency should invalidate the object");
 
     std::vector<mqb::FileSnapshot> incomplete_dependencies{dependencies[0]};
     const auto dependency_snapshot_missing = mqb::CompileCacheValidator::validate(
-        unit, toolchain, options, entry, source, object, incomplete_dependencies);
+        unit, toolchain, options, entry, source, outputs, incomplete_dependencies);
     expect(has_reason(dependency_snapshot_missing, mqb::BuildReason::dependency_changed),
            "missing dependency snapshot should conservatively rebuild");
 
     auto changed_toolchain = toolchain;
     changed_toolchain.binary_stamp = "stamp-b";
     const auto toolchain_changed = mqb::CompileCacheValidator::validate(
-        unit, changed_toolchain, options, entry, source, object, dependencies);
+        unit, changed_toolchain, options, entry, source, outputs, dependencies);
     expect(has_reason(toolchain_changed, mqb::BuildReason::toolchain_changed),
            "compiler binary identity change should invalidate the cache");
     expect(!has_reason(toolchain_changed, mqb::BuildReason::compiler_options_changed),
@@ -168,7 +175,7 @@ int main() {
     auto release_options = options;
     release_options.configuration = mqb::BuildConfiguration::release;
     const auto options_changed = mqb::CompileCacheValidator::validate(
-        unit, toolchain, release_options, entry, source, object, dependencies);
+        unit, toolchain, release_options, entry, source, outputs, dependencies);
     expect(has_reason(options_changed, mqb::BuildReason::compiler_options_changed),
            "compile recipe change should invalidate the cache");
 
@@ -185,12 +192,131 @@ int main() {
         options,
         entry,
         moved_source_snapshot,
-        object,
+        outputs,
         dependencies);
     expect(has_reason(source_identity_changed, mqb::BuildReason::source_changed),
            "translation-unit identity change should invalidate the cache");
     expect(!has_reason(source_identity_changed, mqb::BuildReason::compiler_options_changed),
            "source identity change should not be mislabeled as compiler options");
+
+    {
+        auto moved_object_unit = unit;
+        moved_object_unit.outputs[0].path = "another/main.obj";
+        const std::vector<mqb::FileSnapshot> moved_object_outputs{
+            mqb::FileSnapshot{
+                .path = "another/main.obj",
+                .exists = true,
+                .modified = time_at(30),
+            },
+        };
+        const auto moved_object = mqb::CompileCacheValidator::validate(
+            moved_object_unit,
+            toolchain,
+            options,
+            entry,
+            source,
+            moved_object_outputs,
+            dependencies);
+        expect(has_reason(moved_object, mqb::BuildReason::missing_output),
+               "cache metadata for a different object path must not authorize reuse");
+    }
+
+    {
+        auto module_unit = unit;
+        module_unit.kind = mqb::TranslationUnitKind::module_interface;
+        module_unit.source = "src/math.ixx";
+        module_unit.outputs = {
+            mqb::Artifact{.path = "build/math.obj", .kind = mqb::ArtifactKind::object},
+            mqb::Artifact{.path = "ifc/math.ifc", .kind = mqb::ArtifactKind::module_interface},
+        };
+        const auto module_entry = make_entry(module_unit, toolchain, options);
+        const mqb::FileSnapshot module_source{
+            .path = module_unit.source,
+            .exists = true,
+            .modified = time_at(10),
+        };
+        const std::vector<mqb::FileSnapshot> module_outputs{
+            mqb::FileSnapshot{.path = "build/math.obj", .exists = true, .modified = time_at(30)},
+            mqb::FileSnapshot{.path = "ifc/math.ifc", .exists = true, .modified = time_at(30)},
+        };
+        const auto module_fresh = mqb::CompileCacheValidator::validate(
+            module_unit,
+            toolchain,
+            options,
+            module_entry,
+            module_source,
+            module_outputs,
+            dependencies);
+        expect(module_fresh.reusable(),
+               "module provider should reuse cache only when both object and IFC exist");
+
+        auto missing_ifc_outputs = module_outputs;
+        missing_ifc_outputs[1].exists = false;
+        const auto missing_ifc = mqb::CompileCacheValidator::validate(
+            module_unit,
+            toolchain,
+            options,
+            module_entry,
+            module_source,
+            missing_ifc_outputs,
+            dependencies);
+        expect(has_reason(missing_ifc, mqb::BuildReason::missing_output),
+               "missing IFC output must invalidate an otherwise warm provider cache");
+
+        auto moved_ifc_unit = module_unit;
+        moved_ifc_unit.outputs[1].path = "ifc-v2/math.ifc";
+        const std::vector<mqb::FileSnapshot> moved_ifc_outputs{
+            module_outputs[0],
+            mqb::FileSnapshot{.path = "ifc-v2/math.ifc", .exists = true, .modified = time_at(30)},
+        };
+        const auto moved_ifc = mqb::CompileCacheValidator::validate(
+            moved_ifc_unit,
+            toolchain,
+            options,
+            module_entry,
+            module_source,
+            moved_ifc_outputs,
+            dependencies);
+        expect(has_reason(moved_ifc, mqb::BuildReason::compiler_options_changed),
+               "planned IFC routing change must invalidate provider signature identity");
+    }
+
+    {
+        auto consumer = unit;
+        consumer.module_references = {
+            mqb::ModuleReference{.logical_name = "math", .interface_file = "ifc/math.ifc"},
+        };
+        auto consumer_entry = make_entry(consumer, toolchain, options);
+        consumer_entry.dependencies.push_back("ifc/math.ifc");
+        const std::vector<mqb::FileSnapshot> consumer_dependencies{
+            dependencies[0],
+            dependencies[1],
+            mqb::FileSnapshot{.path = "ifc/math.ifc", .exists = true, .modified = time_at(20)},
+        };
+        const auto consumer_fresh = mqb::CompileCacheValidator::validate(
+            consumer,
+            toolchain,
+            options,
+            consumer_entry,
+            source,
+            outputs,
+            consumer_dependencies);
+        expect(consumer_fresh.reusable(),
+               "consumer may reuse when referenced IFC is older than its object");
+
+        auto newer_ifc = consumer_dependencies;
+        newer_ifc.back().modified = time_at(40);
+        const auto imported_module_changed = mqb::CompileCacheValidator::validate(
+            consumer,
+            toolchain,
+            options,
+            consumer_entry,
+            source,
+            outputs,
+            newer_ifc);
+        expect(has_reason(imported_module_changed, mqb::BuildReason::dependency_changed),
+               "newer imported IFC should invalidate the consumer object");
+    }
 
     if (failures != 0) {
         std::cerr << failures << " test(s) failed\n";

--- a/cpp/tests/msvc_compile_executor_tests.cpp
+++ b/cpp/tests/msvc_compile_executor_tests.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <chrono>
 #include <expected>
 #include <filesystem>
@@ -84,6 +85,25 @@ void write_dependencies(
         + json_escape(path_to_utf8(include))
         + "\"]}}";
     write_text(file, json);
+}
+
+[[nodiscard]] bool has_argument(
+    const mqb::process::ProcessSpec& spec,
+    const std::string_view expected) {
+    return std::find(spec.arguments.begin(), spec.arguments.end(), expected)
+        != spec.arguments.end();
+}
+
+[[nodiscard]] bool has_dependency(
+    const mqb::CompileCacheEntry& entry,
+    const fs::path& expected) {
+    const auto normalized = expected.lexically_normal();
+    return std::find_if(
+        entry.dependencies.begin(),
+        entry.dependencies.end(),
+        [&normalized](const fs::path& value) {
+            return value.lexically_normal() == normalized;
+        }) != entry.dependencies.end();
 }
 
 class RecordingRunner final : public mqb::process::ProcessRunner {
@@ -175,6 +195,8 @@ int main() {
                "cache entry should persist the compile recipe signature");
         expect(runner.last_spec.executable == toolchain.identity.compiler,
                "executor should invoke the discovered compiler directly");
+        expect(!has_argument(runner.last_spec, "/interface"),
+               "ordinary source execution should not accidentally enter module-interface mode");
     }
 
     const fs::path other_source = fixture.path() / "src" / "other.cpp";
@@ -209,6 +231,131 @@ int main() {
         expect(compiler_failure.error().compiler_error.has_value(),
                "executor should preserve the lower-level compiler error");
     }
+
+    runner.next_result = mqb::process::ProcessResult{
+        .exit_code = 0,
+        .stdout_text = "compiled-module",
+    };
+
+    const fs::path module_source = fixture.path() / "modules" / "math.ixx";
+    const fs::path module_object = fixture.path() / "cache" / "math.obj";
+    const fs::path module_ifc = fixture.path() / "cache" / "math.ifc";
+    const fs::path module_dependencies = fixture.path() / "cache" / "math.deps.json";
+    write_text(module_source, "export module math;\n");
+    write_text(module_object, "fake-module-object");
+    write_text(module_ifc, "fake-ifc");
+    write_dependencies(module_dependencies, module_source, header);
+
+    mqb::TranslationUnit module_unit;
+    module_unit.source = module_source;
+    module_unit.kind = mqb::TranslationUnitKind::module_interface;
+    module_unit.outputs = {
+        mqb::Artifact{module_object, mqb::ArtifactKind::object},
+        mqb::Artifact{module_ifc, mqb::ArtifactKind::module_interface},
+    };
+    mqb::msvc::CompileExecutionRequest module_request{
+        .unit = module_unit,
+        .options = options,
+        .source_dependencies_file = module_dependencies,
+        .working_directory = fixture.path(),
+    };
+
+    const auto module_result = executor.execute(module_request);
+    expect(module_result.has_value(),
+           "module-interface execution should preserve object, IFC, and dependency metadata");
+    if (module_result) {
+        expect(module_result->cache_entry.kind == mqb::TranslationUnitKind::module_interface,
+               "provider cache entry should preserve module-interface kind");
+        expect(has_argument(runner.last_spec, "/interface")
+                   && has_argument(runner.last_spec, "/ifcOutput")
+                   && has_argument(runner.last_spec, path_to_utf8(module_ifc)),
+               "executor should route the planned IFC through the compiler invocation");
+        expect(!has_dependency(module_result->cache_entry, module_ifc),
+               "provider must not treat its own generated IFC as an input dependency");
+    }
+
+    fs::remove(module_ifc);
+    const auto missing_ifc = executor.execute(module_request);
+    expect(!missing_ifc.has_value(), "compiler success without planned IFC must fail closed");
+    if (!missing_ifc) {
+        expect(missing_ifc.error().code == mqb::msvc::CompileExecutorErrorCode::output_missing,
+               "missing planned IFC should report output_missing");
+    }
+    write_text(module_ifc, "fake-ifc");
+
+    const fs::path consumer_source = fixture.path() / "src" / "consumer.cpp";
+    const fs::path consumer_object = fixture.path() / "cache" / "consumer.obj";
+    const fs::path consumer_dependencies = fixture.path() / "cache" / "consumer.deps.json";
+    write_text(consumer_source, "import math;\nint use_math();\n");
+    write_text(consumer_object, "fake-consumer-object");
+    write_dependencies(consumer_dependencies, consumer_source, header);
+
+    mqb::TranslationUnit consumer_unit;
+    consumer_unit.source = consumer_source;
+    consumer_unit.kind = mqb::TranslationUnitKind::source;
+    consumer_unit.module_references = {
+        mqb::ModuleReference{
+            .logical_name = "math",
+            .interface_file = module_ifc,
+        },
+    };
+    consumer_unit.outputs = {
+        mqb::Artifact{consumer_object, mqb::ArtifactKind::object},
+    };
+    mqb::msvc::CompileExecutionRequest consumer_request{
+        .unit = consumer_unit,
+        .options = options,
+        .source_dependencies_file = consumer_dependencies,
+        .working_directory = fixture.path(),
+    };
+
+    const auto consumer_result = executor.execute(consumer_request);
+    expect(consumer_result.has_value(),
+           "ordinary consumer should execute with typed module references");
+    if (consumer_result) {
+        const std::string reference = "math=" + path_to_utf8(module_ifc);
+        expect(has_argument(runner.last_spec, "/reference")
+                   && has_argument(runner.last_spec, reference),
+               "consumer compile argv should contain logical-name to IFC mapping");
+        expect(has_dependency(consumer_result->cache_entry, header),
+               "consumer cache should retain compiler-discovered headers");
+        expect(has_dependency(consumer_result->cache_entry, module_ifc),
+               "consumer cache should persist imported IFC as a freshness dependency");
+        expect(consumer_result->cache_entry.dependencies.size() == 2,
+               "consumer cache should store header and IFC without unrelated artifacts");
+    }
+
+    const int calls_before_invalid_contracts = runner.calls;
+    auto missing_ifc_unit = module_unit;
+    missing_ifc_unit.outputs.pop_back();
+    auto missing_ifc_request = module_request;
+    missing_ifc_request.unit = missing_ifc_unit;
+    const auto invalid_module = executor.execute(missing_ifc_request);
+    expect(!invalid_module
+               && invalid_module.error().code == mqb::msvc::CompileExecutorErrorCode::invalid_request,
+           "module interface without planned IFC should fail before launching compiler");
+
+    auto ordinary_with_ifc = consumer_unit;
+    ordinary_with_ifc.outputs.push_back(
+        mqb::Artifact{module_ifc, mqb::ArtifactKind::module_interface});
+    auto ordinary_with_ifc_request = consumer_request;
+    ordinary_with_ifc_request.unit = ordinary_with_ifc;
+    const auto invalid_ordinary = executor.execute(ordinary_with_ifc_request);
+    expect(!invalid_ordinary
+               && invalid_ordinary.error().code == mqb::msvc::CompileExecutorErrorCode::invalid_request,
+           "ordinary source with planned IFC output should fail before compiler launch");
+
+    auto bad_output_unit = consumer_unit;
+    bad_output_unit.outputs.push_back(
+        mqb::Artifact{fixture.path() / "unexpected.exe", mqb::ArtifactKind::executable});
+    auto bad_output_request = consumer_request;
+    bad_output_request.unit = bad_output_unit;
+    const auto invalid_output = executor.execute(bad_output_request);
+    expect(!invalid_output
+               && invalid_output.error().code == mqb::msvc::CompileExecutorErrorCode::invalid_request,
+           "compile plan must reject executable/link artifacts in TU outputs");
+    expect(runner.calls == calls_before_invalid_contracts,
+           "invalid module/output contracts must not launch the compiler");
 
     if (failures != 0) {
         std::cerr << failures << " test(s) failed\n";

--- a/cpp/tests/msvc_compiler_arguments_tests.cpp
+++ b/cpp/tests/msvc_compiler_arguments_tests.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "mqb/core/CompilerOptions.hpp"
+#include "mqb/core/TranslationUnit.hpp"
 #include "mqb/msvc/MsvcCompiler.hpp"
 
 namespace {
@@ -64,6 +65,8 @@ int main() {
         expect(contains(*result, "/Iinclude"), "include path should become one /I argv element");
         expect(contains(*result, "/Ivendor include"), "include path with spaces should remain one argv element");
         expect(contains(*result, "/sourceDependencies"), "dependency output should enable /sourceDependencies");
+        expect(!contains(*result, "/interface") && !contains(*result, "/ifcOutput"),
+               "ordinary source compilation should not emit module-interface switches");
 
         expect(result->size() >= 2, "argv should end with object routing and source");
         if (result->size() >= 2) {
@@ -108,6 +111,78 @@ int main() {
                "dependency switch should be omitted when no output path was requested");
     }
 
+    {
+        auto module = invocation;
+        module.source = "modules/math.ixx";
+        module.object = "build/modules/math.ixx.obj";
+        module.source_dependencies = "deps/modules/math.ixx.json";
+        module.kind = mqb::TranslationUnitKind::module_interface;
+        module.module_interface_output = "ifc/modules/math.ixx.ifc";
+        module.module_references = {
+            mqb::msvc::ModuleReference{
+                .logical_name = "base",
+                .interface_file = "ifc/base.ixx.ifc",
+            },
+        };
+        module.options.additional_arguments = {
+            "/ifcOutput",
+            "ignored.ifc",
+            "/Foignored-module.obj",
+        };
+
+        const auto module_result = mqb::msvc::MsvcCompiler::build_arguments(module);
+        expect(module_result.has_value(), "module interface invocation should produce argv");
+        if (module_result) {
+            expect(contains(*module_result, "/interface") && contains(*module_result, "/TP"),
+                   "module interface should use explicit /interface and /TP mode");
+            expect(contains(*module_result, "/reference"),
+                   "module imports should use MSVC /reference mapping");
+            expect(contains(*module_result, "base=ifc/base.ixx.ifc"),
+                   "module reference should preserve logical-name to IFC mapping");
+            expect(contains(*module_result, "/ifcOutput"),
+                   "module interface should route its IFC explicitly");
+            expect(contains(*module_result, "ifc/modules/math.ixx.ifc"),
+                   "structured IFC path should be present");
+
+            const auto raw_ifc = std::find(module_result->begin(), module_result->end(), "ignored.ifc");
+            const auto planned_ifc = std::find(
+                module_result->begin(), module_result->end(), "ifc/modules/math.ixx.ifc");
+            const auto raw_fo = std::find(
+                module_result->begin(), module_result->end(), "/Foignored-module.obj");
+            const auto planned_fo = std::find(
+                module_result->begin(), module_result->end(), "/Fobuild/modules/math.ixx.obj");
+            expect(raw_ifc != module_result->end()
+                       && planned_ifc != module_result->end()
+                       && raw_ifc < planned_ifc,
+                   "structured IFC routing should follow raw /ifcOutput arguments");
+            expect(raw_fo != module_result->end()
+                       && planned_fo != module_result->end()
+                       && raw_fo < planned_fo,
+                   "structured module object routing should follow raw /Fo arguments");
+            expect(module_result->back() == "modules/math.ixx",
+                   "module source should remain the final argv element");
+        }
+    }
+
+    {
+        auto consumer = invocation;
+        consumer.module_references = {
+            mqb::msvc::ModuleReference{
+                .logical_name = "math",
+                .interface_file = "ifc/math.ixx.ifc",
+            },
+        };
+        consumer.options.additional_arguments.clear();
+        auto consumer_result = mqb::msvc::MsvcCompiler::build_arguments(consumer);
+        expect(consumer_result.has_value(), "ordinary source may consume named module IFC references");
+        if (consumer_result) {
+            expect(!contains(*consumer_result, "/interface") && !contains(*consumer_result, "/ifcOutput"),
+                   "module-consuming ordinary source must remain an ordinary compile");
+            expect(contains(*consumer_result, "math=ifc/math.ixx.ifc"),
+                   "ordinary consumer should map imported module name to IFC path");
+        }
+    }
+
     auto invalid = invocation;
     invalid.source.clear();
     const auto invalid_result = mqb::msvc::MsvcCompiler::build_arguments(invalid);
@@ -115,6 +190,47 @@ int main() {
     if (!invalid_result) {
         expect(invalid_result.error().code == mqb::msvc::CompilerErrorCode::invalid_request,
                "invalid invocation should report invalid_request");
+    }
+
+    {
+        auto missing_ifc = invocation;
+        missing_ifc.kind = mqb::TranslationUnitKind::module_interface;
+        auto invalid_module = mqb::msvc::MsvcCompiler::build_arguments(missing_ifc);
+        expect(!invalid_module
+                   && invalid_module.error().code == mqb::msvc::CompilerErrorCode::invalid_request,
+               "module interface without IFC output should fail before launching cl.exe");
+    }
+
+    {
+        auto ordinary_ifc = invocation;
+        ordinary_ifc.module_interface_output = "unexpected.ifc";
+        auto invalid_ordinary = mqb::msvc::MsvcCompiler::build_arguments(ordinary_ifc);
+        expect(!invalid_ordinary
+                   && invalid_ordinary.error().code == mqb::msvc::CompilerErrorCode::invalid_request,
+               "ordinary source must not request an IFC output");
+    }
+
+    {
+        auto duplicate_reference = invocation;
+        duplicate_reference.module_references = {
+            mqb::msvc::ModuleReference{.logical_name = "M", .interface_file = "one.ifc"},
+            mqb::msvc::ModuleReference{.logical_name = "M", .interface_file = "two.ifc"},
+        };
+        auto invalid_reference = mqb::msvc::MsvcCompiler::build_arguments(duplicate_reference);
+        expect(!invalid_reference
+                   && invalid_reference.error().code == mqb::msvc::CompilerErrorCode::invalid_request,
+               "duplicate logical module references should fail closed");
+    }
+
+    {
+        auto empty_reference = invocation;
+        empty_reference.module_references = {
+            mqb::msvc::ModuleReference{.logical_name = "", .interface_file = "one.ifc"},
+        };
+        auto invalid_reference = mqb::msvc::MsvcCompiler::build_arguments(empty_reference);
+        expect(!invalid_reference
+                   && invalid_reference.error().code == mqb::msvc::CompilerErrorCode::invalid_request,
+               "empty logical module reference should fail validation");
     }
 
     if (failures != 0) {

--- a/cpp/tests/msvc_incremental_loop_tests.cpp
+++ b/cpp/tests/msvc_incremental_loop_tests.cpp
@@ -91,6 +91,16 @@ void write_text(const fs::path& path, const std::string_view text) {
     return snapshots;
 }
 
+[[nodiscard]] std::vector<mqb::FileSnapshot> snapshot_outputs(
+    const mqb::TranslationUnit& unit) {
+    std::vector<mqb::FileSnapshot> snapshots;
+    snapshots.reserve(unit.outputs.size());
+    for (const auto& output : unit.outputs) {
+        snapshots.push_back(snapshot(output.path));
+    }
+    return snapshots;
+}
+
 [[nodiscard]] bool has_reason(
     const mqb::CompileCacheValidation& validation,
     const mqb::BuildReason reason) {
@@ -115,7 +125,7 @@ void write_text(const fs::path& path, const std::string_view text) {
     const mqb::CompilerOptions& options,
     const std::optional<mqb::CompileCacheEntry>& cached) {
     const auto source_snapshot = snapshot(unit.source);
-    const auto object_snapshot = snapshot(unit.outputs.front().path);
+    const auto output_snapshots = snapshot_outputs(unit);
     const std::vector<mqb::FileSnapshot> dependency_snapshots = cached
         ? snapshot_all(cached->dependencies)
         : std::vector<mqb::FileSnapshot>{};
@@ -126,7 +136,7 @@ void write_text(const fs::path& path, const std::string_view text) {
         options,
         cached,
         source_snapshot,
-        object_snapshot,
+        output_snapshots,
         dependency_snapshots);
 }
 

--- a/cpp/tests/project_artifact_layout_tests.cpp
+++ b/cpp/tests/project_artifact_layout_tests.cpp
@@ -41,9 +41,28 @@ int main() {
                "in-project object path should preserve relative source identity");
         expect(src_foo->dependencies == root / ".mqb" / "deps" / "src" / "foo.cpp.json",
                "dependency metadata should preserve relative source identity");
+        expect(src_foo->module_dependencies
+                   == root / ".mqb" / "scan" / "src" / "foo.cpp.json",
+               "module scan metadata should preserve relative source identity");
+        expect(src_foo->module_interface
+                   == root / ".mqb" / "ifc" / "src" / "foo.cpp.ifc",
+               "compiled module interface path should preserve relative source identity");
         expect(src_foo->compile_cache
                    == root / ".mqb" / "cache" / "compile" / "src" / "foo.cpp.mqbcache",
                "compile cache should preserve relative source identity");
+        expect(src_foo->module_dependencies != tests_foo->module_dependencies
+                   && src_foo->module_interface != tests_foo->module_interface,
+               "same-basename module artifacts in different directories must not collide");
+    }
+
+    auto partition = layout->for_source(root / "modules" / "math-part.ixx");
+    expect(partition.has_value(), "module interface source should map to module artifacts");
+    if (partition) {
+        expect(partition->module_interface
+                   == root / ".mqb" / "ifc" / "modules" / "math-part.ixx.ifc",
+               "IFC filename should come from source identity rather than logical module spelling");
+        expect(partition->module_interface.generic_string().find(':') == std::string::npos,
+               "IFC artifact routing must not require logical-name characters such as partition ':'");
     }
 
     auto outside = layout->for_source(fs::path{"D:/vendor/foo.cpp"});
@@ -54,6 +73,9 @@ int main() {
                "external source artifacts should be isolated under .external hash namespace");
         expect(generic.ends_with("/foo.cpp.obj"),
                "external artifact should retain source filename for diagnostics");
+        expect(outside->module_interface.generic_string().find(".mqb/ifc/.external/")
+                   != std::string::npos,
+               "external IFCs should share the stable external-source namespace");
     }
 
     auto target = layout->for_target("demo");

--- a/cpp/tests/project_artifact_layout_tests.cpp
+++ b/cpp/tests/project_artifact_layout_tests.cpp
@@ -61,8 +61,8 @@ int main() {
         expect(partition->module_interface
                    == root / ".mqb" / "ifc" / "modules" / "math-part.ixx.ifc",
                "IFC filename should come from source identity rather than logical module spelling");
-        expect(partition->module_interface.generic_string().find(':') == std::string::npos,
-               "IFC artifact routing must not require logical-name characters such as partition ':'");
+        expect(partition->module_interface.filename().generic_string().find(':') == std::string::npos,
+               "IFC filename must not require logical-name characters such as partition ':'");
     }
 
     auto outside = layout->for_source(fs::path{"D:/vendor/foo.cpp"});

--- a/docs/CPP_V2_ARCHITECTURE.md
+++ b/docs/CPP_V2_ARCHITECTURE.md
@@ -5,11 +5,11 @@ This document defines the architecture for migrating MSVC Quick Build from the P
 ## Goals
 
 - Keep the PowerShell implementation as the behavioral reference until parity is proven.
-- Separate source selection, build policy, compiler/linker execution, and process execution.
+- Separate source selection, build policy, dependency topology, compiler/linker execution, and process execution.
 - Keep MSVC-specific spellings out of the core model.
 - Make compile and link cache invalidation explainable and regression-testable.
 - Treat paths and argv as structured data rather than shell command strings.
-- Prefer a conservative rebuild/relink over reusing uncertain artifacts.
+- Prefer a conservative rebuild/relink or an explicit unsupported error over reusing uncertain artifacts.
 
 ## Layers
 
@@ -24,28 +24,35 @@ CLI (mqb.exe)
     |      ordinary C++ candidate-TU selection
     |
     v
-Target orchestration
+Ordinary target orchestration
   bounded parallel N x compile coordinator -> ordered results -> one link coordinator
+
+Named-module orchestration (internal milestone API; not public CLI wiring yet)
+  parallel /scanDependencies
+      -> P1689R5 typed model
+      -> resolved provider graph + compile levels
+      -> level-barrier bounded compile waves
+      -> one incremental link coordinator
     |
-    +--------------------+
-    v                    v
-Core                  MSVC backend
-  BuildRequest           MsvcToolchainLocator
-  Artifact / TU          MsvcCompiler
-  ProjectArtifactLayout  MsvcCompileExecutor
-  BuildSignature         MsvcLibraryResolver
-  CompileCache           MsvcLinker
-  LinkCache              /sourceDependencies reader
-  DependencyGraph              |
-  BuildPlanner                 v
-    |                    Process abstraction
-    |                    ProcessSpec { executable, argv, cwd, env }
-    |                          |
-    +--------------------------+
-                               v
-                        Windows platform
-                        WindowsProcessRunner
-                        CreateProcessW
+    +--------------------+--------------------+
+    v                    v                    v
+Core                  Modules              MSVC backend
+  BuildRequest           P1689 parser          MsvcToolchainLocator
+  Artifact / TU          provider graph        MsvcCompiler
+  ProjectArtifactLayout  compile levels        MsvcCompileExecutor
+  BuildSignature                               MsvcModuleDependencyScanner
+  CompileCache                                 MsvcLibraryResolver
+  LinkCache                                    MsvcLinker
+  DependencyGraph                              /sourceDependencies reader
+  BuildPlanner                                       |
+    |                                                v
+    +----------------------------------------> Process abstraction
+                                              ProcessSpec { executable, argv, cwd, env }
+                                                    |
+                                                    v
+                                             Windows platform
+                                             WindowsProcessRunner
+                                             CreateProcessW
 ```
 
 ## Architectural rules
@@ -57,11 +64,15 @@ Core                  MSVC backend
 5. **UTF-8 at the process abstraction boundary.** Windows converts textual argv/environment data to UTF-16 immediately before `CreateProcessW`.
 6. **Compile state and link state are independent.** A compile cache hit does not imply a link cache hit, and link-only changes must never force unnecessary compilation.
 7. **A fresh compile is an explicit relink signal.** Linking must not depend solely on filesystem timestamp granularity.
-8. **Source identity is not a basename.** Project artifacts preserve relative source identity; external sources receive a stable hashed namespace, and duplicate object mappings are rejected before execution.
-9. **Run-time argv is not build identity.** `--run` and arguments after `--` are execution state only; changing them must not invalidate compile or link caches.
-10. **Discovery is not dependency freshness.** Smart discovery chooses candidate translation units; MSVC `/sourceDependencies` remains the authority for header freshness.
-11. **Configuration is typed policy, not shell text.** `mqb.json` decodes into optional typed overrides before MSVC arguments are produced.
-12. **Compile parallelism is execution policy, not build identity.** `-j/--jobs` controls how many ordinary TUs may execute concurrently; changing it must not invalidate compile or link caches.
+8. **Source identity is not a basename.** Project artifacts preserve relative source identity; external sources receive a stable hashed namespace.
+9. **Writable artifacts are exclusive.** Module target preflight rejects empty or colliding object, dependency, scan, IFC, compile-cache, executable, and link-cache paths before external processes start.
+10. **Run-time argv is not build identity.** `--run` and arguments after `--` are execution state only; changing them must not invalidate compile or link caches.
+11. **Discovery is not dependency freshness.** Smart discovery chooses candidate translation units; MSVC `/sourceDependencies` remains the authority for header freshness after compilation.
+12. **Configuration is typed policy, not shell text.** `mqb.json` decodes into optional typed overrides before MSVC arguments are produced.
+13. **Parallelism is execution policy, not build identity.** Job counts must not invalidate compile or link caches.
+14. **Module topology and header freshness are different data.** `/scanDependencies` determines pre-compile module ordering; `/sourceDependencies` remains the post-compile freshness source for headers.
+15. **Provider selection has one owner.** `ModuleDependencyGraphBuilder` resolves named-module providers once; orchestration consumes those exact resolved edges for `/reference` wiring and downstream rebuild propagation.
+16. **Unsupported module requirements fail closed.** Header units and unresolved external/prebuilt named modules are never silently ignored.
 
 ## Project configuration
 
@@ -83,46 +94,44 @@ built-in defaults
         <- explicitly supplied CLI scalar options
 ```
 
-The CLI parser therefore tracks whether `--debug`, `--release`, `--x86`, `--x64`, `--std`, `--discover`, and `--no-discover` were actually supplied. Parser defaults must never accidentally override project configuration.
-
-List-like build inputs are additive and deterministic: project-config entries appear first, then CLI entries. This currently applies to defines, include directories, library directories, and libraries.
-
-The v1 schema and examples are documented in `docs/MQB_CONFIG.md`. Unknown fields, duplicate JSON keys, wrong field types, malformed JSON, and unsupported schema versions are rejected instead of guessed.
+List-like build inputs are additive and deterministic: project-config entries appear first, then CLI entries. The v1 schema and examples are documented in `docs/MQB_CONFIG.md`. Unknown fields, duplicate JSON keys, wrong field types, malformed JSON, and unsupported schema versions are rejected instead of guessed.
 
 ## Smart ordinary-C++ discovery
 
 With one positional source, MQB smart-discovers the connected ordinary-C++ target by default. Multiple positional sources remain an explicit ordered source set. `--no-discover` disables discovery; `--discover` explicitly enables it and can override project configuration.
 
-Discovery uses:
+Discovery uses quoted `#include "..."` connectivity, configured include directories, same-basename ownership, deterministic traversal, built-in directory exclusions, and project-config corrections. A reachable non-entry source defining `main(...)` is a traversal barrier. Explicitly excluded sources and directories are also traversal barriers.
 
-- quoted `#include "..."` connectivity;
-- configured include directories;
-- same-basename ownership such as `foo.hpp <-> foo.cpp/.cc/.cxx`;
-- deterministic traversal from the entry TU;
-- built-in directory exclusions (`.mqb`, `.git`, `.vs`, `build`, `out`, `cmake-build-*`);
-- project-config `exclude_dirs`, `extra_sources`, and `exclude_sources` exact-path corrections.
+Discovery output only selects ordinary TUs. Incremental header invalidation continues to use compiler-emitted `/sourceDependencies` metadata.
 
-A reachable non-entry source defining `main(...)` is a traversal barrier, not merely a final-result filter. An explicitly excluded source is also a traversal barrier, so a test/tool TU cannot bridge the graph into a private subgraph. Configured excluded directories are pruned before graph construction. Explicit extra sources may add disconnected ordinary TUs but may not define another `main()`.
-
-Discovery output only selects TUs. Incremental header invalidation continues to use compiler-emitted `/sourceDependencies` metadata.
+The named-module target pipeline added in the Modules milestone is currently an internal orchestration API. Public `mqb.exe` source discovery/CLI routing has not yet been switched to that pipeline.
 
 ## Compile identity and cache freshness
 
-`BuildSignature::for_compile` models the versioned compiler recipe identity: source/unit identity, compiler identity, configuration, architecture, language standard, ordered defines, ordered include paths, and ordered extra arguments.
+`BuildSignature::for_compile` models the versioned compiler recipe identity. Compile signature v3 includes:
+
+- source and translation-unit kind;
+- compiler identity;
+- configuration, architecture, and language standard;
+- ordered defines, include paths, and extra compiler arguments;
+- ordered typed module references (`logical-name -> IFC path`);
+- for a module interface unit, the planned IFC output path.
+
+Ordinary object placement remains outside recipe identity. Module IFC placement is different: a provider's planned IFC path is part of the recipe because consumers reference that exact interface artifact.
 
 ```text
 compiler recipe identity ----> BuildSignature
-source/header freshness ------> CompileCacheValidator
+source/header/IFC freshness --> CompileCacheValidator
 artifact placement -----------> ProjectArtifactLayout
 ```
 
-`CompileCacheValidator` is pure and returns typed `BuildReason` values; it does not touch the filesystem or launch a process.
+`CompileCacheValidator` is pure and returns typed `BuildReason` values; it does not touch the filesystem or launch a process. It validates all planned compile outputs, not only the object. Therefore a provider with an existing object but a missing IFC is stale.
+
+Consumer cache metadata records imported IFC files alongside compiler-discovered header dependencies. A provider that actually recompiles in the current module wave also propagates an explicit downstream rebuild signal, preventing timestamp-granularity races from producing a false consumer hit.
 
 `CompileCacheFile` persists compile metadata in a versioned binary format. Missing metadata is a normal cold-cache condition; corrupt/truncated/unsupported metadata is rejected and conservatively rebuilt.
 
-A config-only change that alters effective compiler options therefore changes compile identity even when no source timestamp changes.
-
-Ordinary Debug and Release compilation use MSVC `/Z7`, keeping compiler debug information inside each TU's object instead of sharing a compiler PDB between concurrent `cl.exe` processes. Final link debug information remains a linker concern. The compile signature recipe was version-bumped when this policy changed so old `/Zi` cache entries are conservatively rebuilt once.
+Ordinary Debug and Release compilation use MSVC `/Z7`, keeping compiler debug information inside each TU's object instead of sharing a compiler PDB between concurrent `cl.exe` processes.
 
 ## Link identity and cache freshness
 
@@ -139,69 +148,105 @@ output/object/library freshness ---> LinkCacheValidator
 fresh compile ---------------------> force_relink
 ```
 
-`LinkerIdentity` stamps `link.exe` independently from `cl.exe`, so a linker update can invalidate only link state.
-
-User-requested libraries are resolved deterministically to exact `.lib` files before invoking `link.exe`. Link cache v2 persists the resolved library inputs, so updating a `.lib` can trigger compile-0/link-1 invalidation. Library names/search paths are recipe state; the resolved files themselves are freshness inputs.
+`LinkerIdentity` stamps `link.exe` independently from `cl.exe`. User-requested libraries are resolved deterministically to exact `.lib` files before invoking `link.exe`; link-cache metadata persists those resolved inputs.
 
 Current boundary: explicitly requested libraries are tracked precisely. Indirect `/DEFAULTLIB` dependencies embedded in objects or libraries are still resolved by `link.exe` and are not claimed as fully tracked transitive link inputs.
 
 ## Project artifact layout
 
-Without `mqb.json`, the invocation directory is the project root. With `mqb.json`, its directory becomes the project root even when MQB is launched from a nested directory.
+Without `mqb.json`, the invocation directory is the project root. With `mqb.json`, its directory becomes the project root. Sources inside the root preserve relative source identity; sources outside it are isolated under `.external/<stable-path-hash>/`.
 
-Sources inside the root preserve relative identity; sources outside it are isolated under `.external/<stable-path-hash>/`.
+For a source such as `src/foo.cpp` or `modules/math.ixx`, the layout owns separate namespaces:
 
 ```text
 project/
-  mqb.json
-  main.cpp
-  src/foo.cpp
   .mqb/
-    obj/
-      main.cpp.obj
-      src/foo.cpp.obj
-    deps/
-      main.cpp.json
-      src/foo.cpp.json
+    obj/     <source-key>.obj
+    deps/    <source-key>.json
+    scan/    <source-key>.json
+    ifc/     <source-key>.ifc
     cache/
-      compile/...
-      link/main.linkcache
+      compile/<source-key>.mqbcache
+      link/<target>.linkcache
     bin/
-      main.exe
+      <target>.exe
 ```
 
-This prevents same-basename sources in different directories from aliasing one object/cache artifact.
+IFCs are keyed by source identity rather than logical module spelling. This avoids Windows filename problems such as partition `:` characters and avoids same-basename collisions. The module target coordinator additionally validates global writable-artifact exclusivity before scanning.
 
-## Dependency graph and planner
+## Dependency graphs and planning
 
 `DependencyGraph` stores `node depends on dependency` edges. It rejects duplicate/missing nodes, makes duplicate edges idempotent, returns deterministic topological levels, and fails cycles explicitly.
 
-For compile planning:
+`ModuleDependencyGraphBuilder` consumes typed P1689 rules and produces one `ModuleDependencyPlan` containing:
 
 ```text
-CompilePlanItem
-    +-- reusable cache ------> no action
-    +-- stale cache ---------> CompileAction
-                                  source
-                                  exactly one object artifact
-                                  typed rebuild reasons
+compile_levels
+resolved_dependencies {
+    consumer_source,
+    provider_source,
+    logical_name
+}
+unresolved_requirements
 ```
 
-For link planning:
+Named-provider selection prefers the unique `is-interface=true` provider when same-name module units exist. Multiple interface providers fail explicitly. Header-unit identity remains typed but unresolved until the dedicated header-unit milestone.
+
+The exact resolved dependency edges are reused for both compile ordering and MSVC `/reference logical-name=ifc` wiring. Orchestration does not run a second provider-selection algorithm.
+
+## Named-module MSVC pipeline
+
+The current implemented module pipeline supports the internal named-module-interface -> named-consumer path:
 
 ```text
-LinkPlanItem
-    +-- reusable cache ------> no action
-    +-- stale cache ---------> LinkAction
-                                  ordered object inputs
-                                  ordered resolved libraries
-                                  executable output
-                                  typed relink reasons
+selected source requests
+      -> preflight all writable artifacts
+      -> bounded parallel MsvcModuleDependencyScanner
+             cl.exe /scanDependencies <per-source P1689 JSON>
+      -> exactly one P1689 rule per one-source scan
+      -> ModuleDependencyGraphBuilder
+             provider resolution
+             deterministic topological compile levels
+      -> MsvcModuleCompileCoordinator
+             for each level:
+                 bounded parallel incremental compile
+                 module interface: /interface /TP /ifcOutput
+                 consumer: /reference logical-name=<planned-ifc>
+             barrier between levels
+             provider compiled this run -> downstream explicit_rebuild
+      -> MsvcIncrementalLinkCoordinator
+             any TU compiled -> force_relink
+      -> target executable
 ```
 
-Executors therefore receive actions rather than policy decisions.
+`/scanDependencies` is topology-only; it does not produce `.obj` or `.ifc`. The real compile remains responsible for `/sourceDependencies`, object output, and IFC output.
 
-## Orchestration
+Warm module target builds currently repeat topology scanning. The proven cache guarantee is **compile 0 / link 0**, not scan 0. Scan-result caching is a future optimization and must not change build identity semantics.
+
+### Current module capability boundary
+
+Supported and regression-tested in this milestone:
+
+- P1689R5 parsing and strict schema validation;
+- internal named-module interface providers;
+- named consumers resolved to exact provider sources;
+- source-identity IFC routing;
+- bounded same-level parallelism with dependency-level barriers;
+- module-aware compile signatures and cache freshness;
+- downstream rebuild propagation when a provider recompiles;
+- incremental final linking;
+- real VS2026 provider/consumer executable E2E.
+
+Not yet supported by `MsvcModuleTargetCoordinator`:
+
+- header units;
+- unresolved external/prebuilt named-module providers;
+- `import std` (currently appears as an unresolved external named module and fails closed);
+- public CLI/source-discovery routing into the module target coordinator.
+
+The P1689 model can represent more cases than the current execution policy accepts. That is intentional: parsing a requirement is not permission to compile it incorrectly.
+
+## Ordinary orchestration
 
 ### Incremental compile
 
@@ -215,6 +260,8 @@ CompileCacheFile
       -> CompileCacheFile::save
 ```
 
+`force_rebuild` is a request-local execution signal represented by `BuildReason::explicit_rebuild`. It does not enter the compile signature and is not persisted into the cache.
+
 ### Incremental link
 
 ```text
@@ -227,7 +274,7 @@ LinkCacheFile
       -> LinkCacheFile::save
 ```
 
-### Incremental target
+### Ordinary incremental target
 
 ```text
 ordered source requests
@@ -235,31 +282,22 @@ ordered source requests
       -> BoundedWorkScheduler(max_parallel_compiles)
       -> parallel IncrementalCompileCoordinator per ordinary TU
       -> join every in-flight compile
-      -> scan attempts in original source order
-      -> any compile failure? ---- yes ----> report lowest source index; never link
+      -> deterministic failure selection
       -> collect collision-free objects in original source order
       -> any TU compiled? -------- yes ----> force_relink
       -> IncrementalLinkCoordinator
       -> one target executable
 ```
 
-`MsvcIncrementalTargetCoordinator` performs bounded ordinary-TU compilation. `-j/--jobs` selects the maximum concurrency; if omitted, the CLI starts from hardware concurrency and clamps it to the selected TU count. `-j1` preserves the sequential execution mode for debugging. Parallelism does not participate in compile or link signatures.
-
-The scheduler assigns indices monotonically and at most once, joins all work that was already assigned, and publishes a stop request when a callback fails. Stop publication also quenches the dispatch counter so a worker that observed an older stop flag but had not yet claimed an index cannot start later work. Target results are reassembled in source order, and concurrent compile failures deterministically surface the lowest source index among recorded failures.
-
-Ordinary cache-load/save failures are surfaced as warnings and conservatively rebuild/relink. Compiler/linker execution failures are build errors.
+The scheduler assigns indices monotonically and at most once, joins all work that was already assigned, and quenches dispatch after stop publication. Target results are reassembled in source order.
 
 ## Process boundary
 
 `mqb_process` defines a platform-neutral `ProcessSpec` with executable, argv, working directory, structured environment overrides, inheritance choice, and stdout/stderr capture controls.
 
-`mqb_platform_windows` isolates Windows command-line quoting and the real `CreateProcessW` runner. Tests cover complex argv round-trips, Unicode environment blocks, separate stdout/stderr capture, non-zero child exit codes, native launch errors, concurrent draining of large output streams, and concurrent use of one runner instance.
+`mqb_platform_windows` isolates Windows command-line quoting and the real `CreateProcessW` runner. Captured child processes use `STARTUPINFOEXW` with `PROC_THREAD_ATTRIBUTE_HANDLE_LIST`, so unrelated pipe handles from concurrent compiler launches are not inherited by sibling children.
 
-`--run` uses the same structured process boundary. Arguments after `--` remain distinct argv elements, including whitespace-containing strings, option-looking strings, and empty arguments. Run mode and child argv do not participate in build signatures.
-
-Captured CRLF is normalized before forwarding through Windows text streams so nested output does not become `\r\r\n`; lone carriage returns are preserved.
-
-Captured child processes use `STARTUPINFOEXW` with `PROC_THREAD_ATTRIBUTE_HANDLE_LIST`. Only that child's explicit stdin/stdout/stderr handles are inheritable through `CreateProcessW`; unrelated pipe handles from concurrent compiler launches are not exposed to sibling children. Non-capture launches continue to use no inherited handles.
+`--run` uses the same structured process boundary. Arguments after `--` remain distinct argv elements and do not participate in build signatures.
 
 ## MSVC toolchain boundary
 
@@ -267,53 +305,29 @@ Captured child processes use `STARTUPINFOEXW` with `PROC_THREAD_ATTRIBUTE_HANDLE
 
 GitHub CI enables installed-MSVC integration tests explicitly; local tests keep them opt-in.
 
+## Current verification milestone
+
+The VS2026 PR suite now contains **46 registered CTest cases**. It verifies ordinary CLI behavior plus the new module backend/orchestration path.
+
+Among the real installed-MSVC cases are:
+
+- ordinary single/multi-TU compile and incremental link behavior;
+- same-directory four-TU cold `-j4` and warm `-j1`, proving job count is not build identity;
+- real `/scanDependencies` P1689 output before IFCs exist;
+- real module provider IFC creation and consumer `/reference` compilation;
+- full named-module target cold build and executable launch;
+- warm named-module target with compile 0 / link 0;
+- provider-source mutation causing provider + consumer + link rebuild;
+- provider IFC deletion with source/object otherwise warm, causing provider + consumer + link repair;
+- artifact collision/empty-artifact validation before any external process starts.
+
+The named-module target E2E uses the installed Visual Studio 2026 compiler and linker, not a fake process runner.
+
 ## Current CLI milestone
 
-Examples:
+The public `mqb.exe` CLI currently owns the ordinary-C++ path: project config, smart ordinary source discovery, bounded `-j/--jobs` compilation, independent link caching, library resolution, and structured `--run` argv.
 
-```powershell
-# One entry: smart discovery
-mqb main.cpp
-
-# Explicit source set
-mqb main.cpp src/utils.cpp a/helper.cpp b/helper.cpp -o product
-
-# Bound ordinary-TU compilation to four concurrent jobs
-mqb main.cpp --jobs 4
-
-# Force sequential compile scheduling without changing build identity
-mqb main.cpp -j1
-
-# Exact static library request
-mqb main.cpp -L "vendor libs" -l math
-
-# Structured run argv
-mqb main.cpp --run -- "hello world" --child-option ""
-```
-
-When an `mqb.json` is found, effective build/discovery options are resolved before toolchain discovery and artifact planning.
-
-The real VS2026 suite now verifies, among other cases:
-
-- single-entry smart discovery plus same-basename artifact isolation;
-- second-entry traversal barriers and project discovery corrections;
-- warm compile/link reuse;
-- private-header partial rebuild through `/sourceDependencies`;
-- Debug/Release recipe invalidation without source edits;
-- exact static-library resolution and library-only relink;
-- custom output names and independent link-cache identities;
-- structured `--run` argv and child exit propagation;
-- upward `mqb.json` lookup from a nested working directory;
-- config-relative include/library paths and config-root artifact placement;
-- config-only define changes invalidating compile recipes;
-- explicit CLI scalar overrides winning over project config while config list inputs remain available;
-- three-way bounded scheduler concurrency, stop/join semantics, and deterministic target failure selection;
-- same-directory four-TU real MSVC cold build with `-j4`;
-- warm reuse of those exact artifacts under `-j1`, proving job count is not build identity.
-
-The current VS2026 PR suite contains 35 registered CTest cases, including real target, project-config, and parallel CLI E2E tests.
-
-Not yet implemented in the C++ V2 path: C++ Modules/P1689/IFC handling. PowerShell/C++ behavioral parity and final cutover also remain future gates.
+The named-module pipeline described above is implemented and integration-tested behind typed orchestration APIs, but it is **not yet wired into the public CLI/source-discovery path**. Therefore this document does not claim that the C++ V2 CLI has reached full Modules parity with the PowerShell tool.
 
 ## Migration sequence
 
@@ -329,9 +343,10 @@ Not yet implemented in the C++ V2 path: C++ Modules/P1689/IFC handling. PowerShe
 10. **Smart source discovery** — single-entry graph selection, secondary-entry barriers, corrections. ✅
 11. **Project config v1** — upward `mqb.json`, typed schema, path semantics, CLI precedence, config E2E. ✅
 12. **Parallel ordinary-TU scheduling** — bounded concurrency with deterministic reporting/failure semantics. ✅
-13. **Modules** — P1689 `/scanDependencies`, module graph, IFC/object artifacts, `import std`.
-14. **Parity** — run PowerShell and C++ against the same E2E fixtures.
-15. **Cutover** — make `mqb.exe` primary only after parity tests pass.
+13. **Named Modules core/orchestration** — P1689 scan, provider graph, IFC artifacts, module-aware cache, dependency waves, incremental link, real VS2026 E2E. ✅
+14. **Modules expansion/UX** — public CLI routing, module-aware source selection, header units, external/prebuilt provider policy, `import std`.
+15. **Parity** — run PowerShell and C++ against the same E2E fixtures.
+16. **Cutover** — make `mqb.exe` primary only after parity tests pass.
 
 ## Local build
 


### PR DESCRIPTION
## Scope

Adds the C++ V2 incremental **named-module** build pipeline on top of `main@103ebbff644ff690f9031c407615a5b2a3879161`.

This PR now includes:

- shared strict `mqb_json` parsing;
- typed P1689R5 model/schema validation;
- MSVC `/scanDependencies` topology scanner with real VS2026 coverage;
- deterministic named-module provider resolution and compile levels;
- resolved `consumer -> logical-name -> provider-source` edges owned by the graph layer;
- source-identity `.obj/.deps/.scan/.ifc/.mqbcache` artifact routing;
- typed `/interface`, `/ifcOutput`, and `/reference logical-name=ifc` compiler inputs;
- compile signature v3 with module-reference/provider-IFC identity;
- cache validation for every planned output, including missing IFC repair;
- imported IFC freshness tracking plus explicit downstream rebuild propagation when a provider recompiles;
- bounded same-level parallel module compile waves with level barriers;
- complete scan -> graph -> incremental compile -> incremental link target orchestration;
- fail-fast global writable-artifact collision validation before external processes start;
- a real installed-VS2026 named-module target E2E that builds and launches the final executable.

## Correctness model

`/scanDependencies` and `/sourceDependencies` intentionally remain separate:

- `/scanDependencies` provides pre-compile module topology/P1689 data and does not produce `.obj` or `.ifc`;
- `/sourceDependencies` remains authoritative for post-compile header freshness.

Module consumers use graph-selected typed `/reference` inputs. If a provider recompiles in the current wave, downstream consumers receive a request-local `BuildReason::explicit_rebuild` so correctness does not depend on filesystem timestamp granularity. That signal is not persisted and is not build identity.

Warm named-module builds currently repeat topology scanning. The proven cache guarantee is **compile 0 / link 0**; scan-result caching is intentionally left for a later optimization.

## Current capability boundary

This milestone supports and regression-tests the internal **named module interface -> named consumer** path.

It does **not** yet claim full C++ Modules parity. The module target coordinator currently fails closed for:

- header units;
- unresolved external/prebuilt named-module providers;
- `import std` (currently an unresolved external named module);
- public `mqb.exe` CLI/source-discovery routing into the module target pipeline.

The P1689 model can represent more cases than the current execution policy accepts; unsupported requirements are retained as typed unresolved requirements rather than silently ignored.

## Verification

The current VS2026 CI suite registers **46 CTest cases**. Relevant real-toolchain evidence includes:

1. real `/scanDependencies` before IFC creation;
2. real module interface IFC generation and consumer `/reference` compilation;
3. full module target cold build + link + executable launch;
4. warm target with provider compile 0 / consumer compile 0 / link 0;
5. provider source mutation -> provider + consumer + link rebuild;
6. deleting only the provider IFC -> provider + consumer + link repair;
7. artifact collision/empty-artifact rejection before scanner/compiler/linker process execution.

Latest hardening run: C++ V2 workflow #166, **46/46 passed** on the Windows 2025 + Visual Studio 2026 runner.

## Follow-up gates

- public CLI/module-aware source-selection integration;
- header-unit and external/prebuilt-provider policy;
- `import std` support;
- PowerShell/C++ parity fixtures;
- final `mqb.exe` cutover only after parity is demonstrated.