### PR TITLE
feat: discover project-local named-module providers

### DIFF
--- a/cpp/apps/mqb/Cli.cpp
+++ b/cpp/apps/mqb/Cli.cpp
@@ -285,15 +285,16 @@ Project configuration:
   Config paths are relative to mqb.json; CLI paths are relative to the invocation directory.
 
 Source selection:
-  One positional source       Smart-discover connected ordinary C++ TUs (default)
+  One positional source       Smart-discover connected C++ TUs and reachable project-local named-module providers (default)
   Multiple positional sources Build exactly that explicit ordered source set
-  Explicit .ixx source(s)     Route the explicit target through P1689 named-module scanning
+  Explicit module source(s)   Route targets containing .ixx/.cppm/.mpp through P1689 named-module scanning
   --discover                  Explicitly enable smart discovery for one ordinary source
   --no-discover               Disable smart discovery for a single ordinary source
 
-Named-module provider sources are explicit in this milestone; automatic provider discovery
-from an ordinary entry source remains a follow-up. Header units, external/prebuilt providers,
-and import std continue to fail closed in the module pipeline.
+Single-entry discovery follows reachable project-local named imports to project-local
+module-interface candidates. Discovery selects candidates only; MSVC P1689 scanning remains
+the authority for module topology and provider validation. Header units, external/prebuilt
+provider execution, and import std remain unsupported and fail closed in the module pipeline.
 
 Options:
   --debug                  Explicitly select Debug compile/link preset

