### PR TITLE
feat: add typed MSVC header-unit compile contract

### DIFF
--- a/cpp/backends/msvc/include/mqb/msvc/MsvcCompiler.hpp
+++ b/cpp/backends/msvc/include/mqb/msvc/MsvcCompiler.hpp
@@ -13,6 +13,7 @@
 
 namespace mqb::msvc {
 
+using HeaderUnitReference = mqb::HeaderUnitReference;
 using ModuleReference = mqb::ModuleReference;
 
 struct CompileInvocation {
@@ -22,6 +23,16 @@ struct CompileInvocation {
     TranslationUnitKind kind{TranslationUnitKind::source};
     std::optional<std::filesystem::path> module_interface_output;
     std::vector<ModuleReference> module_references;
+    std::vector<HeaderUnitReference> header_unit_references;
+    CompilerOptions options;
+    std::optional<std::filesystem::path> working_directory;
+};
+
+struct HeaderUnitCompileInvocation {
+    std::string header_name;
+    HeaderUnitLookupMethod lookup_method{HeaderUnitLookupMethod::quote};
+    std::filesystem::path interface_output;
+    std::optional<std::filesystem::path> object;
     CompilerOptions options;
     std::optional<std::filesystem::path> working_directory;
 };
@@ -48,8 +59,14 @@ public:
     [[nodiscard]] static std::expected<std::vector<std::string>, CompilerError>
     build_arguments(const CompileInvocation& invocation);
 
+    [[nodiscard]] static std::expected<std::vector<std::string>, CompilerError>
+    build_header_unit_arguments(const HeaderUnitCompileInvocation& invocation);
+
     [[nodiscard]] std::expected<process::ProcessResult, CompilerError>
     compile(const CompileInvocation& invocation) const;
+
+    [[nodiscard]] std::expected<process::ProcessResult, CompilerError>
+    compile_header_unit(const HeaderUnitCompileInvocation& invocation) const;
 
 private:
     const MsvcToolchain& toolchain_;

--- a/cpp/backends/msvc/src/MsvcCompileExecutor.cpp
+++ b/cpp/backends/msvc/src/MsvcCompileExecutor.cpp
@@ -65,6 +65,20 @@ namespace fs = std::filesystem;
     return fs::is_regular_file(path, error_code) && !error_code;
 }
 
+void add_interface_dependency(
+    std::vector<fs::path>& dependencies,
+    const fs::path& interface_file) {
+    const auto duplicate = std::find_if(
+        dependencies.begin(),
+        dependencies.end(),
+        [&interface_file](const fs::path& dependency) {
+            return same_dependency_path(dependency, interface_file);
+        });
+    if (duplicate == dependencies.end()) {
+        dependencies.push_back(interface_file.lexically_normal());
+    }
+}
+
 } // namespace
 
 std::expected<CompileExecutionResult, CompileExecutorError>
@@ -121,6 +135,7 @@ MsvcCompileExecutor::execute(const CompileExecutionRequest& request) const {
         invocation.module_interface_output = module_interface->path;
     }
     invocation.module_references = request.unit.module_references;
+    invocation.header_unit_references = request.unit.header_unit_references;
     invocation.options = request.options;
     invocation.working_directory = request.working_directory;
 
@@ -164,15 +179,10 @@ MsvcCompileExecutor::execute(const CompileExecutionRequest& request) const {
 
     std::vector<fs::path> cache_dependencies = std::move(dependencies->includes);
     for (const auto& reference : request.unit.module_references) {
-        const auto duplicate = std::find_if(
-            cache_dependencies.begin(),
-            cache_dependencies.end(),
-            [&reference](const fs::path& dependency) {
-                return same_dependency_path(dependency, reference.interface_file);
-            });
-        if (duplicate == cache_dependencies.end()) {
-            cache_dependencies.push_back(reference.interface_file.lexically_normal());
-        }
+        add_interface_dependency(cache_dependencies, reference.interface_file);
+    }
+    for (const auto& reference : request.unit.header_unit_references) {
+        add_interface_dependency(cache_dependencies, reference.interface_file);
     }
 
     CompileCacheEntry cache_entry{

--- a/cpp/backends/msvc/src/MsvcCompiler.cpp
+++ b/cpp/backends/msvc/src/MsvcCompiler.cpp
@@ -62,6 +62,46 @@ void append_configuration_arguments(
     }
 }
 
+[[nodiscard]] std::expected<void, CompilerError> append_common_compile_arguments(
+    std::vector<std::string>& arguments,
+    const CompilerOptions& options) {
+    arguments.emplace_back("/nologo");
+    arguments.emplace_back("/c");
+    arguments.emplace_back("/utf-8");
+    arguments.emplace_back("/W3");
+    arguments.emplace_back("/EHsc");
+    arguments.emplace_back("/permissive-");
+    arguments.emplace_back("/Zc:__cplusplus");
+    arguments.emplace_back("/Zc:preprocessor");
+    arguments.emplace_back("/diagnostics:column");
+
+    append_configuration_arguments(arguments, options.configuration);
+    arguments.push_back(standard_argument(options.standard));
+
+    for (const auto& define : options.defines) {
+        if (define.empty()) {
+            return std::unexpected(invalid_request("compiler define must not be empty"));
+        }
+        arguments.push_back("/D" + define);
+    }
+
+    for (const auto& include_directory : options.include_directories) {
+        if (include_directory.empty()) {
+            return std::unexpected(invalid_request("include directory must not be empty"));
+        }
+        arguments.push_back("/I" + path_to_utf8(include_directory));
+    }
+
+    for (const auto& argument : options.additional_arguments) {
+        if (argument.empty()) {
+            return std::unexpected(invalid_request("additional compiler argument must not be empty"));
+        }
+        arguments.push_back(argument);
+    }
+
+    return {};
+}
+
 [[nodiscard]] std::expected<void, CompilerError> prepare_parent_directory(
     const fs::path& output,
     const std::string_view description) {
@@ -79,6 +119,12 @@ void append_configuration_arguments(
         });
     }
     return {};
