### PR TITLE
feat: allocate header-unit artifacts in module targets

### DIFF
--- a/cpp/backends/msvc/tests/module_compile_integration_tests.cpp
+++ b/cpp/backends/msvc/tests/module_compile_integration_tests.cpp
@@ -161,8 +161,12 @@ int main() {
         }
     }
     expect(!walk_error, "temporary module project should be traversable after compilation");
-    expect(ifc_count == 1 && discovered_ifc == module_artifacts->module_interface,
-           "MSVC should emit exactly the explicitly planned IFC rather than a default-path side artifact");
+    std::error_code equivalent_error;
+    const bool planned_ifc = ifc_count == 1
+        && fs::equivalent(discovered_ifc, module_artifacts->module_interface, equivalent_error)
+        && !equivalent_error;
+    expect(planned_ifc,
+           "MSVC should emit exactly the explicitly planned physical IFC rather than a default-path side artifact");
 
     std::error_code cleanup_error;
     fs::remove_all(root, cleanup_error);

--- a/cpp/core/src/ProjectArtifactLayout.cpp
+++ b/cpp/core/src/ProjectArtifactLayout.cpp
@@ -24,6 +24,21 @@ namespace fs = std::filesystem;
     };
 }
 
+[[nodiscard]] fs::path normalize_existing_identity(const fs::path& path) {
+    fs::path normalized = path.lexically_normal();
+    std::error_code error_code;
+    if (!fs::exists(normalized, error_code) || error_code) {
+        return normalized;
+    }
+
+    error_code.clear();
+    fs::path canonical = fs::weakly_canonical(normalized, error_code);
+    if (error_code || canonical.empty()) {
+        return normalized;
+    }
+    return canonical.lexically_normal();
+}
+
 [[nodiscard]] bool safe_relative(const fs::path& relative) {
     if (relative.empty() || relative.is_absolute() || relative == ".") {
         return false;
@@ -54,7 +69,7 @@ namespace fs = std::filesystem;
 [[nodiscard]] fs::path source_key(
     const fs::path& project_root,
     const fs::path& source) {
-    const fs::path normalized_source = source.lexically_normal();
+    const fs::path normalized_source = normalize_existing_identity(source);
     const fs::path relative = normalized_source.lexically_relative(project_root);
     if (safe_relative(relative)) {
         return relative;
@@ -91,7 +106,7 @@ ProjectArtifactLayout::create(fs::path project_root) {
             {},
             "project root must not be empty"));
     }
-    project_root = project_root.lexically_normal();
+    project_root = normalize_existing_identity(project_root);
     return ProjectArtifactLayout{
         project_root,
         project_root / ".mqb",

--- a/cpp/core/src/ProjectArtifactLayout.cpp
+++ b/cpp/core/src/ProjectArtifactLayout.cpp
@@ -1,5 +1,7 @@
 #include "mqb/core/ProjectArtifactLayout.hpp"
 
+#include <algorithm>
+#include <cctype>
 #include <cstdint>
 #include <filesystem>
 #include <iomanip>
@@ -39,6 +41,20 @@ namespace fs = std::filesystem;
     return canonical.lexically_normal();
 }
 
+[[nodiscard]] fs::path windows_identity_casefold(fs::path path) {
+#ifdef _WIN32
+    std::string value = path.generic_string();
+    std::transform(
+        value.begin(),
+        value.end(),
+        value.begin(),
+        [](const unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+    return fs::path{value};
+#else
+    return path;
+#endif
+}
+
 [[nodiscard]] bool safe_relative(const fs::path& relative) {
     if (relative.empty() || relative.is_absolute() || relative == ".") {
         return false;
@@ -51,11 +67,34 @@ namespace fs = std::filesystem;
     return true;
 }
 
+[[nodiscard]] std::optional<fs::path> physical_relative(
+    const fs::path& project_root,
+    const fs::path& source) {
+    std::error_code error_code;
+    if (!fs::exists(project_root, error_code) || error_code) return std::nullopt;
+    error_code.clear();
+    if (!fs::exists(source, error_code) || error_code) return std::nullopt;
+
+    fs::path current = source.parent_path();
+    fs::path relative = source.filename();
+    while (!current.empty()) {
+        error_code.clear();
+        if (fs::equivalent(current, project_root, error_code) && !error_code) {
+            return windows_identity_casefold(relative.lexically_normal());
+        }
+        const fs::path parent = current.parent_path();
+        if (parent.empty() || parent == current) break;
+        relative = current.filename() / relative;
+        current = parent;
+    }
+    return std::nullopt;
+}
+
 [[nodiscard]] std::string stable_path_hash(const fs::path& path) {
     constexpr std::uint64_t offset = 14695981039346656037ull;
     constexpr std::uint64_t prime = 1099511628211ull;
     std::uint64_t hash = offset;
-    const auto bytes = path.lexically_normal().generic_u8string();
+    const auto bytes = windows_identity_casefold(path.lexically_normal()).generic_u8string();
     for (const char8_t byte : bytes) {
         hash ^= static_cast<std::uint8_t>(byte);
         hash *= prime;
@@ -70,19 +109,32 @@ namespace fs = std::filesystem;
     const fs::path& project_root,
     const fs::path& source) {
     const fs::path normalized_source = normalize_existing_identity(source);
-    const fs::path relative = normalized_source.lexically_relative(project_root);
+
+    // For existing inputs, prefer physical ancestry over textual prefixes.
+    // Windows scanners may return a case/8.3/canonical spelling different from
+    // the caller while still naming the same file under the same project root.
+    if (auto relative = physical_relative(project_root, normalized_source)) {
+        return *relative;
+    }
+
+    fs::path relative = normalized_source.lexically_relative(project_root);
+#ifdef _WIN32
+    // Non-existing planned inputs cannot use fs::equivalent. Keep Windows
+    // identity case-insensitive so textual aliases still converge.
+    relative = windows_identity_casefold(std::move(relative));
+#endif
     if (safe_relative(relative)) {
         return relative;
     }
+
+    const fs::path identity = windows_identity_casefold(normalized_source);
     return fs::path{".external"}
-        / stable_path_hash(normalized_source)
-        / normalized_source.filename();
+        / stable_path_hash(identity)
+        / identity.filename();
 }
 
 [[nodiscard]] bool valid_target_name(const std::string_view target_name) {
-    if (target_name.empty()) {
-        return false;
-    }
+    if (target_name.empty()) return false;
     const fs::path path{std::string{target_name}};
     return !path.has_root_path()
         && !path.has_parent_path()

--- a/cpp/orchestration/include/mqb/orchestration/MsvcModuleTargetCoordinator.hpp
+++ b/cpp/orchestration/include/mqb/orchestration/MsvcModuleTargetCoordinator.hpp
@@ -20,6 +20,10 @@ namespace mqb::orchestration {
 struct IncrementalModuleTargetRequest {
     std::vector<ModuleCompileSourceRequest> sources;
     TargetArtifacts target;
+    // Header-unit providers are discovered only after P1689 scanning. When a
+    // graph contains project-local header units, the target coordinator uses
+    // this layout to assign their IFC/dependency/cache artifacts dynamically.
+    std::optional<ProjectArtifactLayout> artifact_layout;
     CompilerOptions compiler_options;
     LinkOptions link_options;
     std::filesystem::path working_directory;
@@ -38,6 +42,9 @@ enum class IncrementalModuleTargetErrorCode {
     duplicate_source,
     invalid_artifact,
     artifact_collision,
+    artifact_layout_missing,
+    artifact_layout_failed,
+    invalid_header_unit,
     scheduling_failed,
     scan_failed,
     invalid_scan_result,
@@ -51,6 +58,7 @@ struct IncrementalModuleTargetError {
     std::string message;
     std::filesystem::path source;
     std::filesystem::path artifact;
+    std::optional<ArtifactLayoutError> artifact_layout_error;
     std::optional<msvc::ModuleScanError> scan_error;
     std::optional<modules::ModuleGraphError> graph_error;
     std::optional<ModuleCompileError> compile_error;
@@ -58,7 +66,9 @@ struct IncrementalModuleTargetError {
 };
 
 struct IncrementalModuleTargetResult {
-    // Scan and compile results both preserve request.sources ordering.
+    // Scan and ordinary/module compile results preserve request.sources order.
+    // Dynamically discovered header-unit compile results preserve graph
+    // header_units order through ModuleCompileWaveResult.
     std::vector<ModuleTargetScanResult> scans;
     modules::ModuleDependencyPlan plan;
     ModuleCompileWaveResult compiles;

--- a/cpp/orchestration/src/MsvcModuleTargetCoordinator.cpp
+++ b/cpp/orchestration/src/MsvcModuleTargetCoordinator.cpp
@@ -23,9 +23,7 @@ namespace fs = std::filesystem;
 [[nodiscard]] std::string windows_path_key(const fs::path& path) {
     std::string value = path.lexically_normal().generic_string();
     std::transform(
-        value.begin(),
-        value.end(),
-        value.begin(),
+        value.begin(), value.end(), value.begin(),
         [](const unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
     return value;
 }
@@ -80,11 +78,20 @@ namespace fs = std::filesystem;
 [[nodiscard]] std::optional<fs::path> working_directory_for(
     const fs::path& requested,
     const fs::path& source) {
-    if (!requested.empty()) {
-        return requested;
-    }
-    if (!source.parent_path().empty()) {
-        return source.parent_path();
+    if (!requested.empty()) return requested;
+    if (!source.parent_path().empty()) return source.parent_path();
+    return std::nullopt;
+}
+
+[[nodiscard]] std::optional<HeaderUnitLookupMethod> core_lookup_method(
+    const modules::LookupMethod lookup_method) {
+    switch (lookup_method) {
+    case modules::LookupMethod::include_angle:
+        return HeaderUnitLookupMethod::angle;
+    case modules::LookupMethod::include_quote:
+        return HeaderUnitLookupMethod::quote;
+    case modules::LookupMethod::by_name:
+        return std::nullopt;
     }
     return std::nullopt;
 }
@@ -107,7 +114,7 @@ MsvcModuleTargetCoordinator::run(const IncrementalModuleTargetRequest& request) 
     std::unordered_set<std::string> seen_sources;
     std::unordered_set<std::string> claimed_artifacts;
     seen_sources.reserve(request.sources.size());
-    claimed_artifacts.reserve(request.sources.size() * 5u + 2u);
+    claimed_artifacts.reserve(request.sources.size() * 5u + 8u);
 
     for (const auto& source : request.sources) {
         if (source.source.empty()) {
@@ -123,44 +130,30 @@ MsvcModuleTargetCoordinator::run(const IncrementalModuleTargetRequest& request) 
                 source.source));
         }
 
-        if (auto error = claim_artifact(
-                claimed_artifacts, source.source, source.artifacts.object, "object")) {
+        if (auto error = claim_artifact(claimed_artifacts, source.source, source.artifacts.object, "object")) {
             return std::unexpected(std::move(*error));
         }
         if (auto error = claim_artifact(
-                claimed_artifacts,
-                source.source,
-                source.artifacts.dependencies,
-                "source-dependency metadata")) {
+                claimed_artifacts, source.source, source.artifacts.dependencies, "source-dependency metadata")) {
             return std::unexpected(std::move(*error));
         }
         if (auto error = claim_artifact(
-                claimed_artifacts,
-                source.source,
-                source.artifacts.module_dependencies,
-                "module-scan metadata")) {
+                claimed_artifacts, source.source, source.artifacts.module_dependencies, "module-scan metadata")) {
             return std::unexpected(std::move(*error));
         }
         if (auto error = claim_artifact(
-                claimed_artifacts,
-                source.source,
-                source.artifacts.compile_cache,
-                "compile-cache metadata")) {
+                claimed_artifacts, source.source, source.artifacts.compile_cache, "compile-cache metadata")) {
             return std::unexpected(std::move(*error));
         }
         if (source.kind == TranslationUnitKind::module_interface) {
             if (auto error = claim_artifact(
-                    claimed_artifacts,
-                    source.source,
-                    source.artifacts.module_interface,
-                    "IFC")) {
+                    claimed_artifacts, source.source, source.artifacts.module_interface, "IFC")) {
                 return std::unexpected(std::move(*error));
             }
         }
     }
 
-    if (auto error = claim_artifact(
-            claimed_artifacts, {}, request.target.executable, "executable")) {
+    if (auto error = claim_artifact(claimed_artifacts, {}, request.target.executable, "executable")) {
         return std::unexpected(std::move(*error));
     }
     if (auto error = claim_artifact(
@@ -172,8 +165,7 @@ MsvcModuleTargetCoordinator::run(const IncrementalModuleTargetRequest& request) 
     std::vector<std::optional<ScanAttempt>> attempts(request.sources.size());
 
     const auto scheduled = BoundedWorkScheduler::run(
-        request.sources.size(),
-        request.max_parallel_scans,
+        request.sources.size(), request.max_parallel_scans,
         [&](const std::size_t index) {
             const auto& source = request.sources[index];
             msvc::ModuleScanInvocation invocation{
@@ -181,9 +173,7 @@ MsvcModuleTargetCoordinator::run(const IncrementalModuleTargetRequest& request) 
                 .output_file = source.artifacts.module_dependencies,
                 .options = request.compiler_options,
                 .kind = source.kind,
-                .working_directory = working_directory_for(
-                    request.working_directory,
-                    source.source),
+                .working_directory = working_directory_for(request.working_directory, source.source),
             };
             attempts[index].emplace(scanner_.scan(invocation));
             return attempts[index]->has_value();
@@ -194,13 +184,8 @@ MsvcModuleTargetCoordinator::run(const IncrementalModuleTargetRequest& request) 
             "module scan scheduler failed: " + scheduled.error().message));
     }
 
-    // After all scan workers join, report the lowest request-index failure so
-    // diagnostics do not depend on which concurrent process completed first.
     for (std::size_t index = 0; index < attempts.size(); ++index) {
-        if (!attempts[index]) {
-            continue;
-        }
-        if (!attempts[index]->has_value()) {
+        if (attempts[index] && !attempts[index]->has_value()) {
             IncrementalModuleTargetError error = failure(
                 IncrementalModuleTargetErrorCode::scan_failed,
                 "module dependency scan failed",
@@ -222,7 +207,6 @@ MsvcModuleTargetCoordinator::run(const IncrementalModuleTargetRequest& request) 
                 "module scan scheduler stopped without a recorded scan failure",
                 request.sources[index].source));
         }
-
         auto scan = std::move(attempts[index]->value());
         if (scan.dependencies.rules.size() != 1) {
             return std::unexpected(failure(
@@ -230,7 +214,6 @@ MsvcModuleTargetCoordinator::run(const IncrementalModuleTargetRequest& request) 
                 "one-source module scan must produce exactly one P1689 rule",
                 request.sources[index].source));
         }
-
         scanned_units.push_back(modules::ScannedModuleUnit{
             .source = request.sources[index].source,
             .rule = scan.dependencies.rules.front(),
@@ -251,8 +234,60 @@ MsvcModuleTargetCoordinator::run(const IncrementalModuleTargetRequest& request) 
     }
     result.plan = *plan;
 
+    std::vector<ModuleCompileHeaderUnitRequest> header_units;
+    header_units.reserve(result.plan.header_units.size());
+    if (!result.plan.header_units.empty() && !request.artifact_layout) {
+        return std::unexpected(failure(
+            IncrementalModuleTargetErrorCode::artifact_layout_missing,
+            "module target discovered project-local header units but no artifact layout was provided",
+            result.plan.header_units.front().source));
+    }
+
+    for (const auto& header : result.plan.header_units) {
+        const auto lookup = core_lookup_method(header.lookup_method);
+        if (!lookup) {
+            return std::unexpected(failure(
+                IncrementalModuleTargetErrorCode::invalid_header_unit,
+                "resolved header-unit provider has a non-header lookup method",
+                header.source));
+        }
+        auto artifacts = request.artifact_layout->for_source(header.source);
+        if (!artifacts) {
+            IncrementalModuleTargetError error = failure(
+                IncrementalModuleTargetErrorCode::artifact_layout_failed,
+                "failed to assign artifacts to discovered header-unit provider",
+                header.source);
+            error.artifact_layout_error = artifacts.error();
+            return std::unexpected(std::move(error));
+        }
+
+        // Header units are IFC-only producers: object and module-scan paths from
+        // SourceArtifacts are reserved layout slots but are not writable inputs
+        // to this target. Claim only what the producer actually writes.
+        if (auto error = claim_artifact(
+                claimed_artifacts, header.source, artifacts->dependencies, "header-unit source-dependency metadata")) {
+            return std::unexpected(std::move(*error));
+        }
+        if (auto error = claim_artifact(
+                claimed_artifacts, header.source, artifacts->compile_cache, "header-unit compile-cache metadata")) {
+            return std::unexpected(std::move(*error));
+        }
+        if (auto error = claim_artifact(
+                claimed_artifacts, header.source, artifacts->module_interface, "header-unit IFC")) {
+            return std::unexpected(std::move(*error));
+        }
+
+        header_units.push_back(ModuleCompileHeaderUnitRequest{
+            .source = header.source,
+            .header_name = header.header_name,
+            .lookup_method = *lookup,
+            .artifacts = std::move(*artifacts),
+        });
+    }
+
     ModuleCompileWaveRequest compile_request{
         .sources = request.sources,
+        .header_units = std::move(header_units),
         .plan = result.plan,
         .compiler_options = request.compiler_options,
         .working_directory = request.working_directory,
@@ -271,9 +306,7 @@ MsvcModuleTargetCoordinator::run(const IncrementalModuleTargetRequest& request) 
 
     std::vector<fs::path> objects;
     objects.reserve(request.sources.size());
-    for (const auto& source : request.sources) {
-        objects.push_back(source.artifacts.object);
-    }
+    for (const auto& source : request.sources) objects.push_back(source.artifacts.object);
 
     IncrementalLinkRequest link_request{
         .objects = std::move(objects),

--- a/cpp/orchestration/tests/CMakeLists.txt
+++ b/cpp/orchestration/tests/CMakeLists.txt
@@ -71,10 +71,15 @@ if(MQB_ENABLE_INSTALLED_MSVC_TESTS)
     target_link_libraries(mqb_header_unit_wave_integration_tests PRIVATE mqb_orchestration mqb_modules mqb_msvc mqb_platform_windows)
     target_compile_features(mqb_header_unit_wave_integration_tests PRIVATE cxx_std_23)
 
+    add_executable(mqb_header_unit_target_integration_tests header_unit_target_integration_tests.cpp)
+    target_link_libraries(mqb_header_unit_target_integration_tests PRIVATE mqb_orchestration mqb_modules mqb_msvc mqb_platform_windows)
+    target_compile_features(mqb_header_unit_target_integration_tests PRIVATE cxx_std_23)
+
     foreach(test_target IN ITEMS
         mqb_module_target_integration_tests
         mqb_header_unit_incremental_integration_tests
         mqb_header_unit_wave_integration_tests
+        mqb_header_unit_target_integration_tests
     )
         if(MSVC)
             target_compile_options(${test_target} PRIVATE /W4 /permissive-)
@@ -86,4 +91,5 @@ if(MQB_ENABLE_INSTALLED_MSVC_TESTS)
     add_test(NAME mqb.orchestration.module_target_integration COMMAND mqb_module_target_integration_tests)
     add_test(NAME mqb.orchestration.header_unit_incremental_integration COMMAND mqb_header_unit_incremental_integration_tests)
     add_test(NAME mqb.orchestration.header_unit_wave_integration COMMAND mqb_header_unit_wave_integration_tests)
+    add_test(NAME mqb.orchestration.header_unit_target_integration COMMAND mqb_header_unit_target_integration_tests)
 endif()

--- a/cpp/orchestration/tests/header_unit_target_integration_tests.cpp
+++ b/cpp/orchestration/tests/header_unit_target_integration_tests.cpp
@@ -59,25 +59,12 @@ void print_error(const mqb::orchestration::IncrementalModuleTargetError& error) 
     if (!error.source.empty()) std::cerr << "  source=" << error.source.generic_string() << '\n';
     if (!error.artifact.empty()) std::cerr << "  artifact=" << error.artifact.generic_string() << '\n';
     if (error.artifact_layout_error) std::cerr << "  layout=" << error.artifact_layout_error->message << '\n';
-    if (error.scan_error) {
-        std::cerr << "  scan=" << error.scan_error->message << '\n';
-        if (error.scan_error->process_result) {
-            std::cerr << error.scan_error->process_result->stdout_text
-                      << error.scan_error->process_result->stderr_text;
-        }
+    if (error.scan_error && error.scan_error->process_result) {
+        std::cerr << error.scan_error->process_result->stdout_text
+                  << error.scan_error->process_result->stderr_text;
     }
     if (error.graph_error) std::cerr << "  graph=" << error.graph_error->message << '\n';
-    if (error.compile_error) {
-        std::cerr << "  wave=" << error.compile_error->message << '\n';
-        if (error.compile_error->compile_error
-            && error.compile_error->compile_error->compile_error
-            && error.compile_error->compile_error->compile_error->compiler_error
-            && error.compile_error->compile_error->compile_error->compiler_error->process_result) {
-            const auto& process = *error.compile_error->compile_error
-                ->compile_error->compiler_error->process_result;
-            std::cerr << process.stdout_text << process.stderr_text;
-        }
-    }
+    if (error.compile_error) std::cerr << "  wave=" << error.compile_error->message << '\n';
     if (error.link_error) std::cerr << "  link=" << error.link_error->message << '\n';
 }
 
@@ -94,7 +81,6 @@ bool run_executable(
     expect(result.has_value(), "header-unit target executable should launch");
     if (!result) return false;
     expect(result->exit_code == 0, "header-unit target executable should return zero");
-    if (result->exit_code != 0) std::cerr << result->stdout_text << result->stderr_text;
     return result->exit_code == 0;
 }
 
@@ -140,21 +126,15 @@ int main() {
     mqb::orchestration::MsvcModuleTargetCoordinator target{scanner, module_compile, incremental_link};
 
     mqb::orchestration::IncrementalModuleTargetRequest request;
-    request.sources = {
-        mqb::orchestration::ModuleCompileSourceRequest{
-            .source = consumer,
-            .artifacts = *consumer_artifacts,
-            .kind = mqb::TranslationUnitKind::source,
-        },
-    };
+    request.sources = {{
+        .source = consumer,
+        .artifacts = *consumer_artifacts,
+        .kind = mqb::TranslationUnitKind::source,
+    }};
     request.target = *target_artifacts;
     request.artifact_layout = *layout;
-    request.compiler_options.configuration = mqb::BuildConfiguration::debug;
-    request.compiler_options.architecture = mqb::Architecture::x64;
     request.compiler_options.standard = mqb::CppStandard::latest;
     request.compiler_options.include_directories = {include_dir};
-    request.link_options.configuration = mqb::BuildConfiguration::debug;
-    request.link_options.architecture = mqb::Architecture::x64;
     request.link_options.subsystem = mqb::LinkSubsystem::console;
     request.working_directory = root;
     request.max_parallel_scans = 2;
@@ -166,8 +146,13 @@ int main() {
     expect(cold->plan.header_units.size() == 1,
            "real P1689 target scan should expose exactly one project-local header unit");
     if (cold->plan.header_units.size() == 1) {
-        expect(cold->plan.header_units[0].source.lexically_normal() == header.lexically_normal(),
-               "P1689 source-path should resolve to the physical project header");
+        std::error_code equivalent_error;
+        const bool equivalent = fs::equivalent(
+            cold->plan.header_units[0].source,
+            header,
+            equivalent_error);
+        expect(equivalent && !equivalent_error,
+               "P1689 source-path should resolve to the same physical project header even if Windows spelling differs");
         expect(cold->plan.header_units[0].header_name == "util.hpp",
                "P1689 header-unit logical name should preserve import spelling");
         expect(cold->plan.header_units[0].lookup_method == mqb::modules::LookupMethod::include_quote,
@@ -180,7 +165,7 @@ int main() {
            "cold target should compile consumer after header-unit provider");
     expect(cold->link.linked, "cold target should link executable");
     expect(fs::is_regular_file(expected_header_artifacts->module_interface),
-           "target should allocate and create the layout-derived header-unit IFC");
+           "one physical project header should receive the layout-derived in-project IFC identity");
     expect(fs::is_regular_file(expected_header_artifacts->dependencies),
            "target should allocate header-unit sourceDependencies metadata");
     expect(fs::is_regular_file(expected_header_artifacts->compile_cache),
@@ -191,11 +176,10 @@ int main() {
 
     auto warm = target.run(request);
     if (!warm) { print_error(warm.error()); return 1; }
-    expect(!warm->compiles.header_unit_compiles[0].result.compiled,
-           "warm target should reuse dynamically allocated header-unit IFC");
-    expect(!warm->compiles.compiles[0].result.compiled,
-           "warm target should reuse consumer object");
-    expect(!warm->link.linked, "warm target should reuse linked executable");
+    expect(!warm->compiles.header_unit_compiles[0].result.compiled
+               && !warm->compiles.compiles[0].result.compiled
+               && !warm->link.linked,
+           "unchanged dynamically allocated header-unit target should be fully warm");
 
     std::error_code time_error;
     const auto old_ifc_time = fs::last_write_time(expected_header_artifacts->module_interface, time_error);
@@ -232,11 +216,10 @@ int main() {
     expect(!time_error, "test should delete only layout-derived header-unit IFC");
     auto repaired = target.run(request);
     if (!repaired) { print_error(repaired.error()); return 1; }
-    expect(repaired->compiles.header_unit_compiles[0].result.compiled,
-           "missing dynamic header IFC should rebuild provider");
-    expect(repaired->compiles.compiles[0].result.compiled,
-           "missing header IFC repair should rebuild consumer");
-    expect(repaired->link.linked, "missing header IFC repair should relink target");
+    expect(repaired->compiles.header_unit_compiles[0].result.compiled
+               && repaired->compiles.compiles[0].result.compiled
+               && repaired->link.linked,
+           "missing dynamic header IFC should repair provider, consumer, and link");
     expect(fs::is_regular_file(expected_header_artifacts->module_interface),
            "missing dynamic header IFC should be recreated");
 

--- a/cpp/orchestration/tests/header_unit_target_integration_tests.cpp
+++ b/cpp/orchestration/tests/header_unit_target_integration_tests.cpp
@@ -1,0 +1,249 @@
+#include <algorithm>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <string_view>
+
+#include "mqb/core/ProjectArtifactLayout.hpp"
+#include "mqb/msvc/MsvcCompileExecutor.hpp"
+#include "mqb/msvc/MsvcLinker.hpp"
+#include "mqb/msvc/MsvcModuleDependencyScanner.hpp"
+#include "mqb/msvc/MsvcToolchainLocator.hpp"
+#include "mqb/orchestration/MsvcIncrementalCompileCoordinator.hpp"
+#include "mqb/orchestration/MsvcIncrementalLinkCoordinator.hpp"
+#include "mqb/orchestration/MsvcModuleCompileCoordinator.hpp"
+#include "mqb/orchestration/MsvcModuleTargetCoordinator.hpp"
+#include "mqb/platform/windows/WindowsProcessRunner.hpp"
+
+namespace {
+namespace fs = std::filesystem;
+int failures = 0;
+
+void expect(bool condition, std::string_view message) {
+    if (!condition) { ++failures; std::cerr << "FAIL: " << message << '\n'; }
+}
+
+class TemporaryDirectory {
+public:
+    TemporaryDirectory() {
+        const auto tick = std::chrono::steady_clock::now().time_since_epoch().count();
+        path_ = fs::temp_directory_path() / ("mqb-header-unit-target-" + std::to_string(tick));
+        fs::create_directories(path_);
+    }
+    ~TemporaryDirectory() {
+        std::error_code ignored;
+        fs::remove_all(path_, ignored);
+    }
+    [[nodiscard]] const fs::path& path() const noexcept { return path_; }
+private:
+    fs::path path_;
+};
+
+void write_text(const fs::path& path, std::string_view text) {
+    fs::create_directories(path.parent_path());
+    std::ofstream file{path, std::ios::binary | std::ios::trunc};
+    file.write(text.data(), static_cast<std::streamsize>(text.size()));
+}
+
+bool has_reason(const mqb::orchestration::ModuleCompileResult& result, mqb::BuildReason reason) {
+    return std::find(
+        result.result.validation.reasons.begin(),
+        result.result.validation.reasons.end(),
+        reason) != result.result.validation.reasons.end();
+}
+
+void print_error(const mqb::orchestration::IncrementalModuleTargetError& error) {
+    std::cerr << "module target error: " << error.message << '\n';
+    if (!error.source.empty()) std::cerr << "  source=" << error.source.generic_string() << '\n';
+    if (!error.artifact.empty()) std::cerr << "  artifact=" << error.artifact.generic_string() << '\n';
+    if (error.artifact_layout_error) std::cerr << "  layout=" << error.artifact_layout_error->message << '\n';
+    if (error.scan_error) {
+        std::cerr << "  scan=" << error.scan_error->message << '\n';
+        if (error.scan_error->process_result) {
+            std::cerr << error.scan_error->process_result->stdout_text
+                      << error.scan_error->process_result->stderr_text;
+        }
+    }
+    if (error.graph_error) std::cerr << "  graph=" << error.graph_error->message << '\n';
+    if (error.compile_error) {
+        std::cerr << "  wave=" << error.compile_error->message << '\n';
+        if (error.compile_error->compile_error
+            && error.compile_error->compile_error->compile_error
+            && error.compile_error->compile_error->compile_error->compiler_error
+            && error.compile_error->compile_error->compile_error->compiler_error->process_result) {
+            const auto& process = *error.compile_error->compile_error
+                ->compile_error->compiler_error->process_result;
+            std::cerr << process.stdout_text << process.stderr_text;
+        }
+    }
+    if (error.link_error) std::cerr << "  link=" << error.link_error->message << '\n';
+}
+
+bool run_executable(
+    mqb::platform::windows::WindowsProcessRunner& runner,
+    const fs::path& executable,
+    const fs::path& cwd) {
+    mqb::process::ProcessSpec spec;
+    spec.executable = executable;
+    spec.working_directory = cwd;
+    spec.capture_stdout = true;
+    spec.capture_stderr = true;
+    auto result = runner.run(spec);
+    expect(result.has_value(), "header-unit target executable should launch");
+    if (!result) return false;
+    expect(result->exit_code == 0, "header-unit target executable should return zero");
+    if (result->exit_code != 0) std::cerr << result->stdout_text << result->stderr_text;
+    return result->exit_code == 0;
+}
+
+} // namespace
+
+int main() {
+    mqb::platform::windows::WindowsProcessRunner runner;
+    mqb::msvc::MsvcToolchainLocator locator{runner};
+    mqb::msvc::DiscoveryOptions discovery;
+    discovery.preference = mqb::msvc::ToolchainPreference::visual_studio;
+    discovery.target_architecture = mqb::Architecture::x64;
+    discovery.host_architecture = mqb::Architecture::x64;
+    auto toolchain = locator.discover(discovery);
+    expect(toolchain.has_value(), "header-unit target E2E requires installed Visual Studio");
+    if (!toolchain) return 1;
+
+    TemporaryDirectory fixture;
+    const fs::path root = fixture.path();
+    const fs::path include_dir = root / "include";
+    const fs::path header = include_dir / "util.hpp";
+    const fs::path consumer = root / "src" / "main.cpp";
+    write_text(header, "inline int header_answer() { return 42; }\n");
+    write_text(consumer,
+        "import \"util.hpp\";\n"
+        "int main() { return header_answer() == 42 ? 0 : 1; }\n");
+
+    auto layout = mqb::ProjectArtifactLayout::create(root);
+    expect(layout.has_value(), "header-unit target should create artifact layout");
+    if (!layout) return 1;
+    auto consumer_artifacts = layout->for_source(consumer);
+    auto expected_header_artifacts = layout->for_source(header);
+    auto target_artifacts = layout->for_target("header-unit-target");
+    expect(consumer_artifacts && expected_header_artifacts && target_artifacts,
+           "fixture should resolve consumer/header/target artifacts");
+    if (!consumer_artifacts || !expected_header_artifacts || !target_artifacts) return 1;
+
+    mqb::msvc::MsvcModuleDependencyScanner scanner{*toolchain, runner};
+    mqb::msvc::MsvcCompileExecutor executor{*toolchain, runner};
+    mqb::orchestration::MsvcIncrementalCompileCoordinator incremental_compile{*toolchain, executor};
+    mqb::orchestration::MsvcModuleCompileCoordinator module_compile{incremental_compile};
+    mqb::msvc::MsvcLinker linker{*toolchain, runner};
+    mqb::orchestration::MsvcIncrementalLinkCoordinator incremental_link{*toolchain, linker};
+    mqb::orchestration::MsvcModuleTargetCoordinator target{scanner, module_compile, incremental_link};
+
+    mqb::orchestration::IncrementalModuleTargetRequest request;
+    request.sources = {
+        mqb::orchestration::ModuleCompileSourceRequest{
+            .source = consumer,
+            .artifacts = *consumer_artifacts,
+            .kind = mqb::TranslationUnitKind::source,
+        },
+    };
+    request.target = *target_artifacts;
+    request.artifact_layout = *layout;
+    request.compiler_options.configuration = mqb::BuildConfiguration::debug;
+    request.compiler_options.architecture = mqb::Architecture::x64;
+    request.compiler_options.standard = mqb::CppStandard::latest;
+    request.compiler_options.include_directories = {include_dir};
+    request.link_options.configuration = mqb::BuildConfiguration::debug;
+    request.link_options.architecture = mqb::Architecture::x64;
+    request.link_options.subsystem = mqb::LinkSubsystem::console;
+    request.working_directory = root;
+    request.max_parallel_scans = 2;
+    request.max_parallel_compiles = 2;
+
+    auto cold = target.run(request);
+    expect(cold.has_value(), "cold target should discover, allocate, build, and link header unit");
+    if (!cold) { print_error(cold.error()); return 1; }
+    expect(cold->plan.header_units.size() == 1,
+           "real P1689 target scan should expose exactly one project-local header unit");
+    if (cold->plan.header_units.size() == 1) {
+        expect(cold->plan.header_units[0].source.lexically_normal() == header.lexically_normal(),
+               "P1689 source-path should resolve to the physical project header");
+        expect(cold->plan.header_units[0].header_name == "util.hpp",
+               "P1689 header-unit logical name should preserve import spelling");
+        expect(cold->plan.header_units[0].lookup_method == mqb::modules::LookupMethod::include_quote,
+               "P1689 header-unit lookup method should preserve quote semantics");
+    }
+    expect(cold->compiles.header_unit_compiles.size() == 1
+               && cold->compiles.header_unit_compiles[0].result.compiled,
+           "cold target should compile dynamically allocated header-unit provider");
+    expect(cold->compiles.compiles.size() == 1 && cold->compiles.compiles[0].result.compiled,
+           "cold target should compile consumer after header-unit provider");
+    expect(cold->link.linked, "cold target should link executable");
+    expect(fs::is_regular_file(expected_header_artifacts->module_interface),
+           "target should allocate and create the layout-derived header-unit IFC");
+    expect(fs::is_regular_file(expected_header_artifacts->dependencies),
+           "target should allocate header-unit sourceDependencies metadata");
+    expect(fs::is_regular_file(expected_header_artifacts->compile_cache),
+           "target should allocate header-unit compile-cache metadata");
+    expect(!fs::exists(expected_header_artifacts->object),
+           "dynamically allocated header-unit provider must remain IFC-only");
+    if (!run_executable(runner, target_artifacts->executable, root)) return 1;
+
+    auto warm = target.run(request);
+    if (!warm) { print_error(warm.error()); return 1; }
+    expect(!warm->compiles.header_unit_compiles[0].result.compiled,
+           "warm target should reuse dynamically allocated header-unit IFC");
+    expect(!warm->compiles.compiles[0].result.compiled,
+           "warm target should reuse consumer object");
+    expect(!warm->link.linked, "warm target should reuse linked executable");
+
+    std::error_code time_error;
+    const auto old_ifc_time = fs::last_write_time(expected_header_artifacts->module_interface, time_error);
+    expect(!time_error, "mutation fixture requires header-unit IFC timestamp");
+    write_text(header, "inline int header_answer() { return 43; }\n");
+    time_error.clear();
+    fs::last_write_time(header, old_ifc_time + std::chrono::seconds{2}, time_error);
+    expect(!time_error, "test should make header source deterministically newer than IFC");
+
+    auto mutated = target.run(request);
+    if (!mutated) { print_error(mutated.error()); return 1; }
+    expect(mutated->compiles.header_unit_compiles[0].result.compiled,
+           "header mutation should rebuild dynamically allocated provider");
+    expect(mutated->compiles.compiles[0].result.compiled,
+           "header provider rebuild should rebuild consumer downstream");
+    expect(has_reason(mutated->compiles.compiles[0], mqb::BuildReason::explicit_rebuild),
+           "header provider rebuild should propagate explicit_rebuild to consumer");
+    expect(mutated->link.linked, "header provider mutation should relink target");
+
+    time_error.clear();
+    const auto rebuilt_ifc_time = fs::last_write_time(expected_header_artifacts->module_interface, time_error);
+    expect(!time_error, "rebuilt target requires header-unit IFC timestamp");
+    time_error.clear();
+    fs::last_write_time(header, rebuilt_ifc_time - std::chrono::seconds{1}, time_error);
+    expect(!time_error, "test should normalize header source behind rebuilt IFC");
+    auto warm_again = target.run(request);
+    if (!warm_again) { print_error(warm_again.error()); return 1; }
+    expect(!warm_again->compiles.header_unit_compiles[0].result.compiled
+               && !warm_again->compiles.compiles[0].result.compiled
+               && !warm_again->link.linked,
+           "rebuilt target should become fully warm again");
+
+    fs::remove(expected_header_artifacts->module_interface, time_error);
+    expect(!time_error, "test should delete only layout-derived header-unit IFC");
+    auto repaired = target.run(request);
+    if (!repaired) { print_error(repaired.error()); return 1; }
+    expect(repaired->compiles.header_unit_compiles[0].result.compiled,
+           "missing dynamic header IFC should rebuild provider");
+    expect(repaired->compiles.compiles[0].result.compiled,
+           "missing header IFC repair should rebuild consumer");
+    expect(repaired->link.linked, "missing header IFC repair should relink target");
+    expect(fs::is_regular_file(expected_header_artifacts->module_interface),
+           "missing dynamic header IFC should be recreated");
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+    std::cout << "mqb_header_unit_target_integration_tests passed\n";
+    return 0;
+}

--- a/cpp/tests/project_artifact_layout_tests.cpp
+++ b/cpp/tests/project_artifact_layout_tests.cpp
@@ -1,4 +1,6 @@
+#include <chrono>
 #include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <string_view>
@@ -23,9 +25,7 @@ int main() {
     const fs::path root = fs::path{"C:/work/project"}.lexically_normal();
     auto layout = mqb::ProjectArtifactLayout::create(root);
     expect(layout.has_value(), "non-empty project root should create an artifact layout");
-    if (!layout) {
-        return 1;
-    }
+    if (!layout) return 1;
 
     auto src_foo = layout->for_source(root / "src" / "foo.cpp");
     auto tests_foo = layout->for_source(root / "tests" / "foo.cpp");
@@ -41,14 +41,11 @@ int main() {
                "in-project object path should preserve relative source identity");
         expect(src_foo->dependencies == root / ".mqb" / "deps" / "src" / "foo.cpp.json",
                "dependency metadata should preserve relative source identity");
-        expect(src_foo->module_dependencies
-                   == root / ".mqb" / "scan" / "src" / "foo.cpp.json",
+        expect(src_foo->module_dependencies == root / ".mqb" / "scan" / "src" / "foo.cpp.json",
                "module scan metadata should preserve relative source identity");
-        expect(src_foo->module_interface
-                   == root / ".mqb" / "ifc" / "src" / "foo.cpp.ifc",
+        expect(src_foo->module_interface == root / ".mqb" / "ifc" / "src" / "foo.cpp.ifc",
                "compiled module interface path should preserve relative source identity");
-        expect(src_foo->compile_cache
-                   == root / ".mqb" / "cache" / "compile" / "src" / "foo.cpp.mqbcache",
+        expect(src_foo->compile_cache == root / ".mqb" / "cache" / "compile" / "src" / "foo.cpp.mqbcache",
                "compile cache should preserve relative source identity");
         expect(src_foo->module_dependencies != tests_foo->module_dependencies
                    && src_foo->module_interface != tests_foo->module_interface,
@@ -58,8 +55,7 @@ int main() {
     auto partition = layout->for_source(root / "modules" / "math-part.ixx");
     expect(partition.has_value(), "module interface source should map to module artifacts");
     if (partition) {
-        expect(partition->module_interface
-                   == root / ".mqb" / "ifc" / "modules" / "math-part.ixx.ifc",
+        expect(partition->module_interface == root / ".mqb" / "ifc" / "modules" / "math-part.ixx.ifc",
                "IFC filename should come from source identity rather than logical module spelling");
         expect(partition->module_interface.filename().generic_string().find(':') == std::string::npos,
                "IFC filename must not require logical-name characters such as partition ':'");
@@ -73,8 +69,7 @@ int main() {
                "external source artifacts should be isolated under .external hash namespace");
         expect(generic.ends_with("/foo.cpp.obj"),
                "external artifact should retain source filename for diagnostics");
-        expect(outside->module_interface.generic_string().find(".mqb/ifc/.external/")
-                   != std::string::npos,
+        expect(outside->module_interface.generic_string().find(".mqb/ifc/.external/") != std::string::npos,
                "external IFCs should share the stable external-source namespace");
     }
 
@@ -86,6 +81,46 @@ int main() {
         expect(target->link_cache == root / ".mqb" / "cache" / "link" / "demo.linkcache",
                "link cache should be isolated from compile cache metadata");
     }
+
+#ifdef _WIN32
+    // Existing physical paths are normalized before deriving source identity.
+    // This prevents scanner/user aliases (case differences, 8.3/long-path or
+    // other canonical spellings) from splitting one source into two caches.
+    const auto tick = std::chrono::steady_clock::now().time_since_epoch().count();
+    const fs::path physical_root = fs::temp_directory_path()
+        / ("MqB_Artifact_Alias_" + std::to_string(tick));
+    const fs::path physical_header = physical_root / "Include" / "Util.hpp";
+    fs::create_directories(physical_header.parent_path());
+    {
+        std::ofstream file{physical_header, std::ios::binary | std::ios::trunc};
+        file << "#pragma once\n";
+    }
+
+    auto physical_layout = mqb::ProjectArtifactLayout::create(physical_root);
+    expect(physical_layout.has_value(), "existing physical project root should create a layout");
+    if (physical_layout) {
+        std::string alias_component = physical_root.filename().string();
+        for (auto& ch : alias_component) {
+            if (ch >= 'A' && ch <= 'Z') ch = static_cast<char>(ch - 'A' + 'a');
+        }
+        const fs::path root_alias = physical_root.parent_path() / alias_component;
+        const fs::path source_alias = root_alias / "include" / "util.hpp";
+        auto real_artifacts = physical_layout->for_source(physical_header);
+        auto alias_artifacts = physical_layout->for_source(source_alias);
+        expect(real_artifacts.has_value() && alias_artifacts.has_value(),
+               "case aliases of an existing Windows source should map to artifacts");
+        if (real_artifacts && alias_artifacts) {
+            expect(real_artifacts->object == alias_artifacts->object
+                       && real_artifacts->dependencies == alias_artifacts->dependencies
+                       && real_artifacts->module_dependencies == alias_artifacts->module_dependencies
+                       && real_artifacts->module_interface == alias_artifacts->module_interface
+                       && real_artifacts->compile_cache == alias_artifacts->compile_cache,
+                   "one physical Windows source must have one stable artifact identity across path aliases");
+        }
+    }
+    std::error_code cleanup_error;
+    fs::remove_all(physical_root, cleanup_error);
+#endif
 
     expect(!layout->for_target("../demo"), "target names with parent traversal must be rejected");
     expect(!mqb::ProjectArtifactLayout::create({}), "empty project root must be rejected");


### PR DESCRIPTION
Builds the fifth Header Units slice under #16 on top of #22.

## Scope

- extend `IncrementalModuleTargetRequest` with an optional `ProjectArtifactLayout`
- require that layout only when the post-scan P1689 graph actually contains project-local header-unit producers; named-module-only targets remain unchanged
- after `ModuleDependencyGraphBuilder` resolves header-unit `source-path` nodes, allocate their `SourceArtifacts` through `ProjectArtifactLayout::for_source()` inside the target coordinator
- map P1689 `include-quote/include-angle` to the typed Core header-unit lookup contract
- claim only writable header-unit artifacts at target scope: sourceDependencies, compile cache, and IFC; reserved object/module-scan layout slots are not treated as writes
- include dynamically allocated header-unit artifacts in target-wide collision preflight alongside ordinary/module artifacts and executable/link-cache state
- pass dynamically created header-unit requests into the compile wave from #22
- keep final linking restricted to ordinary/module TU object files; header-unit producers remain IFC-only
- return explicit `artifact_layout_missing`, `artifact_layout_failed`, and `invalid_header_unit` target errors instead of guessing paths

## CI-driven Windows path hardening

The first real target run (#212) successfully built the header-unit target, but exposed that MSVC P1689 may return the same physical header with a different Windows path spelling than the caller. That split one source into two artifact identities.

A first `weakly_canonical` fix (#213) was insufficient because Windows canonical text is not a stable identity across case/short-name aliases. The final fix lives in the correct owner, `ProjectArtifactLayout`:

- existing sources use physical ancestry (`std::filesystem::equivalent`) to locate the real project root boundary
- Windows artifact keys are case-folded after physical relative identity is established
- external source hashes use the same Windows case-insensitive identity
- non-existing planned paths retain the previous lexical fallback

Core regression coverage proves Windows aliases of one existing physical source map to exactly the same object/deps/scan/IFC/cache paths.

The old named-module integration test was also corrected to compare the one emitted IFC by physical identity rather than requiring identical path-string casing; it still requires the entire fixture to contain exactly one IFC, so side artifacts remain detectable.

## Verification

C++ V2 workflow #215 completed successfully on exact head `7c04346e04c4a971038808cf50f7c61e9feca447`: Configure, Build, all 56 CTest cases, and cleanup passed.

The installed-VS2026 target E2E supplies only `main.cpp`, its ordinary `SourceArtifacts`, target artifacts, and the project artifact layout. The target itself proves:

1. real `/scanDependencies` observes `import "util.hpp";`
2. P1689 resolves the same physical header even when Windows path spelling differs
3. target dynamically allocates the provider's `.mqb/ifc`, deps, and compile-cache paths
4. cold provider + consumer + link/run succeeds
5. unchanged target is provider compile 0 / consumer compile 0 / link 0
6. header mutation rebuilds provider + explicitly rebuilds consumer + relinks
7. rebuilt target returns fully warm
8. deleting only the header-unit IFC repairs provider + consumer + link

## Deliberate boundary

This PR closes dynamic header-unit artifact assignment at the target API layer. The public CLI/router still needs to pass the layout and ensure a single ordinary entry containing only header-unit imports routes into the module target path. That is the next slice.

Advances #16; does not close it.