--- a/cpp/apps/mqb/ModuleCliTarget.cpp
+++ b/cpp/apps/mqb/ModuleCliTarget.cpp
@@ -214,6 +214,7 @@ int run_module_target(
         .link_options = std::move(request.link_options),
         .working_directory = request.project_root,
         .max_parallel_jobs = request.max_parallel_jobs,
+        .force_named_modules = request.force_named_modules,
     };
     auto result = router.run(target_request);
     if (!result) {

--- a/cpp/apps/mqb/ModuleCliTarget.hpp
+++ b/cpp/apps/mqb/ModuleCliTarget.hpp
@@ -27,6 +27,7 @@ struct ModuleCliTargetRequest {
     std::string target_name;
     std::size_t max_parallel_jobs{1};
     bool jobs_explicit{false};
+    bool force_named_modules{false};
     bool verbose{false};
     bool run_after_build{false};
     std::vector<std::string> run_arguments;

--- a/cpp/apps/mqb/main.cpp
+++ b/cpp/apps/mqb/main.cpp
@@ -1,5 +1,4 @@
 #include <algorithm>
-#include <cctype>
 #include <expected>
 #include <filesystem>
 #include <iostream>
@@ -20,6 +19,7 @@
 #include "mqb/core/CompilerOptions.hpp"
 #include "mqb/core/LinkOptions.hpp"
 #include "mqb/core/ProjectArtifactLayout.hpp"
+#include "mqb/core/TranslationUnitClassifier.hpp"
 #include "mqb/discovery/SourceDiscovery.hpp"
 #include "mqb/msvc/MsvcCompileExecutor.hpp"
 #include "mqb/msvc/MsvcLinker.hpp"
@@ -57,16 +57,7 @@ absolute_path_from(
 }
 
 [[nodiscard]] bool supported_source(const fs::path& source) {
-    if (mqb::cli::is_module_interface_source(source)) {
-        return true;
-    }
-    std::string extension = source.extension().string();
-    std::transform(
-        extension.begin(),
-        extension.end(),
-        extension.begin(),
-        [](const unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
-    return extension == ".cpp" || extension == ".cc" || extension == ".cxx";
+    return mqb::is_translation_unit_path(source);
 }
 
 [[nodiscard]] bool safe_relative(const fs::path& relative) {
@@ -281,7 +272,7 @@ int main(const int argc, char* argv[]) {
             return 2;
         }
         if (!supported_source(*source)) {
-            std::cerr << "error: only .cpp, .cc, .cxx, and .ixx sources are supported: "
+            std::cerr << "error: only .cpp, .cc, .cxx, .ixx, .cppm, and .mpp sources are supported: "
                       << path_text(*source) << '\n';
             return 2;
         }
@@ -365,6 +356,7 @@ int main(const int argc, char* argv[]) {
     options.libraries = effective.libraries;
 
     std::vector<fs::path> sources = requested_sources;
+    bool discovery_requires_module_pipeline = false;
     if (options.discover_sources
         && requested_sources.size() == 1
         && !mqb::cli::is_module_interface_source(requested_sources.front())) {
@@ -399,6 +391,7 @@ int main(const int argc, char* argv[]) {
             }
             std::cerr << '\n';
         }
+        discovery_requires_module_pipeline = discovered->requires_module_pipeline;
         sources = std::move(discovered->sources);
         if (sources.size() > 1 || options.verbose) {
             std::cout << "[discover] " << sources.size() << " translation units";
@@ -485,7 +478,7 @@ int main(const int argc, char* argv[]) {
     link_options.library_directories = std::move(options.library_directories);
     link_options.libraries = std::move(options.libraries);
 
-    const bool module_target = std::any_of(
+    const bool module_target = discovery_requires_module_pipeline || std::any_of(
         target_sources.begin(),
         target_sources.end(),
         [](const mqb::orchestration::TargetSourceRequest& source) {
@@ -505,6 +498,7 @@ int main(const int argc, char* argv[]) {
                 .target_name = target_name,
                 .max_parallel_jobs = compile_jobs,
                 .jobs_explicit = options.jobs.has_value(),
+                .force_named_modules = discovery_requires_module_pipeline,
                 .verbose = options.verbose,
                 .run_after_build = options.build.run_after_build,
                 .run_arguments = std::move(options.build.run_arguments),

--- a/cpp/discovery/CMakeLists.txt
+++ b/cpp/discovery/CMakeLists.txt
@@ -8,6 +8,7 @@ target_include_directories(mqb_discovery
         ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
+target_link_libraries(mqb_discovery PRIVATE mqb_core)
 target_compile_features(mqb_discovery PUBLIC cxx_std_23)
 
 if(MSVC)

--- a/cpp/discovery/CMakeLists.txt
+++ b/cpp/discovery/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(mqb_discovery STATIC
+    src/ModuleSyntax.cpp
     src/SourceDiscovery.cpp
 )
 

--- a/cpp/discovery/include/mqb/discovery/ModuleSyntax.hpp
+++ b/cpp/discovery/include/mqb/discovery/ModuleSyntax.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace mqb::discovery {
+
+// Lightweight source-selection metadata only. This parser intentionally does
+// not replace compiler/P1689 dependency scanning; it only helps discovery find
+// project-local candidate translation units before the real module scan runs.
+struct NamedModuleSyntax {
+    std::optional<std::string> declared_module;
+    std::vector<std::string> imported_modules;
+};
+
+class ModuleSyntaxParser {
+public:
+    [[nodiscard]] static NamedModuleSyntax parse(std::string_view source_text);
+};
+
+} // namespace mqb::discovery

--- a/cpp/discovery/include/mqb/discovery/SourceDiscovery.hpp
+++ b/cpp/discovery/include/mqb/discovery/SourceDiscovery.hpp
@@ -44,6 +44,10 @@ struct Result {
     std::vector<std::filesystem::path> sources;
     std::size_t indexed_files{};
     std::vector<Warning> warnings;
+    // True when at least one selected translation unit contains module syntax
+    // that requires the P1689/module pipeline, even if discovery found no local
+    // interface provider (for example `import external.module;`).
+    bool requires_module_pipeline{false};
 };
 
 class SourceDiscovery {

--- a/cpp/discovery/src/ModuleSyntax.cpp
+++ b/cpp/discovery/src/ModuleSyntax.cpp
@@ -163,7 +163,18 @@ struct Token {
         }
         if (ch == '/' && next == '*') {
             const std::size_t close = text.find("*/", index + 2);
-            index = close == std::string_view::npos ? text.size() : close + 2;
+            const std::size_t comment_end = close == std::string_view::npos
+                ? text.size()
+                : close + 2;
+            const std::string_view comment = text.substr(index, comment_end - index);
+            if (comment.find('\n') != std::string_view::npos
+                || comment.find('\r') != std::string_view::npos) {
+                // A block comment is preprocessing whitespace. If it crosses a
+                // physical line boundary, code before the comment must not make
+                // a following `#` look like mid-line code on the new line.
+                line_has_code = false;
+            }
+            index = comment_end;
             continue;
         }
 

--- a/cpp/discovery/src/ModuleSyntax.cpp
+++ b/cpp/discovery/src/ModuleSyntax.cpp
@@ -1,0 +1,347 @@
+#include "mqb/discovery/ModuleSyntax.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace mqb::discovery {
+namespace {
+
+enum class TokenKind {
+    identifier,
+    colon,
+    dot,
+    semicolon,
+    less,
+    string_literal,
+    other,
+};
+
+struct Token {
+    TokenKind kind{TokenKind::other};
+    std::string text;
+};
+
+[[nodiscard]] bool identifier_start(const char ch) {
+    const unsigned char value = static_cast<unsigned char>(ch);
+    return std::isalpha(value) != 0 || ch == '_';
+}
+
+[[nodiscard]] bool identifier_continue(const char ch) {
+    const unsigned char value = static_cast<unsigned char>(ch);
+    return std::isalnum(value) != 0 || ch == '_';
+}
+
+[[nodiscard]] bool starts_with_at(
+    const std::string_view text,
+    const std::size_t offset,
+    const std::string_view prefix) {
+    return offset <= text.size() && text.substr(offset, prefix.size()) == prefix;
+}
+
+[[nodiscard]] std::optional<std::size_t> literal_prefix_length(
+    const std::string_view text,
+    const std::size_t offset,
+    bool& raw,
+    char& quote) {
+    struct Prefix {
+        std::string_view text;
+        bool raw;
+        char quote;
+    };
+    constexpr Prefix prefixes[]{
+        {"u8R\"", true, '"'}, {"uR\"", true, '"'}, {"UR\"", true, '"'},
+        {"LR\"", true, '"'}, {"R\"", true, '"'},
+        {"u8\"", false, '"'}, {"u\"", false, '"'}, {"U\"", false, '"'},
+        {"L\"", false, '"'}, {"\"", false, '"'},
+        {"u8'", false, '\''}, {"u'", false, '\''}, {"U'", false, '\''},
+        {"L'", false, '\''}, {"'", false, '\''},
+    };
+    for (const auto& prefix : prefixes) {
+        if (starts_with_at(text, offset, prefix.text)) {
+            raw = prefix.raw;
+            quote = prefix.quote;
+            return prefix.text.size();
+        }
+    }
+    return std::nullopt;
+}
+
+[[nodiscard]] std::size_t skip_literal(
+    const std::string_view text,
+    const std::size_t offset,
+    const std::size_t prefix_length,
+    const bool raw,
+    const char quote) {
+    if (raw) {
+        // prefix_length includes the opening quote. The raw delimiter follows
+        // that quote and ends at the first '('. Invalid/incomplete literals are
+        // conservatively consumed to EOF so their contents cannot create edges.
+        const std::size_t delimiter_begin = offset + prefix_length;
+        const std::size_t open = text.find('(', delimiter_begin);
+        if (open == std::string_view::npos || open - delimiter_begin > 16) {
+            return text.size();
+        }
+        const std::string delimiter{text.substr(delimiter_begin, open - delimiter_begin)};
+        const std::string terminator = ")" + delimiter + "\"";
+        const std::size_t close = text.find(terminator, open + 1);
+        return close == std::string_view::npos
+            ? text.size()
+            : close + terminator.size();
+    }
+
+    std::size_t cursor = offset + prefix_length;
+    bool escaped = false;
+    while (cursor < text.size()) {
+        const char ch = text[cursor++];
+        if (escaped) {
+            escaped = false;
+            continue;
+        }
+        if (ch == '\\') {
+            escaped = true;
+            continue;
+        }
+        if (ch == quote) {
+            return cursor;
+        }
+    }
+    return text.size();
+}
+
+[[nodiscard]] std::vector<Token> tokenize(const std::string_view text) {
+    std::vector<Token> tokens;
+    bool line_has_code = false;
+
+    for (std::size_t index = 0; index < text.size();) {
+        const char ch = text[index];
+        const char next = index + 1 < text.size() ? text[index + 1] : '\0';
+
+        if (ch == '\n' || ch == '\r') {
+            line_has_code = false;
+            ++index;
+            continue;
+        }
+        if (std::isspace(static_cast<unsigned char>(ch)) != 0) {
+            ++index;
+            continue;
+        }
+
+        // Ignore preprocessor directive lines, including simple backslash
+        // continuations. Module declarations/import-declarations are not
+        // preprocessor directives, so this avoids macro-text false positives.
+        if (!line_has_code && ch == '#') {
+            while (index < text.size()) {
+                const std::size_t newline = text.find('\n', index);
+                if (newline == std::string_view::npos) {
+                    index = text.size();
+                    break;
+                }
+                std::size_t before = newline;
+                while (before > index
+                       && (text[before - 1] == ' ' || text[before - 1] == '\t'
+                           || text[before - 1] == '\r')) {
+                    --before;
+                }
+                const bool continued = before > index && text[before - 1] == '\\';
+                index = newline + 1;
+                if (!continued) break;
+            }
+            line_has_code = false;
+            continue;
+        }
+
+        if (ch == '/' && next == '/') {
+            const std::size_t newline = text.find('\n', index + 2);
+            index = newline == std::string_view::npos ? text.size() : newline;
+            continue;
+        }
+        if (ch == '/' && next == '*') {
+            const std::size_t close = text.find("*/", index + 2);
+            index = close == std::string_view::npos ? text.size() : close + 2;
+            continue;
+        }
+
+        bool raw = false;
+        char quote = '\0';
+        if (auto prefix = literal_prefix_length(text, index, raw, quote)) {
+            tokens.push_back(Token{.kind = TokenKind::string_literal});
+            index = skip_literal(text, index, *prefix, raw, quote);
+            line_has_code = true;
+            continue;
+        }
+
+        if (identifier_start(ch)) {
+            const std::size_t begin = index++;
+            while (index < text.size() && identifier_continue(text[index])) ++index;
+            tokens.push_back(Token{
+                .kind = TokenKind::identifier,
+                .text = std::string{text.substr(begin, index - begin)},
+            });
+            line_has_code = true;
+            continue;
+        }
+
+        TokenKind kind = TokenKind::other;
+        switch (ch) {
+        case ':': kind = TokenKind::colon; break;
+        case '.': kind = TokenKind::dot; break;
+        case ';': kind = TokenKind::semicolon; break;
+        case '<': kind = TokenKind::less; break;
+        default: break;
+        }
+        tokens.push_back(Token{.kind = kind, .text = std::string(1, ch)});
+        line_has_code = true;
+        ++index;
+    }
+    return tokens;
+}
+
+struct ParsedName {
+    std::string name;
+    std::size_t semicolon_index{};
+    bool relative_partition{false};
+};
+
+[[nodiscard]] std::optional<ParsedName> parse_module_name(
+    const std::vector<Token>& tokens,
+    std::size_t index,
+    const bool allow_relative) {
+    ParsedName parsed;
+    if (index < tokens.size() && tokens[index].kind == TokenKind::colon) {
+        if (!allow_relative) return std::nullopt;
+        parsed.relative_partition = true;
+        parsed.name.push_back(':');
+        ++index;
+    }
+
+    if (index >= tokens.size() || tokens[index].kind != TokenKind::identifier) {
+        return std::nullopt;
+    }
+    parsed.name += tokens[index++].text;
+
+    bool saw_partition = parsed.relative_partition;
+    while (index < tokens.size()) {
+        if (tokens[index].kind == TokenKind::dot) {
+            if (index + 1 >= tokens.size()
+                || tokens[index + 1].kind != TokenKind::identifier) {
+                return std::nullopt;
+            }
+            parsed.name.push_back('.');
+            parsed.name += tokens[index + 1].text;
+            index += 2;
+            continue;
+        }
+        if (tokens[index].kind == TokenKind::colon && !saw_partition) {
+            if (index + 1 >= tokens.size()
+                || tokens[index + 1].kind != TokenKind::identifier) {
+                return std::nullopt;
+            }
+            saw_partition = true;
+            parsed.name.push_back(':');
+            parsed.name += tokens[index + 1].text;
+            index += 2;
+            continue;
+        }
+        break;
+    }
+
+    if (index >= tokens.size() || tokens[index].kind != TokenKind::semicolon) {
+        return std::nullopt;
+    }
+    parsed.semicolon_index = index;
+    return parsed;
+}
+
+[[nodiscard]] std::string primary_module_name(const std::string& declared) {
+    const std::size_t partition = declared.find(':');
+    return partition == std::string::npos ? declared : declared.substr(0, partition);
+}
+
+void append_unique(std::vector<std::string>& values, std::string value) {
+    if (std::find(values.begin(), values.end(), value) == values.end()) {
+        values.push_back(std::move(value));
+    }
+}
+
+} // namespace
+
+NamedModuleSyntax ModuleSyntaxParser::parse(const std::string_view source_text) {
+    const std::vector<Token> tokens = tokenize(source_text);
+    NamedModuleSyntax syntax;
+
+    // First determine the named module declaration so relative partition imports
+    // can be normalized even though import extraction is a separate pass.
+    for (std::size_t index = 0; index < tokens.size(); ++index) {
+        std::size_t module_index = index;
+        if (tokens[index].kind == TokenKind::identifier
+            && tokens[index].text == "export") {
+            if (index + 1 >= tokens.size()
+                || tokens[index + 1].kind != TokenKind::identifier
+                || tokens[index + 1].text != "module") {
+                continue;
+            }
+            module_index = index + 1;
+        } else if (tokens[index].kind != TokenKind::identifier
+                   || tokens[index].text != "module") {
+            continue;
+        }
+
+        const std::size_t name_index = module_index + 1;
+        if (name_index >= tokens.size()
+            || tokens[name_index].kind == TokenKind::semicolon
+            || tokens[name_index].kind == TokenKind::colon) {
+            // global module fragment `module;` and private fragment
+            // `module : private;` are not named providers.
+            continue;
+        }
+        if (auto parsed = parse_module_name(tokens, name_index, false)) {
+            syntax.declared_module = std::move(parsed->name);
+            break;
+        }
+    }
+
+    for (std::size_t index = 0; index < tokens.size(); ++index) {
+        std::size_t import_index = index;
+        if (tokens[index].kind == TokenKind::identifier
+            && tokens[index].text == "export") {
+            if (index + 1 >= tokens.size()
+                || tokens[index + 1].kind != TokenKind::identifier
+                || tokens[index + 1].text != "import") {
+                continue;
+            }
+            import_index = index + 1;
+        } else if (tokens[index].kind != TokenKind::identifier
+                   || tokens[index].text != "import") {
+            continue;
+        }
+
+        const std::size_t name_index = import_index + 1;
+        if (name_index >= tokens.size()) continue;
+        if (tokens[name_index].kind == TokenKind::less
+            || tokens[name_index].kind == TokenKind::string_literal) {
+            // Header units are intentionally not source-discovery named-module
+            // edges. The real module pipeline continues to fail them closed.
+            continue;
+        }
+
+        auto parsed = parse_module_name(tokens, name_index, true);
+        if (!parsed) continue;
+
+        std::string name = std::move(parsed->name);
+        if (parsed->relative_partition) {
+            if (!syntax.declared_module) continue;
+            name = primary_module_name(*syntax.declared_module) + name;
+        }
+        append_unique(syntax.imported_modules, std::move(name));
+    }
+
+    return syntax;
+}
+
+} // namespace mqb::discovery

--- a/cpp/discovery/src/SourceDiscovery.cpp
+++ b/cpp/discovery/src/SourceDiscovery.cpp
@@ -383,6 +383,12 @@ void add_undirected_edge(
     return path_key(path.parent_path() / path.stem());
 }
 
+[[nodiscard]] bool file_requires_module_pipeline(const FileRecord& file) {
+    return module_interface_translation_unit(file)
+        || file.module_syntax.declared_module.has_value()
+        || !file.module_syntax.imported_modules.empty();
+}
+
 } // namespace
 
 std::expected<Result, Error>
@@ -570,8 +576,6 @@ SourceDiscovery::discover(const Request& request) {
 
     std::vector<std::vector<std::size_t>> adjacency(files.size());
 
-    // Existing quoted-include connectivity remains unchanged and applies to
-    // both ordinary and module translation units.
     for (std::size_t file_index = 0; file_index < files.size(); ++file_index) {
         const auto& file = files[file_index];
         for (const auto& include : file.local_includes) {
@@ -592,9 +596,6 @@ SourceDiscovery::discover(const Request& request) {
         }
     }
 
-    // Same-basename header ownership is intentionally restricted to ordinary
-    // translation units. A module interface must be selected through module
-    // syntax, not merely because it happens to share a header basename.
     std::unordered_map<std::string, std::vector<std::size_t>> ordinary_sources_by_owner;
     for (std::size_t index = 0; index < files.size(); ++index) {
         if (ordinary_translation_unit(files[index])) {
@@ -610,9 +611,6 @@ SourceDiscovery::discover(const Request& request) {
         }
     }
 
-    // Named imports connect to every project-local interface candidate. We do
-    // not choose a winner here: duplicate/ambiguous providers are deliberately
-    // retained so the authoritative P1689 graph can diagnose them later.
     std::unordered_map<std::string, std::vector<std::size_t>> interface_providers;
     std::unordered_map<std::string, std::vector<std::size_t>> declared_module_units;
     for (std::size_t index = 0; index < files.size(); ++index) {
@@ -638,10 +636,6 @@ SourceDiscovery::discover(const Request& request) {
         }
     }
 
-    // A module implementation unit (`module M;`) contributes an object even
-    // though it does not itself satisfy named import M. Connect all units that
-    // declare the exact same logical module so selecting the interface also
-    // selects its project-local implementation units.
     for (const auto& [logical_name, units] : declared_module_units) {
         static_cast<void>(logical_name);
         if (units.size() < 2) continue;
@@ -711,6 +705,15 @@ SourceDiscovery::discover(const Request& request) {
     const auto entry_position = std::find(result.sources.begin(), result.sources.end(), entry);
     if (entry_position != result.sources.end() && entry_position != result.sources.begin()) {
         std::rotate(result.sources.begin(), entry_position, entry_position + 1);
+    }
+
+    for (const auto& source : result.sources) {
+        const auto selected = index_by_path.find(path_key(source));
+        if (selected != index_by_path.end()
+            && file_requires_module_pipeline(files[selected->second])) {
+            result.requires_module_pipeline = true;
+            break;
+        }
     }
 
     if (result.sources.empty() || result.sources.front() != entry) {

--- a/cpp/discovery/src/SourceDiscovery.cpp
+++ b/cpp/discovery/src/SourceDiscovery.cpp
@@ -7,6 +7,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iterator>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <system_error>
@@ -15,20 +16,25 @@
 #include <utility>
 #include <vector>
 
+#include "mqb/core/TranslationUnitClassifier.hpp"
+#include "mqb/discovery/ModuleSyntax.hpp"
+
 namespace mqb::discovery {
 namespace {
 
 namespace fs = std::filesystem;
 
 enum class FileKind {
-    source,
+    translation_unit,
     header,
 };
 
 struct FileRecord {
     fs::path path;
     FileKind kind{FileKind::header};
+    std::optional<TranslationUnitKind> translation_unit_kind;
     std::vector<std::string> local_includes;
+    NamedModuleSyntax module_syntax;
     bool defines_main{false};
 };
 
@@ -60,11 +66,6 @@ struct FileRecord {
     return ascii_lower(path.extension().string());
 }
 
-[[nodiscard]] bool source_extension(const fs::path& path) {
-    const std::string extension = extension_lower(path);
-    return extension == ".cpp" || extension == ".cc" || extension == ".cxx";
-}
-
 [[nodiscard]] bool header_extension(const fs::path& path) {
     const std::string extension = extension_lower(path);
     return extension == ".h"
@@ -75,8 +76,8 @@ struct FileRecord {
         || extension == ".ipp";
 }
 
-[[nodiscard]] bool indexed_extension(const fs::path& path) {
-    return source_extension(path) || header_extension(path);
+[[nodiscard]] bool indexed_path(const fs::path& path) {
+    return is_translation_unit_path(path) || header_extension(path);
 }
 
 [[nodiscard]] bool default_excluded_directory(const fs::path& path) {
@@ -357,15 +358,29 @@ void add_undirected_edge(
     if (error_code
         || !fs::is_regular_file(absolute, error_code)
         || error_code
-        || !source_extension(absolute)
+        || !is_translation_unit_path(absolute)
         || !inside_root(root, absolute)) {
         return std::unexpected(failure(
             ErrorCode::invalid_correction,
             requested,
             std::string{description}
-                + " must be an existing ordinary C++ source inside the project root"));
+                + " must be an existing supported C++ translation unit inside the project root"));
     }
     return absolute;
+}
+
+[[nodiscard]] bool ordinary_translation_unit(const FileRecord& file) {
+    return file.kind == FileKind::translation_unit
+        && file.translation_unit_kind == TranslationUnitKind::source;
+}
+
+[[nodiscard]] bool module_interface_translation_unit(const FileRecord& file) {
+    return file.kind == FileKind::translation_unit
+        && file.translation_unit_kind == TranslationUnitKind::module_interface;
+}
+
+[[nodiscard]] std::string ownership_key(const fs::path& path) {
+    return path_key(path.parent_path() / path.stem());
 }
 
 } // namespace
@@ -385,12 +400,12 @@ SourceDiscovery::discover(const Request& request) {
     if (error_code
         || !fs::is_regular_file(entry, error_code)
         || error_code
-        || !source_extension(entry)
+        || !is_translation_unit_path(entry)
         || !inside_root(root, entry)) {
         return std::unexpected(failure(
             ErrorCode::invalid_entry,
             request.entry,
-            "source discovery entry must be an ordinary C++ source inside the project root"));
+            "source discovery entry must be a supported C++ translation unit inside the project root"));
     }
 
     std::vector<fs::path> excluded_directories;
@@ -451,8 +466,9 @@ SourceDiscovery::discover(const Request& request) {
                     *source,
                     text.error()));
             }
+            const auto source_kind = classify_translation_unit_path(*source);
             const std::string comment_free = strip_comments_preserve_literals(*text);
-            if (contains_main(comment_free)) {
+            if (source_kind == TranslationUnitKind::source && contains_main(comment_free)) {
                 return std::unexpected(failure(
                     ErrorCode::invalid_correction,
                     *source,
@@ -496,7 +512,7 @@ SourceDiscovery::discover(const Request& request) {
             continue;
         }
         error_code.clear();
-        if (!item.is_regular_file(error_code) || error_code || !indexed_extension(item.path())) {
+        if (!item.is_regular_file(error_code) || error_code || !indexed_path(item.path())) {
             error_code.clear();
             continue;
         }
@@ -507,12 +523,19 @@ SourceDiscovery::discover(const Request& request) {
             error_code.clear();
             continue;
         }
-        record.kind = source_extension(record.path) ? FileKind::source : FileKind::header;
+        record.translation_unit_kind = classify_translation_unit_path(record.path);
+        record.kind = record.translation_unit_kind
+            ? FileKind::translation_unit
+            : FileKind::header;
 
         if (auto text = read_text(record.path)) {
             const std::string comment_free = strip_comments_preserve_literals(*text);
             record.local_includes = parse_local_includes(comment_free);
-            record.defines_main = record.kind == FileKind::source && contains_main(comment_free);
+            if (record.kind == FileKind::translation_unit) {
+                record.module_syntax = ModuleSyntaxParser::parse(*text);
+                record.defines_main = ordinary_translation_unit(record)
+                    && contains_main(comment_free);
+            }
         } else {
             result.warnings.push_back(Warning{
                 .code = WarningCode::file_read_failed,
@@ -546,6 +569,9 @@ SourceDiscovery::discover(const Request& request) {
     }
 
     std::vector<std::vector<std::size_t>> adjacency(files.size());
+
+    // Existing quoted-include connectivity remains unchanged and applies to
+    // both ordinary and module translation units.
     for (std::size_t file_index = 0; file_index < files.size(); ++file_index) {
         const auto& file = files[file_index];
         for (const auto& include : file.local_includes) {
@@ -566,19 +592,62 @@ SourceDiscovery::discover(const Request& request) {
         }
     }
 
-    constexpr std::string_view source_extensions[]{".cpp", ".cc", ".cxx"};
-    for (std::size_t file_index = 0; file_index < files.size(); ++file_index) {
-        const auto& file = files[file_index];
-        if (file.kind != FileKind::header) {
+    // Same-basename header ownership is intentionally restricted to ordinary
+    // translation units. A module interface must be selected through module
+    // syntax, not merely because it happens to share a header basename.
+    std::unordered_map<std::string, std::vector<std::size_t>> ordinary_sources_by_owner;
+    for (std::size_t index = 0; index < files.size(); ++index) {
+        if (ordinary_translation_unit(files[index])) {
+            ordinary_sources_by_owner[ownership_key(files[index].path)].push_back(index);
+        }
+    }
+    for (std::size_t index = 0; index < files.size(); ++index) {
+        if (files[index].kind != FileKind::header) continue;
+        const auto owners = ordinary_sources_by_owner.find(ownership_key(files[index].path));
+        if (owners == ordinary_sources_by_owner.end()) continue;
+        for (const std::size_t owner : owners->second) {
+            add_undirected_edge(adjacency, index, owner);
+        }
+    }
+
+    // Named imports connect to every project-local interface candidate. We do
+    // not choose a winner here: duplicate/ambiguous providers are deliberately
+    // retained so the authoritative P1689 graph can diagnose them later.
+    std::unordered_map<std::string, std::vector<std::size_t>> interface_providers;
+    std::unordered_map<std::string, std::vector<std::size_t>> declared_module_units;
+    for (std::size_t index = 0; index < files.size(); ++index) {
+        if (files[index].kind != FileKind::translation_unit
+            || !files[index].module_syntax.declared_module) {
             continue;
         }
-        for (const auto extension : source_extensions) {
-            fs::path sibling = file.path;
-            sibling.replace_extension(extension);
-            const auto found = index_by_path.find(path_key(sibling));
-            if (found != index_by_path.end()) {
-                add_undirected_edge(adjacency, file_index, found->second);
+        const std::string& logical_name = *files[index].module_syntax.declared_module;
+        declared_module_units[logical_name].push_back(index);
+        if (module_interface_translation_unit(files[index])) {
+            interface_providers[logical_name].push_back(index);
+        }
+    }
+
+    for (std::size_t index = 0; index < files.size(); ++index) {
+        if (files[index].kind != FileKind::translation_unit) continue;
+        for (const auto& imported : files[index].module_syntax.imported_modules) {
+            const auto providers = interface_providers.find(imported);
+            if (providers == interface_providers.end()) continue;
+            for (const std::size_t provider : providers->second) {
+                add_undirected_edge(adjacency, index, provider);
             }
+        }
+    }
+
+    // A module implementation unit (`module M;`) contributes an object even
+    // though it does not itself satisfy named import M. Connect all units that
+    // declare the exact same logical module so selecting the interface also
+    // selects its project-local implementation units.
+    for (const auto& [logical_name, units] : declared_module_units) {
+        static_cast<void>(logical_name);
+        if (units.size() < 2) continue;
+        const std::size_t first = units.front();
+        for (std::size_t offset = 1; offset < units.size(); ++offset) {
+            add_undirected_edge(adjacency, first, units[offset]);
         }
     }
 
@@ -597,9 +666,9 @@ SourceDiscovery::discover(const Request& request) {
             visited[next] = true;
 
             const bool second_main = next != entry_index
-                && files[next].kind == FileKind::source
+                && ordinary_translation_unit(files[next])
                 && files[next].defines_main;
-            const bool excluded_source = files[next].kind == FileKind::source
+            const bool excluded_source = files[next].kind == FileKind::translation_unit
                 && excluded_source_keys.contains(path_key(files[next].path));
             if (!second_main && !excluded_source) {
                 queue.push_back(next);
@@ -608,10 +677,12 @@ SourceDiscovery::discover(const Request& request) {
     }
 
     for (std::size_t index = 0; index < files.size(); ++index) {
-        if (!visited[index] || files[index].kind != FileKind::source) {
+        if (!visited[index] || files[index].kind != FileKind::translation_unit) {
             continue;
         }
-        if (files[index].path != entry && files[index].defines_main) {
+        if (files[index].path != entry
+            && ordinary_translation_unit(files[index])
+            && files[index].defines_main) {
             continue;
         }
         if (excluded_source_keys.contains(path_key(files[index].path))) {

--- a/cpp/discovery/tests/CMakeLists.txt
+++ b/cpp/discovery/tests/CMakeLists.txt
@@ -10,7 +10,17 @@ add_executable(mqb_source_discovery_corrections_tests
 target_link_libraries(mqb_source_discovery_corrections_tests PRIVATE mqb_discovery)
 target_compile_features(mqb_source_discovery_corrections_tests PRIVATE cxx_std_23)
 
-foreach(target IN ITEMS mqb_source_discovery_tests mqb_source_discovery_corrections_tests)
+add_executable(mqb_module_syntax_tests
+    module_syntax_tests.cpp
+)
+target_link_libraries(mqb_module_syntax_tests PRIVATE mqb_discovery)
+target_compile_features(mqb_module_syntax_tests PRIVATE cxx_std_23)
+
+foreach(target IN ITEMS
+    mqb_source_discovery_tests
+    mqb_source_discovery_corrections_tests
+    mqb_module_syntax_tests
+)
     if(MSVC)
         target_compile_options(${target} PRIVATE /W4 /permissive-)
     else()
@@ -20,3 +30,4 @@ endforeach()
 
 add_test(NAME mqb.discovery.source_graph COMMAND mqb_source_discovery_tests)
 add_test(NAME mqb.discovery.corrections COMMAND mqb_source_discovery_corrections_tests)
+add_test(NAME mqb.discovery.module_syntax COMMAND mqb_module_syntax_tests)

--- a/cpp/discovery/tests/CMakeLists.txt
+++ b/cpp/discovery/tests/CMakeLists.txt
@@ -16,10 +16,17 @@ add_executable(mqb_module_syntax_tests
 target_link_libraries(mqb_module_syntax_tests PRIVATE mqb_discovery)
 target_compile_features(mqb_module_syntax_tests PRIVATE cxx_std_23)
 
+add_executable(mqb_module_source_discovery_tests
+    module_source_discovery_tests.cpp
+)
+target_link_libraries(mqb_module_source_discovery_tests PRIVATE mqb_discovery)
+target_compile_features(mqb_module_source_discovery_tests PRIVATE cxx_std_23)
+
 foreach(target IN ITEMS
     mqb_source_discovery_tests
     mqb_source_discovery_corrections_tests
     mqb_module_syntax_tests
+    mqb_module_source_discovery_tests
 )
     if(MSVC)
         target_compile_options(${target} PRIVATE /W4 /permissive-)
@@ -31,3 +38,4 @@ endforeach()
 add_test(NAME mqb.discovery.source_graph COMMAND mqb_source_discovery_tests)
 add_test(NAME mqb.discovery.corrections COMMAND mqb_source_discovery_corrections_tests)
 add_test(NAME mqb.discovery.module_syntax COMMAND mqb_module_syntax_tests)
+add_test(NAME mqb.discovery.module_graph COMMAND mqb_module_source_discovery_tests)

--- a/cpp/discovery/tests/module_source_discovery_tests.cpp
+++ b/cpp/discovery/tests/module_source_discovery_tests.cpp
@@ -1,0 +1,175 @@
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <vector>
+
+#include "mqb/discovery/SourceDiscovery.hpp"
+
+namespace {
+
+namespace fs = std::filesystem;
+int failures = 0;
+
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+void write_text(const fs::path& path, const std::string_view text) {
+    fs::create_directories(path.parent_path());
+    std::ofstream stream{path, std::ios::binary | std::ios::trunc};
+    stream << text;
+}
+
+[[nodiscard]] bool contains_source(
+    const std::vector<fs::path>& sources,
+    const fs::path& source) {
+    const fs::path normalized = source.lexically_normal();
+    for (const auto& candidate : sources) {
+        if (candidate.lexically_normal() == normalized) return true;
+    }
+    return false;
+}
+
+struct TempTree {
+    fs::path root;
+    ~TempTree() {
+        std::error_code ignored;
+        fs::remove_all(root, ignored);
+    }
+};
+
+} // namespace
+
+int main() {
+    const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
+    TempTree tree{
+        .root = fs::temp_directory_path() / ("mqb_module_discovery_" + std::to_string(unique)),
+    };
+    fs::create_directories(tree.root);
+
+    const fs::path main_cpp = tree.root / "main.cpp";
+    const fs::path stats_cppm = tree.root / "modules" / "stats.cppm";
+    const fs::path math_ixx = tree.root / "modules" / "math.ixx";
+    const fs::path math_impl = tree.root / "modules" / "math_impl.cpp";
+    const fs::path detail_mpp = tree.root / "modules" / "detail.mpp";
+    const fs::path unused_mpp = tree.root / "modules" / "unused.mpp";
+
+    write_text(
+        main_cpp,
+        "// import ignored.comment;\n"
+        "const char* fake = \"import ignored.string;\";\n"
+        "import app.stats;\n"
+        "int main() { return 0; }\n");
+    write_text(
+        stats_cppm,
+        "export module app.stats;\n"
+        "export import math;\n"
+        "export int stats();\n");
+    write_text(
+        math_ixx,
+        "export module math;\n"
+        "export import :detail;\n"
+        "export int value();\n");
+    write_text(
+        math_impl,
+        "module math;\n"
+        "int value() { return 42; }\n");
+    write_text(
+        detail_mpp,
+        "export module math:detail;\n"
+        "export int detail() { return 1; }\n");
+    write_text(
+        unused_mpp,
+        "export module unused;\n"
+        "export int unused_value() { return 9; }\n");
+
+    const auto discovered = mqb::discovery::SourceDiscovery::discover({
+        .project_root = tree.root,
+        .entry = main_cpp,
+    });
+    expect(discovered.has_value(), "named-module source discovery should succeed");
+    if (discovered) {
+        expect(!discovered->sources.empty() && discovered->sources.front() == main_cpp,
+               "ordinary entry should remain first after module-aware discovery");
+        expect(contains_source(discovered->sources, stats_cppm),
+               "named import should select a .cppm interface provider");
+        expect(contains_source(discovered->sources, math_ixx),
+               "export import should transitively select a .ixx provider");
+        expect(contains_source(discovered->sources, detail_mpp),
+               "relative partition import should select its normalized .mpp provider");
+        expect(contains_source(discovered->sources, math_impl),
+               "same logical module implementation unit should follow its interface provider");
+        expect(!contains_source(discovered->sources, unused_mpp),
+               "unreferenced module interfaces must not be pulled into the target");
+        expect(discovered->sources.size() == 5,
+               "module chain should select exactly entry plus four required module TUs");
+
+        const auto repeated = mqb::discovery::SourceDiscovery::discover({
+            .project_root = tree.root,
+            .entry = main_cpp,
+        });
+        expect(repeated.has_value() && repeated->sources == discovered->sources,
+               "module-aware discovery ordering must remain deterministic");
+    }
+
+    const fs::path duplicate_main = tree.root / "duplicate_main.cpp";
+    const fs::path duplicate_a = tree.root / "duplicates" / "first.ixx";
+    const fs::path duplicate_b = tree.root / "duplicates" / "second.cppm";
+    write_text(duplicate_main, "import duplicate;\nint main() { return 0; }\n");
+    write_text(duplicate_a, "export module duplicate;\nexport int first();\n");
+    write_text(duplicate_b, "export module duplicate;\nexport int second();\n");
+
+    const auto duplicate = mqb::discovery::SourceDiscovery::discover({
+        .project_root = tree.root,
+        .entry = duplicate_main,
+    });
+    expect(duplicate.has_value(),
+           "discovery must retain duplicate provider candidates for P1689 validation");
+    if (duplicate) {
+        expect(contains_source(duplicate->sources, duplicate_a)
+                   && contains_source(duplicate->sources, duplicate_b),
+               "all matching local interface candidates should be selected rather than guessed");
+    }
+
+    const auto excluded_provider = mqb::discovery::SourceDiscovery::discover({
+        .project_root = tree.root,
+        .entry = duplicate_main,
+        .excluded_sources = {duplicate_a},
+    });
+    expect(excluded_provider.has_value(),
+           "module interface should be usable as an exact excluded-source correction");
+    if (excluded_provider) {
+        expect(!contains_source(excluded_provider->sources, duplicate_a)
+                   && contains_source(excluded_provider->sources, duplicate_b),
+               "excluded module provider should be a traversal barrier while other candidates remain");
+    }
+
+    const fs::path plain_main = tree.root / "plain_main.cpp";
+    write_text(plain_main, "int main() { return 0; }\n");
+    const auto extra_module = mqb::discovery::SourceDiscovery::discover({
+        .project_root = tree.root,
+        .entry = plain_main,
+        .extra_sources = {unused_mpp},
+    });
+    expect(extra_module.has_value(),
+           "module interface should be usable as an exact extra-source correction");
+    if (extra_module) {
+        expect(contains_source(extra_module->sources, unused_mpp),
+               "exact extra module interface should be retained even when disconnected");
+    }
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+
+    std::cout << "mqb_module_source_discovery_tests passed\n";
+    return 0;
+}

--- a/cpp/discovery/tests/module_source_discovery_tests.cpp
+++ b/cpp/discovery/tests/module_source_discovery_tests.cpp
@@ -96,6 +96,8 @@ int main() {
     });
     expect(discovered.has_value(), "named-module source discovery should succeed");
     if (discovered) {
+        expect(discovered->requires_module_pipeline,
+               "selected named-module chain must request the module pipeline");
         expect(!discovered->sources.empty() && discovered->sources.front() == main_cpp,
                "ordinary entry should remain first after module-aware discovery");
         expect(contains_source(discovered->sources, stats_cppm),
@@ -133,6 +135,8 @@ int main() {
     expect(duplicate.has_value(),
            "discovery must retain duplicate provider candidates for P1689 validation");
     if (duplicate) {
+        expect(duplicate->requires_module_pipeline,
+               "duplicate provider candidate targets still require authoritative module validation");
         expect(contains_source(duplicate->sources, duplicate_a)
                    && contains_source(duplicate->sources, duplicate_b),
                "all matching local interface candidates should be selected rather than guessed");
@@ -146,13 +150,43 @@ int main() {
     expect(excluded_provider.has_value(),
            "module interface should be usable as an exact excluded-source correction");
     if (excluded_provider) {
+        expect(excluded_provider->requires_module_pipeline,
+               "excluding one provider must not erase the consumer's module-routing requirement");
         expect(!contains_source(excluded_provider->sources, duplicate_a)
                    && contains_source(excluded_provider->sources, duplicate_b),
                "excluded module provider should be a traversal barrier while other candidates remain");
     }
 
+    const fs::path external_main = tree.root / "external_main.cpp";
+    write_text(
+        external_main,
+        "import definitely.external.module;\n"
+        "int main() { return 0; }\n");
+    const auto external = mqb::discovery::SourceDiscovery::discover({
+        .project_root = tree.root,
+        .entry = external_main,
+    });
+    expect(external.has_value(),
+           "import-only discovery with no local provider should still produce a source selection");
+    if (external) {
+        expect(external->sources == std::vector<fs::path>{external_main},
+               "missing local named-module providers must not invent source candidates");
+        expect(external->requires_module_pipeline,
+               "import-only targets with no local provider must fail closed through the module pipeline");
+    }
+
     const fs::path plain_main = tree.root / "plain_main.cpp";
     write_text(plain_main, "int main() { return 0; }\n");
+    const auto plain = mqb::discovery::SourceDiscovery::discover({
+        .project_root = tree.root,
+        .entry = plain_main,
+    });
+    expect(plain.has_value(), "ordinary source discovery should remain valid");
+    if (plain) {
+        expect(!plain->requires_module_pipeline,
+               "unrelated module files elsewhere in the project must not reroute an ordinary target");
+    }
+
     const auto extra_module = mqb::discovery::SourceDiscovery::discover({
         .project_root = tree.root,
         .entry = plain_main,
@@ -161,6 +195,8 @@ int main() {
     expect(extra_module.has_value(),
            "module interface should be usable as an exact extra-source correction");
     if (extra_module) {
+        expect(extra_module->requires_module_pipeline,
+               "an explicitly selected module interface must request the module pipeline");
         expect(contains_source(extra_module->sources, unused_mpp),
                "exact extra module interface should be retained even when disconnected");
     }

--- a/cpp/discovery/tests/module_syntax_tests.cpp
+++ b/cpp/discovery/tests/module_syntax_tests.cpp
@@ -91,6 +91,18 @@ int main() {
 
     {
         const auto syntax = ModuleSyntaxParser::parse(
+            "int prior_code = 0; /* crosses a physical line\n"
+            "and ends before a directive */ #define FAKE import macro.after_comment;\n"
+            "export module real;\n"
+            "import actual;\n");
+        expect(syntax.declared_module == "real",
+               "a multiline block comment must reset preprocessing-line state");
+        expect(syntax.imported_modules == std::vector<std::string>({"actual"}),
+               "directive text after a multiline block comment must remain ignored");
+    }
+
+    {
+        const auto syntax = ModuleSyntaxParser::parse(
             "export module app;\n"
             "import dep;\n"
             "import dep;\n"

--- a/cpp/discovery/tests/module_syntax_tests.cpp
+++ b/cpp/discovery/tests/module_syntax_tests.cpp
@@ -1,0 +1,120 @@
+#include <iostream>
+#include <string_view>
+#include <vector>
+
+#include "mqb/discovery/ModuleSyntax.hpp"
+
+namespace {
+
+int failures = 0;
+
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+} // namespace
+
+int main() {
+    using mqb::discovery::ModuleSyntaxParser;
+
+    {
+        const auto syntax = ModuleSyntaxParser::parse(
+            "export module math.core;\n"
+            "import util;\n"
+            "export import stats.detail;\n");
+        expect(syntax.declared_module == "math.core",
+               "export module should expose its logical module name");
+        expect(syntax.imported_modules == std::vector<std::string>({"util", "stats.detail"}),
+               "named import and export import should be preserved in source order");
+    }
+
+    {
+        const auto syntax = ModuleSyntaxParser::parse(
+            "module graphics:render;\n"
+            "import :types;\n"
+            "import graphics.io:codec;\n");
+        expect(syntax.declared_module == "graphics:render",
+               "module partitions should remain part of the declaration identity");
+        expect(syntax.imported_modules
+                   == std::vector<std::string>({"graphics:types", "graphics.io:codec"}),
+               "relative partition imports should normalize against the primary module name");
+    }
+
+    {
+        const auto syntax = ModuleSyntaxParser::parse(
+            "module;\n"
+            "export module actual;\n"
+            "module : private;\n");
+        expect(syntax.declared_module == "actual",
+               "global/private module fragments must not replace the named module declaration");
+    }
+
+    {
+        const auto syntax = ModuleSyntaxParser::parse(
+            "import <vector>;\n"
+            "import \"local.hpp\";\n"
+            "import project.api;\n");
+        expect(syntax.imported_modules == std::vector<std::string>({"project.api"}),
+               "header-unit imports must be excluded from named-module discovery edges");
+    }
+
+    {
+        const auto syntax = ModuleSyntaxParser::parse(
+            "// import fake.comment;\n"
+            "/* export module fake.block; */\n"
+            "const char* a = \"import fake.string;\";\n"
+            "const char* b = R\"tag(export module fake.raw;)tag\";\n"
+            "char c = ';';\n"
+            "export module real;\n"
+            "import dependency;\n");
+        expect(syntax.declared_module == "real",
+               "comment and literal contents must not create fake module declarations");
+        expect(syntax.imported_modules == std::vector<std::string>({"dependency"}),
+               "comment and literal contents must not create fake imports");
+    }
+
+    {
+        const auto syntax = ModuleSyntaxParser::parse(
+            "#define FAKE import macro.module;\n"
+            "#define LONG export module macro\\\n"
+            "  .continued;\n"
+            "export module real;\n"
+            "import actual;\n");
+        expect(syntax.declared_module == "real",
+               "preprocessor directives must not create discovery module declarations");
+        expect(syntax.imported_modules == std::vector<std::string>({"actual"}),
+               "preprocessor directive text must not create discovery imports");
+    }
+
+    {
+        const auto syntax = ModuleSyntaxParser::parse(
+            "export module app;\n"
+            "import dep;\n"
+            "import dep;\n"
+            "export import dep;\n");
+        expect(syntax.imported_modules == std::vector<std::string>({"dep"}),
+               "duplicate named imports should collapse deterministically");
+    }
+
+    {
+        const auto syntax = ModuleSyntaxParser::parse(
+            "import :orphan;\n"
+            "int import_value = 0;\n"
+            "void import_fn();\n");
+        expect(!syntax.declared_module.has_value(),
+               "ordinary source without a module declaration should remain undeclared");
+        expect(syntax.imported_modules.empty(),
+               "relative partition imports without module context should not invent providers");
+    }
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+
+    std::cout << "mqb_module_syntax_tests passed\n";
+    return 0;
+}

--- a/cpp/orchestration/include/mqb/orchestration/MsvcTargetRouter.hpp
+++ b/cpp/orchestration/include/mqb/orchestration/MsvcTargetRouter.hpp
@@ -35,6 +35,10 @@ struct RoutedTargetRequest {
     LinkOptions link_options;
     std::filesystem::path working_directory;
     std::size_t max_parallel_jobs{1};
+    // Execution-routing state only. This is used when discovery observed named
+    // module syntax but found no local interface provider; it must not affect
+    // compile/link signatures or cache identity.
+    bool force_named_modules{false};
 };
 
 enum class RoutedTargetErrorCode {
@@ -64,7 +68,8 @@ public:
         : ordinary_target_(ordinary_target), module_target_(module_target) {}
 
     [[nodiscard]] static MsvcTargetPipeline select_pipeline(
-        std::span<const RoutedTargetSourceRequest> sources) noexcept;
+        std::span<const RoutedTargetSourceRequest> sources,
+        bool force_named_modules = false) noexcept;
 
     [[nodiscard]] std::expected<RoutedTargetResult, RoutedTargetError>
     run(const RoutedTargetRequest& request) const;

--- a/cpp/orchestration/src/MsvcTargetRouter.cpp
+++ b/cpp/orchestration/src/MsvcTargetRouter.cpp
@@ -9,7 +9,11 @@
 namespace mqb::orchestration {
 
 MsvcTargetPipeline MsvcTargetRouter::select_pipeline(
-    const std::span<const RoutedTargetSourceRequest> sources) noexcept {
+    const std::span<const RoutedTargetSourceRequest> sources,
+    const bool force_named_modules) noexcept {
+    if (force_named_modules) {
+        return MsvcTargetPipeline::named_modules;
+    }
     const bool has_module_interface = std::any_of(
         sources.begin(),
         sources.end(),
@@ -23,7 +27,9 @@ MsvcTargetPipeline MsvcTargetRouter::select_pipeline(
 
 std::expected<RoutedTargetResult, RoutedTargetError>
 MsvcTargetRouter::run(const RoutedTargetRequest& request) const {
-    const MsvcTargetPipeline pipeline = select_pipeline(request.sources);
+    const MsvcTargetPipeline pipeline = select_pipeline(
+        request.sources,
+        request.force_named_modules);
 
     if (pipeline == MsvcTargetPipeline::ordinary) {
         std::vector<TargetSourceRequest> sources;

--- a/cpp/orchestration/tests/target_router_tests.cpp
+++ b/cpp/orchestration/tests/target_router_tests.cpp
@@ -40,6 +40,9 @@ int main() {
         expect(
             MsvcTargetRouter::select_pipeline(sources) == MsvcTargetPipeline::ordinary,
             "ordinary-only source sets must preserve the existing target pipeline");
+        expect(
+            MsvcTargetRouter::select_pipeline(sources, true) == MsvcTargetPipeline::named_modules,
+            "discovery must be able to force the module pipeline for import-only ordinary sources");
     }
 
     {
@@ -67,6 +70,9 @@ int main() {
         expect(
             MsvcTargetRouter::select_pipeline(sources) == MsvcTargetPipeline::ordinary,
             "empty routing input should defer validation to the ordinary target contract");
+        expect(
+            MsvcTargetRouter::select_pipeline(sources, true) == MsvcTargetPipeline::named_modules,
+            "explicit fail-closed routing must take precedence over inferred source kinds");
     }
 
     if (failures != 0) {

--- a/cpp/tests/mqb_module_cli_e2e_tests.cpp
+++ b/cpp/tests/mqb_module_cli_e2e_tests.cpp
@@ -134,6 +134,10 @@ int main(const int argc, char* argv[]) {
         "export module math;\n"
         "export int answer() { return 42; }\n");
     write_text(
+        tree.root / "unused.ixx",
+        "export module unused;\n"
+        "export int unused_value() { return 7; }\n");
+    write_text(
         tree.root / "main.cpp",
         "import math;\n"
         "int main() { return answer() >= 40 ? 0 : 1; }\n");
@@ -220,7 +224,9 @@ int main(const int argc, char* argv[]) {
                "single-entry module target should discover its provider, build, and run");
         expect(discovered_cold->stdout_text.find("[discover] 2 translation units")
                    != std::string::npos,
-               "single-entry discovery should select the ordinary consumer and module provider");
+               "single-entry discovery should select only the ordinary consumer and imported provider");
+        expect(discovered_cold->stdout_text.find("unused.ixx") == std::string::npos,
+               "unreferenced project-local module interfaces must not be selected by discovery");
         expect(discovered_cold->stdout_text.find("  pipeline: named-modules")
                    != std::string::npos,
                "discovered module target should route through the named-module pipeline");
@@ -313,6 +319,33 @@ int main(const int argc, char* argv[]) {
                        != std::string::npos,
                    "single-entry IFC repair should relink the executable");
         }
+    }
+
+    // Replace the entry with an import that has no project-local provider. The
+    // build must still enter the P1689 path and fail closed; falling back to the
+    // ordinary target here would bypass module provider validation.
+    write_text(
+        tree.root / "main.cpp",
+        "import definitely.missing.module;\n"
+        "int main() { return 0; }\n");
+    auto missing_provider = run_mqb(
+        runner,
+        mqb_executable,
+        tree.root,
+        "1",
+        false,
+        "module-missing");
+    expect(missing_provider.has_value(),
+           "missing-provider public CLI invocation should launch");
+    if (missing_provider) {
+        expect(missing_provider->exit_code != 0,
+               "unsupported external named module must fail instead of building as an ordinary target");
+        expect(missing_provider->stdout_text.find("  pipeline: named-modules")
+                   != std::string::npos,
+               "import-only target with zero local providers must explicitly enter named-module routing");
+        expect(missing_provider->stdout_text.find("[link] module-missing.exe")
+                   == std::string::npos,
+               "missing named-module provider must fail before final link");
     }
 
     if (failures != 0) {

--- a/cpp/tests/mqb_module_cli_e2e_tests.cpp
+++ b/cpp/tests/mqb_module_cli_e2e_tests.cpp
@@ -81,25 +81,31 @@ struct TempTree {
     mqb::platform::windows::WindowsProcessRunner& runner,
     const fs::path& mqb,
     const fs::path& root,
-    const std::string& jobs) {
+    const std::string& jobs,
+    const bool explicit_provider,
+    const std::string& output_name) {
     mqb::process::ProcessSpec spec;
     spec.executable = mqb;
-    // Consumer first intentionally verifies that the public CLI delegates ordering
-    // to the P1689 provider graph rather than positional source order.
-    spec.arguments = {
-        "main.cpp",
-        "math.ixx",
-        "--env",
-        "vs",
-        "--std",
-        "latest",
-        "--jobs",
-        jobs,
-        "--verbose",
-        "-o",
-        "module-cli",
-        "--run",
-    };
+    spec.arguments = {"main.cpp"};
+    if (explicit_provider) {
+        // Consumer first intentionally verifies that the public CLI delegates ordering
+        // to the P1689 provider graph rather than positional source order.
+        spec.arguments.push_back("math.ixx");
+    }
+    spec.arguments.insert(
+        spec.arguments.end(),
+        {
+            "--env",
+            "vs",
+            "--std",
+            "latest",
+            "--jobs",
+            jobs,
+            "--verbose",
+            "-o",
+            output_name,
+            "--run",
+        });
     spec.working_directory = root;
     spec.capture_stdout = true;
     spec.capture_stderr = true;
@@ -130,16 +136,16 @@ int main(const int argc, char* argv[]) {
     write_text(
         tree.root / "main.cpp",
         "import math;\n"
-        "int main() { return answer() == 42 ? 0 : 1; }\n");
+        "int main() { return answer() >= 40 ? 0 : 1; }\n");
 
     mqb::platform::windows::WindowsProcessRunner runner;
 
-    auto cold = run_mqb(runner, mqb_executable, tree.root, "2");
+    auto cold = run_mqb(runner, mqb_executable, tree.root, "2", true, "module-cli");
     expect(cold.has_value(), "cold public module CLI invocation should launch");
     if (cold) {
         if (cold->exit_code != 0) dump_failure(*cold);
         expect(cold->exit_code == 0,
-               "cold explicit .ixx + consumer CLI target should build and run successfully");
+               "cold explicit module CLI target should build and run successfully");
         expect(cold->stdout_text.find("  pipeline: named-modules") != std::string::npos,
                "verbose CLI output should report the named-module pipeline");
         expect(cold->stdout_text.find("[compile] math.ixx") != std::string::npos,
@@ -156,11 +162,11 @@ int main(const int argc, char* argv[]) {
     expect(fs::is_regular_file(executable),
            "public module CLI target should produce its executable");
 
-    const auto ifc = first_ifc(tree.root);
-    expect(ifc.has_value() && fs::is_regular_file(*ifc),
+    const auto explicit_ifc = first_ifc(tree.root);
+    expect(explicit_ifc.has_value() && fs::is_regular_file(*explicit_ifc),
            "public module CLI target should produce a provider IFC");
 
-    auto warm = run_mqb(runner, mqb_executable, tree.root, "1");
+    auto warm = run_mqb(runner, mqb_executable, tree.root, "1", true, "module-cli");
     expect(warm.has_value(), "warm public module CLI invocation should launch");
     if (warm) {
         if (warm->exit_code != 0) dump_failure(*warm);
@@ -174,11 +180,11 @@ int main(const int argc, char* argv[]) {
                "warm module target should reuse its link cache");
     }
 
-    if (ifc) {
+    if (explicit_ifc) {
         std::error_code remove_error;
-        fs::remove(*ifc, remove_error);
+        fs::remove(*explicit_ifc, remove_error);
         expect(!remove_error, "test should be able to remove the provider IFC");
-        auto repaired = run_mqb(runner, mqb_executable, tree.root, "2");
+        auto repaired = run_mqb(runner, mqb_executable, tree.root, "2", true, "module-cli");
         expect(repaired.has_value(), "IFC-repair public module CLI invocation should launch");
         if (repaired) {
             if (repaired->exit_code != 0) dump_failure(*repaired);
@@ -190,6 +196,122 @@ int main(const int argc, char* argv[]) {
                    "provider repair should propagate an explicit consumer rebuild");
             expect(repaired->stdout_text.find("[link] module-cli.exe") != std::string::npos,
                    "provider repair should relink the final executable");
+        }
+    }
+
+    // Clear the explicit-target state so the next phase proves source discovery
+    // from a single ordinary entry rather than reusing explicit source selection.
+    std::error_code cleanup_error;
+    fs::remove_all(tree.root / ".mqb", cleanup_error);
+    expect(!cleanup_error, "test should be able to clear explicit module build state");
+
+    auto discovered_cold = run_mqb(
+        runner,
+        mqb_executable,
+        tree.root,
+        "2",
+        false,
+        "module-discovered");
+    expect(discovered_cold.has_value(),
+           "cold single-entry module-discovery CLI invocation should launch");
+    if (discovered_cold) {
+        if (discovered_cold->exit_code != 0) dump_failure(*discovered_cold);
+        expect(discovered_cold->exit_code == 0,
+               "single-entry module target should discover its provider, build, and run");
+        expect(discovered_cold->stdout_text.find("[discover] 2 translation units")
+                   != std::string::npos,
+               "single-entry discovery should select the ordinary consumer and module provider");
+        expect(discovered_cold->stdout_text.find("  pipeline: named-modules")
+                   != std::string::npos,
+               "discovered module target should route through the named-module pipeline");
+        expect(discovered_cold->stdout_text.find("[compile] math.ixx") != std::string::npos,
+               "discovered provider should compile on the cold build");
+        expect(discovered_cold->stdout_text.find("[compile] main.cpp") != std::string::npos,
+               "single-entry consumer should compile on the cold build");
+        expect(discovered_cold->stdout_text.find("[link] module-discovered.exe")
+                   != std::string::npos,
+               "discovered module target should link the requested output");
+        expect(discovered_cold->stdout_text.find("[run] module-discovered.exe")
+                   != std::string::npos,
+               "discovered module target should preserve structured --run behavior");
+    }
+
+    auto discovered_warm = run_mqb(
+        runner,
+        mqb_executable,
+        tree.root,
+        "1",
+        false,
+        "module-discovered");
+    expect(discovered_warm.has_value(),
+           "warm single-entry module-discovery CLI invocation should launch");
+    if (discovered_warm) {
+        if (discovered_warm->exit_code != 0) dump_failure(*discovered_warm);
+        expect(discovered_warm->exit_code == 0,
+               "warm discovered module target should build and run successfully");
+        expect(contains_line(discovered_warm->stdout_text, "[up-to-date] main.cpp"),
+               "warm discovered consumer should reuse its compile cache");
+        expect(contains_line(discovered_warm->stdout_text, "[up-to-date] math.ixx"),
+               "warm discovered provider should reuse its compile cache");
+        expect(contains_line(discovered_warm->stdout_text, "[up-to-date] module-discovered.exe"),
+               "warm discovered target should reuse its link cache even when job count changes");
+    }
+
+    write_text(
+        tree.root / "math.ixx",
+        "export module math;\n"
+        "export int answer() { return 43; }\n");
+    auto provider_mutation = run_mqb(
+        runner,
+        mqb_executable,
+        tree.root,
+        "2",
+        false,
+        "module-discovered");
+    expect(provider_mutation.has_value(),
+           "provider-mutation single-entry CLI invocation should launch");
+    if (provider_mutation) {
+        if (provider_mutation->exit_code != 0) dump_failure(*provider_mutation);
+        expect(provider_mutation->exit_code == 0,
+               "provider-only source mutation should rebuild and preserve executable behavior");
+        expect(provider_mutation->stdout_text.find("[compile] math.ixx") != std::string::npos,
+               "provider source mutation should rebuild the provider");
+        expect(provider_mutation->stdout_text.find("[compile] main.cpp") != std::string::npos,
+               "provider source mutation should explicitly rebuild the consumer");
+        expect(provider_mutation->stdout_text.find("[link] module-discovered.exe")
+                   != std::string::npos,
+               "provider source mutation should relink the discovered target");
+    }
+
+    const auto discovered_ifc = first_ifc(tree.root);
+    expect(discovered_ifc.has_value() && fs::is_regular_file(*discovered_ifc),
+           "single-entry module target should produce a provider IFC");
+    if (discovered_ifc) {
+        std::error_code remove_error;
+        fs::remove(*discovered_ifc, remove_error);
+        expect(!remove_error, "test should be able to remove discovered provider IFC");
+        auto discovered_repair = run_mqb(
+            runner,
+            mqb_executable,
+            tree.root,
+            "2",
+            false,
+            "module-discovered");
+        expect(discovered_repair.has_value(),
+               "single-entry IFC-repair module CLI invocation should launch");
+        if (discovered_repair) {
+            if (discovered_repair->exit_code != 0) dump_failure(*discovered_repair);
+            expect(discovered_repair->exit_code == 0,
+                   "single-entry discovered target should repair a missing provider IFC");
+            expect(discovered_repair->stdout_text.find("[compile] math.ixx")
+                       != std::string::npos,
+                   "single-entry IFC repair should rebuild the provider");
+            expect(discovered_repair->stdout_text.find("[compile] main.cpp")
+                       != std::string::npos,
+                   "single-entry IFC repair should rebuild the consumer");
+            expect(discovered_repair->stdout_text.find("[link] module-discovered.exe")
+                       != std::string::npos,
+                   "single-entry IFC repair should relink the executable");
         }
     }
 

--- a/docs/CPP_V2_ARCHITECTURE.md
+++ b/docs/CPP_V2_ARCHITECTURE.md
@@ -22,17 +22,20 @@ CLI (mqb.exe)
     |
     +--> Source Discovery (mqb_discovery)
     |      ordinary C++ candidate-TU selection
+    |      reachable project-local named-module provider candidates
+    |      module-pipeline routing requirement
     |
     v
-Ordinary target orchestration
-  bounded parallel N x compile coordinator -> ordered results -> one link coordinator
-
-Named-module orchestration (internal milestone API; not public CLI wiring yet)
-  parallel /scanDependencies
-      -> P1689R5 typed model
-      -> resolved provider graph + compile levels
-      -> level-barrier bounded compile waves
-      -> one incremental link coordinator
+Target routing
+    +--> Ordinary target orchestration
+    |      bounded parallel N x compile coordinator -> ordered results -> one link coordinator
+    |
+    +--> Named-module orchestration
+           parallel /scanDependencies
+               -> P1689R5 typed model
+               -> resolved provider graph + compile levels
+               -> level-barrier bounded compile waves
+               -> one incremental link coordinator
     |
     +--------------------+--------------------+
     v                    v                    v
@@ -73,6 +76,8 @@ Core                  Modules              MSVC backend
 14. **Module topology and header freshness are different data.** `/scanDependencies` determines pre-compile module ordering; `/sourceDependencies` remains the post-compile freshness source for headers.
 15. **Provider selection has one owner.** `ModuleDependencyGraphBuilder` resolves named-module providers once; orchestration consumes those exact resolved edges for `/reference` wiring and downstream rebuild propagation.
 16. **Unsupported module requirements fail closed.** Header units and unresolved external/prebuilt named modules are never silently ignored.
+17. **Discovery does not become a second module compiler.** Its lexical module pass selects project-local candidates and records whether module routing is required; P1689 remains authoritative for topology and provider validation.
+18. **Module routing is explicit execution state, not cache identity.** A discovery result may force the named-module pipeline even when no local interface was selected, preventing import-only targets from silently falling back to ordinary compilation.
 
 ## Project configuration
 
@@ -96,15 +101,17 @@ built-in defaults
 
 List-like build inputs are additive and deterministic: project-config entries appear first, then CLI entries. The v1 schema and examples are documented in `docs/MQB_CONFIG.md`. Unknown fields, duplicate JSON keys, wrong field types, malformed JSON, and unsupported schema versions are rejected instead of guessed.
 
-## Smart ordinary-C++ discovery
+## Smart source discovery
 
-With one positional source, MQB smart-discovers the connected ordinary-C++ target by default. Multiple positional sources remain an explicit ordered source set. `--no-discover` disables discovery; `--discover` explicitly enables it and can override project configuration.
+With one positional ordinary source, MQB smart-discovers the connected target by default. Multiple positional sources remain an explicit ordered source set. `--no-discover` disables discovery; `--discover` explicitly enables it and can override project configuration.
 
-Discovery uses quoted `#include "..."` connectivity, configured include directories, same-basename ownership, deterministic traversal, built-in directory exclusions, and project-config corrections. A reachable non-entry source defining `main(...)` is a traversal barrier. Explicitly excluded sources and directories are also traversal barriers.
+Ordinary discovery uses quoted `#include "..."` connectivity, configured include directories, same-basename ownership, deterministic traversal, built-in directory exclusions, and project-config corrections. A reachable non-entry ordinary source defining `main(...)` is a traversal barrier. Explicitly excluded sources and directories are also traversal barriers.
 
-Discovery output only selects ordinary TUs. Incremental header invalidation continues to use compiler-emitted `/sourceDependencies` metadata.
+The discovery index also understands the supported translation-unit extension classes from `mqb_core`: ordinary `.cpp/.cc/.cxx` units and module-interface `.ixx/.cppm/.mpp` units. A lightweight lexical module pass extracts named module declarations/imports only for source selection. It ignores comments, literals, preprocessor directives, and header-unit imports. Reachable named imports connect to all matching project-local interface candidates; discovery deliberately does not choose a winner among duplicate providers.
 
-The named-module target pipeline added in the Modules milestone is currently an internal orchestration API. Public `mqb.exe` source discovery/CLI routing has not yet been switched to that pipeline.
+When a selected TU contains named-module syntax, discovery reports that the target requires the module pipeline even if no project-local interface provider was found. The CLI propagates that execution-only state through `MsvcTargetRouter`, so `import std` or an unresolved external/prebuilt named module cannot silently fall back to the ordinary pipeline.
+
+Discovery output selects candidate TUs only. Incremental header invalidation continues to use compiler-emitted `/sourceDependencies` metadata, while the real module target pipeline runs `/scanDependencies` and the P1689 graph builder to determine authoritative module topology and provider resolution.
 
 ## Compile identity and cache freshness
 
@@ -196,7 +203,7 @@ The exact resolved dependency edges are reused for both compile ordering and MSV
 
 ## Named-module MSVC pipeline
 
-The current implemented module pipeline supports the internal named-module-interface -> named-consumer path:
+The implemented named-module pipeline supports project-local named-module interfaces and consumers through both explicit CLI target sets and single-entry module-aware discovery:
 
 ```text
 selected source requests
@@ -225,24 +232,25 @@ Warm module target builds currently repeat topology scanning. The proven cache g
 
 ### Current module capability boundary
 
-Supported and regression-tested in this milestone:
+Supported and regression-tested:
 
 - P1689R5 parsing and strict schema validation;
-- internal named-module interface providers;
+- project-local named-module interface providers;
 - named consumers resolved to exact provider sources;
 - source-identity IFC routing;
 - bounded same-level parallelism with dependency-level barriers;
 - module-aware compile signatures and cache freshness;
 - downstream rebuild propagation when a provider recompiles;
 - incremental final linking;
-- real VS2026 provider/consumer executable E2E.
+- explicit public CLI module-interface targets;
+- single-entry public CLI discovery of reachable project-local named-module providers;
+- real VS2026 provider/consumer executable E2E, including warm builds, provider-only mutation, and missing-IFC repair.
 
-Not yet supported by `MsvcModuleTargetCoordinator`:
+Not yet supported by the execution policy:
 
 - header units;
 - unresolved external/prebuilt named-module providers;
-- `import std` (currently appears as an unresolved external named module and fails closed);
-- public CLI/source-discovery routing into the module target coordinator.
+- `import std` (currently appears as an unresolved external named module and fails closed).
 
 The P1689 model can represent more cases than the current execution policy accepts. That is intentional: parsing a requirement is not permission to compile it incorrectly.
 
@@ -307,7 +315,7 @@ GitHub CI enables installed-MSVC integration tests explicitly; local tests keep 
 
 ## Current verification milestone
 
-The VS2026 PR suite now contains **46 registered CTest cases**. It verifies ordinary CLI behavior plus the new module backend/orchestration path.
+The VS2026 PR suite verifies ordinary CLI behavior plus the named-module backend, routing, and source-discovery path.
 
 Among the real installed-MSVC cases are:
 
@@ -317,6 +325,7 @@ Among the real installed-MSVC cases are:
 - real module provider IFC creation and consumer `/reference` compilation;
 - full named-module target cold build and executable launch;
 - warm named-module target with compile 0 / link 0;
+- single-entry `mqb main.cpp` discovery of a reachable project-local module provider;
 - provider-source mutation causing provider + consumer + link rebuild;
 - provider IFC deletion with source/object otherwise warm, causing provider + consumer + link repair;
 - artifact collision/empty-artifact validation before any external process starts.
@@ -325,9 +334,9 @@ The named-module target E2E uses the installed Visual Studio 2026 compiler and l
 
 ## Current CLI milestone
 
-The public `mqb.exe` CLI currently owns the ordinary-C++ path: project config, smart ordinary source discovery, bounded `-j/--jobs` compilation, independent link caching, library resolution, and structured `--run` argv.
+The public `mqb.exe` CLI now owns both the ordinary-C++ path and the supported project-local named-module path: project config, smart source discovery, bounded `-j/--jobs` execution, independent link caching, library resolution, structured `--run` argv, explicit module-interface target routing, and single-entry discovery of reachable project-local named-module providers.
 
-The named-module pipeline described above is implemented and integration-tested behind typed orchestration APIs, but it is **not yet wired into the public CLI/source-discovery path**. Therefore this document does not claim that the C++ V2 CLI has reached full Modules parity with the PowerShell tool.
+This is not full C++ Modules parity. Header units, external/prebuilt provider execution, and `import std` remain explicit fail-closed gaps, and PowerShell/C++ parity testing still precedes cutover.
 
 ## Migration sequence
 
@@ -344,7 +353,7 @@ The named-module pipeline described above is implemented and integration-tested 
 11. **Project config v1** — upward `mqb.json`, typed schema, path semantics, CLI precedence, config E2E. ✅
 12. **Parallel ordinary-TU scheduling** — bounded concurrency with deterministic reporting/failure semantics. ✅
 13. **Named Modules core/orchestration** — P1689 scan, provider graph, IFC artifacts, module-aware cache, dependency waves, incremental link, real VS2026 E2E. ✅
-14. **Modules expansion/UX** — public CLI routing, module-aware source selection, header units, external/prebuilt provider policy, `import std`.
+14. **Modules expansion/UX** — public CLI routing and project-local module-aware source selection ✅; header units, external/prebuilt provider policy, and `import std` remain.
 15. **Parity** — run PowerShell and C++ against the same E2E fixtures.
 16. **Cutover** — make `mqb.exe` primary only after parity tests pass.
 


### PR DESCRIPTION
Completes the module-aware single-entry source-discovery slice on top of #14.

## Implemented

- discovery-layer named-module syntax parser used only for candidate source selection
  - named module declarations/imports
  - relative partition normalization
  - comments, ordinary/raw string literals, char literals, preprocessor directives, and header-unit imports excluded from named-module discovery edges
  - multiline block-comment/preprocessor boundary regression hardened
- source discovery indexes ordinary C++ and module-interface TUs through the shared translation-unit classifier
- reachable named imports connect to all matching project-local module-interface candidates; duplicate providers are deliberately not resolved by discovery and remain P1689/module-graph policy
- matching module implementation units are included without pulling unrelated module trees into the target
- `SourceDiscovery::requires_module_pipeline` records selected named-module semantics even when no local provider exists
- orchestration routing accepts an execution-only `force_named_modules` signal so import-only targets cannot silently fall back to the ordinary pipeline
- public `mqb.exe` propagates the discovery routing requirement through both CLI/orchestration routing layers
- public source-extension validation uses the shared classifier and accepts `.cpp/.cc/.cxx/.ixx/.cppm/.mpp`
- CLI help and `docs/CPP_V2_ARCHITECTURE.md` describe the implemented module-aware public discovery boundary

## Regression coverage

Discovery/router tests cover transitive providers, partitions, implementation units, unrelated-module exclusion, duplicate provider candidates, extra/excluded module corrections, selection-scoped module-routing state, and forced named-module routing even when the selected set has no interface TU.

Real VS2026 public CLI E2E covers:

- explicit provider + consumer cold/warm/IFC repair
- **single-entry `mqb main.cpp`** discovering the project-local provider automatically
- cold build/link/run
- warm compile 0 / link 0 with changed job count
- provider-only source mutation rebuilding provider + consumer + link
- provider IFC deletion rebuilding provider + consumer + link
- an unreferenced local `.ixx` staying outside the selected target
- an unresolved named import with **zero local providers** explicitly entering named-module routing, exiting nonzero, and never linking

## Verification

C++ V2 workflow #195 completed successfully on head `5a80166c393afe777f5e75d0225939de7ed0eaca`: Configure, Build, and CTest all passed on the real VS2026 runner.

## Deliberate follow-up boundary

Header-unit execution, external/prebuilt provider execution/configuration, macro-generated module declarations/imports during lexical source selection, and `import std` support remain outside this slice. Unsupported requirements remain fail-closed. The remaining Modules expansion policies are tracked in #16.

Closes #13.