### PR TITLE
refactor: make compile cache track planned outputs

### DIFF
--- a/cpp/backends/msvc/src/MsvcCompileExecutor.cpp
+++ b/cpp/backends/msvc/src/MsvcCompileExecutor.cpp
@@ -183,7 +183,7 @@ MsvcCompileExecutor::execute(const CompileExecutionRequest& request) const {
             request.unit,
             toolchain_.identity,
             request.options),
-        .object = *object,
+        .outputs = request.unit.outputs,
         .dependencies = std::move(cache_dependencies),
     };
 

--- a/cpp/core/include/mqb/core/CompileCache.hpp
+++ b/cpp/core/include/mqb/core/CompileCache.hpp
@@ -20,7 +20,7 @@ struct CompileCacheEntry {
     TranslationUnitKind kind{TranslationUnitKind::source};
     ToolchainIdentity toolchain;
     BuildSignature signature;
-    Artifact object;
+    std::vector<Artifact> outputs;
     std::vector<std::filesystem::path> dependencies;
 };
 

--- a/cpp/core/src/CompileCache.cpp
+++ b/cpp/core/src/CompileCache.cpp
@@ -4,7 +4,6 @@
 #include <filesystem>
 #include <optional>
 #include <span>
-#include <string_view>
 
 namespace mqb {
 namespace {
@@ -21,6 +20,12 @@ namespace {
     return same_path(left.compiler, right.compiler)
         && left.version == right.version
         && left.binary_stamp == right.binary_stamp;
+}
+
+[[nodiscard]] bool same_artifact(
+    const Artifact& left,
+    const Artifact& right) {
+    return left.kind == right.kind && same_path(left.path, right.path);
 }
 
 void add_reason(std::vector<BuildReason>& reasons, const BuildReason reason) {
@@ -42,16 +47,49 @@ void add_reason(std::vector<BuildReason>& reasons, const BuildReason reason) {
     return it == snapshots.end() ? nullptr : &*it;
 }
 
-[[nodiscard]] const Artifact* find_artifact(
+[[nodiscard]] bool same_outputs(
+    const std::vector<Artifact>& cached,
+    const std::vector<Artifact>& current) {
+    if (cached.size() != current.size()) {
+        return false;
+    }
+
+    std::vector<bool> matched(cached.size(), false);
+    for (const auto& current_output : current) {
+        bool found = false;
+        for (std::size_t index = 0; index < cached.size(); ++index) {
+            if (!matched[index] && same_artifact(cached[index], current_output)) {
+                matched[index] = true;
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            return false;
+        }
+    }
+    return true;
+}
+
+[[nodiscard]] std::optional<std::filesystem::file_time_type>
+oldest_output_time(
     const TranslationUnit& unit,
-    const ArtifactKind kind) {
-    const auto it = std::find_if(
-        unit.outputs.begin(),
-        unit.outputs.end(),
-        [kind](const Artifact& artifact) {
-            return artifact.kind == kind;
-        });
-    return it == unit.outputs.end() ? nullptr : &*it;
+    const std::span<const FileSnapshot> output_snapshots) {
+    if (unit.outputs.empty()) {
+        return std::nullopt;
+    }
+
+    std::optional<std::filesystem::file_time_type> oldest;
+    for (const auto& output : unit.outputs) {
+        const FileSnapshot* snapshot = find_snapshot(output_snapshots, output.path);
+        if (snapshot == nullptr || !snapshot->exists) {
+            return std::nullopt;
+        }
+        if (!oldest || snapshot->modified < *oldest) {
+            oldest = snapshot->modified;
+        }
+    }
+    return oldest;
 }
 
 } // namespace
@@ -66,15 +104,14 @@ CompileCacheValidation CompileCacheValidator::validate(
     const std::span<const FileSnapshot> dependency_snapshots) {
     CompileCacheValidation result;
 
-    const Artifact* current_object = find_artifact(current_unit, ArtifactKind::object);
-    const FileSnapshot* object_snapshot = current_object == nullptr
-        ? nullptr
-        : find_snapshot(output_snapshots, current_object->path);
-
     const auto validate_outputs = [&] {
+        if (current_unit.outputs.empty()) {
+            add_reason(result.reasons, BuildReason::missing_output);
+            return;
+        }
         for (const auto& output : current_unit.outputs) {
             const auto* snapshot = find_snapshot(output_snapshots, output.path);
-            if (snapshot == nullptr || !snapshot->exists) {
+            if (output.path.empty() || snapshot == nullptr || !snapshot->exists) {
                 add_reason(result.reasons, BuildReason::missing_output);
             }
         }
@@ -106,18 +143,15 @@ CompileCacheValidation CompileCacheValidator::validate(
         add_reason(result.reasons, BuildReason::compiler_options_changed);
     }
 
-    if (current_object == nullptr
-        || !same_path(cached.object.path, current_object->path)
-        || cached.object.kind != ArtifactKind::object) {
+    if (!same_outputs(cached.outputs, current_unit.outputs)) {
         add_reason(result.reasons, BuildReason::missing_output);
     }
     validate_outputs();
 
+    const auto freshness_anchor = oldest_output_time(current_unit, output_snapshots);
     if (!source_snapshot.exists) {
         add_reason(result.reasons, BuildReason::source_changed);
-    } else if (object_snapshot != nullptr
-               && object_snapshot->exists
-               && source_snapshot.modified > object_snapshot->modified) {
+    } else if (freshness_anchor && source_snapshot.modified > *freshness_anchor) {
         add_reason(result.reasons, BuildReason::source_changed);
     }
 
@@ -128,9 +162,7 @@ CompileCacheValidation CompileCacheValidator::validate(
             continue;
         }
 
-        if (object_snapshot != nullptr
-            && object_snapshot->exists
-            && snapshot->modified > object_snapshot->modified) {
+        if (freshness_anchor && snapshot->modified > *freshness_anchor) {
             add_reason(result.reasons, BuildReason::dependency_changed);
         }
     }

--- a/cpp/core/src/CompileCacheFile.cpp
+++ b/cpp/core/src/CompileCacheFile.cpp
@@ -9,6 +9,7 @@
 #include <fstream>
 #include <limits>
 #include <optional>
+#include <span>
 #include <string>
 #include <string_view>
 #include <system_error>
@@ -27,9 +28,10 @@ namespace fs = std::filesystem;
 
 constexpr std::array<std::uint8_t, 8> magic{
     'M', 'Q', 'B', 'C', 'A', 'C', 'H', 'E'};
-constexpr std::uint32_t format_version = 1;
+constexpr std::uint32_t format_version = 2;
 constexpr std::size_t max_cache_file_size = 64u * 1024u * 1024u;
 constexpr std::uint32_t max_string_size = 4u * 1024u * 1024u;
+constexpr std::uint32_t max_output_count = 100000u;
 constexpr std::uint32_t max_dependency_count = 100000u;
 
 [[nodiscard]] CompileCacheFileError make_error(
@@ -200,6 +202,20 @@ private:
 
 [[nodiscard]] std::expected<std::vector<std::uint8_t>, CompileCacheFileError>
 serialize(const fs::path& file, const CompileCacheEntry& entry) {
+    if (entry.outputs.empty()) {
+        return std::unexpected(make_error(
+            CompileCacheFileErrorCode::file_write_failed,
+            file,
+            0,
+            "compile cache entry must contain at least one planned output"));
+    }
+    if (entry.outputs.size() > max_output_count) {
+        return std::unexpected(make_error(
+            CompileCacheFileErrorCode::file_write_failed,
+            file,
+            0,
+            "output count exceeds cache format safety limit"));
+    }
     if (entry.dependencies.size() > max_dependency_count) {
         return std::unexpected(make_error(
             CompileCacheFileErrorCode::file_write_failed,
@@ -234,14 +250,24 @@ serialize(const fs::path& file, const CompileCacheEntry& entry) {
     writer.write_u64(entry.signature.digest().high);
     writer.write_u64(entry.signature.digest().low);
 
-    if (!writer.write_path(entry.object.path)) {
-        return std::unexpected(make_error(
-            CompileCacheFileErrorCode::file_write_failed,
-            file,
-            0,
-            "object path is too long for cache format"));
+    writer.write_u32(static_cast<std::uint32_t>(entry.outputs.size()));
+    for (const auto& output : entry.outputs) {
+        if (output.path.empty()) {
+            return std::unexpected(make_error(
+                CompileCacheFileErrorCode::file_write_failed,
+                file,
+                0,
+                "compile cache output path must not be empty"));
+        }
+        if (!writer.write_path(output.path)) {
+            return std::unexpected(make_error(
+                CompileCacheFileErrorCode::file_write_failed,
+                file,
+                0,
+                "output path is too long for cache format"));
+        }
+        writer.write_u32(static_cast<std::uint32_t>(output.kind));
     }
-    writer.write_u32(static_cast<std::uint32_t>(entry.object.kind));
 
     writer.write_u32(static_cast<std::uint32_t>(entry.dependencies.size()));
     for (const auto& dependency : entry.dependencies) {
@@ -304,9 +330,7 @@ deserialize(const fs::path& file, const std::span<const std::uint8_t> bytes) {
     auto binary_stamp = reader.read_string();
     auto signature_high = reader.read_u64();
     auto signature_low = reader.read_u64();
-    auto object_path = reader.read_path();
-    auto object_kind_value = reader.read_u32();
-    auto dependency_count = reader.read_u32();
+    auto output_count = reader.read_u32();
 
     if (!source) return std::unexpected(source.error());
     if (!kind_value) return std::unexpected(kind_value.error());
@@ -315,16 +339,36 @@ deserialize(const fs::path& file, const std::span<const std::uint8_t> bytes) {
     if (!binary_stamp) return std::unexpected(binary_stamp.error());
     if (!signature_high) return std::unexpected(signature_high.error());
     if (!signature_low) return std::unexpected(signature_low.error());
-    if (!object_path) return std::unexpected(object_path.error());
-    if (!object_kind_value) return std::unexpected(object_kind_value.error());
-    if (!dependency_count) return std::unexpected(dependency_count.error());
+    if (!output_count) return std::unexpected(output_count.error());
 
     if (!valid_translation_unit_kind(*kind_value)) {
         return std::unexpected(reader.corrupt("invalid translation-unit kind in cache file"));
     }
-    if (!valid_artifact_kind(*object_kind_value)) {
-        return std::unexpected(reader.corrupt("invalid artifact kind in cache file"));
+    if (*output_count == 0 || *output_count > max_output_count) {
+        return std::unexpected(reader.corrupt("output count is outside the supported safety range"));
     }
+
+    std::vector<Artifact> outputs;
+    outputs.reserve(*output_count);
+    for (std::uint32_t index = 0; index < *output_count; ++index) {
+        auto output_path = reader.read_path();
+        auto output_kind_value = reader.read_u32();
+        if (!output_path) return std::unexpected(output_path.error());
+        if (!output_kind_value) return std::unexpected(output_kind_value.error());
+        if (output_path->empty()) {
+            return std::unexpected(reader.corrupt("compile cache output path is empty"));
+        }
+        if (!valid_artifact_kind(*output_kind_value)) {
+            return std::unexpected(reader.corrupt("invalid artifact kind in cache file"));
+        }
+        outputs.push_back(Artifact{
+            .path = std::move(*output_path),
+            .kind = static_cast<ArtifactKind>(*output_kind_value),
+        });
+    }
+
+    auto dependency_count = reader.read_u32();
+    if (!dependency_count) return std::unexpected(dependency_count.error());
     if (*dependency_count > max_dependency_count) {
         return std::unexpected(reader.corrupt("dependency count exceeds safety limit"));
     }
@@ -355,10 +399,7 @@ deserialize(const fs::path& file, const std::span<const std::uint8_t> bytes) {
             .high = *signature_high,
             .low = *signature_low,
         }),
-        .object = Artifact{
-            .path = std::move(*object_path),
-            .kind = static_cast<ArtifactKind>(*object_kind_value),
-        },
+        .outputs = std::move(outputs),
         .dependencies = std::move(dependencies),
     };
 }

--- a/cpp/tests/compile_cache_file_tests.cpp
+++ b/cpp/tests/compile_cache_file_tests.cpp
@@ -5,6 +5,7 @@
 #include <fstream>
 #include <iostream>
 #include <string_view>
+#include <vector>
 
 #include "mqb/core/Artifact.hpp"
 #include "mqb/core/BuildSignature.hpp"
@@ -45,6 +46,24 @@ private:
     fs::path path_;
 };
 
+mqb::ToolchainIdentity make_toolchain(const std::string_view version) {
+    return mqb::ToolchainIdentity{
+        .compiler = "toolchain/cl.exe",
+        .version = std::string{version},
+        .binary_stamp = "size=123;mtime=456",
+    };
+}
+
+mqb::CompilerOptions make_options() {
+    mqb::CompilerOptions options;
+    options.configuration = mqb::BuildConfiguration::debug;
+    options.architecture = mqb::Architecture::x64;
+    options.standard = mqb::CppStandard::cpp23;
+    options.defines = {"FEATURE=1"};
+    options.include_directories = {"include"};
+    return options;
+}
+
 mqb::CompileCacheEntry make_entry(const std::string_view version = "19.50.10000") {
     mqb::TranslationUnit unit;
     unit.source = "src/main file.cpp";
@@ -53,25 +72,14 @@ mqb::CompileCacheEntry make_entry(const std::string_view version = "19.50.10000"
         mqb::Artifact{"cache/main file.obj", mqb::ArtifactKind::object},
     };
 
-    mqb::ToolchainIdentity toolchain{
-        .compiler = "toolchain/cl.exe",
-        .version = std::string{version},
-        .binary_stamp = "size=123;mtime=456",
-    };
-
-    mqb::CompilerOptions options;
-    options.configuration = mqb::BuildConfiguration::debug;
-    options.architecture = mqb::Architecture::x64;
-    options.standard = mqb::CppStandard::cpp23;
-    options.defines = {"FEATURE=1"};
-    options.include_directories = {"include"};
-
+    const auto toolchain = make_toolchain(version);
+    const auto options = make_options();
     return mqb::CompileCacheEntry{
         .source = unit.source,
         .kind = unit.kind,
         .toolchain = toolchain,
         .signature = mqb::BuildSignature::for_compile(unit, toolchain, options),
-        .object = unit.outputs.front(),
+        .outputs = unit.outputs,
         .dependencies = {
             fs::path{"src/main file.cpp"},
             fs::path{"include/a.hpp"},
@@ -80,11 +88,76 @@ mqb::CompileCacheEntry make_entry(const std::string_view version = "19.50.10000"
     };
 }
 
+mqb::CompileCacheEntry make_module_entry(const bool ifc_only) {
+    mqb::TranslationUnit unit;
+    unit.source = ifc_only ? fs::path{"include/value.hpp"} : fs::path{"src/math.ixx"};
+    unit.kind = mqb::TranslationUnitKind::module_interface;
+    if (!ifc_only) {
+        unit.outputs.push_back(mqb::Artifact{
+            .path = "cache/math.obj",
+            .kind = mqb::ArtifactKind::object,
+        });
+    }
+    unit.outputs.push_back(mqb::Artifact{
+        .path = ifc_only ? fs::path{"ifc/value.ifc"} : fs::path{"ifc/math.ifc"},
+        .kind = mqb::ArtifactKind::module_interface,
+    });
+
+    const auto toolchain = make_toolchain("19.51.modules");
+    const auto options = make_options();
+    return mqb::CompileCacheEntry{
+        .source = unit.source,
+        .kind = unit.kind,
+        .toolchain = toolchain,
+        .signature = mqb::BuildSignature::for_compile(unit, toolchain, options),
+        .outputs = unit.outputs,
+        .dependencies = {fs::path{"include/shared.hpp"}},
+    };
+}
+
 void write_bytes(const fs::path& file, const std::initializer_list<std::uint8_t> bytes) {
     std::ofstream stream{file, std::ios::binary | std::ios::trunc};
     for (const auto byte : bytes) {
         stream.put(static_cast<char>(byte));
     }
+}
+
+void expect_round_trip(
+    const fs::path& file,
+    const mqb::CompileCacheEntry& original,
+    const std::string_view description) {
+    const auto saved = mqb::CompileCacheFile::save(file, original);
+    expect(saved.has_value(), std::string{description} + " should save");
+    const auto loaded = mqb::CompileCacheFile::load(file);
+    expect(loaded.has_value() && loaded->has_value(),
+           std::string{description} + " should load");
+    if (!loaded || !*loaded) return;
+
+    const auto& entry = **loaded;
+    expect(entry.source == original.source,
+           std::string{description} + " source should round-trip");
+    expect(entry.kind == original.kind,
+           std::string{description} + " TU kind should round-trip");
+    expect(entry.toolchain.compiler == original.toolchain.compiler,
+           std::string{description} + " compiler path should round-trip");
+    expect(entry.toolchain.version == original.toolchain.version,
+           std::string{description} + " toolchain version should round-trip");
+    expect(entry.toolchain.binary_stamp == original.toolchain.binary_stamp,
+           std::string{description} + " binary stamp should round-trip");
+    expect(entry.signature == original.signature,
+           std::string{description} + " signature should round-trip");
+    expect(entry.outputs.size() == original.outputs.size(),
+           std::string{description} + " output count should round-trip");
+    if (entry.outputs.size() == original.outputs.size()) {
+        for (std::size_t index = 0; index < entry.outputs.size(); ++index) {
+            expect(entry.outputs[index].path == original.outputs[index].path,
+                   std::string{description} + " output path ordering should round-trip");
+            expect(entry.outputs[index].kind == original.outputs[index].kind,
+                   std::string{description} + " output kind ordering should round-trip");
+        }
+    }
+    expect(entry.dependencies == original.dependencies,
+           std::string{description} + " dependencies should round-trip");
 }
 
 } // namespace
@@ -100,26 +173,31 @@ int main() {
     }
 
     const auto original = make_entry();
-    const auto save_result = mqb::CompileCacheFile::save(file, original);
-    expect(save_result.has_value(), "cache entry should save to a newly created parent directory");
+    expect_round_trip(file, original, "ordinary object-only cache entry");
     expect(fs::is_regular_file(file), "save should install the final cache file");
 
-    const auto loaded = mqb::CompileCacheFile::load(file);
-    expect(loaded.has_value() && loaded->has_value(), "saved cache entry should load successfully");
-    if (loaded && *loaded) {
-        const auto& entry = **loaded;
-        expect(entry.source == original.source, "source path should round-trip");
-        expect(entry.kind == original.kind, "translation-unit kind should round-trip");
-        expect(entry.toolchain.compiler == original.toolchain.compiler,
-               "compiler path should round-trip");
-        expect(entry.toolchain.version == original.toolchain.version,
-               "toolchain version should round-trip");
-        expect(entry.toolchain.binary_stamp == original.toolchain.binary_stamp,
-               "toolchain binary stamp should round-trip");
-        expect(entry.signature == original.signature, "signature digest should round-trip exactly");
-        expect(entry.object.path == original.object.path, "object path should round-trip");
-        expect(entry.object.kind == original.object.kind, "artifact kind should round-trip");
-        expect(entry.dependencies == original.dependencies, "dependency ordering should round-trip");
+    const auto module_entry = make_module_entry(false);
+    expect_round_trip(
+        fixture.path() / "module.mqbcache",
+        module_entry,
+        "module object+IFC cache entry");
+
+    const auto ifc_only_entry = make_module_entry(true);
+    expect_round_trip(
+        fixture.path() / "ifc-only.mqbcache",
+        ifc_only_entry,
+        "IFC-only cache entry");
+
+    auto empty_outputs = original;
+    empty_outputs.outputs.clear();
+    const auto empty_output_save = mqb::CompileCacheFile::save(
+        fixture.path() / "empty-output.mqbcache",
+        empty_outputs);
+    expect(!empty_output_save.has_value(),
+           "cache serializer should reject entries without planned outputs");
+    if (!empty_output_save) {
+        expect(empty_output_save.error().code == mqb::CompileCacheFileErrorCode::file_write_failed,
+               "empty planned outputs should report file_write_failed");
     }
 
     const auto replacement = make_entry("19.51.20000");
@@ -133,7 +211,7 @@ int main() {
     }
 
     const fs::path bad_magic = fixture.path() / "bad-magic.mqbcache";
-    write_bytes(bad_magic, {0, 1, 2, 3, 4, 5, 6, 7, 1, 0, 0, 0});
+    write_bytes(bad_magic, {0, 1, 2, 3, 4, 5, 6, 7, 2, 0, 0, 0});
     const auto bad_magic_result = mqb::CompileCacheFile::load(bad_magic);
     expect(!bad_magic_result.has_value(), "invalid cache magic should fail loading");
     if (!bad_magic_result) {
@@ -141,18 +219,28 @@ int main() {
                "invalid magic should have a precise error code");
     }
 
-    const fs::path unsupported = fixture.path() / "unsupported.mqbcache";
-    write_bytes(unsupported, {'M', 'Q', 'B', 'C', 'A', 'C', 'H', 'E', 2, 0, 0, 0});
-    const auto unsupported_result = mqb::CompileCacheFile::load(unsupported);
-    expect(!unsupported_result.has_value(), "unsupported cache version should fail loading");
-    if (!unsupported_result) {
-        expect(unsupported_result.error().code == mqb::CompileCacheFileErrorCode::unsupported_version,
-               "unsupported version should have a precise error code");
+    const fs::path legacy_v1 = fixture.path() / "legacy-v1.mqbcache";
+    write_bytes(legacy_v1, {'M', 'Q', 'B', 'C', 'A', 'C', 'H', 'E', 1, 0, 0, 0});
+    const auto legacy_v1_result = mqb::CompileCacheFile::load(legacy_v1);
+    expect(!legacy_v1_result.has_value(),
+           "object-only v1 cache must not be interpreted as v2 planned-output metadata");
+    if (!legacy_v1_result) {
+        expect(legacy_v1_result.error().code == mqb::CompileCacheFileErrorCode::unsupported_version,
+               "legacy v1 should request a conservative cache epoch rebuild");
+    }
+
+    const fs::path future_version = fixture.path() / "future.mqbcache";
+    write_bytes(future_version, {'M', 'Q', 'B', 'C', 'A', 'C', 'H', 'E', 3, 0, 0, 0});
+    const auto future_result = mqb::CompileCacheFile::load(future_version);
+    expect(!future_result.has_value(), "future cache version should fail loading");
+    if (!future_result) {
+        expect(future_result.error().code == mqb::CompileCacheFileErrorCode::unsupported_version,
+               "future version should have a precise error code");
     }
 
     const fs::path truncated = fixture.path() / "truncated.mqbcache";
-    expect(mqb::CompileCacheFile::save(truncated, original).has_value(),
-           "truncation fixture should start as a valid cache file");
+    expect(mqb::CompileCacheFile::save(truncated, module_entry).has_value(),
+           "truncation fixture should start as a valid multi-output cache file");
     fs::resize_file(truncated, 20);
     const auto truncated_result = mqb::CompileCacheFile::load(truncated);
     expect(!truncated_result.has_value(), "truncated cache file should never deserialize partially");

--- a/cpp/tests/compile_cache_tests.cpp
+++ b/cpp/tests/compile_cache_tests.cpp
@@ -69,18 +69,12 @@ mqb::CompileCacheEntry make_entry(
     const mqb::TranslationUnit& unit,
     const mqb::ToolchainIdentity& toolchain,
     const mqb::CompilerOptions& options) {
-    const auto object = std::find_if(
-        unit.outputs.begin(),
-        unit.outputs.end(),
-        [](const mqb::Artifact& artifact) {
-            return artifact.kind == mqb::ArtifactKind::object;
-        });
     return mqb::CompileCacheEntry{
         .source = unit.source,
         .kind = unit.kind,
         .toolchain = toolchain,
         .signature = mqb::BuildSignature::for_compile(unit, toolchain, options),
-        .object = object == unit.outputs.end() ? mqb::Artifact{} : *object,
+        .outputs = unit.outputs,
         .dependencies = {
             std::filesystem::path{"include/app.hpp"},
             std::filesystem::path{"include/config.hpp"},
@@ -102,7 +96,7 @@ int main() {
         .modified = time_at(10),
     };
     const mqb::FileSnapshot object{
-        .path = entry.object.path,
+        .path = entry.outputs.front().path,
         .exists = true,
         .modified = time_at(30),
     };
@@ -114,7 +108,7 @@ int main() {
 
     const auto fresh = mqb::CompileCacheValidator::validate(
         unit, toolchain, options, entry, source, outputs, dependencies);
-    expect(fresh.reusable(), "unchanged recipe and older dependencies should reuse the object");
+    expect(fresh.reusable(), "unchanged recipe and older dependencies should reuse planned outputs");
     expect(fresh.reasons.empty(), "reusable cache entry should not invent rebuild reasons");
 
     const auto no_entry = mqb::CompileCacheValidator::validate(
@@ -128,14 +122,14 @@ int main() {
     const auto missing_output = mqb::CompileCacheValidator::validate(
         unit, toolchain, options, entry, source, missing_outputs, dependencies);
     expect(has_reason(missing_output, mqb::BuildReason::missing_output),
-           "missing object artifact should force a rebuild");
+           "missing planned artifact should force a rebuild");
 
     auto newer_source = source;
     newer_source.modified = time_at(40);
     const auto source_changed = mqb::CompileCacheValidator::validate(
         unit, toolchain, options, entry, newer_source, outputs, dependencies);
     expect(has_reason(source_changed, mqb::BuildReason::source_changed),
-           "source newer than object should invalidate the cache");
+           "source newer than the oldest planned output should invalidate the cache");
 
     auto newer_dependencies = dependencies;
     newer_dependencies[0].modified = time_at(50);
@@ -143,7 +137,7 @@ int main() {
     const auto dependency_changed = mqb::CompileCacheValidator::validate(
         unit, toolchain, options, entry, source, outputs, newer_dependencies);
     expect(has_reason(dependency_changed, mqb::BuildReason::dependency_changed),
-           "newer cached dependency should invalidate the object");
+           "newer cached dependency should invalidate planned outputs");
     expect(std::count(
                dependency_changed.reasons.begin(),
                dependency_changed.reasons.end(),
@@ -155,7 +149,7 @@ int main() {
     const auto dependency_missing = mqb::CompileCacheValidator::validate(
         unit, toolchain, options, entry, source, outputs, missing_dependency);
     expect(has_reason(dependency_missing, mqb::BuildReason::dependency_changed),
-           "deleted cached dependency should invalidate the object");
+           "deleted cached dependency should invalidate planned outputs");
 
     std::vector<mqb::FileSnapshot> incomplete_dependencies{dependencies[0]};
     const auto dependency_snapshot_missing = mqb::CompileCacheValidator::validate(
@@ -218,7 +212,7 @@ int main() {
             moved_object_outputs,
             dependencies);
         expect(has_reason(moved_object, mqb::BuildReason::missing_output),
-               "cache metadata for a different object path must not authorize reuse");
+               "cache metadata for a different planned output path must not authorize reuse");
     }
 
     {
@@ -236,7 +230,7 @@ int main() {
             .modified = time_at(10),
         };
         const std::vector<mqb::FileSnapshot> module_outputs{
-            mqb::FileSnapshot{.path = "build/math.obj", .exists = true, .modified = time_at(30)},
+            mqb::FileSnapshot{.path = "build/math.obj", .exists = true, .modified = time_at(35)},
             mqb::FileSnapshot{.path = "ifc/math.ifc", .exists = true, .modified = time_at(30)},
         };
         const auto module_fresh = mqb::CompileCacheValidator::validate(
@@ -248,7 +242,20 @@ int main() {
             module_outputs,
             dependencies);
         expect(module_fresh.reusable(),
-               "module provider should reuse cache only when both object and IFC exist");
+               "module provider should reuse cache only when both object and IFC are fresh");
+
+        auto between_outputs_source = module_source;
+        between_outputs_source.modified = time_at(32);
+        const auto oldest_output_guards_source = mqb::CompileCacheValidator::validate(
+            module_unit,
+            toolchain,
+            options,
+            module_entry,
+            between_outputs_source,
+            module_outputs,
+            dependencies);
+        expect(has_reason(oldest_output_guards_source, mqb::BuildReason::source_changed),
+               "source newer than IFC but older than object must still rebuild the provider");
 
         auto missing_ifc_outputs = module_outputs;
         missing_ifc_outputs[1].exists = false;
@@ -277,8 +284,51 @@ int main() {
             module_source,
             moved_ifc_outputs,
             dependencies);
+        expect(has_reason(moved_ifc, mqb::BuildReason::missing_output),
+               "cached planned outputs for the old IFC path must not authorize reuse");
         expect(has_reason(moved_ifc, mqb::BuildReason::compiler_options_changed),
-               "planned IFC routing change must invalidate provider signature identity");
+               "planned IFC routing change must also invalidate provider signature identity");
+    }
+
+    {
+        auto ifc_only_unit = unit;
+        ifc_only_unit.kind = mqb::TranslationUnitKind::module_interface;
+        ifc_only_unit.source = "include/header.hpp";
+        ifc_only_unit.outputs = {
+            mqb::Artifact{.path = "ifc/header.ifc", .kind = mqb::ArtifactKind::module_interface},
+        };
+        const auto ifc_only_entry = make_entry(ifc_only_unit, toolchain, options);
+        const mqb::FileSnapshot ifc_only_source{
+            .path = ifc_only_unit.source,
+            .exists = true,
+            .modified = time_at(10),
+        };
+        const std::vector<mqb::FileSnapshot> ifc_only_outputs{
+            mqb::FileSnapshot{.path = "ifc/header.ifc", .exists = true, .modified = time_at(30)},
+        };
+        const auto ifc_only_fresh = mqb::CompileCacheValidator::validate(
+            ifc_only_unit,
+            toolchain,
+            options,
+            ifc_only_entry,
+            ifc_only_source,
+            ifc_only_outputs,
+            dependencies);
+        expect(ifc_only_fresh.reusable(),
+               "core compile cache must support IFC-only planned outputs without a fake object");
+
+        auto ifc_only_dependency_newer = dependencies;
+        ifc_only_dependency_newer[0].modified = time_at(31);
+        const auto ifc_only_stale = mqb::CompileCacheValidator::validate(
+            ifc_only_unit,
+            toolchain,
+            options,
+            ifc_only_entry,
+            ifc_only_source,
+            ifc_only_outputs,
+            ifc_only_dependency_newer);
+        expect(has_reason(ifc_only_stale, mqb::BuildReason::dependency_changed),
+               "IFC-only output must use its own timestamp as dependency freshness anchor");
     }
 
     {

--- a/cpp/tests/msvc_compile_executor_tests.cpp
+++ b/cpp/tests/msvc_compile_executor_tests.cpp
@@ -106,6 +106,20 @@ void write_dependencies(
         }) != entry.dependencies.end();
 }
 
+[[nodiscard]] bool has_output(
+    const mqb::CompileCacheEntry& entry,
+    const fs::path& expected,
+    const mqb::ArtifactKind kind) {
+    const auto normalized = expected.lexically_normal();
+    return std::find_if(
+        entry.outputs.begin(),
+        entry.outputs.end(),
+        [&normalized, kind](const mqb::Artifact& output) {
+            return output.kind == kind
+                && output.path.lexically_normal() == normalized;
+        }) != entry.outputs.end();
+}
+
 class RecordingRunner final : public mqb::process::ProcessRunner {
 public:
     std::expected<mqb::process::ProcessResult, mqb::process::ProcessError>
@@ -180,7 +194,9 @@ int main() {
     if (result) {
         expect(result->process.exit_code == 0, "execution result should preserve compiler process result");
         expect(result->cache_entry.source == source, "cache entry should preserve translation-unit source");
-        expect(result->cache_entry.object.path == object, "cache entry should preserve planned object artifact");
+        expect(result->cache_entry.outputs.size() == 1
+                   && has_output(result->cache_entry, object, mqb::ArtifactKind::object),
+               "ordinary cache entry should preserve exactly the planned object output");
         expect(result->cache_entry.toolchain.compiler == toolchain.identity.compiler,
                "cache entry should preserve compiler identity path");
         expect(result->cache_entry.toolchain.version == toolchain.identity.version,
@@ -266,6 +282,10 @@ int main() {
     if (module_result) {
         expect(module_result->cache_entry.kind == mqb::TranslationUnitKind::module_interface,
                "provider cache entry should preserve module-interface kind");
+        expect(module_result->cache_entry.outputs.size() == 2
+                   && has_output(module_result->cache_entry, module_object, mqb::ArtifactKind::object)
+                   && has_output(module_result->cache_entry, module_ifc, mqb::ArtifactKind::module_interface),
+               "provider cache entry should preserve both planned object and IFC outputs");
         expect(has_argument(runner.last_spec, "/interface")
                    && has_argument(runner.last_spec, "/ifcOutput")
                    && has_argument(runner.last_spec, path_to_utf8(module_ifc)),
@@ -317,6 +337,9 @@ int main() {
         expect(has_argument(runner.last_spec, "/reference")
                    && has_argument(runner.last_spec, reference),
                "consumer compile argv should contain logical-name to IFC mapping");
+        expect(consumer_result->cache_entry.outputs.size() == 1
+                   && has_output(consumer_result->cache_entry, consumer_object, mqb::ArtifactKind::object),
+               "consumer cache entry should preserve only its own object as a planned output");
         expect(has_dependency(consumer_result->cache_entry, header),
                "consumer cache should retain compiler-discovered headers");
         expect(has_dependency(consumer_result->cache_entry, module_ifc),

--- a/cpp/tests/msvc_incremental_loop_tests.cpp
+++ b/cpp/tests/msvc_incremental_loop_tests.cpp
@@ -179,7 +179,7 @@ void write_text(const fs::path& path, const std::string_view text) {
         .kind = unit.kind,
         .toolchain = toolchain.identity,
         .signature = mqb::BuildSignature::for_compile(unit, toolchain.identity, options),
-        .object = unit.outputs.front(),
+        .outputs = unit.outputs,
         .dependencies = dependencies->includes,
     };
 


### PR DESCRIPTION
Prepares the C++ V2 compile-cache model for output shapes that do not necessarily contain an object file, without implementing header-unit execution yet.

Base: main@a0f7932aa84ed327daecfe5044b32ac3c1cf0f05 (verified 51/51 post-merge baseline).

## Scope

- replace `CompileCacheEntry::object` with complete typed `outputs`
- bump `MQBCACHE` disk format from v1 to v2 and serialize all planned artifacts
- deliberately reject v1 as `unsupported_version`; the existing incremental coordinator degrades that to a warning + conservative rebuild
- validate cached output identity against the current TranslationUnit output set
- use the **oldest existing planned output** as the source/dependency freshness anchor, so every output must be at least as fresh as its inputs
- persist the full `TranslationUnit.outputs` vector from `MsvcCompileExecutor`
- cover ordinary object-only, named-module object+IFC, and core IFC-only cache shapes

## Non-goals

- no new TranslationUnitKind
- no `/exportHeader`, `/headerName`, `/headerUnit`, or header-unit graph resolution
- no external/prebuilt provider or `import std` policy
- no compile/link signature recipe changes beyond the cache file format epoch

## Verification

The first CI run found one stale real-MSVC test fixture that still initialized the old single-object cache field; it was migrated to `.outputs = unit.outputs` without changing product behavior.

Workflow run `31420684192` on exact head `44181b40baa01e79438dd4e5023ba2f9d39865aa` completed successfully with **51/51 CTest**. The same candidate passed:

- `mqb.core.compile_cache`
- `mqb.core.compile_cache_file`
- `mqb.msvc.compile_executor`
- real installed-MSVC `mqb.msvc.incremental_loop`
- ordinary target/config/parallel CLI E2Es
- public named-module CLI E2E
- real module-target integration

This proves the cache-v2 epoch and plural-output freshness model preserve the existing ordinary/named-module behavior while allowing the core to represent a future IFC-only producer without inventing a fake object artifact.