+}
+
+[[nodiscard]] std::string header_unit_key(const HeaderUnitReference& reference) {
+    return std::string{
+        reference.lookup_method == HeaderUnitLookupMethod::angle ? "angle:" : "quote:"
+    } + reference.header_name;
 }
 
 [[nodiscard]] std::expected<void, CompilerError> validate_module_contract(
@@ -110,7 +156,71 @@ void append_configuration_arguments(
                 "duplicate module reference logical name '" + reference.logical_name + "'"));
         }
     }
+
+    std::unordered_set<std::string> header_names;
+    header_names.reserve(invocation.header_unit_references.size());
+    for (const auto& reference : invocation.header_unit_references) {
+        if (reference.header_name.empty()) {
+            return std::unexpected(invalid_request(
+                "header-unit reference name must not be empty"));
+        }
+        if (reference.interface_file.empty()) {
+            return std::unexpected(invalid_request(
+                "header-unit reference IFC path must not be empty"));
+        }
+        const std::string key = header_unit_key(reference);
+        if (!header_names.emplace(key).second) {
+            return std::unexpected(invalid_request(
+                "duplicate header-unit reference '" + reference.header_name + "'"));
+        }
+    }
     return {};
+}
+
+[[nodiscard]] std::string header_name_argument(const HeaderUnitLookupMethod lookup_method) {
+    return lookup_method == HeaderUnitLookupMethod::angle
+        ? "/headerName:angle"
+        : "/headerName:quote";
+}
+
+[[nodiscard]] std::string header_unit_argument(const HeaderUnitLookupMethod lookup_method) {
+    return lookup_method == HeaderUnitLookupMethod::angle
+        ? "/headerUnit:angle"
+        : "/headerUnit:quote";
+}
+
+[[nodiscard]] std::expected<process::ProcessResult, CompilerError> run_compiler(
+    const MsvcToolchain& toolchain,
+    process::ProcessRunner& runner,
+    std::vector<std::string> arguments,
+    const std::optional<fs::path>& working_directory) {
+    process::ProcessSpec spec;
+    spec.executable = toolchain.identity.compiler;
+    spec.arguments = std::move(arguments);
+    spec.working_directory = working_directory;
+    spec.environment = toolchain.environment;
+    spec.inherit_environment = true;
+    spec.capture_stdout = true;
+    spec.capture_stderr = true;
+
+    auto result = runner.run(spec);
+    if (!result) {
+        return std::unexpected(CompilerError{
+            .code = CompilerErrorCode::process_failed,
+            .message = "failed to launch MSVC compiler",
+            .process_error = result.error(),
+        });
+    }
+
+    if (result->exit_code != 0) {
+        return std::unexpected(CompilerError{
+            .code = CompilerErrorCode::compilation_failed,
+            .message = "MSVC compiler returned a non-zero exit code",
+            .process_result = std::move(*result),
+        });
+    }
+
+    return std::move(*result);
 }
 
 } // namespace
@@ -137,44 +247,14 @@ MsvcCompiler::build_arguments(const CompileInvocation& invocation) {
         + invocation.options.defines.size()
         + invocation.options.include_directories.size()
         + invocation.options.additional_arguments.size()
-        + (invocation.module_references.size() * 2));
+        + (invocation.module_references.size() * 2)
+        + (invocation.header_unit_references.size() * 2));
 
