### PR TITLE
feat: resolve project-local header units in module graph

### DIFF
--- a/cpp/modules/include/mqb/modules/ModuleDependencyGraph.hpp
+++ b/cpp/modules/include/mqb/modules/ModuleDependencyGraph.hpp
@@ -33,14 +33,32 @@ struct ResolvedModuleDependency {
     std::string logical_name;
 };
 
+struct PlannedHeaderUnit {
+    std::filesystem::path source;
+    std::string header_name;
+    LookupMethod lookup_method{LookupMethod::include_quote};
+};
+
+struct ResolvedHeaderUnitDependency {
+    std::filesystem::path consumer_source;
+    std::filesystem::path provider_source;
+    std::string header_name;
+    LookupMethod lookup_method{LookupMethod::include_quote};
+};
+
 struct ModuleDependencyPlan {
     // Each inner vector may be compiled concurrently. Earlier levels must
-    // complete before later levels begin.
+    // complete before later levels begin. Resolved project-local header-unit
+    // producer paths participate as first-class nodes alongside scanned TUs.
     std::vector<std::vector<std::filesystem::path>> compile_levels;
     // Named-module imports that were resolved to another source in this plan.
-    // Orchestration uses these exact edges both for /reference wiring and for
-    // downstream rebuild propagation; provider selection must not be repeated.
     std::vector<ResolvedModuleDependency> resolved_dependencies;
+    // Unique project-local header-unit producer recipes selected from P1689
+    // source-path identities. Execution assigns artifacts in a later layer.
+    std::vector<PlannedHeaderUnit> header_units;
+    // Consumer -> header-unit provider edges, preserving import spelling and
+    // quote/angle lookup semantics for later /headerUnit routing.
+    std::vector<ResolvedHeaderUnitDependency> resolved_header_unit_dependencies;
     std::vector<UnresolvedModuleRequirement> unresolved_requirements;
 };
 
@@ -49,6 +67,8 @@ enum class ModuleGraphErrorCode {
     duplicate_source,
     duplicate_interface_provider,
     ambiguous_named_provider,
+    header_unit_source_conflict,
+    conflicting_header_unit_identity,
     dependency_cycle,
 };
 

--- a/cpp/modules/src/ModuleDependencyGraph.cpp
+++ b/cpp/modules/src/ModuleDependencyGraph.cpp
@@ -44,9 +44,7 @@ struct ProviderCandidate {
     const std::vector<ScannedModuleUnit>& units) {
     std::vector<std::size_t> interface_candidates;
     for (const auto& candidate : candidates) {
-        if (candidate.is_interface) {
-            interface_candidates.push_back(candidate.unit_index);
-        }
+        if (candidate.is_interface) interface_candidates.push_back(candidate.unit_index);
     }
 
     if (interface_candidates.size() > 1) {
@@ -56,12 +54,8 @@ struct ProviderCandidate {
             units[interface_candidates.front()].source,
             logical_name));
     }
-    if (interface_candidates.size() == 1) {
-        return interface_candidates.front();
-    }
-    if (candidates.size() == 1) {
-        return candidates.front().unit_index;
-    }
+    if (interface_candidates.size() == 1) return interface_candidates.front();
+    if (candidates.size() == 1) return candidates.front().unit_index;
 
     return std::unexpected(graph_failure(
         ModuleGraphErrorCode::ambiguous_named_provider,
@@ -71,13 +65,22 @@ struct ProviderCandidate {
         logical_name));
 }
 
+[[nodiscard]] bool same_header_identity(
+    const PlannedHeaderUnit& planned,
+    const RequiredModule& required) {
+    return planned.header_name == required.logical_name
+        && planned.lookup_method == required.lookup_method;
+}
+
 } // namespace
 
 std::expected<ModuleDependencyPlan, ModuleGraphError>
 ModuleDependencyGraphBuilder::build(const std::vector<ScannedModuleUnit>& units) {
     DependencyGraph graph;
     std::unordered_map<std::string, std::size_t> unit_by_key;
+    std::unordered_map<std::string, fs::path> source_by_key;
     unit_by_key.reserve(units.size());
+    source_by_key.reserve(units.size());
 
     for (std::size_t index = 0; index < units.size(); ++index) {
         if (units[index].source.empty()) {
@@ -93,6 +96,7 @@ ModuleDependencyGraphBuilder::build(const std::vector<ScannedModuleUnit>& units)
                 units[index].source));
         }
         unit_by_key.emplace(key, index);
