### PR TITLE
feat: route public CLI through named-module pipeline

### DIFF
--- a/cpp/apps/mqb/CMakeLists.txt
+++ b/cpp/apps/mqb/CMakeLists.txt
@@ -22,6 +22,7 @@ target_compile_features(mqb_cli PUBLIC cxx_std_23)
 
 add_executable(mqb
     main.cpp
+    ModuleCliTarget.cpp
 )
 
 target_link_libraries(mqb

--- a/cpp/apps/mqb/Cli.cpp
+++ b/cpp/apps/mqb/Cli.cpp
@@ -277,7 +277,7 @@ std::string_view usage() noexcept {
 
 Usage:
   mqb <entry.cpp> [options] [-- program-args...]
-  mqb <source.cpp> <more-sources...> [options] [-- program-args...]
+  mqb <source.cpp> <more-sources...|module.ixx...> [options] [-- program-args...]
 
 Project configuration:
   MQB searches upward from the invocation directory for the nearest mqb.json.
@@ -287,15 +287,20 @@ Project configuration:
 Source selection:
   One positional source       Smart-discover connected ordinary C++ TUs (default)
   Multiple positional sources Build exactly that explicit ordered source set
-  --discover                  Explicitly enable smart discovery for one source
-  --no-discover               Disable smart discovery for a single source
+  Explicit .ixx source(s)     Route the explicit target through P1689 named-module scanning
+  --discover                  Explicitly enable smart discovery for one ordinary source
+  --no-discover               Disable smart discovery for a single ordinary source
+
+Named-module provider sources are explicit in this milestone; automatic provider discovery
+from an ordinary entry source remains a follow-up. Header units, external/prebuilt providers,
+and import std continue to fail closed in the module pipeline.
 
 Options:
   --debug                  Explicitly select Debug compile/link preset
   --release                Explicitly select Release compile/link preset
   --std <20|23|latest>     Explicitly select C++ language standard
   --x86 | --x64            Explicitly select target architecture
-  -j, --jobs <N>           Maximum concurrent TU compiles (default: hardware concurrency)
+  -j, --jobs <N>           Maximum concurrent TU scans/compiles (default: hardware concurrency)
   -o, --output <name>      Set target executable name under .mqb/bin/
   --run                    Run the executable after a successful build
   -I <dir>, -I<dir>        Add an include directory
@@ -310,13 +315,15 @@ Options:
   -h, --help               Show this help
   --                       Pass all remaining argv elements to the program
 
-Compile job count is execution policy only; changing -j does not invalidate build caches.
+Job count is execution policy only; changing -j does not invalidate build caches.
 Discovery is source selection only. Incremental header freshness continues to use
-MSVC /sourceDependencies metadata.
+MSVC /sourceDependencies metadata; /scanDependencies is module topology only.
 
 Generated state:
   .mqb/obj/    collision-free object files
   .mqb/deps/   compiler dependency metadata
+  .mqb/scan/   module dependency scan metadata
+  .mqb/ifc/    module interface artifacts
   .mqb/cache/  compile and link cache metadata
   .mqb/bin/    linked executable
 )";

--- a/cpp/apps/mqb/ModuleCliTarget.cpp
+++ b/cpp/apps/mqb/ModuleCliTarget.cpp
@@ -1,0 +1,278 @@
+#include "ModuleCliTarget.hpp"
+
+#include <filesystem>
+#include <iostream>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "mqb/core/BuildTypes.hpp"
+#include "mqb/core/TranslationUnitClassifier.hpp"
+#include "mqb/msvc/MsvcCompileExecutor.hpp"
+#include "mqb/msvc/MsvcLinker.hpp"
+#include "mqb/msvc/MsvcModuleDependencyScanner.hpp"
+#include "mqb/orchestration/MsvcIncrementalCompileCoordinator.hpp"
+#include "mqb/orchestration/MsvcIncrementalLinkCoordinator.hpp"
+#include "mqb/orchestration/MsvcIncrementalTargetCoordinator.hpp"
+#include "mqb/orchestration/MsvcModuleCompileCoordinator.hpp"
+#include "mqb/orchestration/MsvcModuleTargetCoordinator.hpp"
+#include "mqb/orchestration/MsvcTargetRouter.hpp"
+
+namespace mqb::cli {
+namespace {
+
+namespace fs = std::filesystem;
+
+[[nodiscard]] std::string path_text(const fs::path& path) {
+    const auto bytes = path.generic_u8string();
+    return std::string{reinterpret_cast<const char*>(bytes.data()), bytes.size()};
+}
+
+[[nodiscard]] bool safe_relative(const fs::path& relative) {
+    if (relative.empty() || relative.is_absolute() || relative == ".") return false;
+    for (const auto& component : relative) {
+        if (component == "..") return false;
+    }
+    return true;
+}
+
+[[nodiscard]] fs::path display_source(const fs::path& root, const fs::path& source) {
+    const fs::path relative = source.lexically_relative(root);
+    return safe_relative(relative) ? relative : source;
+}
+
+void write_forwarded_text(std::ostream& stream, const std::string_view text) {
+    for (std::size_t index = 0; index < text.size(); ++index) {
+        const char ch = text[index];
+        if (ch == '\r' && index + 1 < text.size() && text[index + 1] == '\n') {
+            stream.put('\n');
+            ++index;
+        } else {
+            stream.put(ch);
+        }
+    }
+}
+
+void print_process_output(const process::ProcessResult& process_result) {
+    if (!process_result.stdout_text.empty()) {
+        write_forwarded_text(std::cout, process_result.stdout_text);
+        if (process_result.stdout_text.back() != '\n') std::cout << '\n';
+    }
+    if (!process_result.stderr_text.empty()) {
+        write_forwarded_text(std::cerr, process_result.stderr_text);
+        if (process_result.stderr_text.back() != '\n') std::cerr << '\n';
+    }
+}
+
+void print_reasons(const std::vector<BuildReason>& reasons) {
+    if (reasons.empty()) return;
+    std::cout << " [";
+    for (std::size_t index = 0; index < reasons.size(); ++index) {
+        if (index != 0) std::cout << ", ";
+        std::cout << to_string(reasons[index]);
+    }
+    std::cout << ']';
+}
+
+void print_compile_failure(const orchestration::IncrementalCompileError& error) {
+    std::cerr << "error: " << error.message << '\n';
+    if (!error.compile_error) return;
+    const auto& compile_error = *error.compile_error;
+    std::cerr << "  " << compile_error.message << '\n';
+    if (compile_error.compiler_error) {
+        std::cerr << "  " << compile_error.compiler_error->message << '\n';
+        if (compile_error.compiler_error->process_result) {
+            print_process_output(*compile_error.compiler_error->process_result);
+        }
+    }
+    if (compile_error.dependency_error) {
+        std::cerr << "  " << compile_error.dependency_error->message << '\n';
+    }
+}
+
+void print_link_failure(const orchestration::IncrementalLinkError& error) {
+    std::cerr << "error: " << error.message << '\n';
+    if (error.library_resolution_error) {
+        const auto& resolution = *error.library_resolution_error;
+        std::cerr << "  " << resolution.message;
+        if (!resolution.library.empty()) std::cerr << ": " << resolution.library;
+        if (!resolution.path.empty()) std::cerr << " (" << path_text(resolution.path) << ')';
+        std::cerr << '\n';
+    }
+    if (!error.linker_error) return;
+    std::cerr << "  " << error.linker_error->message << '\n';
+    if (error.linker_error->process_result) print_process_output(*error.linker_error->process_result);
+    if (error.linker_error->process_error) {
+        std::cerr << "  " << error.linker_error->process_error->message << '\n';
+    }
+}
+
+void print_module_failure(const orchestration::IncrementalModuleTargetError& error) {
+    std::cerr << "error: " << error.message;
+    if (!error.source.empty()) std::cerr << ": " << path_text(error.source);
+    if (!error.artifact.empty()) std::cerr << " (" << path_text(error.artifact) << ')';
+    std::cerr << '\n';
+    if (error.scan_error) {
+        std::cerr << "  " << error.scan_error->message << '\n';
+        if (error.scan_error->process_result) print_process_output(*error.scan_error->process_result);
+        if (error.scan_error->process_error) std::cerr << "  " << error.scan_error->process_error->message << '\n';
+        if (error.scan_error->dependency_error) std::cerr << "  " << error.scan_error->dependency_error->message << '\n';
+    }
+    if (error.graph_error) std::cerr << "  " << error.graph_error->message << '\n';
+    if (error.compile_error) {
+        std::cerr << "  " << error.compile_error->message << '\n';
+        if (error.compile_error->compile_error) print_compile_failure(*error.compile_error->compile_error);
+    }
+    if (error.link_error) print_link_failure(*error.link_error);
+}
+
+void print_compile_warnings(const orchestration::IncrementalCompileResult& result) {
+    for (const auto& warning : result.warnings) {
+        std::cerr << "warning: " << warning.message;
+        if (!warning.path.empty()) std::cerr << ": " << path_text(warning.path);
+        std::cerr << '\n';
+    }
+}
+
+void print_link_warnings(const orchestration::IncrementalLinkResult& result) {
+    for (const auto& warning : result.warnings) {
+        std::cerr << "warning: " << warning.message;
+        if (!warning.path.empty()) std::cerr << ": " << path_text(warning.path);
+        std::cerr << '\n';
+    }
+}
+
+} // namespace
+
+bool is_module_interface_source(const fs::path& source) {
+    const auto kind = classify_translation_unit_path(source);
+    return kind && *kind == TranslationUnitKind::module_interface;
+}
+
+int run_module_target(
+    ModuleCliTargetRequest request,
+    const msvc::MsvcToolchain& toolchain,
+    process::ProcessRunner& runner) {
+    std::vector<orchestration::RoutedTargetSourceRequest> routed_sources;
+    routed_sources.reserve(request.sources.size());
+    for (auto& source : request.sources) {
+        const auto kind = classify_translation_unit_path(source.source);
+        if (!kind) {
+            std::cerr << "error: unsupported translation unit: " << path_text(source.source) << '\n';
+            return 2;
+        }
+        routed_sources.push_back(orchestration::RoutedTargetSourceRequest{
+            .source = source.source,
+            .artifacts = std::move(source.artifacts),
+            .kind = *kind,
+        });
+    }
+
+    if (request.verbose) {
+        std::cout << "[target] " << request.target_name << "\n"
+                  << "  project: " << path_text(request.project_root) << '\n';
+        if (request.config_file) std::cout << "  config:  " << path_text(*request.config_file) << '\n';
+        std::cout << "  pipeline: named-modules\n"
+                  << "  jobs:    " << request.max_parallel_jobs
+                  << (request.jobs_explicit ? "" : " (auto)") << '\n'
+                  << "  cl:      " << path_text(toolchain.identity.compiler) << '\n'
+                  << "  link:    " << path_text(toolchain.linker) << '\n';
+        for (const auto& source : routed_sources) {
+            std::cout << "  source:  " << path_text(display_source(request.project_root, source.source)) << '\n'
+                      << "    kind:  " << (source.kind == TranslationUnitKind::module_interface ? "module-interface" : "source") << '\n'
+                      << "    obj:   " << path_text(source.artifacts.object) << '\n'
+                      << "    deps:  " << path_text(source.artifacts.dependencies) << '\n'
+                      << "    scan:  " << path_text(source.artifacts.module_dependencies) << '\n';
+            if (source.kind == TranslationUnitKind::module_interface) {
+                std::cout << "    ifc:   " << path_text(source.artifacts.module_interface) << '\n';
+            }
+            std::cout << "    cache: " << path_text(source.artifacts.compile_cache) << '\n';
+        }
+        for (const auto& directory : request.link_options.library_directories) {
+            std::cout << "  libpath: " << path_text(directory) << '\n';
+        }
+        for (const auto& library : request.link_options.libraries) std::cout << "  lib:     " << library << '\n';
+        std::cout << "  exe:     " << path_text(request.target.executable) << '\n'
+                  << "  cache:   " << path_text(request.target.link_cache) << '\n';
+    }
+
+    msvc::MsvcCompileExecutor compile_executor{toolchain, runner};
+    orchestration::MsvcIncrementalCompileCoordinator incremental_compile{toolchain, compile_executor};
+    msvc::MsvcLinker linker{toolchain, runner};
+    orchestration::MsvcIncrementalLinkCoordinator incremental_link{toolchain, linker};
+    orchestration::MsvcIncrementalTargetCoordinator ordinary_target{incremental_compile, incremental_link};
+    msvc::MsvcModuleDependencyScanner scanner{toolchain, runner};
+    orchestration::MsvcModuleCompileCoordinator module_compile{incremental_compile};
+    orchestration::MsvcModuleTargetCoordinator module_target{scanner, module_compile, incremental_link};
+    orchestration::MsvcTargetRouter router{ordinary_target, module_target};
+
+    orchestration::RoutedTargetRequest target_request{
+        .sources = std::move(routed_sources),
+        .target = request.target,
+        .compiler_options = std::move(request.compiler_options),
+        .link_options = std::move(request.link_options),
+        .working_directory = request.project_root,
+        .max_parallel_jobs = request.max_parallel_jobs,
+    };
+    auto result = router.run(target_request);
+    if (!result) {
+        if (result.error().ordinary_error) {
+            const auto& ordinary = *result.error().ordinary_error;
+            std::cerr << "error: " << ordinary.message;
+            if (!ordinary.source.empty()) std::cerr << ": " << path_text(ordinary.source);
+            std::cerr << '\n';
+            if (ordinary.compile_error) print_compile_failure(*ordinary.compile_error);
+            if (ordinary.link_error) print_link_failure(*ordinary.link_error);
+            return ordinary.code == orchestration::IncrementalTargetErrorCode::link_failed ? 5 : 4;
+        }
+        if (result.error().module_error) {
+            print_module_failure(*result.error().module_error);
+            return result.error().module_error->code == orchestration::IncrementalModuleTargetErrorCode::link_failed ? 5 : 4;
+        }
+        std::cerr << "error: " << result.error().message << '\n';
+        return 4;
+    }
+
+    for (const auto& compile : result->compiles) {
+        print_compile_warnings(compile.result);
+        const fs::path label = display_source(request.project_root, compile.source);
+        if (compile.result.compiled) {
+            std::cout << "[compile] " << path_text(label);
+            print_reasons(compile.result.validation.reasons);
+            std::cout << '\n';
+            if (compile.result.process) print_process_output(*compile.result.process);
+        } else {
+            std::cout << "[up-to-date] " << path_text(label) << '\n';
+        }
+    }
+
+    print_link_warnings(result->link);
+    if (result->link.linked) {
+        std::cout << "[link] " << path_text(target_request.target.executable.filename());
+        print_reasons(result->link.validation.reasons);
+        std::cout << '\n';
+        if (result->link.process) print_process_output(*result->link.process);
+    } else {
+        std::cout << "[up-to-date] " << path_text(target_request.target.executable.filename()) << '\n';
+    }
+    std::cout << "executable: " << path_text(target_request.target.executable) << '\n';
+
+    if (!request.run_after_build) return 0;
+    std::cout << "[run] " << path_text(target_request.target.executable.filename()) << '\n';
+    process::ProcessSpec run_spec;
+    run_spec.executable = target_request.target.executable;
+    run_spec.arguments = std::move(request.run_arguments);
+    run_spec.working_directory = request.project_root;
+    run_spec.capture_stdout = true;
+    run_spec.capture_stderr = true;
+    auto run_result = runner.run(run_spec);
+    if (!run_result) {
+        std::cerr << "error: failed to run executable: " << run_result.error().message << '\n';
+        return 6;
+    }
+    print_process_output(*run_result);
+    return run_result->exit_code;
+}
+
+} // namespace mqb::cli

--- a/cpp/apps/mqb/ModuleCliTarget.hpp
+++ b/cpp/apps/mqb/ModuleCliTarget.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <cstddef>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "mqb/core/CompilerOptions.hpp"
+#include "mqb/core/LinkOptions.hpp"
+#include "mqb/core/ProjectArtifactLayout.hpp"
+#include "mqb/msvc/MsvcToolchainLocator.hpp"
+#include "mqb/orchestration/MsvcIncrementalTargetCoordinator.hpp"
+#include "mqb/process/Process.hpp"
+
+namespace mqb::cli {
+
+[[nodiscard]] bool is_module_interface_source(const std::filesystem::path& source);
+
+struct ModuleCliTargetRequest {
+    std::vector<orchestration::TargetSourceRequest> sources;
+    TargetArtifacts target;
+    CompilerOptions compiler_options;
+    LinkOptions link_options;
+    std::filesystem::path project_root;
+    std::optional<std::filesystem::path> config_file;
+    std::string target_name;
+    std::size_t max_parallel_jobs{1};
+    bool jobs_explicit{false};
+    bool verbose{false};
+    bool run_after_build{false};
+    std::vector<std::string> run_arguments;
+};
+
+[[nodiscard]] int run_module_target(
+    ModuleCliTargetRequest request,
+    const msvc::MsvcToolchain& toolchain,
+    process::ProcessRunner& runner);
+
+} // namespace mqb::cli

--- a/cpp/apps/mqb/main.cpp
+++ b/cpp/apps/mqb/main.cpp
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "Cli.hpp"
+#include "ModuleCliTarget.hpp"
 #include "mqb/config/ProjectConfig.hpp"
 #include "mqb/config/ProjectOptions.hpp"
 #include "mqb/core/BuildTypes.hpp"
@@ -56,6 +57,9 @@ absolute_path_from(
 }
 
 [[nodiscard]] bool supported_source(const fs::path& source) {
+    if (mqb::cli::is_module_interface_source(source)) {
+        return true;
+    }
     std::string extension = source.extension().string();
     std::transform(
         extension.begin(),
@@ -277,7 +281,7 @@ int main(const int argc, char* argv[]) {
             return 2;
         }
         if (!supported_source(*source)) {
-            std::cerr << "error: only .cpp, .cc, and .cxx sources are supported in this milestone: "
+            std::cerr << "error: only .cpp, .cc, .cxx, and .ixx sources are supported: "
                       << path_text(*source) << '\n';
             return 2;
         }
@@ -361,7 +365,9 @@ int main(const int argc, char* argv[]) {
     options.libraries = effective.libraries;
 
     std::vector<fs::path> sources = requested_sources;
-    if (options.discover_sources && requested_sources.size() == 1) {
+    if (options.discover_sources
+        && requested_sources.size() == 1
+        && !mqb::cli::is_module_interface_source(requested_sources.front())) {
         const fs::path& entry = requested_sources.front();
         const bool project_scoped = inside_project(project_root, entry);
         const fs::path discovery_root = project_scoped
@@ -478,6 +484,34 @@ int main(const int argc, char* argv[]) {
     link_options.subsystem = mqb::LinkSubsystem::console;
     link_options.library_directories = std::move(options.library_directories);
     link_options.libraries = std::move(options.libraries);
+
+    const bool module_target = std::any_of(
+        target_sources.begin(),
+        target_sources.end(),
+        [](const mqb::orchestration::TargetSourceRequest& source) {
+            return mqb::cli::is_module_interface_source(source.source);
+        });
+    if (module_target) {
+        return mqb::cli::run_module_target(
+            mqb::cli::ModuleCliTargetRequest{
+                .sources = std::move(target_sources),
+                .target = std::move(*target_artifacts),
+                .compiler_options = std::move(compiler_options),
+                .link_options = std::move(link_options),
+                .project_root = project_root,
+                .config_file = project_config
+                    ? std::optional<fs::path>{project_config->file}
+                    : std::nullopt,
+                .target_name = target_name,
+                .max_parallel_jobs = compile_jobs,
+                .jobs_explicit = options.jobs.has_value(),
+                .verbose = options.verbose,
+                .run_after_build = options.build.run_after_build,
+                .run_arguments = std::move(options.build.run_arguments),
+            },
+            *toolchain,
+            runner);
+    }
 
     if (options.verbose) {
         std::cout << "[target] " << target_name << "\n"

--- a/cpp/core/CMakeLists.txt
+++ b/cpp/core/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(mqb_core STATIC
     src/LinkCache.cpp
     src/LinkCacheFile.cpp
     src/ProjectArtifactLayout.cpp
+    src/TranslationUnitClassifier.cpp
 )
 
 target_include_directories(mqb_core

--- a/cpp/core/include/mqb/core/TranslationUnitClassifier.hpp
+++ b/cpp/core/include/mqb/core/TranslationUnitClassifier.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <filesystem>
+#include <optional>
+
+#include "mqb/core/TranslationUnit.hpp"
+
+namespace mqb {
+
+[[nodiscard]] std::optional<TranslationUnitKind>
+classify_translation_unit_path(const std::filesystem::path& path);
+
+[[nodiscard]] bool is_translation_unit_path(const std::filesystem::path& path);
+
+} // namespace mqb

--- a/cpp/core/src/TranslationUnitClassifier.cpp
+++ b/cpp/core/src/TranslationUnitClassifier.cpp
@@ -1,0 +1,40 @@
+#include "mqb/core/TranslationUnitClassifier.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <filesystem>
+#include <optional>
+#include <string>
+
+namespace mqb {
+namespace {
+
+[[nodiscard]] std::string extension_lower(const std::filesystem::path& path) {
+    std::string extension = path.extension().string();
+    std::transform(
+        extension.begin(),
+        extension.end(),
+        extension.begin(),
+        [](const unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+    return extension;
+}
+
+} // namespace
+
+std::optional<TranslationUnitKind>
+classify_translation_unit_path(const std::filesystem::path& path) {
+    const std::string extension = extension_lower(path);
+    if (extension == ".cpp" || extension == ".cc" || extension == ".cxx") {
+        return TranslationUnitKind::source;
+    }
+    if (extension == ".ixx" || extension == ".cppm" || extension == ".mpp") {
+        return TranslationUnitKind::module_interface;
+    }
+    return std::nullopt;
+}
+
+bool is_translation_unit_path(const std::filesystem::path& path) {
+    return classify_translation_unit_path(path).has_value();
+}
+
+} // namespace mqb

--- a/cpp/orchestration/CMakeLists.txt
+++ b/cpp/orchestration/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(mqb_orchestration STATIC
     src/MsvcIncrementalTargetCoordinator.cpp
     src/MsvcModuleCompileCoordinator.cpp
     src/MsvcModuleTargetCoordinator.cpp
+    src/MsvcTargetRouter.cpp
 )
 
 target_include_directories(mqb_orchestration

--- a/cpp/orchestration/include/mqb/orchestration/MsvcTargetRouter.hpp
+++ b/cpp/orchestration/include/mqb/orchestration/MsvcTargetRouter.hpp
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <cstddef>
+#include <expected>
+#include <filesystem>
+#include <optional>
+#include <span>
+#include <string>
+#include <vector>
+
+#include "mqb/core/CompilerOptions.hpp"
+#include "mqb/core/LinkOptions.hpp"
+#include "mqb/core/ProjectArtifactLayout.hpp"
+#include "mqb/core/TranslationUnit.hpp"
+#include "mqb/orchestration/MsvcIncrementalTargetCoordinator.hpp"
+#include "mqb/orchestration/MsvcModuleTargetCoordinator.hpp"
+
+namespace mqb::orchestration {
+
+enum class MsvcTargetPipeline {
+    ordinary,
+    named_modules,
+};
+
+struct RoutedTargetSourceRequest {
+    std::filesystem::path source;
+    SourceArtifacts artifacts;
+    TranslationUnitKind kind{TranslationUnitKind::source};
+};
+
+struct RoutedTargetRequest {
+    std::vector<RoutedTargetSourceRequest> sources;
+    TargetArtifacts target;
+    CompilerOptions compiler_options;
+    LinkOptions link_options;
+    std::filesystem::path working_directory;
+    std::size_t max_parallel_jobs{1};
+};
+
+enum class RoutedTargetErrorCode {
+    ordinary_target_failed,
+    module_target_failed,
+};
+
+struct RoutedTargetError {
+    RoutedTargetErrorCode code{RoutedTargetErrorCode::ordinary_target_failed};
+    std::string message;
+    std::optional<IncrementalTargetError> ordinary_error;
+    std::optional<IncrementalModuleTargetError> module_error;
+};
+
+struct RoutedTargetResult {
+    MsvcTargetPipeline pipeline{MsvcTargetPipeline::ordinary};
+    std::vector<TargetCompileResult> compiles;
+    IncrementalLinkResult link;
+    bool any_compiled{false};
+};
+
+class MsvcTargetRouter {
+public:
+    MsvcTargetRouter(
+        MsvcIncrementalTargetCoordinator& ordinary_target,
+        MsvcModuleTargetCoordinator& module_target)
+        : ordinary_target_(ordinary_target), module_target_(module_target) {}
+
+    [[nodiscard]] static MsvcTargetPipeline select_pipeline(
+        std::span<const RoutedTargetSourceRequest> sources) noexcept;
+
+    [[nodiscard]] std::expected<RoutedTargetResult, RoutedTargetError>
+    run(const RoutedTargetRequest& request) const;
+
+private:
+    MsvcIncrementalTargetCoordinator& ordinary_target_;
+    MsvcModuleTargetCoordinator& module_target_;
+};
+
+} // namespace mqb::orchestration

--- a/cpp/orchestration/src/MsvcTargetRouter.cpp
+++ b/cpp/orchestration/src/MsvcTargetRouter.cpp
@@ -1,0 +1,105 @@
+#include "mqb/orchestration/MsvcTargetRouter.hpp"
+
+#include <algorithm>
+#include <expected>
+#include <span>
+#include <utility>
+#include <vector>
+
+namespace mqb::orchestration {
+
+MsvcTargetPipeline MsvcTargetRouter::select_pipeline(
+    const std::span<const RoutedTargetSourceRequest> sources) noexcept {
+    const bool has_module_interface = std::any_of(
+        sources.begin(),
+        sources.end(),
+        [](const RoutedTargetSourceRequest& source) {
+            return source.kind == TranslationUnitKind::module_interface;
+        });
+    return has_module_interface
+        ? MsvcTargetPipeline::named_modules
+        : MsvcTargetPipeline::ordinary;
+}
+
+std::expected<RoutedTargetResult, RoutedTargetError>
+MsvcTargetRouter::run(const RoutedTargetRequest& request) const {
+    const MsvcTargetPipeline pipeline = select_pipeline(request.sources);
+
+    if (pipeline == MsvcTargetPipeline::ordinary) {
+        std::vector<TargetSourceRequest> sources;
+        sources.reserve(request.sources.size());
+        for (const auto& source : request.sources) {
+            sources.push_back(TargetSourceRequest{
+                .source = source.source,
+                .artifacts = source.artifacts,
+            });
+        }
+
+        IncrementalTargetRequest ordinary_request{
+            .sources = std::move(sources),
+            .target = request.target,
+            .compiler_options = request.compiler_options,
+            .link_options = request.link_options,
+            .working_directory = request.working_directory,
+            .max_parallel_compiles = request.max_parallel_jobs,
+        };
+        auto result = ordinary_target_.run(ordinary_request);
+        if (!result) {
+            return std::unexpected(RoutedTargetError{
+                .code = RoutedTargetErrorCode::ordinary_target_failed,
+                .message = "ordinary MSVC target build failed",
+                .ordinary_error = result.error(),
+            });
+        }
+
+        return RoutedTargetResult{
+            .pipeline = MsvcTargetPipeline::ordinary,
+            .compiles = std::move(result->compiles),
+            .link = std::move(result->link),
+            .any_compiled = result->any_compiled,
+        };
+    }
+
+    std::vector<ModuleCompileSourceRequest> sources;
+    sources.reserve(request.sources.size());
+    for (const auto& source : request.sources) {
+        sources.push_back(ModuleCompileSourceRequest{
+            .source = source.source,
+            .artifacts = source.artifacts,
+            .kind = source.kind,
+        });
+    }
+
+    IncrementalModuleTargetRequest module_request{
+        .sources = std::move(sources),
+        .target = request.target,
+        .compiler_options = request.compiler_options,
+        .link_options = request.link_options,
+        .working_directory = request.working_directory,
+        .max_parallel_scans = request.max_parallel_jobs,
+        .max_parallel_compiles = request.max_parallel_jobs,
+    };
+    auto result = module_target_.run(module_request);
+    if (!result) {
+        return std::unexpected(RoutedTargetError{
+            .code = RoutedTargetErrorCode::module_target_failed,
+            .message = "named-module MSVC target build failed",
+            .module_error = result.error(),
+        });
+    }
+
+    RoutedTargetResult routed;
+    routed.pipeline = MsvcTargetPipeline::named_modules;
+    routed.any_compiled = result->compiles.any_compiled;
+    routed.link = std::move(result->link);
+    routed.compiles.reserve(result->compiles.compiles.size());
+    for (auto& compile : result->compiles.compiles) {
+        routed.compiles.push_back(TargetCompileResult{
+            .source = std::move(compile.source),
+            .result = std::move(compile.result),
+        });
+    }
+    return routed;
+}
+
+} // namespace mqb::orchestration

--- a/cpp/orchestration/tests/CMakeLists.txt
+++ b/cpp/orchestration/tests/CMakeLists.txt
@@ -70,6 +70,12 @@ target_link_libraries(mqb_module_target_validation_tests
 )
 target_compile_features(mqb_module_target_validation_tests PRIVATE cxx_std_23)
 
+add_executable(mqb_target_router_tests
+    target_router_tests.cpp
+)
+target_link_libraries(mqb_target_router_tests PRIVATE mqb_orchestration)
+target_compile_features(mqb_target_router_tests PRIVATE cxx_std_23)
+
 foreach(test_target IN ITEMS
     mqb_orchestration_incremental_tests
     mqb_orchestration_incremental_link_tests
@@ -78,6 +84,7 @@ foreach(test_target IN ITEMS
     mqb_module_compile_coordinator_tests
     mqb_module_target_coordinator_tests
     mqb_module_target_validation_tests
+    mqb_target_router_tests
 )
     if(MSVC)
         target_compile_options(${test_target} PRIVATE /W4 /permissive-)
@@ -119,6 +126,11 @@ add_test(
 add_test(
     NAME mqb.orchestration.module_target_validation
     COMMAND mqb_module_target_validation_tests
+)
+
+add_test(
+    NAME mqb.orchestration.target_router
+    COMMAND mqb_target_router_tests
 )
 
 if(MQB_ENABLE_INSTALLED_MSVC_TESTS)

--- a/cpp/orchestration/tests/target_router_tests.cpp
+++ b/cpp/orchestration/tests/target_router_tests.cpp
@@ -1,0 +1,79 @@
+#include <filesystem>
+#include <iostream>
+#include <string_view>
+#include <vector>
+
+#include "mqb/orchestration/MsvcTargetRouter.hpp"
+
+namespace {
+
+int failures = 0;
+
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+[[nodiscard]] mqb::orchestration::RoutedTargetSourceRequest source(
+    std::filesystem::path path,
+    const mqb::TranslationUnitKind kind) {
+    return mqb::orchestration::RoutedTargetSourceRequest{
+        .source = std::move(path),
+        .kind = kind,
+    };
+}
+
+} // namespace
+
+int main() {
+    using mqb::TranslationUnitKind;
+    using mqb::orchestration::MsvcTargetPipeline;
+    using mqb::orchestration::MsvcTargetRouter;
+
+    {
+        const std::vector<mqb::orchestration::RoutedTargetSourceRequest> sources{
+            source("main.cpp", TranslationUnitKind::source),
+            source("helper.cpp", TranslationUnitKind::source),
+        };
+        expect(
+            MsvcTargetRouter::select_pipeline(sources) == MsvcTargetPipeline::ordinary,
+            "ordinary-only source sets must preserve the existing target pipeline");
+    }
+
+    {
+        const std::vector<mqb::orchestration::RoutedTargetSourceRequest> sources{
+            source("main.cpp", TranslationUnitKind::source),
+            source("math.ixx", TranslationUnitKind::module_interface),
+            source("helper.cpp", TranslationUnitKind::source),
+        };
+        expect(
+            MsvcTargetRouter::select_pipeline(sources) == MsvcTargetPipeline::named_modules,
+            "one module interface must route the whole target through module topology planning");
+    }
+
+    {
+        const std::vector<mqb::orchestration::RoutedTargetSourceRequest> sources{
+            source("math.cppm", TranslationUnitKind::module_interface),
+        };
+        expect(
+            MsvcTargetRouter::select_pipeline(sources) == MsvcTargetPipeline::named_modules,
+            "module-interface-only source sets must use the named-module pipeline");
+    }
+
+    {
+        const std::vector<mqb::orchestration::RoutedTargetSourceRequest> sources;
+        expect(
+            MsvcTargetRouter::select_pipeline(sources) == MsvcTargetPipeline::ordinary,
+            "empty routing input should defer validation to the ordinary target contract");
+    }
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+
+    std::cout << "mqb_target_router_tests passed\n";
+    return 0;
+}

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -38,6 +38,10 @@ add_executable(mqb_project_artifact_layout_tests project_artifact_layout_tests.c
 target_link_libraries(mqb_project_artifact_layout_tests PRIVATE mqb_core)
 target_compile_features(mqb_project_artifact_layout_tests PRIVATE cxx_std_23)
 
+add_executable(mqb_translation_unit_classifier_tests translation_unit_classifier_tests.cpp)
+target_link_libraries(mqb_translation_unit_classifier_tests PRIVATE mqb_core)
+target_compile_features(mqb_translation_unit_classifier_tests PRIVATE cxx_std_23)
+
 add_executable(mqb_process_model_tests process_model_tests.cpp)
 target_link_libraries(mqb_process_model_tests PRIVATE mqb_process)
 target_compile_features(mqb_process_model_tests PRIVATE cxx_std_23)
@@ -53,6 +57,7 @@ set(MQB_TEST_TARGETS
     mqb_link_state_tests
     mqb_link_cache_file_tests
     mqb_project_artifact_layout_tests
+    mqb_translation_unit_classifier_tests
     mqb_process_model_tests
 )
 
@@ -168,6 +173,7 @@ add_test(NAME mqb.core.build_planner COMMAND mqb_build_planner_tests)
 add_test(NAME mqb.core.link_state COMMAND mqb_link_state_tests)
 add_test(NAME mqb.core.link_cache_file COMMAND mqb_link_cache_file_tests)
 add_test(NAME mqb.core.project_artifact_layout COMMAND mqb_project_artifact_layout_tests)
+add_test(NAME mqb.core.translation_unit_classifier COMMAND mqb_translation_unit_classifier_tests)
 add_test(NAME mqb.process.model COMMAND mqb_process_model_tests)
 
 if(WIN32)

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -143,6 +143,10 @@ if(WIN32)
         target_link_libraries(mqb_parallel_cli_e2e_tests PRIVATE mqb_platform_windows)
         target_compile_features(mqb_parallel_cli_e2e_tests PRIVATE cxx_std_23)
 
+        add_executable(mqb_module_cli_e2e_tests mqb_module_cli_e2e_tests.cpp)
+        target_link_libraries(mqb_module_cli_e2e_tests PRIVATE mqb_platform_windows)
+        target_compile_features(mqb_module_cli_e2e_tests PRIVATE cxx_std_23)
+
         list(APPEND MQB_TEST_TARGETS
             mqb_msvc_visual_studio_tests
             mqb_msvc_compile_integration_tests
@@ -151,6 +155,7 @@ if(WIN32)
             mqb_cli_e2e_tests
             mqb_project_config_e2e_tests
             mqb_parallel_cli_e2e_tests
+            mqb_module_cli_e2e_tests
         )
     endif()
 endif()
@@ -206,6 +211,10 @@ if(WIN32)
         add_test(
             NAME mqb.cli.parallel_e2e
             COMMAND mqb_parallel_cli_e2e_tests $<TARGET_FILE:mqb>
+        )
+        add_test(
+            NAME mqb.cli.module_e2e
+            COMMAND mqb_module_cli_e2e_tests $<TARGET_FILE:mqb>
         )
     endif()
 endif()

--- a/cpp/tests/mqb_module_cli_e2e_tests.cpp
+++ b/cpp/tests/mqb_module_cli_e2e_tests.cpp
@@ -1,0 +1,202 @@
+#include <chrono>
+#include <expected>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <system_error>
+
+#include "mqb/platform/windows/WindowsProcessRunner.hpp"
+#include "mqb/process/Process.hpp"
+
+namespace {
+
+namespace fs = std::filesystem;
+int failures = 0;
+
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+void write_text(const fs::path& path, const std::string_view text) {
+    fs::create_directories(path.parent_path());
+    std::ofstream stream{path, std::ios::binary | std::ios::trunc};
+    stream << text;
+}
+
+void dump_failure(const mqb::process::ProcessResult& result) {
+    std::cerr << "exit: " << result.exit_code << '\n'
+              << "stdout:\n" << result.stdout_text << '\n'
+              << "stderr:\n" << result.stderr_text << '\n';
+}
+
+[[nodiscard]] bool contains_line(std::string_view output, std::string_view expected) {
+    std::size_t begin = 0;
+    while (begin <= output.size()) {
+        const std::size_t newline = output.find('\n', begin);
+        const std::size_t end = newline == std::string_view::npos ? output.size() : newline;
+        std::string_view line = output.substr(begin, end - begin);
+        if (!line.empty() && line.back() == '\r') line.remove_suffix(1);
+        if (line == expected) return true;
+        if (newline == std::string_view::npos) break;
+        begin = newline + 1;
+    }
+    return false;
+}
+
+[[nodiscard]] std::optional<fs::path> first_ifc(const fs::path& root) {
+    const fs::path ifc_root = root / ".mqb" / "ifc";
+    std::error_code error_code;
+    fs::recursive_directory_iterator iterator{
+        ifc_root,
+        fs::directory_options::skip_permission_denied,
+        error_code};
+    if (error_code) return std::nullopt;
+    const fs::recursive_directory_iterator end;
+    for (; iterator != end; iterator.increment(error_code)) {
+        if (error_code) return std::nullopt;
+        if (iterator->is_regular_file(error_code) && !error_code
+            && iterator->path().extension() == ".ifc") {
+            return iterator->path();
+        }
+        error_code.clear();
+    }
+    return std::nullopt;
+}
+
+struct TempTree {
+    fs::path root;
+    ~TempTree() {
+        std::error_code ignored;
+        fs::remove_all(root, ignored);
+    }
+};
+
+[[nodiscard]] std::expected<mqb::process::ProcessResult, std::string> run_mqb(
+    mqb::platform::windows::WindowsProcessRunner& runner,
+    const fs::path& mqb,
+    const fs::path& root,
+    const std::string& jobs) {
+    mqb::process::ProcessSpec spec;
+    spec.executable = mqb;
+    // Consumer first intentionally verifies that the public CLI delegates ordering
+    // to the P1689 provider graph rather than positional source order.
+    spec.arguments = {
+        "main.cpp",
+        "math.ixx",
+        "--env",
+        "vs",
+        "--std",
+        "latest",
+        "--jobs",
+        jobs,
+        "--verbose",
+        "-o",
+        "module-cli",
+        "--run",
+    };
+    spec.working_directory = root;
+    spec.capture_stdout = true;
+    spec.capture_stderr = true;
+    auto result = runner.run(spec);
+    if (!result) return std::unexpected("failed to launch mqb: " + result.error().message);
+    return std::move(*result);
+}
+
+} // namespace
+
+int main(const int argc, char* argv[]) {
+    if (argc != 2) {
+        std::cerr << "usage: mqb_module_cli_e2e_tests <mqb-executable>\n";
+        return 2;
+    }
+
+    const fs::path mqb_executable{argv[1]};
+    const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
+    TempTree tree{
+        .root = fs::temp_directory_path() / ("mqb_module_cli_e2e_" + std::to_string(unique)),
+    };
+    fs::create_directories(tree.root);
+
+    write_text(
+        tree.root / "math.ixx",
+        "export module math;\n"
+        "export int answer() { return 42; }\n");
+    write_text(
+        tree.root / "main.cpp",
+        "import math;\n"
+        "int main() { return answer() == 42 ? 0 : 1; }\n");
+
+    mqb::platform::windows::WindowsProcessRunner runner;
+
+    auto cold = run_mqb(runner, mqb_executable, tree.root, "2");
+    expect(cold.has_value(), "cold public module CLI invocation should launch");
+    if (cold) {
+        if (cold->exit_code != 0) dump_failure(*cold);
+        expect(cold->exit_code == 0,
+               "cold explicit .ixx + consumer CLI target should build and run successfully");
+        expect(cold->stdout_text.find("  pipeline: named-modules") != std::string::npos,
+               "verbose CLI output should report the named-module pipeline");
+        expect(cold->stdout_text.find("[compile] math.ixx") != std::string::npos,
+               "cold module CLI target should compile the provider");
+        expect(cold->stdout_text.find("[compile] main.cpp") != std::string::npos,
+               "cold module CLI target should compile the consumer");
+        expect(cold->stdout_text.find("[link] module-cli.exe") != std::string::npos,
+               "cold module CLI target should link the executable");
+        expect(cold->stdout_text.find("[run] module-cli.exe") != std::string::npos,
+               "--run should launch the module target executable");
+    }
+
+    const fs::path executable = tree.root / ".mqb" / "bin" / "module-cli.exe";
+    expect(fs::is_regular_file(executable),
+           "public module CLI target should produce its executable");
+
+    const auto ifc = first_ifc(tree.root);
+    expect(ifc.has_value() && fs::is_regular_file(*ifc),
+           "public module CLI target should produce a provider IFC");
+
+    auto warm = run_mqb(runner, mqb_executable, tree.root, "1");
+    expect(warm.has_value(), "warm public module CLI invocation should launch");
+    if (warm) {
+        if (warm->exit_code != 0) dump_failure(*warm);
+        expect(warm->exit_code == 0,
+               "warm module CLI target should build and run successfully");
+        expect(contains_line(warm->stdout_text, "[up-to-date] main.cpp"),
+               "warm module consumer should reuse its compile cache");
+        expect(contains_line(warm->stdout_text, "[up-to-date] math.ixx"),
+               "warm module provider should reuse its compile cache");
+        expect(contains_line(warm->stdout_text, "[up-to-date] module-cli.exe"),
+               "warm module target should reuse its link cache");
+    }
+
+    if (ifc) {
+        std::error_code remove_error;
+        fs::remove(*ifc, remove_error);
+        expect(!remove_error, "test should be able to remove the provider IFC");
+        auto repaired = run_mqb(runner, mqb_executable, tree.root, "2");
+        expect(repaired.has_value(), "IFC-repair public module CLI invocation should launch");
+        if (repaired) {
+            if (repaired->exit_code != 0) dump_failure(*repaired);
+            expect(repaired->exit_code == 0,
+                   "missing provider IFC should be repaired through the public CLI");
+            expect(repaired->stdout_text.find("[compile] math.ixx") != std::string::npos,
+                   "missing IFC should rebuild its provider");
+            expect(repaired->stdout_text.find("[compile] main.cpp") != std::string::npos,
+                   "provider repair should propagate an explicit consumer rebuild");
+            expect(repaired->stdout_text.find("[link] module-cli.exe") != std::string::npos,
+                   "provider repair should relink the final executable");
+        }
+    }
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+    std::cout << "mqb_module_cli_e2e_tests passed\n";
+    return 0;
+}

--- a/cpp/tests/translation_unit_classifier_tests.cpp
+++ b/cpp/tests/translation_unit_classifier_tests.cpp
@@ -1,0 +1,55 @@
+#include <filesystem>
+#include <iostream>
+#include <string_view>
+
+#include "mqb/core/TranslationUnitClassifier.hpp"
+
+namespace {
+
+int failures = 0;
+
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+} // namespace
+
+int main() {
+    using mqb::TranslationUnitKind;
+    using mqb::classify_translation_unit_path;
+    using mqb::is_translation_unit_path;
+
+    expect(classify_translation_unit_path("main.cpp") == TranslationUnitKind::source,
+           ".cpp should classify as an ordinary source TU");
+    expect(classify_translation_unit_path("helper.CC") == TranslationUnitKind::source,
+           "ordinary source extensions should be case-insensitive");
+    expect(classify_translation_unit_path("feature.cxx") == TranslationUnitKind::source,
+           ".cxx should classify as an ordinary source TU");
+
+    expect(classify_translation_unit_path("math.ixx") == TranslationUnitKind::module_interface,
+           ".ixx should classify as a module interface TU");
+    expect(classify_translation_unit_path("math.CPPM") == TranslationUnitKind::module_interface,
+           ".cppm module extensions should be case-insensitive");
+    expect(classify_translation_unit_path("math.mpp") == TranslationUnitKind::module_interface,
+           ".mpp should classify as a module interface TU");
+
+    expect(!classify_translation_unit_path("header.hpp").has_value(),
+           "headers must not classify as translation units");
+    expect(!classify_translation_unit_path("source.c").has_value(),
+           "C sources are outside the current C++ V2 source contract");
+    expect(is_translation_unit_path("module.ixx"),
+           "is_translation_unit_path should accept module interfaces");
+    expect(!is_translation_unit_path("notes.txt"),
+           "is_translation_unit_path should reject unrelated files");
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+
+    std::cout << "mqb_translation_unit_classifier_tests passed\n";
+    return 0;
+}


### PR DESCRIPTION
Completes the first public-CLI slice of milestone 14 on top of the named-module core pipeline merged in #12.

## Scope completed here

- backend-neutral, case-insensitive translation-unit classifier:
  - ordinary C++: `.cpp`, `.cc`, `.cxx`
  - module interfaces: `.ixx`, `.cppm`, `.mpp`
- orchestration-level `MsvcTargetRouter`:
  - ordinary-only targets preserve `MsvcIncrementalTargetCoordinator`
  - any module-interface TU routes the whole target through `MsvcModuleTargetCoordinator`
- public `mqb.exe` routing for explicit module-interface targets while preserving ordinary one-entry smart discovery
- project config, compiler/link options, `-j/--jobs`, output naming, incremental caches, and structured `--run` are retained on the module path
- CLI help documents module scanning plus `.mqb/scan` / `.mqb/ifc` state
- real VS2026 public-CLI module E2E verifies:
  - consumer-before-provider explicit input order
  - cold provider + consumer compile, link, and `--run`
  - warm build with changed job count: compile 0 / link 0
  - provider IFC deletion: provider + consumer + link repair

## Verification

C++ V2 workflow #175 is green on head `5290edd104f995bf77747f018b5f5c583868f73d`: Configure, Build, and CTest all succeeded.

## Follow-up under #13

The next independent slice is module-aware source discovery so `mqb main.cpp` can follow project-internal named imports to module-interface providers without manually listing them. Header units, external/prebuilt providers, and `import std` remain deliberately fail-closed follow-ups.

Advances #13; does not close it.