-    arguments.emplace_back("/nologo");
-    arguments.emplace_back("/c");
-    arguments.emplace_back("/utf-8");
-    arguments.emplace_back("/W3");
-    arguments.emplace_back("/EHsc");
-    arguments.emplace_back("/permissive-");
-    arguments.emplace_back("/Zc:__cplusplus");
-    arguments.emplace_back("/Zc:preprocessor");
-    arguments.emplace_back("/diagnostics:column");
+    auto common = append_common_compile_arguments(arguments, invocation.options);
+    if (!common) return std::unexpected(common.error());
 
-    append_configuration_arguments(arguments, invocation.options.configuration);
-    arguments.push_back(standard_argument(invocation.options.standard));
-
-    for (const auto& define : invocation.options.defines) {
-        if (define.empty()) {
-            return std::unexpected(invalid_request("compiler define must not be empty"));
-        }
-        arguments.push_back("/D" + define);
-    }
-
-    for (const auto& include_directory : invocation.options.include_directories) {
-        if (include_directory.empty()) {
-            return std::unexpected(invalid_request("include directory must not be empty"));
-        }
-        arguments.push_back("/I" + path_to_utf8(include_directory));
-    }
-
-    for (const auto& argument : invocation.options.additional_arguments) {
-        if (argument.empty()) {
-            return std::unexpected(invalid_request("additional compiler argument must not be empty"));
-        }
-        arguments.push_back(argument);
-    }
-
-    // Module inputs and structured outputs are emitted after raw additional
-    // arguments so the BuildPlan remains authoritative over semantic routing.
+    // Module/header-unit inputs and structured outputs are emitted after raw
+    // additional arguments so the BuildPlan remains authoritative over semantic routing.
     if (invocation.kind == TranslationUnitKind::module_interface) {
         arguments.emplace_back("/interface");
         arguments.emplace_back("/TP");
@@ -184,6 +264,12 @@ MsvcCompiler::build_arguments(const CompileInvocation& invocation) {
         arguments.emplace_back("/reference");
         arguments.push_back(
             reference.logical_name + "=" + path_to_utf8(reference.interface_file));
+    }
+
+    for (const auto& reference : invocation.header_unit_references) {
+        arguments.push_back(header_unit_argument(reference.lookup_method));
+        arguments.push_back(
+            reference.header_name + "=" + path_to_utf8(reference.interface_file));
     }
 
     if (invocation.module_interface_output) {
@@ -198,6 +284,39 @@ MsvcCompiler::build_arguments(const CompileInvocation& invocation) {
 
     arguments.push_back("/Fo" + path_to_utf8(invocation.object));
     arguments.push_back(path_to_utf8(invocation.source));
+    return arguments;
+}
+
+std::expected<std::vector<std::string>, CompilerError>
+MsvcCompiler::build_header_unit_arguments(const HeaderUnitCompileInvocation& invocation) {
+    if (invocation.header_name.empty()) {
+        return std::unexpected(invalid_request("header-unit name must not be empty"));
+    }
+    if (invocation.interface_output.empty()) {
+        return std::unexpected(invalid_request("header-unit IFC output path must not be empty"));
+    }
+    if (invocation.object && invocation.object->empty()) {
+        return std::unexpected(invalid_request("header-unit object output path must not be empty"));
+    }
+
+    std::vector<std::string> arguments;
+    arguments.reserve(
+        20
+        + invocation.options.defines.size()
+        + invocation.options.include_directories.size()
+        + invocation.options.additional_arguments.size());
+
+    auto common = append_common_compile_arguments(arguments, invocation.options);
+    if (!common) return std::unexpected(common.error());
+
+    arguments.emplace_back("/exportHeader");
+    arguments.push_back(header_name_argument(invocation.lookup_method));
+    arguments.push_back(invocation.header_name);
+    arguments.emplace_back("/ifcOutput");
+    arguments.push_back(path_to_utf8(invocation.interface_output));
+    if (invocation.object) {
+        arguments.push_back("/Fo" + path_to_utf8(*invocation.object));
+    }
     return arguments;
 }
 
@@ -229,33 +348,28 @@ MsvcCompiler::compile(const CompileInvocation& invocation) const {
         }
     }
 
-    process::ProcessSpec spec;
-    spec.executable = toolchain_.identity.compiler;
-    spec.arguments = std::move(*arguments);
-    spec.working_directory = invocation.working_directory;
-    spec.environment = toolchain_.environment;
-    spec.inherit_environment = true;
-    spec.capture_stdout = true;
-    spec.capture_stderr = true;
+    return run_compiler(toolchain_, runner_, std::move(*arguments), invocation.working_directory);
+}
 