+        source_by_key.emplace(key, units[index].source);
         auto added = graph.add_node(key);
         if (!added) {
             return std::unexpected(graph_failure(
@@ -105,12 +109,7 @@ ModuleDependencyGraphBuilder::build(const std::vector<ScannedModuleUnit>& units)
     std::unordered_map<std::string, std::vector<ProviderCandidate>> provider_candidates;
     for (std::size_t index = 0; index < units.size(); ++index) {
         for (const auto& provided : units[index].rule.provided_modules) {
-            if (provided.unique_on_source_path) {
-                // Header-unit identity is source-based and is retained as an
-                // unresolved typed requirement until header-unit compilation is
-                // implemented. It must not collide with the named-module map.
-                continue;
-            }
+            if (provided.unique_on_source_path) continue;
             provider_candidates[provided.logical_name].push_back(ProviderCandidate{
                 .unit_index = index,
                 .is_interface = provided.is_interface,
@@ -127,17 +126,76 @@ ModuleDependencyGraphBuilder::build(const std::vector<ScannedModuleUnit>& units)
     }
 
     ModuleDependencyPlan plan;
+    std::unordered_map<std::string, std::size_t> header_unit_by_key;
+
     for (std::size_t consumer_index = 0; consumer_index < units.size(); ++consumer_index) {
         const std::string consumer_key = path_key(units[consumer_index].source);
         for (const auto& required : units[consumer_index].rule.required_modules) {
             const bool header_unit = required.unique_on_source_path
                 || required.lookup_method != LookupMethod::by_name;
             if (header_unit) {
-                plan.unresolved_requirements.push_back(UnresolvedModuleRequirement{
+                if (!required.source_path || required.source_path->empty()) {
+                    plan.unresolved_requirements.push_back(UnresolvedModuleRequirement{
+                        .consumer_source = units[consumer_index].source,
+                        .requirement = required,
+                        .kind = UnresolvedRequirementKind::header_unit,
+                    });
+                    continue;
+                }
+
+                const fs::path header_source = required.source_path->lexically_normal();
+                const std::string header_key = path_key(header_source);
+                if (unit_by_key.contains(header_key)) {
+                    return std::unexpected(graph_failure(
+                        ModuleGraphErrorCode::header_unit_source_conflict,
+                        "header-unit source path collides with a scanned translation unit",
+                        header_source,
+                        required.logical_name));
+                }
+
+                auto header = header_unit_by_key.find(header_key);
+                if (header == header_unit_by_key.end()) {
+                    auto added = graph.add_node(header_key);
+                    if (!added) {
+                        return std::unexpected(graph_failure(
+                            ModuleGraphErrorCode::header_unit_source_conflict,
+                            "header-unit source path collides with another graph node",
+                            header_source,
+                            required.logical_name));
+                    }
+                    source_by_key.emplace(header_key, header_source);
+                    const std::size_t header_index = plan.header_units.size();
+                    plan.header_units.push_back(PlannedHeaderUnit{
+                        .source = header_source,
+                        .header_name = required.logical_name,
+                        .lookup_method = required.lookup_method,
+                    });
+                    header = header_unit_by_key.emplace(header_key, header_index).first;
+                } else if (!same_header_identity(plan.header_units[header->second], required)) {
+                    return std::unexpected(graph_failure(
+                        ModuleGraphErrorCode::conflicting_header_unit_identity,
+                        "the same header-unit source path is required with conflicting import identity",
+                        header_source,
+                        required.logical_name));
+                }
+
+                plan.resolved_header_unit_dependencies.push_back(ResolvedHeaderUnitDependency{
                     .consumer_source = units[consumer_index].source,
-                    .requirement = required,
-                    .kind = UnresolvedRequirementKind::header_unit,
+                    .provider_source = header_source,
+                    .header_name = required.logical_name,
+                    .lookup_method = required.lookup_method,
                 });
+
+                auto dependency = graph.add_dependency(consumer_key, header_key);
+                if (!dependency) {
+                    ModuleGraphError error = graph_failure(
+                        ModuleGraphErrorCode::dependency_cycle,
+                        "failed to add header-unit dependency edge",
+                        units[consumer_index].source,
+                        required.logical_name);
+                    error.graph_error = dependency.error();
+                    return std::unexpected(std::move(error));
+                }
                 continue;
             }
 
@@ -151,11 +209,7 @@ ModuleDependencyGraphBuilder::build(const std::vector<ScannedModuleUnit>& units)
                 continue;
             }
 
-            if (provider->second == consumer_index) {
-                // A source may mention its own module identity in scan metadata.
-                // It does not create a useful build-order edge or /reference.
-                continue;
-            }
+            if (provider->second == consumer_index) continue;
 
             plan.resolved_dependencies.push_back(ResolvedModuleDependency{
                 .consumer_source = units[consumer_index].source,
@@ -192,10 +246,8 @@ ModuleDependencyGraphBuilder::build(const std::vector<ScannedModuleUnit>& units)
         auto& output_level = plan.compile_levels.emplace_back();
         output_level.reserve(level.size());
         for (const auto& key : level) {
-            const auto unit = unit_by_key.find(key);
-            if (unit != unit_by_key.end()) {
-                output_level.push_back(units[unit->second].source);
-            }
+            const auto source = source_by_key.find(key);
+            if (source != source_by_key.end()) output_level.push_back(source->second);
         }
     }
 

--- a/cpp/modules/tests/module_dependency_graph_tests.cpp
+++ b/cpp/modules/tests/module_dependency_graph_tests.cpp
@@ -8,7 +8,6 @@
 namespace {
 
 namespace fs = std::filesystem;
-
 int failures = 0;
 
 void expect(const bool condition, const std::string_view message) {
@@ -30,6 +29,18 @@ void expect(const bool condition, const std::string_view message) {
 [[nodiscard]] mqb::modules::RequiredModule require_named(std::string name) {
     return mqb::modules::RequiredModule{
         .logical_name = std::move(name),
+    };
+}
+
+[[nodiscard]] mqb::modules::RequiredModule require_header(
+    std::string name,
+    fs::path source,
+    const mqb::modules::LookupMethod lookup = mqb::modules::LookupMethod::include_quote) {
+    return mqb::modules::RequiredModule{
+        .logical_name = std::move(name),
+        .source_path = std::move(source),
+        .unique_on_source_path = true,
+        .lookup_method = lookup,
     };
 }
 
@@ -78,6 +89,8 @@ int main() {
                        && plan->unresolved_requirements[0].requirement.logical_name == "std"
                        && plan->unresolved_requirements[0].kind == UnresolvedRequirementKind::named_module,
                    "external named modules should remain typed unresolved requirements");
+            expect(plan->header_units.empty(),
+                   "named-only plans should not manufacture header-unit producers");
         }
     }
 
@@ -94,8 +107,7 @@ int main() {
         if (plan && plan->compile_levels.size() == 3) {
             expect(plan->compile_levels[0] == std::vector<fs::path>{"A.ixx"},
                    "diamond root should be first level");
-            expect(plan->compile_levels[1]
-                       == std::vector<fs::path>({"B.ixx", "C.ixx"}),
+            expect(plan->compile_levels[1] == std::vector<fs::path>({"B.ixx", "C.ixx"}),
                    "independent consumers should share one deterministic compile level");
             expect(plan->compile_levels[2] == std::vector<fs::path>{"D.cpp"},
                    "diamond sink should compile last");
@@ -118,8 +130,7 @@ int main() {
             if (plan->compile_levels.size() == 2) {
                 expect(plan->compile_levels[0] == std::vector<fs::path>{"M.ixx"},
                        "interface unit should be selected as import provider");
-                expect(plan->compile_levels[1]
-                           == std::vector<fs::path>({"M_impl.cpp", "consumer.cpp"}),
+                expect(plan->compile_levels[1] == std::vector<fs::path>({"M_impl.cpp", "consumer.cpp"}),
                        "implementation and ordinary consumer may follow the interface together");
             }
         }
@@ -136,22 +147,86 @@ int main() {
     }
 
     {
-        mqb::modules::RequiredModule header;
-        header.logical_name = "header.hpp";
-        header.source_path = fs::path{"include/header.hpp"};
-        header.unique_on_source_path = true;
-        header.lookup_method = LookupMethod::include_quote;
+        const auto header = require_header("header.hpp", "include/header.hpp");
+        const std::vector units{unit("consumer.cpp", {}, {header})};
+        auto plan = ModuleDependencyGraphBuilder::build(units);
+        expect(plan.has_value(), "source-addressable header unit should become a resolved graph node");
+        if (plan) {
+            expect(plan->unresolved_requirements.empty(),
+                   "project-local source-addressable header unit should no longer remain unresolved");
+            expect(plan->header_units.size() == 1
+                       && plan->header_units[0].source == fs::path{"include/header.hpp"}
+                       && plan->header_units[0].header_name == "header.hpp"
+                       && plan->header_units[0].lookup_method == LookupMethod::include_quote,
+                   "header-unit producer plan should preserve source, spelling, and lookup method");
+            expect(plan->resolved_header_unit_dependencies.size() == 1
+                       && plan->resolved_header_unit_dependencies[0].consumer_source == fs::path{"consumer.cpp"}
+                       && plan->resolved_header_unit_dependencies[0].provider_source == fs::path{"include/header.hpp"},
+                   "consumer should retain the exact resolved header-unit provider edge");
+            expect(plan->compile_levels.size() == 2
+                       && plan->compile_levels[0] == std::vector<fs::path>{"include/header.hpp"}
+                       && plan->compile_levels[1] == std::vector<fs::path>{"consumer.cpp"},
+                   "header-unit producer should precede its consumer in compile levels");
+        }
+    }
 
+    {
+        const auto header = require_header("shared.hpp", "include/shared.hpp");
         const std::vector units{
-            unit("consumer.cpp", {}, {header}),
+            unit("a.cpp", {}, {header}),
+            unit("b.cpp", {}, {header}),
         };
         auto plan = ModuleDependencyGraphBuilder::build(units);
-        expect(plan.has_value(), "header-unit requirements should not corrupt named-module graphing");
+        expect(plan.has_value(), "one header source shared by multiple consumers should deduplicate its producer");
         if (plan) {
+            expect(plan->header_units.size() == 1,
+                   "shared header source should produce exactly one planned header unit");
+            expect(plan->resolved_header_unit_dependencies.size() == 2,
+                   "shared header source should preserve one edge per consumer");
+            expect(plan->compile_levels.size() == 2
+                       && plan->compile_levels[0] == std::vector<fs::path>{"include/shared.hpp"}
+                       && plan->compile_levels[1] == std::vector<fs::path>({"a.cpp", "b.cpp"}),
+                   "shared header producer should compile once before both consumers");
+        }
+    }
+
+    {
+        mqb::modules::RequiredModule header;
+        header.logical_name = "header.hpp";
+        header.lookup_method = LookupMethod::include_quote;
+        const std::vector units{unit("consumer.cpp", {}, {header})};
+        auto plan = ModuleDependencyGraphBuilder::build(units);
+        expect(plan.has_value(), "unlocatable header unit should remain a typed unresolved requirement");
+        if (plan) {
+            expect(plan->header_units.empty(),
+                   "header unit without source-path must not fabricate a producer");
             expect(plan->unresolved_requirements.size() == 1
                        && plan->unresolved_requirements[0].kind == UnresolvedRequirementKind::header_unit,
-                   "header units should remain explicitly unresolved until that milestone exists");
+                   "unlocatable header unit should remain explicitly unresolved");
         }
+    }
+
+    {
+        const auto quoted = require_header("util.hpp", "include/util.hpp", LookupMethod::include_quote);
+        const auto angled = require_header("util.hpp", "include/util.hpp", LookupMethod::include_angle);
+        const std::vector units{
+            unit("a.cpp", {}, {quoted}),
+            unit("b.cpp", {}, {angled}),
+        };
+        auto conflict = ModuleDependencyGraphBuilder::build(units);
+        expect(!conflict && conflict.error().code == ModuleGraphErrorCode::conflicting_header_unit_identity,
+               "one physical header required with conflicting quote/angle identity should fail explicitly");
+    }
+
+    {
+        const auto header = require_header("header.hpp", "include/header.hpp");
+        const std::vector units{
+            unit("include/header.hpp"),
+            unit("consumer.cpp", {}, {header}),
+        };
+        auto conflict = ModuleDependencyGraphBuilder::build(units);
+        expect(!conflict && conflict.error().code == ModuleGraphErrorCode::header_unit_source_conflict,
+               "header-unit provider path colliding with a scanned TU should fail explicitly");
     }
 
     {
@@ -160,8 +235,7 @@ int main() {
             unit("second.ixx", {provide("M", true)}),
         };
         auto duplicate = ModuleDependencyGraphBuilder::build(units);
-        expect(!duplicate
-                   && duplicate.error().code == ModuleGraphErrorCode::duplicate_interface_provider,
+        expect(!duplicate && duplicate.error().code == ModuleGraphErrorCode::duplicate_interface_provider,
                "multiple interface providers for one logical module should fail explicitly");
     }
 
@@ -171,8 +245,7 @@ int main() {
             unit("two.cpp", {provide("M", false)}),
         };
         auto ambiguous = ModuleDependencyGraphBuilder::build(units);
-        expect(!ambiguous
-                   && ambiguous.error().code == ModuleGraphErrorCode::ambiguous_named_provider,
+        expect(!ambiguous && ambiguous.error().code == ModuleGraphErrorCode::ambiguous_named_provider,
                "multiple non-interface providers without an interface should be ambiguous");
     }
 
@@ -194,16 +267,11 @@ int main() {
         auto cycle = ModuleDependencyGraphBuilder::build(units);
         expect(!cycle && cycle.error().code == ModuleGraphErrorCode::dependency_cycle,
                "module import cycles should surface as dependency-cycle errors");
-        if (!cycle) {
-            expect(cycle.error().graph_error.has_value(),
-                   "cycle error should retain the underlying graph diagnostic");
-        }
+        if (!cycle) expect(cycle.error().graph_error.has_value(), "cycle error should retain graph diagnostic");
     }
 
     {
-        const std::vector units{
-            unit({}, {provide("A")}),
-        };
+        const std::vector units{unit({}, {provide("A")})};
         auto empty = ModuleDependencyGraphBuilder::build(units);
         expect(!empty && empty.error().code == ModuleGraphErrorCode::empty_source,
                "empty scanned source identity should fail closed");

--- a/cpp/orchestration/src/MsvcModuleCompileCoordinator.cpp
+++ b/cpp/orchestration/src/MsvcModuleCompileCoordinator.cpp
@@ -137,6 +137,18 @@ MsvcModuleCompileCoordinator::run(const ModuleCompileWaveRequest& request) const
             {},
             unresolved.requirement.logical_name));
     }
+    if (!request.plan.header_units.empty()) {
+        const auto& header = request.plan.header_units.front();
+        const fs::path consumer = request.plan.resolved_header_unit_dependencies.empty()
+            ? fs::path{}
+            : request.plan.resolved_header_unit_dependencies.front().consumer_source;
+        return std::unexpected(failure(
+            ModuleCompileErrorCode::unresolved_requirement,
+            "module dependency plan resolved a project-local header unit, but header-unit wave execution is not wired yet",
+            consumer,
+            header.source,
+            header.header_name));
+    }
 
     std::unordered_map<std::string, std::size_t> source_by_key;
     source_by_key.reserve(request.sources.size());
@@ -293,9 +305,7 @@ MsvcModuleCompileCoordinator::run(const ModuleCompileWaveRequest& request) const
         }
 
         for (const auto source_index : level) {
-            if (!attempts[source_index]) {
-                continue;
-            }
+            if (!attempts[source_index]) continue;
             if (!attempts[source_index]->has_value()) {
                 ModuleCompileError error = failure(
                     ModuleCompileErrorCode::compile_failed,


### PR DESCRIPTION
Builds the third Header Units slice under #16 on top of #20.

## Scope

- promote P1689 header-unit requirements with a usable `source-path` into first-class dependency-graph nodes instead of leaving every header unit unresolved
- add unique `PlannedHeaderUnit` producer records carrying physical source path, header import spelling, and P1689 quote/angle lookup method
- add exact consumer -> header-unit provider edges in `resolved_header_unit_dependencies`
- include header-unit producer paths in deterministic compile levels so ordering is explicit before execution is wired
- deduplicate one physical header source shared by multiple consumers
- fail explicitly if the same physical header is required with conflicting import identity (for example quote vs angle) rather than silently selecting one
- fail explicitly if a planned header-unit source collides with an already scanned translation unit
- keep header-unit requirements without a usable source path typed/unresolved and fail-closed

## Transition guard

`MsvcModuleCompileCoordinator` recognizes that a plan contains resolved header-unit producers and returns an explicit `unresolved_requirement` diagnostic stating that header-unit wave execution is not wired yet. This keeps the intermediate checkpoint fail-closed without degrading into a misleading `plan_source_missing` error.

## Verification

C++ V2 workflow #207 completed successfully on exact head `74493dd396df97b96147918c9c41f2ac75d9f2ab`: Configure, Build, and CTest all passed.

Module-graph regressions cover:

- one project-local quote header unit -> provider level then consumer level
- one header producer shared/deduplicated across multiple consumers
- missing source-path remains typed unresolved
- conflicting quote/angle identity on one physical source fails explicitly
- collision between header-unit source and scanned TU fails explicitly
- named-module behavior remains unchanged

## Deliberate boundary

This PR resolves topology only. It does not yet assign `.mqb` IFC/deps/cache artifacts to the dynamic header nodes or execute them inside `MsvcModuleCompileCoordinator`; #19 and #20 provide the backend and incremental producer primitives that the next slice will consume.

Advances #16; does not close it.