### PR TITLE
feat: make local header-unit producers incremental

### DIFF
--- a/cpp/backends/msvc/include/mqb/msvc/MsvcCompiler.hpp
+++ b/cpp/backends/msvc/include/mqb/msvc/MsvcCompiler.hpp
@@ -33,6 +33,7 @@ struct HeaderUnitCompileInvocation {
     HeaderUnitLookupMethod lookup_method{HeaderUnitLookupMethod::quote};
     std::filesystem::path interface_output;
     std::optional<std::filesystem::path> object;
+    std::optional<std::filesystem::path> source_dependencies;
     CompilerOptions options;
     std::optional<std::filesystem::path> working_directory;
 };

--- a/cpp/backends/msvc/src/MsvcCompileExecutor.cpp
+++ b/cpp/backends/msvc/src/MsvcCompileExecutor.cpp
@@ -95,26 +95,57 @@ MsvcCompileExecutor::execute(const CompileExecutionRequest& request) const {
         request.unit,
         ArtifactKind::object,
         object_count);
-    if (object == nullptr || object_count != 1 || object->path.empty()) {
-        return std::unexpected(invalid_request(
-            "translation unit must expose exactly one non-empty object artifact"));
-    }
-
     std::size_t interface_count = 0;
     const Artifact* module_interface = find_single_artifact(
         request.unit,
         ArtifactKind::module_interface,
         interface_count);
