### PR TITLE
feat: route public CLI header units through module pipeline

### DIFF
--- a/cpp/apps/mqb/ModuleCliTarget.cpp
+++ b/cpp/apps/mqb/ModuleCliTarget.cpp
@@ -207,9 +207,16 @@ int run_module_target(
     orchestration::MsvcModuleTargetCoordinator module_target{scanner, module_compile, incremental_link};
     orchestration::MsvcTargetRouter router{ordinary_target, module_target};
 
+    auto artifact_layout = ProjectArtifactLayout::create(request.project_root);
+    if (!artifact_layout) {
+        std::cerr << "error: " << artifact_layout.error().message << '\n';
+        return 2;
+    }
+
     orchestration::RoutedTargetRequest target_request{
         .sources = std::move(routed_sources),
         .target = request.target,
+        .artifact_layout = std::move(*artifact_layout),
         .compiler_options = std::move(request.compiler_options),
         .link_options = std::move(request.link_options),
         .working_directory = request.project_root,

--- a/cpp/discovery/include/mqb/discovery/ModuleSyntax.hpp
+++ b/cpp/discovery/include/mqb/discovery/ModuleSyntax.hpp
@@ -13,6 +13,10 @@ namespace mqb::discovery {
 struct NamedModuleSyntax {
     std::optional<std::string> declared_module;
     std::vector<std::string> imported_modules;
+    // Header-unit imports are not named-module discovery edges, but they still
+    // require the real module pipeline so P1689 can resolve their source path,
+    // lookup method, and provider artifact authoritatively.
+    bool imports_header_unit{false};
 };
 
 class ModuleSyntaxParser {

--- a/cpp/discovery/src/ModuleSyntax.cpp
+++ b/cpp/discovery/src/ModuleSyntax.cpp
@@ -336,8 +336,10 @@ NamedModuleSyntax ModuleSyntaxParser::parse(const std::string_view source_text) 
         if (name_index >= tokens.size()) continue;
         if (tokens[name_index].kind == TokenKind::less
             || tokens[name_index].kind == TokenKind::string_literal) {
-            // Header units are intentionally not source-discovery named-module
-            // edges. The real module pipeline continues to fail them closed.
+            // Header-unit imports are deliberately not named-module discovery
+            // edges. They still force the module pipeline so the real P1689
+            // scan can resolve source-path and lookup-method authoritatively.
+            syntax.imports_header_unit = true;
             continue;
         }
 

--- a/cpp/discovery/src/SourceDiscovery.cpp
+++ b/cpp/discovery/src/SourceDiscovery.cpp
@@ -386,7 +386,8 @@ void add_undirected_edge(
 [[nodiscard]] bool file_requires_module_pipeline(const FileRecord& file) {
     return module_interface_translation_unit(file)
         || file.module_syntax.declared_module.has_value()
-        || !file.module_syntax.imported_modules.empty();
+        || !file.module_syntax.imported_modules.empty()
+        || file.module_syntax.imports_header_unit;
 }
 
 } // namespace

--- a/cpp/discovery/tests/module_source_discovery_tests.cpp
+++ b/cpp/discovery/tests/module_source_discovery_tests.cpp
@@ -175,6 +175,26 @@ int main() {
                "import-only targets with no local provider must fail closed through the module pipeline");
     }
 
+    const fs::path header_unit_main = tree.root / "header_unit_main.cpp";
+    const fs::path header_unit = tree.root / "util.hpp";
+    write_text(header_unit, "inline int header_value() { return 42; }\n");
+    write_text(
+        header_unit_main,
+        "import \"util.hpp\";\n"
+        "int main() { return header_value() == 42 ? 0 : 1; }\n");
+    const auto header_unit_only = mqb::discovery::SourceDiscovery::discover({
+        .project_root = tree.root,
+        .entry = header_unit_main,
+    });
+    expect(header_unit_only.has_value(),
+           "header-unit-only source discovery should succeed");
+    if (header_unit_only) {
+        expect(header_unit_only->sources == std::vector<fs::path>{header_unit_main},
+               "header units must not be promoted into translation-unit discovery output");
+        expect(header_unit_only->requires_module_pipeline,
+               "header-unit imports must route an ordinary entry through the module pipeline");
+    }
+
     const fs::path plain_main = tree.root / "plain_main.cpp";
     write_text(plain_main, "int main() { return 0; }\n");
     const auto plain = mqb::discovery::SourceDiscovery::discover({

--- a/cpp/discovery/tests/module_syntax_tests.cpp
+++ b/cpp/discovery/tests/module_syntax_tests.cpp
@@ -29,6 +29,8 @@ int main() {
                "export module should expose its logical module name");
         expect(syntax.imported_modules == std::vector<std::string>({"util", "stats.detail"}),
                "named import and export import should be preserved in source order");
+        expect(!syntax.imports_header_unit,
+               "named-module-only syntax must not report a header-unit import");
     }
 
     {
@@ -58,7 +60,9 @@ int main() {
             "import \"local.hpp\";\n"
             "import project.api;\n");
         expect(syntax.imported_modules == std::vector<std::string>({"project.api"}),
-               "header-unit imports must be excluded from named-module discovery edges");
+               "header-unit imports must remain excluded from named-module discovery edges");
+        expect(syntax.imports_header_unit,
+               "angle or quote header-unit imports must request module-pipeline routing");
     }
 
     {
@@ -74,6 +78,8 @@ int main() {
                "comment and literal contents must not create fake module declarations");
         expect(syntax.imported_modules == std::vector<std::string>({"dependency"}),
                "comment and literal contents must not create fake imports");
+        expect(!syntax.imports_header_unit,
+               "literal contents that resemble header imports must not affect routing");
     }
 
     {
@@ -87,6 +93,8 @@ int main() {
                "preprocessor directives must not create discovery module declarations");
         expect(syntax.imported_modules == std::vector<std::string>({"actual"}),
                "preprocessor directive text must not create discovery imports");
+        expect(!syntax.imports_header_unit,
+               "preprocessor text must not create header-unit routing signals");
     }
 
     {
@@ -120,6 +128,8 @@ int main() {
                "ordinary source without a module declaration should remain undeclared");
         expect(syntax.imported_modules.empty(),
                "relative partition imports without module context should not invent providers");
+        expect(!syntax.imports_header_unit,
+               "non-header import-like identifiers must not request header-unit routing");
     }
 
     if (failures != 0) {

--- a/cpp/orchestration/include/mqb/orchestration/MsvcTargetRouter.hpp
+++ b/cpp/orchestration/include/mqb/orchestration/MsvcTargetRouter.hpp
@@ -31,13 +31,16 @@ struct RoutedTargetSourceRequest {
 struct RoutedTargetRequest {
     std::vector<RoutedTargetSourceRequest> sources;
     TargetArtifacts target;
+    // Only consumed by the named-module target when P1689 discovers dynamic
+    // project-local header-unit providers after scanning.
+    std::optional<ProjectArtifactLayout> artifact_layout;
     CompilerOptions compiler_options;
     LinkOptions link_options;
     std::filesystem::path working_directory;
     std::size_t max_parallel_jobs{1};
-    // Execution-routing state only. This is used when discovery observed named
-    // module syntax but found no local interface provider; it must not affect
-    // compile/link signatures or cache identity.
+    // Execution-routing state only. This is used when discovery observed module
+    // syntax but found no local named-module interface provider, including a
+    // header-unit-only entry. It must not affect compile/link cache identity.
     bool force_named_modules{false};
 };
 

--- a/cpp/orchestration/src/MsvcTargetRouter.cpp
+++ b/cpp/orchestration/src/MsvcTargetRouter.cpp
@@ -79,6 +79,7 @@ MsvcTargetRouter::run(const RoutedTargetRequest& request) const {
     IncrementalModuleTargetRequest module_request{
         .sources = std::move(sources),
         .target = request.target,
+        .artifact_layout = request.artifact_layout,
         .compiler_options = request.compiler_options,
         .link_options = request.link_options,
         .working_directory = request.working_directory,

--- a/cpp/tests/mqb_module_cli_e2e_tests.cpp
+++ b/cpp/tests/mqb_module_cli_e2e_tests.cpp
@@ -332,7 +332,7 @@ int main(const int argc, char* argv[]) {
     write_text(
         tree.root / "main.cpp",
         "import \"util.hpp\";\n"
-        "int main() { return header_answer() == 42 ? 0 : 1; }\n");
+        "int main() { return header_answer() >= 42 ? 0 : 1; }\n");
 
     auto header_cold = run_mqb(
         runner,

--- a/cpp/tests/mqb_module_cli_e2e_tests.cpp
+++ b/cpp/tests/mqb_module_cli_e2e_tests.cpp
@@ -321,6 +321,147 @@ int main(const int argc, char* argv[]) {
         }
     }
 
+    // A single ordinary entry containing only a header-unit import must route
+    // through the same public module pipeline without promoting the header into
+    // source discovery output or requiring the caller to pass it positionally.
+    cleanup_error.clear();
+    fs::remove_all(tree.root / ".mqb", cleanup_error);
+    expect(!cleanup_error, "test should clear named-module state before header-unit CLI coverage");
+    const fs::path header = tree.root / "util.hpp";
+    write_text(header, "inline int header_answer() { return 42; }\n");
+    write_text(
+        tree.root / "main.cpp",
+        "import \"util.hpp\";\n"
+        "int main() { return header_answer() == 42 ? 0 : 1; }\n");
+
+    auto header_cold = run_mqb(
+        runner,
+        mqb_executable,
+        tree.root,
+        "2",
+        false,
+        "header-unit-cli");
+    expect(header_cold.has_value(), "cold header-unit public CLI invocation should launch");
+    if (header_cold) {
+        if (header_cold->exit_code != 0) dump_failure(*header_cold);
+        expect(header_cold->exit_code == 0,
+               "single-entry header-unit target should build and run successfully");
+        expect(header_cold->stdout_text.find("[discover] 1 translation units")
+                   != std::string::npos,
+               "header unit must remain outside translation-unit discovery output");
+        expect(header_cold->stdout_text.find("  pipeline: named-modules")
+                   != std::string::npos,
+               "header-unit-only entry must route through the module pipeline");
+        expect(header_cold->stdout_text.find("[compile] main.cpp") != std::string::npos,
+               "cold header-unit CLI target should compile the consumer");
+        expect(header_cold->stdout_text.find("[link] header-unit-cli.exe") != std::string::npos,
+               "cold header-unit CLI target should link the executable");
+        expect(header_cold->stdout_text.find("[run] header-unit-cli.exe") != std::string::npos,
+               "header-unit CLI target should preserve --run behavior");
+    }
+
+    auto header_ifc = first_ifc(tree.root);
+    expect(header_ifc.has_value() && fs::is_regular_file(*header_ifc),
+           "public header-unit CLI target should dynamically create a provider IFC");
+
+    auto header_warm = run_mqb(
+        runner,
+        mqb_executable,
+        tree.root,
+        "1",
+        false,
+        "header-unit-cli");
+    expect(header_warm.has_value(), "warm header-unit public CLI invocation should launch");
+    if (header_warm) {
+        if (header_warm->exit_code != 0) dump_failure(*header_warm);
+        expect(header_warm->exit_code == 0,
+               "warm header-unit target should build and run successfully");
+        expect(contains_line(header_warm->stdout_text, "[up-to-date] main.cpp"),
+               "warm header-unit consumer should reuse its compile cache");
+        expect(contains_line(header_warm->stdout_text, "[up-to-date] header-unit-cli.exe"),
+               "warm header-unit target should reuse its link cache when job count changes");
+    }
+
+    if (header_ifc) {
+        std::error_code time_error;
+        const auto old_ifc_time = fs::last_write_time(*header_ifc, time_error);
+        expect(!time_error, "header-unit CLI mutation fixture requires provider IFC timestamp");
+        write_text(header, "inline int header_answer() { return 43; }\n");
+        time_error.clear();
+        fs::last_write_time(header, old_ifc_time + std::chrono::seconds{2}, time_error);
+        expect(!time_error, "test should make header source deterministically newer than IFC");
+
+        auto header_mutated = run_mqb(
+            runner,
+            mqb_executable,
+            tree.root,
+            "2",
+            false,
+            "header-unit-cli");
+        expect(header_mutated.has_value(), "header mutation public CLI invocation should launch");
+        if (header_mutated) {
+            if (header_mutated->exit_code != 0) dump_failure(*header_mutated);
+            expect(header_mutated->exit_code == 0,
+                   "header mutation should rebuild through the public CLI and preserve behavior");
+            expect(header_mutated->stdout_text.find("[compile] main.cpp") != std::string::npos,
+                   "header-unit provider rebuild should explicitly rebuild the consumer");
+            expect(header_mutated->stdout_text.find("[link] header-unit-cli.exe")
+                       != std::string::npos,
+                   "header-unit provider mutation should relink the executable");
+        }
+
+        header_ifc = first_ifc(tree.root);
+        expect(header_ifc.has_value(), "rebuilt header-unit CLI target should retain provider IFC");
+        if (header_ifc) {
+            time_error.clear();
+            const auto rebuilt_ifc_time = fs::last_write_time(*header_ifc, time_error);
+            expect(!time_error, "rebuilt header-unit target requires IFC timestamp");
+            time_error.clear();
+            fs::last_write_time(header, rebuilt_ifc_time - std::chrono::seconds{1}, time_error);
+            expect(!time_error, "test should normalize header source behind rebuilt IFC");
+
+            auto header_warm_again = run_mqb(
+                runner,
+                mqb_executable,
+                tree.root,
+                "1",
+                false,
+                "header-unit-cli");
+            expect(header_warm_again.has_value(), "rebuilt header-unit target should run warm again");
+            if (header_warm_again) {
+                if (header_warm_again->exit_code != 0) dump_failure(*header_warm_again);
+                expect(contains_line(header_warm_again->stdout_text, "[up-to-date] main.cpp")
+                           && contains_line(header_warm_again->stdout_text, "[up-to-date] header-unit-cli.exe"),
+                       "rebuilt header-unit target should return to compile-0/link-0 state");
+            }
+
+            time_error.clear();
+            fs::remove(*header_ifc, time_error);
+            expect(!time_error, "test should delete only the dynamically allocated header-unit IFC");
+            auto header_repair = run_mqb(
+                runner,
+                mqb_executable,
+                tree.root,
+                "2",
+                false,
+                "header-unit-cli");
+            expect(header_repair.has_value(), "missing header IFC public CLI invocation should launch");
+            if (header_repair) {
+                if (header_repair->exit_code != 0) dump_failure(*header_repair);
+                expect(header_repair->exit_code == 0,
+                       "missing dynamic header IFC should be repaired through public CLI");
+                expect(header_repair->stdout_text.find("[compile] main.cpp") != std::string::npos,
+                       "missing header IFC repair should rebuild the consumer downstream");
+                expect(header_repair->stdout_text.find("[link] header-unit-cli.exe")
+                           != std::string::npos,
+                       "missing header IFC repair should relink the executable");
+                const auto repaired_header_ifc = first_ifc(tree.root);
+                expect(repaired_header_ifc.has_value() && fs::is_regular_file(*repaired_header_ifc),
+                       "missing header IFC should be recreated by the public CLI");
+            }
+        }
+    }
+
     // Replace the entry with an import that has no project-local provider. The
     // build must still enter the P1689 path and fail closed; falling back to the
     // ordinary target here would bypass module provider validation.


### PR DESCRIPTION
Completes the public-CLI Header Units slice under #16 on top of #23.

## Scope

- keep header-unit imports out of named-module discovery edges while recording a dedicated lexical routing signal
- make single-entry source discovery return `requires_module_pipeline=true` for `import "x.hpp";` / `import <x>;`
- preserve source discovery as translation-unit candidate selection only; headers are not promoted into the selected TU set
- pass a typed `ProjectArtifactLayout` through `MsvcTargetRouter` to the module target so P1689-discovered header providers can receive dynamic IFC/deps/cache artifacts
- construct that layout from the existing `ModuleCliTargetRequest::project_root`; no new public CLI argument or `main.cpp` surface is introduced
- add real public `mqb main.cpp --run` VS2026 coverage for a header-unit-only entry

## Public CLI E2E

The test exercises:

1. discovery selects exactly one TU (`main.cpp`) while routing to `named-modules`
2. cold dynamic header-unit provider + consumer + link/run succeeds
3. provider IFC is created under `.mqb/ifc`
4. unchanged build with a different job count is compile-0/link-0 for the visible consumer/target
5. header-only mutation rebuilds the provider internally, explicitly rebuilds `main.cpp`, and relinks
6. rebuilt target becomes warm again
7. deleting only the dynamically allocated header IFC repairs provider + consumer + link and recreates the IFC
8. unresolved external named modules continue to fail closed

## Verification

C++ V2 workflow #218 completed successfully on exact head `4589209b478a28eb1dc5bff65b7b240199fbe7b6`: Configure, Build, all 56 CTest cases, and cleanup passed.

Workflow #217 had already proven the product path (cold/warm/header mutation/missing-IFC all rebuilt as expected); its only failure was a test-fixture runtime predicate that still required the mutated header to return exactly 42 after the fixture intentionally changed it to 43. The fixture was corrected to preserve successful executable behavior across that mutation; product code was unchanged by the fix.

## Boundary

This completes project-local Header Unit routing/execution through the public C++ CLI. External/prebuilt named-module providers and `import std` remain separate #16 policies.

Advances #16; does not close it.