-    auto result = runner_.run(spec);
-    if (!result) {
-        return std::unexpected(CompilerError{
-            .code = CompilerErrorCode::process_failed,
-            .message = "failed to launch MSVC compiler",
-            .process_error = result.error(),
-        });
+std::expected<process::ProcessResult, CompilerError>
+MsvcCompiler::compile_header_unit(const HeaderUnitCompileInvocation& invocation) const {
+    auto arguments = build_header_unit_arguments(invocation);
+    if (!arguments) {
+        return std::unexpected(arguments.error());
     }
 
-    if (result->exit_code != 0) {
-        return std::unexpected(CompilerError{
-            .code = CompilerErrorCode::compilation_failed,
-            .message = "MSVC compiler returned a non-zero exit code",
-            .process_result = std::move(*result),
-        });
+    auto prepared_interface = prepare_parent_directory(invocation.interface_output, "header-unit interface");
+    if (!prepared_interface) {
+        return std::unexpected(prepared_interface.error());
+    }
+    if (invocation.object) {
+        auto prepared_object = prepare_parent_directory(*invocation.object, "header-unit object");
+        if (!prepared_object) {
+            return std::unexpected(prepared_object.error());
+        }
     }
 
-    return std::move(*result);
+    return run_compiler(toolchain_, runner_, std::move(*arguments), invocation.working_directory);
 }
 
 } // namespace mqb::msvc

--- a/cpp/backends/msvc/tests/CMakeLists.txt
+++ b/cpp/backends/msvc/tests/CMakeLists.txt
@@ -4,13 +4,22 @@ add_executable(mqb_msvc_module_scanner_tests
 target_link_libraries(mqb_msvc_module_scanner_tests PRIVATE mqb_msvc)
 target_compile_features(mqb_msvc_module_scanner_tests PRIVATE cxx_std_23)
 
+add_executable(mqb_msvc_header_unit_compiler_tests
+    header_unit_compiler_tests.cpp
+)
+target_link_libraries(mqb_msvc_header_unit_compiler_tests PRIVATE mqb_msvc)
+target_compile_features(mqb_msvc_header_unit_compiler_tests PRIVATE cxx_std_23)
+
 if(MSVC)
     target_compile_options(mqb_msvc_module_scanner_tests PRIVATE /W4 /permissive-)
+    target_compile_options(mqb_msvc_header_unit_compiler_tests PRIVATE /W4 /permissive-)
 else()
     target_compile_options(mqb_msvc_module_scanner_tests PRIVATE -Wall -Wextra -Wpedantic)
+    target_compile_options(mqb_msvc_header_unit_compiler_tests PRIVATE -Wall -Wextra -Wpedantic)
 endif()
 
 add_test(NAME mqb.msvc.module_scanner COMMAND mqb_msvc_module_scanner_tests)
+add_test(NAME mqb.msvc.header_unit_compiler COMMAND mqb_msvc_header_unit_compiler_tests)
 
 if(MQB_ENABLE_INSTALLED_MSVC_TESTS)
     add_executable(mqb_msvc_module_scanner_integration_tests
@@ -35,12 +44,25 @@ if(MQB_ENABLE_INSTALLED_MSVC_TESTS)
     )
     target_compile_features(mqb_msvc_module_compile_integration_tests PRIVATE cxx_std_23)
 
+    add_executable(mqb_msvc_header_unit_compile_integration_tests
+        header_unit_compile_integration_tests.cpp
+    )
+    target_link_libraries(
+        mqb_msvc_header_unit_compile_integration_tests
+        PRIVATE
+            mqb_msvc
+            mqb_platform_windows
+    )
+    target_compile_features(mqb_msvc_header_unit_compile_integration_tests PRIVATE cxx_std_23)
+
     if(MSVC)
         target_compile_options(mqb_msvc_module_scanner_integration_tests PRIVATE /W4 /permissive-)
         target_compile_options(mqb_msvc_module_compile_integration_tests PRIVATE /W4 /permissive-)
+        target_compile_options(mqb_msvc_header_unit_compile_integration_tests PRIVATE /W4 /permissive-)
     else()
         target_compile_options(mqb_msvc_module_scanner_integration_tests PRIVATE -Wall -Wextra -Wpedantic)
         target_compile_options(mqb_msvc_module_compile_integration_tests PRIVATE -Wall -Wextra -Wpedantic)
+        target_compile_options(mqb_msvc_header_unit_compile_integration_tests PRIVATE -Wall -Wextra -Wpedantic)
     endif()
 
     add_test(
@@ -50,5 +72,9 @@ if(MQB_ENABLE_INSTALLED_MSVC_TESTS)
     add_test(
         NAME mqb.msvc.module_compile_integration
         COMMAND mqb_msvc_module_compile_integration_tests
+    )
+    add_test(
+        NAME mqb.msvc.header_unit_compile_integration
+        COMMAND mqb_msvc_header_unit_compile_integration_tests
     )
 endif()

--- a/cpp/backends/msvc/tests/header_unit_compile_integration_tests.cpp
+++ b/cpp/backends/msvc/tests/header_unit_compile_integration_tests.cpp
@@ -1,0 +1,161 @@
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <string_view>
+
+#include "mqb/core/ProjectArtifactLayout.hpp"
+#include "mqb/core/TranslationUnit.hpp"
+#include "mqb/msvc/MsvcCompiler.hpp"
+#include "mqb/msvc/MsvcToolchainLocator.hpp"
+#include "mqb/platform/windows/WindowsProcessRunner.hpp"
+
+namespace {
+
+namespace fs = std::filesystem;
+
+int failures = 0;
+
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+[[nodiscard]] fs::path make_temp_root() {
+    const auto stamp = std::chrono::steady_clock::now().time_since_epoch().count();
+    return fs::temp_directory_path() / ("mqb_header_unit_compile_vs_" + std::to_string(stamp));
+}
+
+void print_compile_error(const mqb::msvc::CompilerError& error) {
+    std::cerr << "compile error: " << error.message << '\n';
+    if (error.process_error) {
+        std::cerr << "process error: " << error.process_error->message
+                  << " native=" << error.process_error->native_code << '\n';
+    }
+    if (error.process_result) {
+        std::cerr << "exit=" << error.process_result->exit_code << '\n';
+        std::cerr << error.process_result->stdout_text;
+        std::cerr << error.process_result->stderr_text;
+    }
+}
+
+} // namespace
+
+int main() {
+    using mqb::Architecture;
+    using mqb::CppStandard;
+    using mqb::HeaderUnitLookupMethod;
+    using mqb::ProjectArtifactLayout;
+    using mqb::msvc::CompileInvocation;
+    using mqb::msvc::DiscoveryOptions;
+    using mqb::msvc::HeaderUnitCompileInvocation;
+    using mqb::msvc::HeaderUnitReference;
+    using mqb::msvc::MsvcCompiler;
+    using mqb::msvc::MsvcToolchainLocator;
+    using mqb::msvc::ToolchainPreference;
+
+    mqb::platform::windows::WindowsProcessRunner runner;
+    MsvcToolchainLocator locator{runner};
+
+    DiscoveryOptions discovery;
+    discovery.preference = ToolchainPreference::visual_studio;
+    discovery.target_architecture = Architecture::x64;
+    discovery.host_architecture = Architecture::x64;
+
+    auto toolchain = locator.discover(discovery);
+    expect(toolchain.has_value(), "Visual Studio toolchain should be available for header-unit compile E2E");
+    if (!toolchain) {
+        std::cerr << "toolchain error: " << toolchain.error().message << '\n';
+        return 1;
+    }
+
+    const fs::path root = make_temp_root();
+    const fs::path include_directory = root / "include";
+    const fs::path header_source = include_directory / "util.hpp";
+    const fs::path consumer_source = root / "src" / "consumer.cpp";
+    fs::create_directories(include_directory);
+    fs::create_directories(consumer_source.parent_path());
+
+    {
+        std::ofstream header(header_source, std::ios::binary | std::ios::trunc);
+        header << "inline int header_answer() { return 42; }\n";
+    }
+    {
+        std::ofstream source(consumer_source, std::ios::binary | std::ios::trunc);
+        source << "import \"util.hpp\";\n"
+                  "int use_header_unit() { return header_answer(); }\n";
+    }
+
+    auto layout = ProjectArtifactLayout::create(root);
+    expect(layout.has_value(), "temporary project should create artifact layout");
+    if (!layout) return 1;
+
+    auto header_artifacts = layout->for_source(header_source);
+    auto consumer_artifacts = layout->for_source(consumer_source);
+    expect(header_artifacts.has_value() && consumer_artifacts.has_value(),
+           "header unit and consumer should receive planned artifact paths");
+    if (!header_artifacts || !consumer_artifacts) return 1;
+
+    MsvcCompiler compiler{*toolchain, runner};
+
+    HeaderUnitCompileInvocation header_unit;
+    header_unit.header_name = "util.hpp";
+    header_unit.lookup_method = HeaderUnitLookupMethod::quote;
+    header_unit.interface_output = header_artifacts->module_interface;
+    header_unit.working_directory = root;
+    header_unit.options.standard = CppStandard::latest;
+    header_unit.options.include_directories = {include_directory};
+
+    auto header_result = compiler.compile_header_unit(header_unit);
+    expect(header_result.has_value(),
+           "real MSVC should export a quote header unit to the explicitly planned IFC");
+    if (!header_result) {
+        print_compile_error(header_result.error());
+    }
+
+    expect(fs::is_regular_file(header_artifacts->module_interface),
+           "header-unit compilation should produce the explicitly planned IFC");
+    expect(!fs::exists(header_artifacts->object),
+           "IFC-only header-unit compilation should not invent an object artifact");
+
+    CompileInvocation consumer;
+    consumer.source = consumer_source;
+    consumer.object = consumer_artifacts->object;
+    consumer.source_dependencies = consumer_artifacts->dependencies;
+    consumer.header_unit_references = {
+        HeaderUnitReference{
+            .header_name = "util.hpp",
+            .lookup_method = HeaderUnitLookupMethod::quote,
+            .interface_file = header_artifacts->module_interface,
+        },
+    };
+    consumer.working_directory = root;
+    consumer.options.standard = CppStandard::latest;
+    consumer.options.include_directories = {include_directory};
+
+    auto consumer_result = compiler.compile(consumer);
+    expect(consumer_result.has_value(),
+           "real MSVC consumer should compile through a typed quote header-unit IFC mapping");
+    if (!consumer_result) {
+        print_compile_error(consumer_result.error());
+    }
+
+    expect(fs::is_regular_file(consumer_artifacts->object),
+           "header-unit consumer should produce the planned object");
+    expect(fs::is_regular_file(consumer_artifacts->dependencies),
+           "header-unit consumer should still emit sourceDependencies metadata");
+
+    std::error_code cleanup_error;
+    fs::remove_all(root, cleanup_error);
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+
+    std::cout << "mqb_msvc_header_unit_compile_integration_tests passed\n";
+    return 0;
+}

--- a/cpp/backends/msvc/tests/header_unit_compiler_tests.cpp
+++ b/cpp/backends/msvc/tests/header_unit_compiler_tests.cpp
@@ -1,0 +1,140 @@
+#include <algorithm>
+#include <filesystem>
+#include <iostream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "mqb/core/TranslationUnit.hpp"
+#include "mqb/msvc/MsvcCompiler.hpp"
+
+namespace {
+
+int failures = 0;
+
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+[[nodiscard]] bool contains_pair(
+    const std::vector<std::string>& arguments,
+    const std::string_view first,
+    const std::string_view second) {
+    for (std::size_t index = 0; index + 1 < arguments.size(); ++index) {
+        if (arguments[index] == first && arguments[index + 1] == second) {
+            return true;
+        }
+    }
+    return false;
+}
+
+[[nodiscard]] bool contains_prefix(
+    const std::vector<std::string>& arguments,
+    const std::string_view prefix) {
+    return std::any_of(
+        arguments.begin(),
+        arguments.end(),
+        [prefix](const std::string& argument) {
+            return argument.starts_with(prefix);
+        });
+}
+
+} // namespace
+
+int main() {
+    namespace fs = std::filesystem;
+    using mqb::HeaderUnitLookupMethod;
+    using mqb::msvc::CompileInvocation;
+    using mqb::msvc::HeaderUnitCompileInvocation;
+    using mqb::msvc::HeaderUnitReference;
+    using mqb::msvc::MsvcCompiler;
+
+    CompileInvocation consumer;
+    consumer.source = fs::path{"src/consumer.cpp"};
+    consumer.object = fs::path{"out/consumer.obj"};
+    consumer.header_unit_references = {
+        HeaderUnitReference{
+            .header_name = "util.hpp",
+            .lookup_method = HeaderUnitLookupMethod::quote,
+            .interface_file = fs::path{"ifc/util.ifc"},
+        },
+        HeaderUnitReference{
+            .header_name = "vector",
+            .lookup_method = HeaderUnitLookupMethod::angle,
+            .interface_file = fs::path{"ifc/vector.ifc"},
+        },
+    };
+
+    auto consumer_arguments = MsvcCompiler::build_arguments(consumer);
+    expect(consumer_arguments.has_value(),
+           "typed quote/angle header-unit references should build compiler arguments");
+    if (consumer_arguments) {
+        expect(contains_pair(*consumer_arguments, "/headerUnit:quote", "util.hpp=ifc/util.ifc"),
+               "quote header unit should emit /headerUnit:quote header=ifc");
+        expect(contains_pair(*consumer_arguments, "/headerUnit:angle", "vector=ifc/vector.ifc"),
+               "angle header unit should emit /headerUnit:angle header=ifc");
+    }
+
+    auto duplicate = consumer;
+    duplicate.header_unit_references.push_back(consumer.header_unit_references.front());
+    auto duplicate_arguments = MsvcCompiler::build_arguments(duplicate);
+    expect(!duplicate_arguments,
+           "duplicate header-unit import identity should be rejected before compiler execution");
+
+    auto missing_ifc = consumer;
+    missing_ifc.header_unit_references.front().interface_file.clear();
+    expect(!MsvcCompiler::build_arguments(missing_ifc),
+           "header-unit reference with an empty IFC path should be rejected");
+
+    HeaderUnitCompileInvocation quote_header;
+    quote_header.header_name = "util.hpp";
+    quote_header.lookup_method = HeaderUnitLookupMethod::quote;
+    quote_header.interface_output = fs::path{"ifc/util.ifc"};
+    quote_header.options.include_directories = {fs::path{"include"}};
+
+    auto quote_arguments = MsvcCompiler::build_header_unit_arguments(quote_header);
+    expect(quote_arguments.has_value(),
+           "quote header-unit producer should build compiler arguments");
+    if (quote_arguments) {
+        expect(std::find(quote_arguments->begin(), quote_arguments->end(), "/exportHeader")
+                   != quote_arguments->end(),
+               "header-unit producer should emit /exportHeader");
+        expect(contains_pair(*quote_arguments, "/headerName:quote", "util.hpp"),
+               "quote producer should preserve quote lookup identity");
+        expect(contains_pair(*quote_arguments, "/ifcOutput", "ifc/util.ifc"),
+               "header-unit producer should route the IFC to the planned path");
+        expect(!contains_prefix(*quote_arguments, "/Fo"),
+               "IFC-only header-unit producer should not invent an object output");
+    }
+
+    auto angle_header = quote_header;
+    angle_header.header_name = "vector";
+    angle_header.lookup_method = HeaderUnitLookupMethod::angle;
+    angle_header.interface_output = fs::path{"ifc/vector.ifc"};
+    angle_header.object = fs::path{"obj/vector.obj"};
+    auto angle_arguments = MsvcCompiler::build_header_unit_arguments(angle_header);
+    expect(angle_arguments.has_value(),
+           "angle header-unit producer with an explicit object should build compiler arguments");
+    if (angle_arguments) {
+        expect(contains_pair(*angle_arguments, "/headerName:angle", "vector"),
+               "angle producer should preserve angle lookup identity");
+        expect(contains_prefix(*angle_arguments, "/Foobj/vector.obj"),
+               "explicit header-unit object output should emit /Fo");
+    }
+
+    auto invalid_header = quote_header;
+    invalid_header.header_name.clear();
+    expect(!MsvcCompiler::build_header_unit_arguments(invalid_header),
+           "empty header-unit name should be rejected before compiler execution");
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+
+    std::cout << "mqb_msvc_header_unit_compiler_tests passed\n";
+    return 0;
+}

--- a/cpp/core/include/mqb/core/TranslationUnit.hpp
+++ b/cpp/core/include/mqb/core/TranslationUnit.hpp
@@ -13,8 +13,19 @@ enum class TranslationUnitKind {
     module_interface,
 };
 
+enum class HeaderUnitLookupMethod {
+    angle,
+    quote,
+};
+
 struct ModuleReference {
     std::string logical_name;
+    std::filesystem::path interface_file;
+};
+
+struct HeaderUnitReference {
+    std::string header_name;
+    HeaderUnitLookupMethod lookup_method{HeaderUnitLookupMethod::quote};
     std::filesystem::path interface_file;
 };
 
@@ -23,6 +34,7 @@ struct TranslationUnit {
     TranslationUnitKind kind{TranslationUnitKind::source};
     std::vector<std::filesystem::path> dependencies;
     std::vector<ModuleReference> module_references;
+    std::vector<HeaderUnitReference> header_unit_references;
     std::vector<Artifact> outputs;
 };
 

--- a/cpp/core/src/BuildSignature.cpp
+++ b/cpp/core/src/BuildSignature.cpp
@@ -72,6 +72,16 @@ public:
         }
     }
 
+    void add_header_unit_references(
+        const std::vector<HeaderUnitReference>& references) noexcept {
+        add_u64(static_cast<std::uint64_t>(references.size()));
+        for (const auto& reference : references) {
+            add_string(reference.header_name);
+            add_enum(reference.lookup_method);
+            add_path(reference.interface_file);
+        }
+    }
+
     void add_module_outputs(const std::vector<Artifact>& outputs) noexcept {
         std::uint64_t count = 0;
         for (const auto& output : outputs) {
@@ -130,16 +140,17 @@ BuildSignature BuildSignature::for_compile(
     const ToolchainIdentity& toolchain,
     const CompilerOptions& options) {
     StableHasher hasher;
-    hasher.add_string("mqb.compile.signature.v3");
+    hasher.add_string("mqb.compile.signature.v4");
 
     // Header dependency membership remains freshness-only state. Ordinary
-    // object placement also remains outside recipe identity. Module references
-    // are different: their logical-name -> compiled-interface mapping affects
-    // import resolution, and a provider's planned interface-file output path is
-    // consumed semantically by downstream translation units.
+    // object placement also remains outside recipe identity. Module and header-
+    // unit references are different: their import identity -> compiled-interface
+    // mapping affects compiler routing, and a provider's planned interface-file
+    // output path is consumed semantically by downstream translation units.
     hasher.add_path(unit.source);
     hasher.add_enum(unit.kind);
     hasher.add_module_references(unit.module_references);
+    hasher.add_header_unit_references(unit.header_unit_references);
     hasher.add_module_outputs(unit.outputs);
 
     hasher.add_path(toolchain.compiler);

--- a/cpp/tests/build_signature_tests.cpp
+++ b/cpp/tests/build_signature_tests.cpp
@@ -151,6 +151,34 @@ int main() {
                != two_references,
            "ordered module-reference routing should be stable build identity");
 
+    auto header_consumer = unit;
+    header_consumer.header_unit_references = {
+        mqb::HeaderUnitReference{
+            .header_name = "util.hpp",
+            .lookup_method = mqb::HeaderUnitLookupMethod::quote,
+            .interface_file = "ifc/util.ifc",
+        },
+    };
+    const auto header_baseline = mqb::BuildSignature::for_compile(
+        header_consumer, toolchain, options);
+    expect(header_baseline != baseline,
+           "header-unit references should participate in consumer recipe identity");
+
+    auto angle_header = header_consumer;
+    angle_header.header_unit_references[0].lookup_method = mqb::HeaderUnitLookupMethod::angle;
+    expect(mqb::BuildSignature::for_compile(angle_header, toolchain, options) != header_baseline,
+           "header-unit lookup method should participate in consumer identity");
+
+    auto renamed_header = header_consumer;
+    renamed_header.header_unit_references[0].header_name = "other.hpp";
+    expect(mqb::BuildSignature::for_compile(renamed_header, toolchain, options) != header_baseline,
+           "header-unit import spelling should participate in consumer identity");
+
+    auto moved_header_ifc = header_consumer;
+    moved_header_ifc.header_unit_references[0].interface_file = "ifc/other-util.ifc";
+    expect(mqb::BuildSignature::for_compile(moved_header_ifc, toolchain, options) != header_baseline,
+           "header-unit IFC path should participate in consumer identity");
+
     auto dependency_only_change = unit;
     dependency_only_change.dependencies.emplace_back("include/transitive.hpp");
     expect(mqb::BuildSignature::for_compile(dependency_only_change, toolchain, options) == baseline,


### PR DESCRIPTION
Starts the first Header Units slice under #16 from `main@21af1954f75aa532843b507447fa63c118ecdb8a`, after compile-cache v2 made IFC-only planned output shapes representable.

## Scope

- add a backend-neutral `HeaderUnitLookupMethod { angle, quote }` and typed `HeaderUnitReference { header_name, lookup_method, interface_file }` alongside (not inside) named-module `ModuleReference`
- include ordered header-unit name / lookup method / IFC routing in compile recipe identity and bump the compile signature epoch from v3 to v4
- propagate header-unit IFCs into consumer cache freshness dependencies
- add an explicit MSVC header-unit producer contract:
  - `/exportHeader`
  - `/headerName:angle|quote`
  - `/ifcOutput`
  - optional `/Fo` only when an object output is explicitly requested
- add an explicit MSVC header-unit consumer contract:
  - `/headerUnit:angle header=ifc`
  - `/headerUnit:quote header=ifc`
- keep named-module `/reference logical-name=ifc` separate from header-unit routing

## Verification

C++ V2 workflow #202 completed successfully on exact head `3e8b57f2b7e621fea7a427b48b6b29686cc5e852`: Configure, Build, and CTest all passed on the real VS2026 runner.

Coverage includes:

- cross-platform argument/validation tests for quote/angle producer and consumer contracts
- compile-signature tests proving header spelling, lookup method, and IFC path are build identity
- real installed-VS2026 integration exporting a project header to an explicitly planned IFC **without inventing an object**, then compiling a consumer through the typed quote-header-unit mapping while still emitting `/sourceDependencies`

This matches the MSVC contract that `/exportHeader` generates IFCs and produces an object only when `/Fo` is explicitly requested; consumers use `/headerUnit` rather than named-module `/reference`.

## Deliberate boundary

This PR does **not** yet resolve P1689 header-unit requirements into generated providers, schedule/cache header-unit production through orchestration, or expose public CLI header-unit behavior. Those are the next slice now that the backend contract is proven on the real compiler.

External/prebuilt named modules and `import std` also remain fail-closed.

Advances #16; does not close it.