-    if (request.unit.kind == TranslationUnitKind::module_interface) {
+
+    const bool header_unit_producer = request.unit.header_unit.has_value();
+    if (header_unit_producer) {
+        if (request.unit.kind != TranslationUnitKind::source) {
+            return std::unexpected(invalid_request(
+                "header-unit producer identity is only valid on a source-kind compile recipe"));
+        }
+        if (request.unit.header_unit->header_name.empty()) {
+            return std::unexpected(invalid_request(
+                "header-unit producer identity must have a non-empty header name"));
+        }
+        if (object_count != 0) {
+            return std::unexpected(invalid_request(
+                "incremental header-unit producer must be IFC-only and must not expose an object artifact"));
+        }
+        if (module_interface == nullptr
+            || interface_count != 1
+            || module_interface->path.empty()) {
+            return std::unexpected(invalid_request(
+                "header-unit producer must expose exactly one non-empty IFC artifact"));
+        }
+        if (!request.unit.module_references.empty()
+            || !request.unit.header_unit_references.empty()) {
+            return std::unexpected(invalid_request(
+                "nested module/header-unit imports in a header-unit producer are not supported yet"));
+        }
+    } else if (request.unit.kind == TranslationUnitKind::module_interface) {
+        if (object == nullptr || object_count != 1 || object->path.empty()) {
+            return std::unexpected(invalid_request(
+                "module interface translation unit must expose exactly one non-empty object artifact"));
+        }
         if (module_interface == nullptr
             || interface_count != 1
             || module_interface->path.empty()) {
             return std::unexpected(invalid_request(
                 "module interface translation unit must expose exactly one non-empty IFC artifact"));
         }
-    } else if (interface_count != 0) {
-        return std::unexpected(invalid_request(
-            "ordinary source translation unit must not expose an IFC output artifact"));
+    } else {
+        if (object == nullptr || object_count != 1 || object->path.empty()) {
+            return std::unexpected(invalid_request(
+                "ordinary source translation unit must expose exactly one non-empty object artifact"));
+        }
+        if (interface_count != 0) {
+            return std::unexpected(invalid_request(
+                "ordinary source translation unit must not expose an IFC output artifact"));
+        }
     }
 
     for (const auto& output : request.unit.outputs) {
@@ -126,20 +157,33 @@ MsvcCompileExecutor::execute(const CompileExecutionRequest& request) const {
     }
 
     MsvcCompiler compiler{toolchain_, runner_};
-    CompileInvocation invocation;
-    invocation.source = request.unit.source;
-    invocation.object = object->path;
-    invocation.source_dependencies = request.source_dependencies_file;
-    invocation.kind = request.unit.kind;
-    if (module_interface != nullptr) {
-        invocation.module_interface_output = module_interface->path;
-    }
-    invocation.module_references = request.unit.module_references;
-    invocation.header_unit_references = request.unit.header_unit_references;
-    invocation.options = request.options;
-    invocation.working_directory = request.working_directory;
+    auto compiled = [&]() -> std::expected<process::ProcessResult, CompilerError> {
+        if (header_unit_producer) {
+            HeaderUnitCompileInvocation invocation;
+            invocation.header_name = request.unit.header_unit->header_name;
+            invocation.lookup_method = request.unit.header_unit->lookup_method;
+            invocation.interface_output = module_interface->path;
+            invocation.source_dependencies = request.source_dependencies_file;
+            invocation.options = request.options;
+            invocation.working_directory = request.working_directory;
+            return compiler.compile_header_unit(invocation);
+        }
 
-    auto compiled = compiler.compile(invocation);
+        CompileInvocation invocation;
+        invocation.source = request.unit.source;
+        invocation.object = object->path;
+        invocation.source_dependencies = request.source_dependencies_file;
+        invocation.kind = request.unit.kind;
+        if (module_interface != nullptr) {
+            invocation.module_interface_output = module_interface->path;
+        }
+        invocation.module_references = request.unit.module_references;
+        invocation.header_unit_references = request.unit.header_unit_references;
+        invocation.options = request.options;
+        invocation.working_directory = request.working_directory;
+        return compiler.compile(invocation);
+    }();
+
     if (!compiled) {
         return std::unexpected(CompileExecutorError{
             .code = CompileExecutorErrorCode::compiler_failed,
@@ -148,17 +192,13 @@ MsvcCompileExecutor::execute(const CompileExecutionRequest& request) const {
         });
     }
 
-    if (!regular_file(object->path)) {
-        return std::unexpected(CompileExecutorError{
-            .code = CompileExecutorErrorCode::output_missing,
-            .message = "MSVC reported success but the planned object artifact is missing",
-        });
-    }
-    if (module_interface != nullptr && !regular_file(module_interface->path)) {
-        return std::unexpected(CompileExecutorError{
-            .code = CompileExecutorErrorCode::output_missing,
-            .message = "MSVC reported success but the planned IFC artifact is missing",
-        });
+    for (const auto& output : request.unit.outputs) {
+        if (!regular_file(output.path)) {
+            return std::unexpected(CompileExecutorError{
+                .code = CompileExecutorErrorCode::output_missing,
+                .message = "MSVC reported success but a planned compile output artifact is missing",
+            });
+        }
     }
 
     auto dependencies = MsvcSourceDependenciesReader::read(request.source_dependencies_file);

--- a/cpp/backends/msvc/src/MsvcCompiler.cpp
+++ b/cpp/backends/msvc/src/MsvcCompiler.cpp
@@ -42,9 +42,6 @@ namespace fs = std::filesystem;
 void append_configuration_arguments(
     std::vector<std::string>& arguments,
     const BuildConfiguration configuration) {
-    // /Z7 keeps compiler debug information inside each object instead of
-    // writing a shared compiler PDB. This makes each TU artifact self-contained
-    // and removes cross-process PDB write contention during parallel builds.
     switch (configuration) {
     case BuildConfiguration::debug:
         arguments.emplace_back("/Od");
@@ -253,8 +250,6 @@ MsvcCompiler::build_arguments(const CompileInvocation& invocation) {
     auto common = append_common_compile_arguments(arguments, invocation.options);
     if (!common) return std::unexpected(common.error());
 
-    // Module/header-unit inputs and structured outputs are emitted after raw
-    // additional arguments so the BuildPlan remains authoritative over semantic routing.
     if (invocation.kind == TranslationUnitKind::module_interface) {
         arguments.emplace_back("/interface");
         arguments.emplace_back("/TP");
@@ -298,10 +293,13 @@ MsvcCompiler::build_header_unit_arguments(const HeaderUnitCompileInvocation& inv
     if (invocation.object && invocation.object->empty()) {
         return std::unexpected(invalid_request("header-unit object output path must not be empty"));
     }
+    if (invocation.source_dependencies && invocation.source_dependencies->empty()) {
+        return std::unexpected(invalid_request("sourceDependencies output path is empty"));
+    }
 
     std::vector<std::string> arguments;
     arguments.reserve(
-        20
+        22
         + invocation.options.defines.size()
         + invocation.options.include_directories.size()
         + invocation.options.additional_arguments.size());
@@ -314,6 +312,10 @@ MsvcCompiler::build_header_unit_arguments(const HeaderUnitCompileInvocation& inv
     arguments.push_back(invocation.header_name);
     arguments.emplace_back("/ifcOutput");
     arguments.push_back(path_to_utf8(invocation.interface_output));
+    if (invocation.source_dependencies) {
+        arguments.emplace_back("/sourceDependencies");
+        arguments.push_back(path_to_utf8(*invocation.source_dependencies));
+    }
     if (invocation.object) {
         arguments.push_back("/Fo" + path_to_utf8(*invocation.object));
     }
@@ -361,6 +363,14 @@ MsvcCompiler::compile_header_unit(const HeaderUnitCompileInvocation& invocation)
     auto prepared_interface = prepare_parent_directory(invocation.interface_output, "header-unit interface");
     if (!prepared_interface) {
         return std::unexpected(prepared_interface.error());
+    }
+    if (invocation.source_dependencies) {
+        auto prepared_dependencies = prepare_parent_directory(
+            *invocation.source_dependencies,
+            "sourceDependencies");
+        if (!prepared_dependencies) {
+            return std::unexpected(prepared_dependencies.error());
+        }
     }
     if (invocation.object) {
         auto prepared_object = prepare_parent_directory(*invocation.object, "header-unit object");

--- a/cpp/core/include/mqb/core/BuildAction.hpp
+++ b/cpp/core/include/mqb/core/BuildAction.hpp
@@ -5,13 +5,14 @@
 #include <variant>
 #include <vector>
 
+#include "mqb/core/Artifact.hpp"
 #include "mqb/core/BuildTypes.hpp"
 
 namespace mqb {
 
 struct CompileAction {
     std::filesystem::path source;
-    std::filesystem::path object;
+    std::vector<Artifact> outputs;
     std::vector<BuildReason> reasons;
 };
 

--- a/cpp/core/include/mqb/core/BuildPlanner.hpp
+++ b/cpp/core/include/mqb/core/BuildPlanner.hpp
@@ -16,6 +16,7 @@ namespace mqb {
 enum class BuildPlannerErrorCode {
     missing_object_output,
     multiple_object_outputs,
+    invalid_header_unit_outputs,
     missing_link_input,
     missing_link_output,
 };
@@ -24,6 +25,7 @@ struct BuildPlannerError {
     BuildPlannerErrorCode code{};
     std::filesystem::path source;
     std::size_t object_output_count{};
+    std::size_t module_interface_output_count{};
 };
 
 struct CompilePlanItem {

--- a/cpp/core/include/mqb/core/TranslationUnit.hpp
+++ b/cpp/core/include/mqb/core/TranslationUnit.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <filesystem>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -23,6 +24,11 @@ struct ModuleReference {
     std::filesystem::path interface_file;
 };
 
+struct HeaderUnitIdentity {
+    std::string header_name;
+    HeaderUnitLookupMethod lookup_method{HeaderUnitLookupMethod::quote};
+};
+
 struct HeaderUnitReference {
     std::string header_name;
     HeaderUnitLookupMethod lookup_method{HeaderUnitLookupMethod::quote};
@@ -32,6 +38,7 @@ struct HeaderUnitReference {
 struct TranslationUnit {
     std::filesystem::path source;
     TranslationUnitKind kind{TranslationUnitKind::source};
+    std::optional<HeaderUnitIdentity> header_unit;
     std::vector<std::filesystem::path> dependencies;
     std::vector<ModuleReference> module_references;
     std::vector<HeaderUnitReference> header_unit_references;

--- a/cpp/core/src/BuildPlanner.cpp
+++ b/cpp/core/src/BuildPlanner.cpp
@@ -18,36 +18,57 @@ std::expected<BuildPlan, BuildPlannerError> BuildPlanner::plan_compile(
             continue;
         }
 
-        const Artifact* object_output = nullptr;
         std::size_t object_output_count = 0;
+        std::size_t module_interface_output_count = 0;
         for (const auto& output : item.unit.outputs) {
             if (output.kind == ArtifactKind::object) {
                 ++object_output_count;
-                if (object_output == nullptr) {
-                    object_output = &output;
-                }
+            } else if (output.kind == ArtifactKind::module_interface) {
+                ++module_interface_output_count;
             }
         }
 
-        if (object_output_count == 0 || object_output == nullptr || object_output->path.empty()) {
-            return std::unexpected(BuildPlannerError{
-                .code = BuildPlannerErrorCode::missing_object_output,
-                .source = item.unit.source,
-                .object_output_count = object_output_count,
-            });
-        }
-
-        if (object_output_count > 1) {
-            return std::unexpected(BuildPlannerError{
-                .code = BuildPlannerErrorCode::multiple_object_outputs,
-                .source = item.unit.source,
-                .object_output_count = object_output_count,
-            });
+        if (item.unit.header_unit) {
+            if (object_output_count != 0
+                || module_interface_output_count != 1
+                || item.unit.outputs.size() != 1
+                || item.unit.outputs.front().path.empty()) {
+                return std::unexpected(BuildPlannerError{
+                    .code = BuildPlannerErrorCode::invalid_header_unit_outputs,
+                    .source = item.unit.source,
+                    .object_output_count = object_output_count,
+                    .module_interface_output_count = module_interface_output_count,
+                });
+            }
+        } else {
+            const Artifact* object_output = nullptr;
+            for (const auto& output : item.unit.outputs) {
+                if (output.kind == ArtifactKind::object) {
+                    object_output = &output;
+                    break;
+                }
+            }
+            if (object_output_count == 0 || object_output == nullptr || object_output->path.empty()) {
+                return std::unexpected(BuildPlannerError{
+                    .code = BuildPlannerErrorCode::missing_object_output,
+                    .source = item.unit.source,
+                    .object_output_count = object_output_count,
+                    .module_interface_output_count = module_interface_output_count,
+                });
+            }
+            if (object_output_count > 1) {
+                return std::unexpected(BuildPlannerError{
+                    .code = BuildPlannerErrorCode::multiple_object_outputs,
+                    .source = item.unit.source,
+                    .object_output_count = object_output_count,
+                    .module_interface_output_count = module_interface_output_count,
+                });
+            }
         }
 
         plan.actions.emplace_back(CompileAction{
             .source = item.unit.source,
-            .object = object_output->path,
+            .outputs = item.unit.outputs,
             .reasons = item.cache_validation.reasons,
         });
     }

--- a/cpp/core/src/BuildSignature.cpp
+++ b/cpp/core/src/BuildSignature.cpp
@@ -64,6 +64,19 @@ public:
         }
     }
 
+    void add_header_unit_identity(
+        const std::optional<HeaderUnitIdentity>& identity) noexcept {
+        if (!identity) {
+            return;
+        }
+        // Preserve the exact v4 byte stream for all pre-header-unit recipes so
+        // #19 caches remain reusable. Only the new producer shape appends a
+        // versioned domain marker and its lookup identity.
+        add_string("mqb.header-unit.producer.v1");
+        add_string(identity->header_name);
+        add_enum(identity->lookup_method);
+    }
+
     void add_module_references(const std::vector<ModuleReference>& references) noexcept {
         add_u64(static_cast<std::uint64_t>(references.size()));
         for (const auto& reference : references) {
@@ -142,16 +155,12 @@ BuildSignature BuildSignature::for_compile(
     StableHasher hasher;
     hasher.add_string("mqb.compile.signature.v4");
 
-    // Header dependency membership remains freshness-only state. Ordinary
-    // object placement also remains outside recipe identity. Module and header-
-    // unit references are different: their import identity -> compiled-interface
-    // mapping affects compiler routing, and a provider's planned interface-file
-    // output path is consumed semantically by downstream translation units.
     hasher.add_path(unit.source);
     hasher.add_enum(unit.kind);
     hasher.add_module_references(unit.module_references);
     hasher.add_header_unit_references(unit.header_unit_references);
     hasher.add_module_outputs(unit.outputs);
+    hasher.add_header_unit_identity(unit.header_unit);
 
     hasher.add_path(toolchain.compiler);
     hasher.add_string(toolchain.version);
@@ -188,26 +197,18 @@ BuildSignature BuildSignature::for_link(
     const LinkOptions& options) {
     StableHasher hasher;
     hasher.add_string("mqb.link.signature.v2");
-
-    // File-input order is intentionally preserved. Library resolution is kept
-    // separate from the requested library recipe, but the exact resolved files
-    // still participate in action identity so a changed search result cannot
-    // silently reuse a link built against a different file.
     hasher.add_paths(objects);
     hasher.add_paths(resolved_libraries);
     hasher.add_path(output);
-
     hasher.add_path(linker.linker);
     hasher.add_string(linker.version);
     hasher.add_string(linker.binary_stamp);
-
     hasher.add_enum(options.configuration);
     hasher.add_enum(options.architecture);
     hasher.add_enum(options.subsystem);
     hasher.add_paths(options.library_directories);
     hasher.add_strings(options.libraries);
     hasher.add_strings(options.additional_arguments);
-
     return BuildSignature{hasher.finish()};
 }
 

--- a/cpp/orchestration/tests/CMakeLists.txt
+++ b/cpp/orchestration/tests/CMakeLists.txt
@@ -93,45 +93,14 @@ foreach(test_target IN ITEMS
     endif()
 endforeach()
 
-add_test(
-    NAME mqb.orchestration.incremental_compile
-    COMMAND mqb_orchestration_incremental_tests
-)
-
-add_test(
-    NAME mqb.orchestration.incremental_link
-    COMMAND mqb_orchestration_incremental_link_tests
-)
-
-add_test(
-    NAME mqb.orchestration.bounded_work_scheduler
-    COMMAND mqb_bounded_work_scheduler_tests
-)
-
-add_test(
-    NAME mqb.orchestration.incremental_target
-    COMMAND mqb_incremental_target_coordinator_tests
-)
-
-add_test(
-    NAME mqb.orchestration.module_compile_wave
-    COMMAND mqb_module_compile_coordinator_tests
-)
-
-add_test(
-    NAME mqb.orchestration.module_target
-    COMMAND mqb_module_target_coordinator_tests
-)
-
-add_test(
-    NAME mqb.orchestration.module_target_validation
-    COMMAND mqb_module_target_validation_tests
-)
-
-add_test(
-    NAME mqb.orchestration.target_router
-    COMMAND mqb_target_router_tests
-)
+add_test(NAME mqb.orchestration.incremental_compile COMMAND mqb_orchestration_incremental_tests)
+add_test(NAME mqb.orchestration.incremental_link COMMAND mqb_orchestration_incremental_link_tests)
+add_test(NAME mqb.orchestration.bounded_work_scheduler COMMAND mqb_bounded_work_scheduler_tests)
+add_test(NAME mqb.orchestration.incremental_target COMMAND mqb_incremental_target_coordinator_tests)
+add_test(NAME mqb.orchestration.module_compile_wave COMMAND mqb_module_compile_coordinator_tests)
+add_test(NAME mqb.orchestration.module_target COMMAND mqb_module_target_coordinator_tests)
+add_test(NAME mqb.orchestration.module_target_validation COMMAND mqb_module_target_validation_tests)
+add_test(NAME mqb.orchestration.target_router COMMAND mqb_target_router_tests)
 
 if(MQB_ENABLE_INSTALLED_MSVC_TESTS)
     add_executable(mqb_module_target_integration_tests
@@ -144,13 +113,32 @@ if(MQB_ENABLE_INSTALLED_MSVC_TESTS)
             mqb_platform_windows
     )
     target_compile_features(mqb_module_target_integration_tests PRIVATE cxx_std_23)
+
+    add_executable(mqb_header_unit_incremental_integration_tests
+        header_unit_incremental_integration_tests.cpp
+    )
+    target_link_libraries(mqb_header_unit_incremental_integration_tests
+        PRIVATE
+            mqb_orchestration
+            mqb_msvc
+            mqb_platform_windows
+    )
+    target_compile_features(mqb_header_unit_incremental_integration_tests PRIVATE cxx_std_23)
+
     if(MSVC)
         target_compile_options(mqb_module_target_integration_tests PRIVATE /W4 /permissive-)
+        target_compile_options(mqb_header_unit_incremental_integration_tests PRIVATE /W4 /permissive-)
     else()
         target_compile_options(mqb_module_target_integration_tests PRIVATE -Wall -Wextra -Wpedantic)
+        target_compile_options(mqb_header_unit_incremental_integration_tests PRIVATE -Wall -Wextra -Wpedantic)
     endif()
+
     add_test(
         NAME mqb.orchestration.module_target_integration
         COMMAND mqb_module_target_integration_tests
+    )
+    add_test(
+        NAME mqb.orchestration.header_unit_incremental_integration
+        COMMAND mqb_header_unit_incremental_integration_tests
     )
 endif()

--- a/cpp/orchestration/tests/header_unit_incremental_integration_tests.cpp
+++ b/cpp/orchestration/tests/header_unit_incremental_integration_tests.cpp
@@ -1,0 +1,209 @@
+#include <algorithm>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <string_view>
+
+#include "mqb/core/Artifact.hpp"
+#include "mqb/core/BuildPlan.hpp"
+#include "mqb/core/CompileCacheFile.hpp"
+#include "mqb/core/CompilerOptions.hpp"
+#include "mqb/core/TranslationUnit.hpp"
+#include "mqb/msvc/MsvcCompileExecutor.hpp"
+#include "mqb/msvc/MsvcToolchainLocator.hpp"
+#include "mqb/orchestration/MsvcIncrementalCompileCoordinator.hpp"
+#include "mqb/platform/windows/WindowsProcessRunner.hpp"
+
+namespace {
+
+namespace fs = std::filesystem;
+int failures = 0;
+
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+class TemporaryDirectory {
+public:
+    TemporaryDirectory() {
+        const auto tick = std::chrono::steady_clock::now().time_since_epoch().count();
+        path_ = fs::temp_directory_path() / ("mqb-header-unit-incremental-" + std::to_string(tick));
+        fs::create_directories(path_);
+    }
+
+    ~TemporaryDirectory() {
+        std::error_code ignored;
+        fs::remove_all(path_, ignored);
+    }
+
+    [[nodiscard]] const fs::path& path() const noexcept { return path_; }
+
+private:
+    fs::path path_;
+};
+
+void write_text(const fs::path& path, const std::string_view text) {
+    fs::create_directories(path.parent_path());
+    std::ofstream file{path, std::ios::binary | std::ios::trunc};
+    file.write(text.data(), static_cast<std::streamsize>(text.size()));
+}
+
+[[nodiscard]] bool has_reason(
+    const mqb::CompileCacheValidation& validation,
+    const mqb::BuildReason reason) {
+    return std::find(validation.reasons.begin(), validation.reasons.end(), reason)
+        != validation.reasons.end();
+}
+
+} // namespace
+
+int main() {
+    mqb::platform::windows::WindowsProcessRunner runner;
+    mqb::msvc::MsvcToolchainLocator locator{runner};
+
+    mqb::msvc::DiscoveryOptions discovery;
+    discovery.preference = mqb::msvc::ToolchainPreference::visual_studio;
+    discovery.target_architecture = mqb::Architecture::x64;
+    discovery.host_architecture = mqb::Architecture::x64;
+
+    auto toolchain = locator.discover(discovery);
+    expect(toolchain.has_value(), "header-unit incremental E2E requires installed Visual Studio");
+    if (!toolchain) {
+        std::cerr << toolchain.error().message << '\n';
+        return 1;
+    }
+
+    TemporaryDirectory fixture;
+    const fs::path include_dir = fixture.path() / "include";
+    const fs::path header = include_dir / "util.hpp";
+    const fs::path ifc = fixture.path() / ".mqb" / "ifc" / "util.ifc";
+    const fs::path object = fixture.path() / ".mqb" / "obj" / "util.obj";
+    const fs::path dependencies = fixture.path() / ".mqb" / "deps" / "util.json";
+    const fs::path cache = fixture.path() / ".mqb" / "cache" / "compile" / "util.mqbcache";
+
+    write_text(header, "inline int header_answer() { return 42; }\n");
+
+    mqb::TranslationUnit unit;
+    unit.source = header;
+    unit.kind = mqb::TranslationUnitKind::source;
+    unit.header_unit = mqb::HeaderUnitIdentity{
+        .header_name = "util.hpp",
+        .lookup_method = mqb::HeaderUnitLookupMethod::quote,
+    };
+    unit.outputs = {
+        mqb::Artifact{ifc, mqb::ArtifactKind::module_interface},
+    };
+
+    mqb::CompilerOptions options;
+    options.configuration = mqb::BuildConfiguration::debug;
+    options.architecture = mqb::Architecture::x64;
+    options.standard = mqb::CppStandard::latest;
+    options.include_directories = {include_dir};
+
+    mqb::msvc::MsvcCompileExecutor executor{*toolchain, runner};
+    mqb::orchestration::MsvcIncrementalCompileCoordinator coordinator{*toolchain, executor};
+    mqb::orchestration::IncrementalCompileRequest request{
+        .unit = unit,
+        .options = options,
+        .cache_file = cache,
+        .source_dependencies_file = dependencies,
+        .working_directory = fixture.path(),
+    };
+
+    // 1. Cold: IFC-only producer is scheduled and persisted without an object.
+    auto cold = coordinator.run(request);
+    expect(cold.has_value() && cold->compiled,
+           "cold header-unit producer should execute exactly one compile action");
+    expect(cold && has_reason(cold->validation, mqb::BuildReason::missing_cache_entry),
+           "cold header-unit build should explain missing cache metadata");
+    expect(cold && has_reason(cold->validation, mqb::BuildReason::missing_output),
+           "cold header-unit build should explain missing IFC output");
+    expect(fs::is_regular_file(ifc), "cold header-unit build should create the planned IFC");
+    expect(fs::is_regular_file(dependencies),
+           "header-unit producer should emit sourceDependencies metadata");
+    expect(fs::is_regular_file(cache), "cold header-unit build should persist compile cache metadata");
+    expect(!fs::exists(object), "incremental header-unit producer must remain IFC-only");
+
+    auto cached = mqb::CompileCacheFile::load(cache);
+    expect(cached.has_value() && cached->has_value(),
+           "header-unit cache should round-trip through compile-cache v2");
+    if (cached && cached->has_value()) {
+        expect((*cached)->outputs.size() == 1
+                   && (*cached)->outputs.front().kind == mqb::ArtifactKind::module_interface
+                   && (*cached)->outputs.front().path.lexically_normal() == ifc.lexically_normal(),
+               "header-unit cache should persist exactly the planned IFC output");
+    }
+
+    // 2. Warm: unchanged producer reuses the IFC and executes nothing.
+    auto warm = coordinator.run(request);
+    expect(warm.has_value() && !warm->compiled,
+           "unchanged header-unit producer should be a compile-cache hit");
+    expect(warm && warm->plan.actions.empty(),
+           "warm header-unit producer should schedule zero actions");
+
+    // 3. Producer identity is recipe state: quote -> angle must rebuild even
+    // with the same physical source and IFC destination.
+    auto angle_request = request;
+    angle_request.unit.header_unit->lookup_method = mqb::HeaderUnitLookupMethod::angle;
+    auto angle = coordinator.run(angle_request);
+    expect(angle.has_value() && angle->compiled,
+           "changing header-unit lookup identity should invalidate the producer recipe");
+    expect(angle && has_reason(angle->validation, mqb::BuildReason::compiler_options_changed),
+           "header-unit identity change should surface as recipe/signature invalidation");
+
+    // Return to quote identity for the freshness tests below.
+    auto quote_again = coordinator.run(request);
+    expect(quote_again.has_value() && quote_again->compiled,
+           "switching header-unit identity back should rebuild the quote producer");
+
+    // 4. Header mutation invalidates the IFC by source freshness.
+    std::error_code time_error;
+    const auto ifc_before_mutation = fs::last_write_time(ifc, time_error);
+    expect(!time_error, "mutation fixture requires an IFC timestamp");
+    write_text(header, "inline int header_answer() { return 43; }\n");
+    time_error.clear();
+    fs::last_write_time(header, ifc_before_mutation + std::chrono::seconds{2}, time_error);
+    expect(!time_error, "test should be able to make the header deterministically newer than the IFC");
+
+    auto mutated = coordinator.run(request);
+    expect(mutated.has_value() && mutated->compiled,
+           "header source mutation should rebuild the header-unit IFC");
+    expect(mutated && has_reason(mutated->validation, mqb::BuildReason::source_changed),
+           "header source mutation should report source_changed");
+
+    // Normalize timestamps after the deliberately future-dated source so the
+    // next warm assertion is deterministic rather than wall-clock dependent.
+    const auto header_time = fs::last_write_time(header, time_error);
+    expect(!time_error, "rebuilt mutation fixture requires the header timestamp");
+    time_error.clear();
+    fs::last_write_time(ifc, header_time + std::chrono::seconds{1}, time_error);
+    expect(!time_error, "test should be able to make rebuilt IFC newer than its source");
+
+    auto warm_after_mutation = coordinator.run(request);
+    expect(warm_after_mutation.has_value() && !warm_after_mutation->compiled,
+           "rebuilt header unit should return to a warm cache hit");
+
+    // 5. Missing planned IFC is repaired even when source/cache metadata are warm.
+    fs::remove(ifc, time_error);
+    expect(!time_error, "test should be able to delete only the header-unit IFC");
+    auto repaired = coordinator.run(request);
+    expect(repaired.has_value() && repaired->compiled,
+           "missing header-unit IFC should schedule a repair compile");
+    expect(repaired && has_reason(repaired->validation, mqb::BuildReason::missing_output),
+           "missing header-unit IFC repair should report missing_output");
+    expect(fs::is_regular_file(ifc), "missing-IFC repair should recreate the planned IFC");
+    expect(!fs::exists(object), "missing-IFC repair must not create an object artifact");
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+
+    std::cout << "mqb_header_unit_incremental_integration_tests passed\n";
+    return 0;
+}

--- a/cpp/orchestration/tests/header_unit_incremental_integration_tests.cpp
+++ b/cpp/orchestration/tests/header_unit_incremental_integration_tests.cpp
@@ -60,6 +60,49 @@ void write_text(const fs::path& path, const std::string_view text) {
         != validation.reasons.end();
 }
 
+void print_incremental_error(const mqb::orchestration::IncrementalCompileError& error) {
+    std::cerr << "incremental compile error: " << error.message << '\n';
+    if (error.planner_error) {
+        std::cerr << "  planner code=" << static_cast<int>(error.planner_error->code)
+                  << " source=" << error.planner_error->source.generic_string()
+                  << " object_outputs=" << error.planner_error->object_output_count
+                  << " ifc_outputs=" << error.planner_error->module_interface_output_count
+                  << '\n';
+    }
+    if (!error.compile_error) {
+        return;
+    }
+    const auto& compile = *error.compile_error;
+    std::cerr << "  executor: " << compile.message << '\n';
+    if (compile.compiler_error) {
+        const auto& compiler = *compile.compiler_error;
+        std::cerr << "  compiler: " << compiler.message << '\n';
+        if (compiler.process_error) {
+            std::cerr << "  process: " << compiler.process_error->message
+                      << " native=" << compiler.process_error->native_code << '\n';
+        }
+        if (compiler.process_result) {
+            std::cerr << "  exit=" << compiler.process_result->exit_code << '\n'
+                      << compiler.process_result->stdout_text
+                      << compiler.process_result->stderr_text;
+        }
+    }
+    if (compile.dependency_error) {
+        std::cerr << "  dependency metadata: " << compile.dependency_error->message << '\n';
+    }
+}
+
+template <typename Result>
+[[nodiscard]] bool require_success(const Result& result, const std::string_view message) {
+    if (result) {
+        return true;
+    }
+    ++failures;
+    std::cerr << "FAIL: " << message << '\n';
+    print_incremental_error(result.error());
+    return false;
+}
+
 } // namespace
 
 int main() {
@@ -115,13 +158,12 @@ int main() {
         .working_directory = fixture.path(),
     };
 
-    // 1. Cold: IFC-only producer is scheduled and persisted without an object.
     auto cold = coordinator.run(request);
-    expect(cold.has_value() && cold->compiled,
-           "cold header-unit producer should execute exactly one compile action");
-    expect(cold && has_reason(cold->validation, mqb::BuildReason::missing_cache_entry),
+    if (!require_success(cold, "cold header-unit producer should execute successfully")) return 1;
+    expect(cold->compiled, "cold header-unit producer should execute exactly one compile action");
+    expect(has_reason(cold->validation, mqb::BuildReason::missing_cache_entry),
            "cold header-unit build should explain missing cache metadata");
-    expect(cold && has_reason(cold->validation, mqb::BuildReason::missing_output),
+    expect(has_reason(cold->validation, mqb::BuildReason::missing_output),
            "cold header-unit build should explain missing IFC output");
     expect(fs::is_regular_file(ifc), "cold header-unit build should create the planned IFC");
     expect(fs::is_regular_file(dependencies),
@@ -139,29 +181,25 @@ int main() {
                "header-unit cache should persist exactly the planned IFC output");
     }
 
-    // 2. Warm: unchanged producer reuses the IFC and executes nothing.
     auto warm = coordinator.run(request);
-    expect(warm.has_value() && !warm->compiled,
-           "unchanged header-unit producer should be a compile-cache hit");
-    expect(warm && warm->plan.actions.empty(),
-           "warm header-unit producer should schedule zero actions");
+    if (!require_success(warm, "warm header-unit producer should validate successfully")) return 1;
+    expect(!warm->compiled, "unchanged header-unit producer should be a compile-cache hit");
+    expect(warm->plan.actions.empty(), "warm header-unit producer should schedule zero actions");
 
-    // 3. Producer identity is recipe state: quote -> angle must rebuild even
-    // with the same physical source and IFC destination.
     auto angle_request = request;
     angle_request.unit.header_unit->lookup_method = mqb::HeaderUnitLookupMethod::angle;
     auto angle = coordinator.run(angle_request);
-    expect(angle.has_value() && angle->compiled,
+    if (!require_success(angle, "angle header-unit producer should rebuild successfully")) return 1;
+    expect(angle->compiled,
            "changing header-unit lookup identity should invalidate the producer recipe");
-    expect(angle && has_reason(angle->validation, mqb::BuildReason::compiler_options_changed),
+    expect(has_reason(angle->validation, mqb::BuildReason::compiler_options_changed),
            "header-unit identity change should surface as recipe/signature invalidation");
 
-    // Return to quote identity for the freshness tests below.
     auto quote_again = coordinator.run(request);
-    expect(quote_again.has_value() && quote_again->compiled,
+    if (!require_success(quote_again, "quote header-unit producer should rebuild successfully")) return 1;
+    expect(quote_again->compiled,
            "switching header-unit identity back should rebuild the quote producer");
 
-    // 4. Header mutation invalidates the IFC by source freshness.
     std::error_code time_error;
     const auto ifc_before_mutation = fs::last_write_time(ifc, time_error);
     expect(!time_error, "mutation fixture requires an IFC timestamp");
@@ -171,13 +209,11 @@ int main() {
     expect(!time_error, "test should be able to make the header deterministically newer than the IFC");
 
     auto mutated = coordinator.run(request);
-    expect(mutated.has_value() && mutated->compiled,
-           "header source mutation should rebuild the header-unit IFC");
-    expect(mutated && has_reason(mutated->validation, mqb::BuildReason::source_changed),
+    if (!require_success(mutated, "mutated header-unit producer should rebuild successfully")) return 1;
+    expect(mutated->compiled, "header source mutation should rebuild the header-unit IFC");
+    expect(has_reason(mutated->validation, mqb::BuildReason::source_changed),
            "header source mutation should report source_changed");
 
-    // Normalize timestamps after the deliberately future-dated source so the
-    // next warm assertion is deterministic rather than wall-clock dependent.
     const auto header_time = fs::last_write_time(header, time_error);
     expect(!time_error, "rebuilt mutation fixture requires the header timestamp");
     time_error.clear();
@@ -185,16 +221,16 @@ int main() {
     expect(!time_error, "test should be able to make rebuilt IFC newer than its source");
 
     auto warm_after_mutation = coordinator.run(request);
-    expect(warm_after_mutation.has_value() && !warm_after_mutation->compiled,
+    if (!require_success(warm_after_mutation, "rebuilt header unit should validate successfully")) return 1;
+    expect(!warm_after_mutation->compiled,
            "rebuilt header unit should return to a warm cache hit");
 
-    // 5. Missing planned IFC is repaired even when source/cache metadata are warm.
     fs::remove(ifc, time_error);
     expect(!time_error, "test should be able to delete only the header-unit IFC");
     auto repaired = coordinator.run(request);
-    expect(repaired.has_value() && repaired->compiled,
-           "missing header-unit IFC should schedule a repair compile");
-    expect(repaired && has_reason(repaired->validation, mqb::BuildReason::missing_output),
+    if (!require_success(repaired, "missing header-unit IFC should repair successfully")) return 1;
+    expect(repaired->compiled, "missing header-unit IFC should schedule a repair compile");
+    expect(has_reason(repaired->validation, mqb::BuildReason::missing_output),
            "missing header-unit IFC repair should report missing_output");
     expect(fs::is_regular_file(ifc), "missing-IFC repair should recreate the planned IFC");
     expect(!fs::exists(object), "missing-IFC repair must not create an object artifact");

--- a/cpp/tests/build_plan_tests.cpp
+++ b/cpp/tests/build_plan_tests.cpp
@@ -3,6 +3,7 @@
 #include <string_view>
 #include <variant>
 
+#include "mqb/core/Artifact.hpp"
 #include "mqb/core/BuildAction.hpp"
 #include "mqb/core/BuildPlan.hpp"
 #include "mqb/core/BuildTypes.hpp"
@@ -26,7 +27,9 @@ int main() {
 
     mqb::CompileAction compile;
     compile.source = std::filesystem::path{"src/main.cpp"};
-    compile.object = std::filesystem::path{"build/main.obj"};
+    compile.outputs = {
+        mqb::Artifact{std::filesystem::path{"build/main.obj"}, mqb::ArtifactKind::object},
+    };
     compile.reasons = {mqb::BuildReason::source_changed};
     plan.actions.emplace_back(compile);
 
@@ -38,8 +41,10 @@ int main() {
     const auto& stored_compile = std::get<mqb::CompileAction>(plan.actions.front());
     expect(stored_compile.source == std::filesystem::path{"src/main.cpp"},
            "compile action should retain its source path");
-    expect(stored_compile.object == std::filesystem::path{"build/main.obj"},
-           "compile action should retain its object path");
+    expect(stored_compile.outputs.size() == 1
+               && stored_compile.outputs.front().path == std::filesystem::path{"build/main.obj"}
+               && stored_compile.outputs.front().kind == mqb::ArtifactKind::object,
+           "compile action should retain its complete planned output set");
     expect(stored_compile.reasons.size() == 1,
            "compile action should retain rebuild reasons");
     expect(stored_compile.reasons.front() == mqb::BuildReason::source_changed,

--- a/cpp/tests/build_planner_tests.cpp
+++ b/cpp/tests/build_planner_tests.cpp
@@ -12,27 +12,16 @@
 #include "mqb/core/TranslationUnit.hpp"
 
 namespace {
-
 int failures = 0;
-
-void expect(const bool condition, const std::string_view message) {
-    if (!condition) {
-        ++failures;
-        std::cerr << "FAIL: " << message << '\n';
-    }
+void expect(bool condition, std::string_view message) {
+    if (!condition) { ++failures; std::cerr << "FAIL: " << message << '\n'; }
 }
-
-mqb::TranslationUnit make_unit(
-    const std::filesystem::path& source,
-    const std::filesystem::path& object) {
+mqb::TranslationUnit make_unit(const std::filesystem::path& source, const std::filesystem::path& object) {
     mqb::TranslationUnit unit;
     unit.source = source;
-    unit.outputs = {
-        mqb::Artifact{object, mqb::ArtifactKind::object},
-    };
+    unit.outputs = {mqb::Artifact{object, mqb::ArtifactKind::object}};
     return unit;
 }
-
 } // namespace
 
 int main() {
@@ -40,33 +29,24 @@ int main() {
         .unit = make_unit("src/cached.cpp", "build/cached.obj"),
         .cache_validation = mqb::CompileCacheValidation{},
     };
-
     const mqb::CompilePlanItem stale{
         .unit = make_unit("src/stale.cpp", "build/stale.obj"),
         .cache_validation = mqb::CompileCacheValidation{
-            .reasons = {
-                mqb::BuildReason::source_changed,
-                mqb::BuildReason::dependency_changed,
-            },
+            .reasons = {mqb::BuildReason::source_changed, mqb::BuildReason::dependency_changed},
         },
     };
-
     const std::vector<mqb::CompilePlanItem> items{cached, stale};
     const auto plan_result = mqb::BuildPlanner::plan_compile(items);
     expect(plan_result.has_value(), "valid compile inputs should produce a build plan");
     if (plan_result) {
-        expect(plan_result->size() == 1,
-               "reusable translation units should be omitted from the build plan");
-        expect(std::holds_alternative<mqb::CompileAction>(plan_result->actions.front()),
-               "stale translation unit should become a compile action");
-
+        expect(plan_result->size() == 1, "reusable translation units should be omitted from the build plan");
         const auto& action = std::get<mqb::CompileAction>(plan_result->actions.front());
-        expect(action.source == std::filesystem::path{"src/stale.cpp"},
-               "compile action should preserve source identity");
-        expect(action.object == std::filesystem::path{"build/stale.obj"},
-               "compile action should preserve object artifact mapping");
-        expect(action.reasons == stale.cache_validation.reasons,
-               "planner should preserve typed cache invalidation reasons");
+        expect(action.source == std::filesystem::path{"src/stale.cpp"}, "compile action should preserve source identity");
+        expect(action.outputs.size() == 1
+                   && action.outputs.front().path == std::filesystem::path{"build/stale.obj"}
+                   && action.outputs.front().kind == mqb::ArtifactKind::object,
+               "compile action should preserve planned object artifact mapping");
+        expect(action.reasons == stale.cache_validation.reasons, "planner should preserve typed invalidation reasons");
     }
 
     mqb::CompilePlanItem module_item;
@@ -77,32 +57,59 @@ int main() {
         mqb::Artifact{"build/math.obj", mqb::ArtifactKind::object},
     };
     module_item.cache_validation.reasons = {mqb::BuildReason::missing_output};
-
     const std::vector<mqb::CompilePlanItem> module_items{module_item};
     const auto module_plan = mqb::BuildPlanner::plan_compile(module_items);
-    expect(module_plan.has_value(),
-           "module translation unit with exactly one object output should be plannable");
+    expect(module_plan.has_value(), "module TU with exactly one object output should be plannable");
     if (module_plan) {
         const auto& action = std::get<mqb::CompileAction>(module_plan->actions.front());
-        expect(action.object == std::filesystem::path{"build/math.obj"},
-               "planner should select the object artifact and ignore additional module artifacts");
+        expect(action.outputs.size() == 2
+                   && action.outputs[0].path == std::filesystem::path{"build/math.ifc"}
+                   && action.outputs[0].kind == mqb::ArtifactKind::module_interface
+                   && action.outputs[1].path == std::filesystem::path{"build/math.obj"}
+                   && action.outputs[1].kind == mqb::ArtifactKind::object,
+               "planner should preserve complete module output set and ordering");
+    }
+
+    mqb::CompilePlanItem header_unit;
+    header_unit.unit.source = "include/util.hpp";
+    header_unit.unit.header_unit = mqb::HeaderUnitIdentity{
+        .header_name = "util.hpp",
+        .lookup_method = mqb::HeaderUnitLookupMethod::quote,
+    };
+    header_unit.unit.outputs = {mqb::Artifact{"build/util.ifc", mqb::ArtifactKind::module_interface}};
+    header_unit.cache_validation.reasons = {mqb::BuildReason::missing_output};
+    const std::vector<mqb::CompilePlanItem> header_items{header_unit};
+    const auto header_plan = mqb::BuildPlanner::plan_compile(header_items);
+    expect(header_plan.has_value() && header_plan->size() == 1,
+           "explicit header-unit producer should be plannable with one IFC and no object");
+    if (header_plan) {
+        const auto& action = std::get<mqb::CompileAction>(header_plan->actions.front());
+        expect(action.outputs.size() == 1
+                   && action.outputs.front().kind == mqb::ArtifactKind::module_interface
+                   && action.outputs.front().path == std::filesystem::path{"build/util.ifc"},
+               "header-unit compile action should preserve IFC-only output set");
+    }
+
+    mqb::CompilePlanItem invalid_header_unit = header_unit;
+    invalid_header_unit.unit.outputs.push_back(mqb::Artifact{"build/util.obj", mqb::ArtifactKind::object});
+    const std::vector<mqb::CompilePlanItem> invalid_header_items{invalid_header_unit};
+    const auto invalid_header_result = mqb::BuildPlanner::plan_compile(invalid_header_items);
+    expect(!invalid_header_result, "header-unit producer with object output should fail planning");
+    if (!invalid_header_result) {
+        expect(invalid_header_result.error().code == mqb::BuildPlannerErrorCode::invalid_header_unit_outputs,
+               "invalid header-unit output shape should have a dedicated planner error");
     }
 
     mqb::CompilePlanItem missing_object;
     missing_object.unit.source = "src/no_object.cpp";
-    missing_object.unit.outputs = {
-        mqb::Artifact{"build/no_object.ifc", mqb::ArtifactKind::module_interface},
-    };
+    missing_object.unit.outputs = {mqb::Artifact{"build/no_object.ifc", mqb::ArtifactKind::module_interface}};
     missing_object.cache_validation.reasons = {mqb::BuildReason::missing_output};
-
     const std::vector<mqb::CompilePlanItem> missing_items{missing_object};
     const auto missing_result = mqb::BuildPlanner::plan_compile(missing_items);
-    expect(!missing_result.has_value(), "stale unit without object output should fail planning");
+    expect(!missing_result, "ordinary stale unit without object output should still fail planning");
     if (!missing_result) {
         expect(missing_result.error().code == mqb::BuildPlannerErrorCode::missing_object_output,
-               "missing object should report the precise planner error");
-        expect(missing_result.error().source == std::filesystem::path{"src/no_object.cpp"},
-               "planner error should identify the invalid source");
+               "missing object should report precise planner error");
     }
 
     mqb::CompilePlanItem duplicate_objects;
@@ -112,22 +119,17 @@ int main() {
         mqb::Artifact{"build/b.obj", mqb::ArtifactKind::object},
     };
     duplicate_objects.cache_validation.reasons = {mqb::BuildReason::explicit_rebuild};
-
     const std::vector<mqb::CompilePlanItem> duplicate_items{duplicate_objects};
     const auto duplicate_result = mqb::BuildPlanner::plan_compile(duplicate_items);
-    expect(!duplicate_result.has_value(), "multiple object outputs should fail planning");
+    expect(!duplicate_result, "multiple object outputs should fail planning");
     if (!duplicate_result) {
         expect(duplicate_result.error().code == mqb::BuildPlannerErrorCode::multiple_object_outputs,
-               "multiple objects should report the precise planner error");
+               "multiple objects should report precise planner error");
         expect(duplicate_result.error().object_output_count == 2,
-               "planner error should report how many object outputs were found");
+               "planner error should report object output count");
     }
 
-    if (failures != 0) {
-        std::cerr << failures << " test(s) failed\n";
-        return 1;
-    }
-
+    if (failures != 0) { std::cerr << failures << " test(s) failed\n"; return 1; }
     std::cout << "mqb_build_planner_tests passed\n";
     return 0;
 }


### PR DESCRIPTION
Builds the second Header Units slice under #16 on top of #19.

## Scope

- add explicit `HeaderUnitIdentity { header_name, lookup_method }` producer state to a compile recipe without expanding the persisted `TranslationUnitKind` enum
- preserve the exact compile-signature v4 byte stream for every pre-existing ordinary/named-module recipe; only header-unit producers append a versioned producer-domain marker
- extend the MSVC header-unit producer to emit `/sourceDependencies` alongside its IFC
- let `MsvcCompileExecutor` execute a strict IFC-only header-unit producer through the existing incremental compile coordinator
- require exactly one IFC output and no object output for this incremental producer shape
- persist compiler-discovered header dependencies and the IFC-only planned output through compile-cache v2
- generalize `CompileAction` from a single object field to the complete planned compile output set
- keep ordinary/named-module planner validation strict: non-header-unit compile recipes still require exactly one object; header-unit producers require exactly one IFC and zero objects
- keep nested named/header-unit imports inside a header-unit producer fail-closed for now

## CI-driven hardening

The first exact-head workflow (#204) exposed a real Core contract mismatch: compile-cache v2 and the executor could represent IFC-only planned outputs, but `BuildPlanner::plan_compile()` still rejected every stale compile recipe without an object before launching `cl.exe`.

The fix makes planner/action semantics agree with cache/executor semantics instead of inventing a fake `.obj`. Core tests now cover the legal IFC-only header-unit shape and preserve the ordinary missing-object error. The installed-MSVC E2E also prints and stops on the first typed planner/compiler/dependency error so future failures do not cascade into noisy assertions.

## Verification

C++ V2 workflow #205 completed successfully on exact head `e27cb5d4eb7a06fff49dafea157a78d581b36f39`: Configure, Build, and CTest all passed.

Real VS2026 coverage verifies:

1. cold header-unit build creates IFC + sourceDependencies + cache and no object
2. unchanged build is compile 0
3. quote -> angle producer identity change invalidates recipe identity
4. header source mutation rebuilds the IFC
5. rebuilt producer becomes warm again
6. deleting only the IFC schedules a repair compile and still does not create an object

## Deliberate boundary

This PR proves a cacheable project-local header-unit producer primitive. It does **not** yet resolve P1689 header-unit requirements into these producers or schedule them ahead of consuming module TUs. That graph/wave integration is the next #16 slice.

Advances #16; does not close it.