### PR TITLE
feat: execute header units in module compile waves

### DIFF
--- a/cpp/orchestration/include/mqb/orchestration/MsvcModuleCompileCoordinator.hpp
+++ b/cpp/orchestration/include/mqb/orchestration/MsvcModuleCompileCoordinator.hpp
@@ -21,8 +21,16 @@ struct ModuleCompileSourceRequest {
     TranslationUnitKind kind{TranslationUnitKind::source};
 };
 
+struct ModuleCompileHeaderUnitRequest {
+    std::filesystem::path source;
+    std::string header_name;
+    HeaderUnitLookupMethod lookup_method{HeaderUnitLookupMethod::quote};
+    SourceArtifacts artifacts;
+};
+
 struct ModuleCompileWaveRequest {
     std::vector<ModuleCompileSourceRequest> sources;
+    std::vector<ModuleCompileHeaderUnitRequest> header_units;
     modules::ModuleDependencyPlan plan;
     CompilerOptions compiler_options;
     std::filesystem::path working_directory;
@@ -31,6 +39,13 @@ struct ModuleCompileWaveRequest {
 
 struct ModuleCompileResult {
     std::filesystem::path source;
+    IncrementalCompileResult result;
+};
+
+struct HeaderUnitCompileResult {
+    std::filesystem::path source;
+    std::string header_name;
+    HeaderUnitLookupMethod lookup_method{HeaderUnitLookupMethod::quote};
     IncrementalCompileResult result;
 };
 
@@ -46,6 +61,7 @@ enum class ModuleCompileErrorCode {
     unresolved_requirement,
     invalid_provider,
     duplicate_reference,
+    invalid_header_unit,
     scheduling_failed,
     compile_failed,
 };
@@ -61,9 +77,11 @@ struct ModuleCompileError {
 };
 
 struct ModuleCompileWaveResult {
-    // Results are returned in request.sources order, independent of graph level
-    // order and worker completion order.
+    // Ordinary/module-TU results preserve request.sources order. Header-unit
+    // results preserve request.header_units order; graph level and worker
+    // completion order never leak into public result ordering.
     std::vector<ModuleCompileResult> compiles;
+    std::vector<HeaderUnitCompileResult> header_unit_compiles;
     bool any_compiled{false};
 };
 

--- a/cpp/orchestration/src/MsvcModuleCompileCoordinator.cpp
+++ b/cpp/orchestration/src/MsvcModuleCompileCoordinator.cpp
@@ -23,9 +23,7 @@ namespace fs = std::filesystem;
 [[nodiscard]] std::string windows_path_key(const fs::path& path) {
     std::string value = path.lexically_normal().generic_string();
     std::transform(
-        value.begin(),
-        value.end(),
-        value.begin(),
+        value.begin(), value.end(), value.begin(),
         [](const unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
     return value;
 }
@@ -81,16 +79,31 @@ namespace fs = std::filesystem;
     return std::nullopt;
 }
 
+[[nodiscard]] std::optional<HeaderUnitLookupMethod> core_lookup_method(
+    const modules::LookupMethod lookup_method) {
+    switch (lookup_method) {
+    case modules::LookupMethod::include_angle:
+        return HeaderUnitLookupMethod::angle;
+    case modules::LookupMethod::include_quote:
+        return HeaderUnitLookupMethod::quote;
+    case modules::LookupMethod::by_name:
+        return std::nullopt;
+    }
+    return std::nullopt;
+}
+
 [[nodiscard]] IncrementalCompileRequest compile_request_for(
     const ModuleCompileSourceRequest& source,
     const CompilerOptions& options,
-    const std::vector<ModuleReference>& references,
+    const std::vector<ModuleReference>& module_references,
+    const std::vector<HeaderUnitReference>& header_unit_references,
     const bool force_rebuild,
     const fs::path& working_directory) {
     TranslationUnit unit;
     unit.source = source.source;
     unit.kind = source.kind;
-    unit.module_references = references;
+    unit.module_references = module_references;
+    unit.header_unit_references = header_unit_references;
     unit.outputs.push_back(Artifact{
         .path = source.artifacts.object,
         .kind = ArtifactKind::object,
@@ -114,14 +127,43 @@ namespace fs = std::filesystem;
     };
 }
 
+[[nodiscard]] IncrementalCompileRequest header_compile_request_for(
+    const ModuleCompileHeaderUnitRequest& header,
+    const CompilerOptions& options,
+    const bool force_rebuild,
+    const fs::path& working_directory) {
+    TranslationUnit unit;
+    unit.source = header.source;
+    unit.kind = TranslationUnitKind::source;
+    unit.header_unit = HeaderUnitIdentity{
+        .header_name = header.header_name,
+        .lookup_method = header.lookup_method,
+    };
+    unit.outputs.push_back(Artifact{
+        .path = header.artifacts.module_interface,
+        .kind = ArtifactKind::module_interface,
+    });
+
+    return IncrementalCompileRequest{
+        .unit = std::move(unit),
+        .options = options,
+        .cache_file = header.artifacts.compile_cache,
+        .source_dependencies_file = header.artifacts.dependencies,
+        .working_directory = working_directory.empty()
+            ? std::optional<fs::path>{header.source.parent_path()}
+            : std::optional<fs::path>{working_directory},
+        .force_rebuild = force_rebuild,
+    };
+}
+
 } // namespace
 
 std::expected<ModuleCompileWaveResult, ModuleCompileError>
 MsvcModuleCompileCoordinator::run(const ModuleCompileWaveRequest& request) const {
-    if (request.sources.empty()) {
+    if (request.sources.empty() && request.header_units.empty()) {
         return std::unexpected(failure(
             ModuleCompileErrorCode::no_sources,
-            "module compile wave requires at least one source"));
+            "module compile wave requires at least one source or header-unit producer"));
     }
     if (request.max_parallel_compiles == 0) {
         return std::unexpected(failure(
@@ -137,72 +179,119 @@ MsvcModuleCompileCoordinator::run(const ModuleCompileWaveRequest& request) const
             {},
             unresolved.requirement.logical_name));
     }
-    if (!request.plan.header_units.empty()) {
-        const auto& header = request.plan.header_units.front();
-        const fs::path consumer = request.plan.resolved_header_unit_dependencies.empty()
-            ? fs::path{}
-            : request.plan.resolved_header_unit_dependencies.front().consumer_source;
-        return std::unexpected(failure(
-            ModuleCompileErrorCode::unresolved_requirement,
-            "module dependency plan resolved a project-local header unit, but header-unit wave execution is not wired yet",
-            consumer,
-            header.source,
-            header.header_name));
-    }
 
+    const std::size_t source_count = request.sources.size();
+    const std::size_t header_count = request.header_units.size();
+    const std::size_t node_count = source_count + header_count;
+
+    std::unordered_map<std::string, std::size_t> node_by_key;
+    node_by_key.reserve(node_count);
     std::unordered_map<std::string, std::size_t> source_by_key;
-    source_by_key.reserve(request.sources.size());
+    source_by_key.reserve(source_count);
+    std::unordered_map<std::string, std::size_t> header_by_key;
+    header_by_key.reserve(header_count);
     std::unordered_set<std::string> claimed_artifacts;
-    claimed_artifacts.reserve(request.sources.size() * 4u);
+    claimed_artifacts.reserve(source_count * 4u + header_count * 3u);
 
-    for (std::size_t index = 0; index < request.sources.size(); ++index) {
+    for (std::size_t index = 0; index < source_count; ++index) {
         const auto& source = request.sources[index];
         const std::string key = windows_path_key(source.source);
-        if (!source_by_key.emplace(key, index).second) {
+        if (!node_by_key.emplace(key, index).second) {
             return std::unexpected(failure(
                 ModuleCompileErrorCode::duplicate_source,
                 "module compile request contains the same source more than once",
                 source.source));
         }
+        source_by_key.emplace(key, index);
 
-        if (auto error = claim_artifact(
-                claimed_artifacts, source.source, source.artifacts.object, "object")) {
+        if (auto error = claim_artifact(claimed_artifacts, source.source, source.artifacts.object, "object")) {
             return std::unexpected(std::move(*error));
         }
         if (auto error = claim_artifact(
-                claimed_artifacts,
-                source.source,
-                source.artifacts.dependencies,
-                "source-dependency metadata")) {
+                claimed_artifacts, source.source, source.artifacts.dependencies, "source-dependency metadata")) {
             return std::unexpected(std::move(*error));
         }
         if (auto error = claim_artifact(
-                claimed_artifacts,
-                source.source,
-                source.artifacts.compile_cache,
-                "compile-cache metadata")) {
+                claimed_artifacts, source.source, source.artifacts.compile_cache, "compile-cache metadata")) {
             return std::unexpected(std::move(*error));
         }
         if (source.kind == TranslationUnitKind::module_interface) {
             if (auto error = claim_artifact(
-                    claimed_artifacts,
-                    source.source,
-                    source.artifacts.module_interface,
-                    "IFC")) {
+                    claimed_artifacts, source.source, source.artifacts.module_interface, "IFC")) {
                 return std::unexpected(std::move(*error));
             }
         }
     }
 
-    std::vector<std::size_t> plan_occurrences(request.sources.size(), 0);
+    for (std::size_t index = 0; index < header_count; ++index) {
+        const auto& header = request.header_units[index];
+        const std::size_t node_index = source_count + index;
+        const std::string key = windows_path_key(header.source);
+        if (!node_by_key.emplace(key, node_index).second) {
+            return std::unexpected(failure(
+                ModuleCompileErrorCode::duplicate_source,
+                "header-unit producer source collides with another compile source",
+                header.source));
+        }
+        header_by_key.emplace(key, index);
+        if (header.header_name.empty()) {
+            return std::unexpected(failure(
+                ModuleCompileErrorCode::invalid_header_unit,
+                "header-unit producer name is empty",
+                header.source));
+        }
+        if (auto error = claim_artifact(
+                claimed_artifacts, header.source, header.artifacts.dependencies, "header-unit source-dependency metadata")) {
+            return std::unexpected(std::move(*error));
+        }
+        if (auto error = claim_artifact(
+                claimed_artifacts, header.source, header.artifacts.compile_cache, "header-unit compile-cache metadata")) {
+            return std::unexpected(std::move(*error));
+        }
+        if (auto error = claim_artifact(
+                claimed_artifacts, header.source, header.artifacts.module_interface, "header-unit IFC")) {
+            return std::unexpected(std::move(*error));
+        }
+    }
+
+    std::unordered_map<std::string, const modules::PlannedHeaderUnit*> planned_header_by_key;
+    planned_header_by_key.reserve(request.plan.header_units.size());
+    for (const auto& planned : request.plan.header_units) {
+        planned_header_by_key.emplace(windows_path_key(planned.source), &planned);
+    }
+    if (planned_header_by_key.size() != request.header_units.size()) {
+        return std::unexpected(failure(
+            ModuleCompileErrorCode::invalid_header_unit,
+            "header-unit compile request does not match dependency-plan producer count"));
+    }
+    for (const auto& header : request.header_units) {
+        const auto planned = planned_header_by_key.find(windows_path_key(header.source));
+        if (planned == planned_header_by_key.end()) {
+            return std::unexpected(failure(
+                ModuleCompileErrorCode::invalid_header_unit,
+                "header-unit compile request contains a provider absent from dependency plan",
+                header.source));
+        }
+        const auto lookup = core_lookup_method(planned->second->lookup_method);
+        if (!lookup || planned->second->header_name != header.header_name || *lookup != header.lookup_method) {
+            return std::unexpected(failure(
+                ModuleCompileErrorCode::invalid_header_unit,
+                "header-unit compile request identity does not match dependency plan",
+                header.source,
+                {},
+                header.header_name));
+        }
+    }
+
+    std::vector<std::size_t> plan_occurrences(node_count, 0);
     std::vector<std::vector<std::size_t>> level_indices;
     level_indices.reserve(request.plan.compile_levels.size());
     for (const auto& level : request.plan.compile_levels) {
         auto& indices = level_indices.emplace_back();
         indices.reserve(level.size());
         for (const auto& source : level) {
-            const auto found = source_by_key.find(windows_path_key(source));
-            if (found == source_by_key.end()) {
+            const auto found = node_by_key.find(windows_path_key(source));
+            if (found == node_by_key.end()) {
                 return std::unexpected(failure(
                     ModuleCompileErrorCode::plan_source_missing,
                     "module dependency plan references a source absent from the compile request",
@@ -219,15 +308,20 @@ MsvcModuleCompileCoordinator::run(const ModuleCompileWaveRequest& request) const
     }
     for (std::size_t index = 0; index < plan_occurrences.size(); ++index) {
         if (plan_occurrences[index] == 0) {
+            const fs::path source = index < source_count
+                ? request.sources[index].source
+                : request.header_units[index - source_count].source;
             return std::unexpected(failure(
                 ModuleCompileErrorCode::plan_source_unlisted,
                 "module compile source is missing from dependency-plan compile levels",
-                request.sources[index].source));
+                source));
         }
     }
 
-    std::vector<std::vector<ModuleReference>> references(request.sources.size());
-    std::vector<std::vector<std::size_t>> provider_indices(request.sources.size());
+    std::vector<std::vector<ModuleReference>> module_references(node_count);
+    std::vector<std::vector<HeaderUnitReference>> header_references(node_count);
+    std::vector<std::vector<std::size_t>> provider_indices(node_count);
+
     for (const auto& dependency : request.plan.resolved_dependencies) {
         const auto consumer = source_by_key.find(windows_path_key(dependency.consumer_source));
         const auto provider = source_by_key.find(windows_path_key(dependency.provider_source));
@@ -251,14 +345,13 @@ MsvcModuleCompileCoordinator::run(const ModuleCompileWaveRequest& request) const
                 dependency.logical_name));
         }
 
-        auto& consumer_references = references[consumer->second];
+        auto& references = module_references[consumer->second];
         const auto duplicate = std::find_if(
-            consumer_references.begin(),
-            consumer_references.end(),
+            references.begin(), references.end(),
             [&dependency](const ModuleReference& reference) {
                 return reference.logical_name == dependency.logical_name;
             });
-        if (duplicate != consumer_references.end()) {
+        if (duplicate != references.end()) {
             return std::unexpected(failure(
                 ModuleCompileErrorCode::duplicate_reference,
                 "module dependency plan resolves the same logical name more than once for one consumer",
@@ -266,37 +359,95 @@ MsvcModuleCompileCoordinator::run(const ModuleCompileWaveRequest& request) const
                 dependency.provider_source,
                 dependency.logical_name));
         }
-
-        consumer_references.push_back(ModuleReference{
+        references.push_back(ModuleReference{
             .logical_name = dependency.logical_name,
             .interface_file = provider_request.artifacts.module_interface,
         });
         provider_indices[consumer->second].push_back(provider->second);
     }
 
+    for (const auto& dependency : request.plan.resolved_header_unit_dependencies) {
+        const auto consumer = source_by_key.find(windows_path_key(dependency.consumer_source));
+        const auto provider = header_by_key.find(windows_path_key(dependency.provider_source));
+        if (consumer == source_by_key.end() || provider == header_by_key.end()) {
+            return std::unexpected(failure(
+                ModuleCompileErrorCode::plan_source_missing,
+                "resolved header-unit dependency references a source absent from the compile request",
+                dependency.consumer_source,
+                dependency.provider_source,
+                dependency.header_name));
+        }
+        const auto lookup = core_lookup_method(dependency.lookup_method);
+        if (!lookup) {
+            return std::unexpected(failure(
+                ModuleCompileErrorCode::invalid_header_unit,
+                "resolved header-unit dependency has a non-header lookup method",
+                dependency.consumer_source,
+                dependency.provider_source,
+                dependency.header_name));
+        }
+        const auto& provider_request = request.header_units[provider->second];
+        if (provider_request.artifacts.module_interface.empty()) {
+            return std::unexpected(failure(
+                ModuleCompileErrorCode::invalid_provider,
+                "resolved header-unit provider cannot produce an IFC artifact",
+                dependency.consumer_source,
+                dependency.provider_source,
+                dependency.header_name));
+        }
+
+        auto& references = header_references[consumer->second];
+        const auto duplicate = std::find_if(
+            references.begin(), references.end(),
+            [&](const HeaderUnitReference& reference) {
+                return reference.header_name == dependency.header_name
+                    && reference.lookup_method == *lookup;
+            });
+        if (duplicate != references.end()) {
+            return std::unexpected(failure(
+                ModuleCompileErrorCode::duplicate_reference,
+                "module dependency plan resolves the same header-unit identity more than once for one consumer",
+                dependency.consumer_source,
+                dependency.provider_source,
+                dependency.header_name));
+        }
+        references.push_back(HeaderUnitReference{
+            .header_name = dependency.header_name,
+            .lookup_method = *lookup,
+            .interface_file = provider_request.artifacts.module_interface,
+        });
+        provider_indices[consumer->second].push_back(source_count + provider->second);
+    }
+
     using CompileAttempt = std::expected<IncrementalCompileResult, IncrementalCompileError>;
-    std::vector<std::optional<CompileAttempt>> attempts(request.sources.size());
-    std::vector<bool> compiled_this_run(request.sources.size(), false);
+    std::vector<std::optional<CompileAttempt>> attempts(node_count);
+    std::vector<bool> compiled_this_run(node_count, false);
 
     for (const auto& level : level_indices) {
         const auto scheduled = BoundedWorkScheduler::run(
-            level.size(),
-            request.max_parallel_compiles,
+            level.size(), request.max_parallel_compiles,
             [&](const std::size_t level_index) {
-                const std::size_t source_index = level[level_index];
+                const std::size_t node_index = level[level_index];
                 bool force_rebuild = false;
-                for (const auto provider_index : provider_indices[source_index]) {
+                for (const auto provider_index : provider_indices[node_index]) {
                     force_rebuild = force_rebuild || compiled_this_run[provider_index];
                 }
 
-                auto compile_request = compile_request_for(
-                    request.sources[source_index],
-                    request.compiler_options,
-                    references[source_index],
-                    force_rebuild,
-                    request.working_directory);
-                attempts[source_index].emplace(compile_coordinator_.run(compile_request));
-                return attempts[source_index]->has_value();
+                IncrementalCompileRequest compile_request = node_index < source_count
+                    ? compile_request_for(
+                        request.sources[node_index],
+                        request.compiler_options,
+                        module_references[node_index],
+                        header_references[node_index],
+                        force_rebuild,
+                        request.working_directory)
+                    : header_compile_request_for(
+                        request.header_units[node_index - source_count],
+                        request.compiler_options,
+                        force_rebuild,
+                        request.working_directory);
+                attempts[node_index].emplace(compile_coordinator_.run(compile_request));
+                return attempts[node_index]->has_value();
             });
         if (!scheduled) {
             return std::unexpected(failure(
@@ -304,32 +455,40 @@ MsvcModuleCompileCoordinator::run(const ModuleCompileWaveRequest& request) const
                 "module compile scheduler failed: " + scheduled.error().message));
         }
 
-        for (const auto source_index : level) {
-            if (!attempts[source_index]) continue;
-            if (!attempts[source_index]->has_value()) {
+        for (const auto node_index : level) {
+            if (!attempts[node_index]) continue;
+            if (!attempts[node_index]->has_value()) {
+                const fs::path source = node_index < source_count
+                    ? request.sources[node_index].source
+                    : request.header_units[node_index - source_count].source;
                 ModuleCompileError error = failure(
                     ModuleCompileErrorCode::compile_failed,
-                    "module translation unit compilation failed",
-                    request.sources[source_index].source);
-                error.compile_error = attempts[source_index]->error();
+                    node_index < source_count
+                        ? "module translation unit compilation failed"
+                        : "header-unit producer compilation failed",
+                    source);
+                error.compile_error = attempts[node_index]->error();
                 return std::unexpected(std::move(error));
             }
         }
 
-        for (const auto source_index : level) {
-            if (!attempts[source_index]) {
+        for (const auto node_index : level) {
+            if (!attempts[node_index]) {
+                const fs::path source = node_index < source_count
+                    ? request.sources[node_index].source
+                    : request.header_units[node_index - source_count].source;
                 return std::unexpected(failure(
                     ModuleCompileErrorCode::scheduling_failed,
                     "module scheduler stopped without a recorded compile failure",
-                    request.sources[source_index].source));
+                    source));
             }
-            compiled_this_run[source_index] = attempts[source_index]->value().compiled;
+            compiled_this_run[node_index] = attempts[node_index]->value().compiled;
         }
     }
 
     ModuleCompileWaveResult result;
-    result.compiles.reserve(request.sources.size());
-    for (std::size_t index = 0; index < request.sources.size(); ++index) {
+    result.compiles.reserve(source_count);
+    for (std::size_t index = 0; index < source_count; ++index) {
         if (!attempts[index] || !attempts[index]->has_value()) {
             return std::unexpected(failure(
                 ModuleCompileErrorCode::scheduling_failed,
@@ -340,6 +499,25 @@ MsvcModuleCompileCoordinator::run(const ModuleCompileWaveRequest& request) const
         result.any_compiled = result.any_compiled || compiled.compiled;
         result.compiles.push_back(ModuleCompileResult{
             .source = request.sources[index].source,
+            .result = std::move(compiled),
+        });
+    }
+
+    result.header_unit_compiles.reserve(header_count);
+    for (std::size_t index = 0; index < header_count; ++index) {
+        const std::size_t node_index = source_count + index;
+        if (!attempts[node_index] || !attempts[node_index]->has_value()) {
+            return std::unexpected(failure(
+                ModuleCompileErrorCode::scheduling_failed,
+                "header-unit compile result is missing after all dependency levels completed",
+                request.header_units[index].source));
+        }
+        auto compiled = std::move(attempts[node_index]->value());
+        result.any_compiled = result.any_compiled || compiled.compiled;
+        result.header_unit_compiles.push_back(HeaderUnitCompileResult{
+            .source = request.header_units[index].source,
+            .header_name = request.header_units[index].header_name,
+            .lookup_method = request.header_units[index].lookup_method,
             .result = std::move(compiled),
         });
     }

--- a/cpp/orchestration/tests/CMakeLists.txt
+++ b/cpp/orchestration/tests/CMakeLists.txt
@@ -1,78 +1,34 @@
 add_executable(mqb_orchestration_incremental_tests
     incremental_compile_coordinator_tests.cpp
 )
-
-target_link_libraries(mqb_orchestration_incremental_tests
-    PRIVATE
-        mqb_orchestration
-        mqb_msvc
-)
-
+target_link_libraries(mqb_orchestration_incremental_tests PRIVATE mqb_orchestration mqb_msvc)
 target_compile_features(mqb_orchestration_incremental_tests PRIVATE cxx_std_23)
 
-add_executable(mqb_orchestration_incremental_link_tests
-    incremental_link_coordinator_tests.cpp
-)
-
-target_link_libraries(mqb_orchestration_incremental_link_tests
-    PRIVATE
-        mqb_orchestration
-        mqb_msvc
-)
-
+add_executable(mqb_orchestration_incremental_link_tests incremental_link_coordinator_tests.cpp)
+target_link_libraries(mqb_orchestration_incremental_link_tests PRIVATE mqb_orchestration mqb_msvc)
 target_compile_features(mqb_orchestration_incremental_link_tests PRIVATE cxx_std_23)
 
-add_executable(mqb_bounded_work_scheduler_tests
-    bounded_work_scheduler_tests.cpp
-)
+add_executable(mqb_bounded_work_scheduler_tests bounded_work_scheduler_tests.cpp)
 target_link_libraries(mqb_bounded_work_scheduler_tests PRIVATE mqb_orchestration)
 target_compile_features(mqb_bounded_work_scheduler_tests PRIVATE cxx_std_23)
 
-add_executable(mqb_incremental_target_coordinator_tests
-    incremental_target_coordinator_tests.cpp
-)
-target_link_libraries(mqb_incremental_target_coordinator_tests
-    PRIVATE
-        mqb_orchestration
-        mqb_msvc
-)
+add_executable(mqb_incremental_target_coordinator_tests incremental_target_coordinator_tests.cpp)
+target_link_libraries(mqb_incremental_target_coordinator_tests PRIVATE mqb_orchestration mqb_msvc)
 target_compile_features(mqb_incremental_target_coordinator_tests PRIVATE cxx_std_23)
 
-add_executable(mqb_module_compile_coordinator_tests
-    module_compile_coordinator_tests.cpp
-)
-target_link_libraries(mqb_module_compile_coordinator_tests
-    PRIVATE
-        mqb_orchestration
-        mqb_modules
-        mqb_msvc
-)
+add_executable(mqb_module_compile_coordinator_tests module_compile_coordinator_tests.cpp)
+target_link_libraries(mqb_module_compile_coordinator_tests PRIVATE mqb_orchestration mqb_modules mqb_msvc)
 target_compile_features(mqb_module_compile_coordinator_tests PRIVATE cxx_std_23)
 
-add_executable(mqb_module_target_coordinator_tests
-    module_target_coordinator_tests.cpp
-)
-target_link_libraries(mqb_module_target_coordinator_tests
-    PRIVATE
-        mqb_orchestration
-        mqb_modules
-        mqb_msvc
-)
+add_executable(mqb_module_target_coordinator_tests module_target_coordinator_tests.cpp)
+target_link_libraries(mqb_module_target_coordinator_tests PRIVATE mqb_orchestration mqb_modules mqb_msvc)
 target_compile_features(mqb_module_target_coordinator_tests PRIVATE cxx_std_23)
 
-add_executable(mqb_module_target_validation_tests
-    module_target_validation_tests.cpp
-)
-target_link_libraries(mqb_module_target_validation_tests
-    PRIVATE
-        mqb_orchestration
-        mqb_msvc
-)
+add_executable(mqb_module_target_validation_tests module_target_validation_tests.cpp)
+target_link_libraries(mqb_module_target_validation_tests PRIVATE mqb_orchestration mqb_msvc)
 target_compile_features(mqb_module_target_validation_tests PRIVATE cxx_std_23)
 
-add_executable(mqb_target_router_tests
-    target_router_tests.cpp
-)
+add_executable(mqb_target_router_tests target_router_tests.cpp)
 target_link_libraries(mqb_target_router_tests PRIVATE mqb_orchestration)
 target_compile_features(mqb_target_router_tests PRIVATE cxx_std_23)
 
@@ -103,42 +59,31 @@ add_test(NAME mqb.orchestration.module_target_validation COMMAND mqb_module_targ
 add_test(NAME mqb.orchestration.target_router COMMAND mqb_target_router_tests)
 
 if(MQB_ENABLE_INSTALLED_MSVC_TESTS)
-    add_executable(mqb_module_target_integration_tests
-        module_target_integration_tests.cpp
-    )
-    target_link_libraries(mqb_module_target_integration_tests
-        PRIVATE
-            mqb_orchestration
-            mqb_msvc
-            mqb_platform_windows
-    )
+    add_executable(mqb_module_target_integration_tests module_target_integration_tests.cpp)
+    target_link_libraries(mqb_module_target_integration_tests PRIVATE mqb_orchestration mqb_msvc mqb_platform_windows)
     target_compile_features(mqb_module_target_integration_tests PRIVATE cxx_std_23)
 
-    add_executable(mqb_header_unit_incremental_integration_tests
-        header_unit_incremental_integration_tests.cpp
-    )
-    target_link_libraries(mqb_header_unit_incremental_integration_tests
-        PRIVATE
-            mqb_orchestration
-            mqb_msvc
-            mqb_platform_windows
-    )
+    add_executable(mqb_header_unit_incremental_integration_tests header_unit_incremental_integration_tests.cpp)
+    target_link_libraries(mqb_header_unit_incremental_integration_tests PRIVATE mqb_orchestration mqb_msvc mqb_platform_windows)
     target_compile_features(mqb_header_unit_incremental_integration_tests PRIVATE cxx_std_23)
 
-    if(MSVC)
-        target_compile_options(mqb_module_target_integration_tests PRIVATE /W4 /permissive-)
-        target_compile_options(mqb_header_unit_incremental_integration_tests PRIVATE /W4 /permissive-)
-    else()
-        target_compile_options(mqb_module_target_integration_tests PRIVATE -Wall -Wextra -Wpedantic)
-        target_compile_options(mqb_header_unit_incremental_integration_tests PRIVATE -Wall -Wextra -Wpedantic)
-    endif()
+    add_executable(mqb_header_unit_wave_integration_tests header_unit_wave_integration_tests.cpp)
+    target_link_libraries(mqb_header_unit_wave_integration_tests PRIVATE mqb_orchestration mqb_modules mqb_msvc mqb_platform_windows)
+    target_compile_features(mqb_header_unit_wave_integration_tests PRIVATE cxx_std_23)
 
-    add_test(
-        NAME mqb.orchestration.module_target_integration
-        COMMAND mqb_module_target_integration_tests
+    foreach(test_target IN ITEMS
+        mqb_module_target_integration_tests
+        mqb_header_unit_incremental_integration_tests
+        mqb_header_unit_wave_integration_tests
     )
-    add_test(
-        NAME mqb.orchestration.header_unit_incremental_integration
-        COMMAND mqb_header_unit_incremental_integration_tests
-    )
+        if(MSVC)
+            target_compile_options(${test_target} PRIVATE /W4 /permissive-)
+        else()
+            target_compile_options(${test_target} PRIVATE -Wall -Wextra -Wpedantic)
+        endif()
+    endforeach()
+
+    add_test(NAME mqb.orchestration.module_target_integration COMMAND mqb_module_target_integration_tests)
+    add_test(NAME mqb.orchestration.header_unit_incremental_integration COMMAND mqb_header_unit_incremental_integration_tests)
+    add_test(NAME mqb.orchestration.header_unit_wave_integration COMMAND mqb_header_unit_wave_integration_tests)
 endif()

--- a/cpp/orchestration/tests/header_unit_wave_integration_tests.cpp
+++ b/cpp/orchestration/tests/header_unit_wave_integration_tests.cpp
@@ -1,0 +1,217 @@
+#include <algorithm>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "mqb/core/ProjectArtifactLayout.hpp"
+#include "mqb/modules/ModuleDependencyGraph.hpp"
+#include "mqb/msvc/MsvcCompileExecutor.hpp"
+#include "mqb/msvc/MsvcToolchainLocator.hpp"
+#include "mqb/orchestration/MsvcIncrementalCompileCoordinator.hpp"
+#include "mqb/orchestration/MsvcModuleCompileCoordinator.hpp"
+#include "mqb/platform/windows/WindowsProcessRunner.hpp"
+
+namespace {
+namespace fs = std::filesystem;
+int failures = 0;
+
+void expect(bool condition, std::string_view message) {
+    if (!condition) { ++failures; std::cerr << "FAIL: " << message << '\n'; }
+}
+
+class TemporaryDirectory {
+public:
+    TemporaryDirectory() {
+        const auto tick = std::chrono::steady_clock::now().time_since_epoch().count();
+        path_ = fs::temp_directory_path() / ("mqb-header-unit-wave-" + std::to_string(tick));
+        fs::create_directories(path_);
+    }
+    ~TemporaryDirectory() {
+        std::error_code ignored;
+        fs::remove_all(path_, ignored);
+    }
+    [[nodiscard]] const fs::path& path() const noexcept { return path_; }
+private:
+    fs::path path_;
+};
+
+void write_text(const fs::path& path, std::string_view text) {
+    fs::create_directories(path.parent_path());
+    std::ofstream file{path, std::ios::binary | std::ios::trunc};
+    file.write(text.data(), static_cast<std::streamsize>(text.size()));
+}
+
+bool has_reason(const mqb::CompileCacheValidation& validation, mqb::BuildReason reason) {
+    return std::find(validation.reasons.begin(), validation.reasons.end(), reason)
+        != validation.reasons.end();
+}
+
+void print_error(const mqb::orchestration::ModuleCompileError& error) {
+    std::cerr << "module wave error: " << error.message << '\n';
+    if (!error.source.empty()) std::cerr << "  source=" << error.source.generic_string() << '\n';
+    if (!error.provider_source.empty()) std::cerr << "  provider=" << error.provider_source.generic_string() << '\n';
+    if (!error.logical_name.empty()) std::cerr << "  logical=" << error.logical_name << '\n';
+    if (error.compile_error) {
+        std::cerr << "  incremental=" << error.compile_error->message << '\n';
+        if (error.compile_error->compile_error) {
+            const auto& executor = *error.compile_error->compile_error;
+            std::cerr << "  executor=" << executor.message << '\n';
+            if (executor.compiler_error) {
+                const auto& compiler = *executor.compiler_error;
+                std::cerr << "  compiler=" << compiler.message << '\n';
+                if (compiler.process_result) {
+                    std::cerr << compiler.process_result->stdout_text
+                              << compiler.process_result->stderr_text;
+                }
+            }
+        }
+    }
+}
+
+} // namespace
+
+int main() {
+    mqb::platform::windows::WindowsProcessRunner runner;
+    mqb::msvc::MsvcToolchainLocator locator{runner};
+    mqb::msvc::DiscoveryOptions discovery;
+    discovery.preference = mqb::msvc::ToolchainPreference::visual_studio;
+    discovery.target_architecture = mqb::Architecture::x64;
+    discovery.host_architecture = mqb::Architecture::x64;
+    auto toolchain = locator.discover(discovery);
+    expect(toolchain.has_value(), "header-unit wave E2E requires installed Visual Studio");
+    if (!toolchain) return 1;
+
+    TemporaryDirectory fixture;
+    const fs::path include_dir = fixture.path() / "include";
+    const fs::path header = include_dir / "util.hpp";
+    const fs::path consumer = fixture.path() / "src" / "consumer.cpp";
+    write_text(header, "inline int header_answer() { return 42; }\n");
+    write_text(consumer,
+        "import \"util.hpp\";\n"
+        "int use_header_unit() { return header_answer(); }\n");
+
+    mqb::modules::RequiredModule required;
+    required.logical_name = "util.hpp";
+    required.source_path = header;
+    required.unique_on_source_path = true;
+    required.lookup_method = mqb::modules::LookupMethod::include_quote;
+    mqb::modules::P1689Rule rule;
+    rule.required_modules = {required};
+    const std::vector scanned{
+        mqb::modules::ScannedModuleUnit{.source = consumer, .rule = rule},
+    };
+    auto plan = mqb::modules::ModuleDependencyGraphBuilder::build(scanned);
+    expect(plan.has_value(), "P1689 header-unit requirement should build a resolved plan");
+    if (!plan) return 1;
+
+    auto layout = mqb::ProjectArtifactLayout::create(fixture.path());
+    expect(layout.has_value(), "fixture should create project artifact layout");
+    if (!layout) return 1;
+    auto consumer_artifacts = layout->for_source(consumer);
+    auto header_artifacts = layout->for_source(header);
+    expect(consumer_artifacts.has_value() && header_artifacts.has_value(),
+           "consumer and header unit should receive collision-free artifacts");
+    if (!consumer_artifacts || !header_artifacts) return 1;
+
+    mqb::CompilerOptions options;
+    options.standard = mqb::CppStandard::latest;
+    options.include_directories = {include_dir};
+
+    mqb::msvc::MsvcCompileExecutor executor{*toolchain, runner};
+    mqb::orchestration::MsvcIncrementalCompileCoordinator incremental{*toolchain, executor};
+    mqb::orchestration::MsvcModuleCompileCoordinator wave{incremental};
+
+    mqb::orchestration::ModuleCompileWaveRequest request;
+    request.sources = {
+        mqb::orchestration::ModuleCompileSourceRequest{
+            .source = consumer,
+            .artifacts = *consumer_artifacts,
+            .kind = mqb::TranslationUnitKind::source,
+        },
+    };
+    request.header_units = {
+        mqb::orchestration::ModuleCompileHeaderUnitRequest{
+            .source = header,
+            .header_name = "util.hpp",
+            .lookup_method = mqb::HeaderUnitLookupMethod::quote,
+            .artifacts = *header_artifacts,
+        },
+    };
+    request.plan = *plan;
+    request.compiler_options = options;
+    request.working_directory = fixture.path();
+    request.max_parallel_compiles = 2;
+
+    auto cold = wave.run(request);
+    if (!cold) {
+        ++failures;
+        std::cerr << "FAIL: cold header-unit wave should succeed\n";
+        print_error(cold.error());
+        return 1;
+    }
+    expect(cold->header_unit_compiles.size() == 1 && cold->header_unit_compiles[0].result.compiled,
+           "cold wave should compile the header-unit producer");
+    expect(cold->compiles.size() == 1 && cold->compiles[0].result.compiled,
+           "cold wave should compile the consumer after the header unit");
+    expect(fs::is_regular_file(header_artifacts->module_interface),
+           "cold wave should produce the header-unit IFC");
+    expect(!fs::exists(header_artifacts->object),
+           "header-unit wave producer should remain IFC-only");
+    expect(fs::is_regular_file(consumer_artifacts->object),
+           "cold wave should produce consumer object");
+
+    auto warm = wave.run(request);
+    if (!warm) { print_error(warm.error()); return 1; }
+    expect(!warm->header_unit_compiles[0].result.compiled,
+           "unchanged header-unit producer should be warm");
+    expect(!warm->compiles[0].result.compiled,
+           "unchanged consumer should be warm");
+
+    std::error_code time_error;
+    const auto ifc_time = fs::last_write_time(header_artifacts->module_interface, time_error);
+    expect(!time_error, "mutation fixture requires IFC timestamp");
+    write_text(header, "inline int header_answer() { return 43; }\n");
+    time_error.clear();
+    fs::last_write_time(header, ifc_time + std::chrono::seconds{2}, time_error);
+    expect(!time_error, "test should make header newer than IFC deterministically");
+
+    auto mutated = wave.run(request);
+    if (!mutated) { print_error(mutated.error()); return 1; }
+    expect(mutated->header_unit_compiles[0].result.compiled,
+           "header mutation should rebuild header-unit producer");
+    expect(mutated->compiles[0].result.compiled,
+           "provider rebuild should explicitly rebuild consumer in the next level");
+    expect(has_reason(mutated->compiles[0].result.validation, mqb::BuildReason::explicit_rebuild),
+           "consumer rebuild propagation should remain an explicit typed reason");
+
+    const auto header_time = fs::last_write_time(header, time_error);
+    time_error.clear();
+    fs::last_write_time(header_artifacts->module_interface, header_time + std::chrono::seconds{1}, time_error);
+    auto warm_again = wave.run(request);
+    if (!warm_again) { print_error(warm_again.error()); return 1; }
+    expect(!warm_again->header_unit_compiles[0].result.compiled
+               && !warm_again->compiles[0].result.compiled,
+           "rebuilt header-unit target should return to fully warm state");
+
+    fs::remove(header_artifacts->module_interface, time_error);
+    expect(!time_error, "test should delete only the header-unit IFC");
+    auto repaired = wave.run(request);
+    if (!repaired) { print_error(repaired.error()); return 1; }
+    expect(repaired->header_unit_compiles[0].result.compiled,
+           "missing IFC should rebuild header-unit producer");
+    expect(repaired->compiles[0].result.compiled,
+           "missing-IFC provider repair should rebuild consumer downstream");
+    expect(fs::is_regular_file(header_artifacts->module_interface),
+           "missing-IFC repair should recreate provider IFC");
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+    std::cout << "mqb_header_unit_wave_integration_tests passed\n";
+    return 0;
+}

--- a/cpp/orchestration/tests/header_unit_wave_integration_tests.cpp
+++ b/cpp/orchestration/tests/header_unit_wave_integration_tests.cpp
@@ -188,9 +188,20 @@ int main() {
     expect(has_reason(mutated->compiles[0].result.validation, mqb::BuildReason::explicit_rebuild),
            "consumer rebuild propagation should remain an explicit typed reason");
 
-    const auto header_time = fs::last_write_time(header, time_error);
+    // The mutation was deliberately future-dated only to make the stale check
+    // deterministic. After the rebuild, restore the source to a timestamp just
+    // before the newly created IFC. Do not push the IFC itself into the future:
+    // consumers track that IFC as a dependency, so doing so would correctly
+    // make their existing object stale again.
     time_error.clear();
-    fs::last_write_time(header_artifacts->module_interface, header_time + std::chrono::seconds{1}, time_error);
+    const auto rebuilt_ifc_time = fs::last_write_time(
+        header_artifacts->module_interface,
+        time_error);
+    expect(!time_error, "rebuilt fixture requires the new header-unit IFC timestamp");
+    time_error.clear();
+    fs::last_write_time(header, rebuilt_ifc_time - std::chrono::seconds{1}, time_error);
+    expect(!time_error, "test should normalize the header timestamp behind the rebuilt IFC");
+
     auto warm_again = wave.run(request);
     if (!warm_again) { print_error(warm_again.error()); return 1; }
     expect(!warm_again->header_unit_compiles[0].result.compiled


### PR DESCRIPTION
Builds the fourth Header Units slice under #16 on top of #21.

## Scope

- extend `MsvcModuleCompileCoordinator` with explicit preplanned header-unit producer requests carrying source, header spelling, quote/angle identity, and `SourceArtifacts`
- validate header-unit requests exactly match the `ModuleDependencyPlan` produced by the P1689 graph layer
- schedule ordinary/module TUs and header-unit producers through the same deterministic dependency-level scheduler
- execute header-unit nodes through the IFC-only incremental producer primitive from #20
- inject exact typed `/headerUnit:quote|angle header=ifc` mappings into consuming TUs
- preserve named-module `/reference` routing independently
- propagate provider rebuild state across levels: if a header-unit producer recompiles in this run, downstream consumers receive an explicit rebuild signal
- preflight header-unit IFC/dependency/cache artifacts for emptiness and cross-target collisions without inventing object outputs
- return ordinary/module compile results and header-unit compile results in their respective request order, independent of graph/worker order

## CI-driven test hardening

Workflow #209 compiled successfully and ran 54/55 tests green. Its only failure was a deterministic-timestamp fixture mistake after the mutation case: the test pushed the rebuilt IFC into the future even though the consumer correctly tracks that IFC as a cache dependency, so the consumer was correctly considered stale again.

The fix changed only the test timeline: after the deliberately future-dated header forces a rebuild, the test normalizes the **header source** behind the newly created IFC instead of pushing the IFC beyond the consumer object. Product code was unchanged.

## Verification

C++ V2 workflow #210 completed successfully on exact head `fe5ecd86616047ee202a2191b0eb6e3d8ba5582c`: Configure, Build, all 55 CTest cases, and job cleanup passed.

The real installed-VS2026 E2E verifies:

1. cold wave builds the IFC-only header-unit provider then the consumer
2. unchanged wave is provider compile 0 / consumer compile 0
3. header source mutation rebuilds the provider and explicitly rebuilds the consumer in the next level
4. rebuilt wave returns to fully warm state
5. deleting only the header-unit IFC repairs the provider and rebuilds the downstream consumer

The E2E uses the actual `ModuleDependencyGraphBuilder`, `ProjectArtifactLayout`, incremental compile coordinator, and installed VS2026 compiler; only artifact assignment is still supplied explicitly by the test/request.

## Deliberate boundary

This PR does not yet make `MsvcModuleTargetCoordinator` allocate artifacts for header nodes discovered after P1689 scanning. Public CLI/target integration remains the next slice. Until that lands, callers must explicitly provide the header-unit `SourceArtifacts` expected by the graph plan.

Advances #16; does not close it.