### PR TITLE
release: prepare v5.0.0-rc.1 C++ refactor candidate

### DIFF
--- a/.github/workflows/cpp-release.yml
+++ b/.github/workflows/cpp-release.yml
@@ -1,0 +1,138 @@
+name: C++ Release Candidate
+
+on:
+  pull_request:
+    paths:
+      - 'cpp/**'
+      - 'README.md'
+      - 'docs/**'
+      - 'release/**'
+      - '.github/workflows/cpp-release.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'release/v5.0.0-rc.1.md'
+
+jobs:
+  build-test-package:
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    env:
+      MQB_RELEASE_VERSION: 5.0.0-rc.1
+      MQB_PACKAGE_NAME: vscode-msvc-quick-build-v5.0.0-rc.1-windows-x64
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Configure Release
+        run: >-
+          cmake -S cpp -B cpp/build-release
+          -G "Visual Studio 18 2026" -A x64
+          -DMQB_ENABLE_INSTALLED_MSVC_TESTS=ON
+          -DMQB_VERSION=${{ env.MQB_RELEASE_VERSION }}
+
+      - name: Build Release
+        run: cmake --build cpp/build-release --config Release --parallel
+
+      - name: Test Release
+        run: ctest --test-dir cpp/build-release -C Release --output-on-failure
+
+      - name: Verify embedded release version
+        shell: pwsh
+        run: |
+          $mqb = Join-Path $PWD 'cpp/build-release/apps/mqb/Release/mqb.exe'
+          if (-not (Test-Path -LiteralPath $mqb -PathType Leaf)) {
+            throw "Release executable not found: $mqb"
+          }
+          $help = & $mqb --help
+          if ($LASTEXITCODE -ne 0) {
+            throw "mqb --help failed with exit code $LASTEXITCODE"
+          }
+          $firstLine = @($help)[0]
+          $expected = "MQB $env:MQB_RELEASE_VERSION - MSVC Quick Build (C++ refactor)"
+          if ($firstLine -ne $expected) {
+            throw "Embedded version mismatch. Expected '$expected', got '$firstLine'"
+          }
+          Write-Host $firstLine
+
+      - name: Stage release package
+        shell: pwsh
+        run: |
+          $dist = Join-Path $PWD 'dist'
+          $stage = Join-Path $dist $env:MQB_PACKAGE_NAME
+          New-Item -ItemType Directory -Force -Path $stage | Out-Null
+
+          Copy-Item 'cpp/build-release/apps/mqb/Release/mqb.exe' (Join-Path $stage 'mqb.exe')
+          Copy-Item 'README.md' (Join-Path $stage 'README.md')
+          Copy-Item 'LICENSE' (Join-Path $stage 'LICENSE')
+          Copy-Item 'docs/MQB_CONFIG.md' (Join-Path $stage 'MQB_CONFIG.md')
+          Copy-Item 'docs/CPP_V2_ARCHITECTURE.md' (Join-Path $stage 'CPP_V2_ARCHITECTURE.md')
+          Copy-Item 'release/v5.0.0-rc.1.md' (Join-Path $stage 'RELEASE_NOTES.md')
+
+          $zip = Join-Path $dist ($env:MQB_PACKAGE_NAME + '.zip')
+          if (Test-Path $zip) { Remove-Item $zip -Force }
+          Compress-Archive -Path (Join-Path $stage '*') -DestinationPath $zip -CompressionLevel Optimal
+
+          $hash = (Get-FileHash -Algorithm SHA256 -LiteralPath $zip).Hash.ToLowerInvariant()
+          $shaPath = $zip + '.sha256'
+          "$hash  $($env:MQB_PACKAGE_NAME).zip" | Set-Content -LiteralPath $shaPath -Encoding ascii -NoNewline
+
+          Write-Host "Package: $zip"
+          Write-Host "SHA256:  $hash"
+
+      - name: Upload validated package
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ env.MQB_PACKAGE_NAME }}
+          path: |
+            dist/${{ env.MQB_PACKAGE_NAME }}.zip
+            dist/${{ env.MQB_PACKAGE_NAME }}.zip.sha256
+          if-no-files-found: error
+          retention-days: 30
+
+  publish-prerelease:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build-test-package
+    runs-on: windows-latest
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      MQB_RELEASE_VERSION: 5.0.0-rc.1
+      MQB_PACKAGE_NAME: vscode-msvc-quick-build-v5.0.0-rc.1-windows-x64
+
+    steps:
+      - name: Checkout release notes
+        uses: actions/checkout@v7
+
+      - name: Download validated package
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ env.MQB_PACKAGE_NAME }}
+          path: dist-publish
+
+      - name: Publish GitHub prerelease
+        shell: pwsh
+        run: |
+          $tag = "v$env:MQB_RELEASE_VERSION"
+          gh release view $tag --repo $env:GITHUB_REPOSITORY *> $null
+          if ($LASTEXITCODE -eq 0) {
+            Write-Host "Release $tag already exists; leaving it unchanged."
+            exit 0
+          }
+
+          $zip = Join-Path $PWD "dist-publish/$($env:MQB_PACKAGE_NAME).zip"
+          $sha = $zip + '.sha256'
+          if (-not (Test-Path -LiteralPath $zip -PathType Leaf)) { throw "Missing release package: $zip" }
+          if (-not (Test-Path -LiteralPath $sha -PathType Leaf)) { throw "Missing checksum: $sha" }
+
+          gh release create $tag $zip $sha `
+            --repo $env:GITHUB_REPOSITORY `
+            --target $env:GITHUB_SHA `
+            --title "$tag — C++ Refactor Release Candidate" `
+            --notes-file 'release/v5.0.0-rc.1.md' `
+            --prerelease
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/.github/workflows/cpp-release.yml
+++ b/.github/workflows/cpp-release.yml
@@ -28,11 +28,12 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Configure Release
-        run: >-
-          cmake -S cpp -B cpp/build-release
-          -G "Visual Studio 18 2026" -A x64
-          -DMQB_ENABLE_INSTALLED_MSVC_TESTS=ON
-          -DMQB_VERSION=${{ env.MQB_RELEASE_VERSION }}
+        shell: pwsh
+        run: |
+          cmake -S cpp -B cpp/build-release `
+            -G "Visual Studio 18 2026" -A x64 `
+            -DMQB_ENABLE_INSTALLED_MSVC_TESTS=ON `
+            "-DMQB_VERSION=$env:MQB_RELEASE_VERSION"
 
       - name: Build Release
         run: cmake --build cpp/build-release --config Release --parallel

--- a/.github/workflows/cpp-v2.yml
+++ b/.github/workflows/cpp-v2.yml
@@ -11,7 +11,9 @@ on:
       - 'README.md'
       - 'docs/CPP_V2_ARCHITECTURE.md'
       - 'docs/MQB_CONFIG.md'
+      - 'release/**'
       - '.github/workflows/cpp-v2.yml'
+      - '.github/workflows/cpp-release.yml'
 
 jobs:
   build-and-test:
@@ -19,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Configure
         run: cmake -S cpp -B cpp/build -G "Visual Studio 18 2026" -A x64 -DMQB_ENABLE_INSTALLED_MSVC_TESTS=ON

--- a/README.md
+++ b/README.md
@@ -4,75 +4,81 @@
 
 > **当前迁移状态**
 >
-> - `cpp/` 中的 **C++23 V2 (`mqb.exe`)** 已具备可执行的普通 C++ / project-local named modules 构建链，并由 Visual Studio 2026 的真实工具链 E2E 持续验证。
-> - `build.ps1` 仍保留为 **PowerShell Golden Reference / 过渡期稳定入口**。最终安装、发布与默认入口切换尚未完成。
-> - MQB 不再宣称与 MSBuild “1:1 等价”。当前原则是：对已实现的常用 MSVC 编译/链接语义进行显式建模，并用回归测试证明行为。
+> - `cpp/` 中的 **C++23 重构版 (`mqb.exe`)** 已具备普通 C++、project-local named modules 与 project-local header units 的端到端构建链，并由 Visual Studio 2026 真实工具链 E2E 持续验证。
+> - `v5.0.0-rc.1` 是 C++ 重构版的首个可分发 Release Candidate；它是独立的 `mqb.exe`，**尚不代表 PowerShell → C++ 的最终 cutover**。
+> - `build.ps1` 仍保留为 **PowerShell Golden Reference / 过渡期稳定入口**；现有 `install.bat` 和 PowerShell profile 不会被 RC 静默替换。
+> - MQB 不宣称与 MSBuild “1:1 等价”。当前原则是：显式建模已支持的常用 MSVC 语义，并用真实编译器回归测试证明行为。
 
-## C++ V2 现在能做什么
+## v5.0.0-rc.1 C++ Release Candidate
+
+RC 的 Windows x64 包由 GitHub Actions 在 **Release 配置**下构建；同一条 workflow 会先运行完整 VS2026 CTest，再生成 zip 和 SHA-256，最后才允许创建 prerelease。
+
+发布资产：
+
+```text
+vscode-msvc-quick-build-v5.0.0-rc.1-windows-x64.zip
+vscode-msvc-quick-build-v5.0.0-rc.1-windows-x64.zip.sha256
+```
+
+安装/试用：
+
+```powershell
+# 解压后，将 mqb.exe 所在目录加入 PATH
+mqb --help
+mqb main.cpp --run
+```
+
+`mqb --help` 第一行会携带二进制内嵌版本；RC 包应显示：
+
+```text
+MQB 5.0.0-rc.1 - MSVC Quick Build (C++ refactor)
+```
+
+发布二进制使用静态 MSVC runtime，避免要求用户额外安装 Visual C++ Redistributable。Release Candidate 的完整边界见 [`release/v5.0.0-rc.1.md`](release/v5.0.0-rc.1.md)。
+
+---
+
+## C++ 重构版现在能做什么
 
 - **结构化 MSVC 调用**：直接执行 `cl.exe` / `link.exe`，不通过 shell 拼接命令字符串。
 - **工具链发现**：支持 Visual Studio 与 portable MSVC 路径，工具链身份进入缓存判断。
-- **单入口智能发现**：`mqb main.cpp` 会从项目内 `#include` 和 named `import` 连接关系选择相关 translation units。
-- **Project-local named modules**：支持 `.ixx` / `.cppm` / `.mpp` interface providers，使用 MSVC `/scanDependencies` + P1689 建立真实拓扑。
+- **单入口智能发现**：`mqb main.cpp` 会从项目内 include / named-import 连接关系选择相关 translation units。
+- **Project-local named modules**：支持 `.ixx` / `.cppm` / `.mpp` interface providers、partitions 与 implementation units，使用 `/scanDependencies` + P1689 建立真实拓扑。
+- **Project-local header units**：`import "header.hpp";` / `import <header>;` 会进入 P1689 模块管线；header 本身不会被伪装成普通 TU，IFC 由 target 动态分配、增量生成与修复。
 - **增量编译**：使用 `/sourceDependencies` 跟踪实际头文件 freshness；编译参数、工具链、模块引用和计划输出参与 compile identity。
-- **IFC 增量正确性**：provider IFC 缺失、provider 重编或引用变化会可靠传导到 consumer。
+- **IFC 增量正确性**：provider IFC 缺失、provider/header-unit 重编或引用变化会可靠传导到 consumer。
 - **增量链接**：对象、显式库、linker identity 与 link options 共同决定是否重新链接。
 - **有界并行**：`-j/--jobs` 控制 TU scan/compile 并发；job count 是 execution policy，不污染 build cache identity。
 - **`mqb.json`**：严格、带版本的项目配置，遵循 `explicit CLI > mqb.json > built-in defaults`。
 - **结构化运行参数**：`--run -- arg1 "arg 2"` 保持 argv 边界。
-- **隔离构建产物**：全部 C++ V2 中间产物放在项目 `.mqb/` 下，不在源码目录通配删除 `.obj/.ifc`。
+- **隔离构建产物**：全部 C++ 中间产物放在项目 `.mqb/` 下，不在源码目录通配删除 `.obj/.ifc`。
 
 ### 当前明确不支持
 
-以下能力目前**故意 fail closed**，不会为了“看起来能编译”而退回普通 TU 路径：
+以下能力目前**故意 fail closed**，不会为了“看起来能编译”而偷偷退回普通 TU 路径：
 
-- C++ header units；
 - external / prebuilt named-module providers；
 - `import std;`；
 - C (`.c`) translation units；
-- 将 C++ V2 宣称为 PowerShell 版本的完整行为替代品。
+- 将 C++ RC 宣称为 PowerShell 版本的完整行为替代品。
 
-这些 Modules 扩展策略跟踪在 Issue #16；每一种能力都会先定义 artifact / ownership / freshness / cache policy，再接真实 MSVC E2E。
+Modules 剩余扩展策略跟踪在 Issue #16；最终 stable v5 还需要 PowerShell ↔ C++ parity / installer / default-entry cutover 的独立验收。
 
 ---
 
-## 构建 `mqb.exe`
+## 从源码构建 `mqb.exe`
 
-要求：
-
-- Windows；
-- CMake 3.25+；
-- Visual Studio 2026 / MSVC（仓库 CI 当前使用 `Visual Studio 18 2026` generator）；
-- C++23 编译能力。
+要求：Windows、CMake 3.25+、Visual Studio 2026 / MSVC、C++23 编译能力。
 
 ```powershell
 cmake -S cpp -B cpp/build -G "Visual Studio 18 2026" -A x64
 cmake --build cpp/build --config Release --target mqb
-```
-
-生成的可执行文件位于：
-
-```text
-cpp/build/apps/mqb/Release/mqb.exe
-```
-
-查看当前 CLI 契约：
-
-```powershell
 .\cpp\build\apps\mqb\Release\mqb.exe --help
 ```
 
+默认开发构建版本为 `5.0.0-dev`。发布流水线会显式传入 `-DMQB_VERSION=5.0.0-rc.1`，因此开发二进制不会冒充已发布版本。
+
 ### 运行完整测试
-
-普通开发测试：
-
-```powershell
-cmake -S cpp -B cpp/build -G "Visual Studio 18 2026" -A x64
-cmake --build cpp/build --config Debug --parallel
-ctest --test-dir cpp/build -C Debug --output-on-failure
-```
-
-启用需要本机 Visual Studio/MSVC 的真实工具链测试：
 
 ```powershell
 cmake -S cpp -B cpp/build -G "Visual Studio 18 2026" -A x64 `
@@ -81,13 +87,11 @@ cmake --build cpp/build --config Debug --parallel
 ctest --test-dir cpp/build -C Debug --output-on-failure
 ```
 
-主线 CI 会运行后一种配置。
+Release Candidate 还会在独立 build tree 中以 `Release` 配置重复完整 installed-MSVC 测试，并对最终包做版本与 SHA-256 校验。
 
 ---
 
-## C++ V2 Quickstart
-
-下面假设 `mqb.exe` 已在 `PATH` 中；开发阶段也可以直接使用上面的构建输出路径。
+## Quickstart
 
 ### 单文件 / 自动发现
 
@@ -95,9 +99,9 @@ ctest --test-dir cpp/build -C Debug --output-on-failure
 mqb main.cpp --env vs --std latest --run
 ```
 
-单个 positional source 默认启用 smart discovery。若 `main.cpp` 通过本地 include/import 连接到其他 C++ TU，MQB 会选择相关源文件再构建。
+单个 positional source 默认启用 smart discovery。若 `main.cpp` 通过本地 include / named import 连接到其他 C++ TU，MQB 会选择相关源文件再构建。
 
-可以显式关闭：
+显式关闭：
 
 ```powershell
 mqb main.cpp --no-discover
@@ -121,8 +125,6 @@ mqb main.cpp --run -- input.txt "hello world" 42
 
 ### Project-local named modules
 
-例如：
-
 ```cpp
 // math.ixx
 export module math;
@@ -141,21 +143,34 @@ int main() { return answer() == 42 ? 0 : 1; }
 mqb main.cpp --env vs --std latest --run
 ```
 
-smart discovery 会把项目内可达的 `math.ixx` 作为**候选 provider** 加入 source set；真正的 provider 选择、依赖顺序和冲突诊断仍由 `/scanDependencies` 的 P1689 结果决定。
+smart discovery 会把项目内可达的 `math.ixx` 作为**候选 provider** 加入 source set；真正的 provider 选择、依赖顺序和冲突诊断仍由 `/scanDependencies` 的 P1689 结果决定。未引用的 module interface 不会因为存在于目录里就自动进入目标。
 
-也可以显式指定：
+### Project-local header units
 
-```powershell
-mqb main.cpp math.ixx --env vs --std latest -j 2 -o app --run
+```cpp
+// util.hpp
+inline int answer() { return 42; }
 ```
 
-未引用的其他 module interface 不会因为存在于项目目录就自动进入目标。
+```cpp
+// main.cpp
+import "util.hpp";
+int main() { return answer() == 42 ? 0 : 1; }
+```
+
+同样只需要：
+
+```powershell
+mqb main.cpp --env vs --std latest --run
+```
+
+lexical discovery 只负责识别“这个 entry 必须进入 module pipeline”，不会把 `util.hpp` 放进 translation-unit source set。MSVC `/scanDependencies` 的 P1689 `source-path` / lookup method 才是 header-unit provider 拓扑的权威来源；MQB 随后为该物理 header 动态分配 `.mqb/ifc`、deps 和 cache artifact。
 
 ---
 
 ## `mqb.json`
 
-C++ V2 使用根目录 `mqb.json`，不是 PowerShell 版本的 `msvc_list.json`。
+C++ 重构版使用根目录 `mqb.json`，不是 PowerShell 版本的 `msvc_list.json`。
 
 最小文件：
 
@@ -189,20 +204,16 @@ C++ V2 使用根目录 `mqb.json`，不是 PowerShell 版本的 `msvc_list.json`
 }
 ```
 
-MQB 从 invocation directory 向上查找最近的 `mqb.json`；配置文件所在目录成为 project root 和 `.mqb/` 根。
-
-完整 schema、路径基准、precedence 与 cache 行为见 [`docs/MQB_CONFIG.md`](docs/MQB_CONFIG.md)。
+MQB 从 invocation directory 向上查找最近的 `mqb.json`；配置文件所在目录成为 project root 和 `.mqb/` 根。完整 schema、路径基准、precedence 与 cache 行为见 [`docs/MQB_CONFIG.md`](docs/MQB_CONFIG.md)。
 
 ---
 
-## 常用 C++ V2 CLI
+## 常用 CLI
 
 ```text
 mqb <entry.cpp> [options] [-- program-args...]
 mqb <source.cpp|module.ixx|module.cppm|module.mpp> <more-sources...> [options]
 ```
-
-常用选项：
 
 | 选项 | 作用 |
 |---|---|
@@ -222,7 +233,7 @@ mqb <source.cpp|module.ixx|module.cppm|module.mpp> <more-sources...> [options]
 | `-v, --verbose` | 输出 project/config/toolchain/artifact/pipeline 信息 |
 | `--` | 后续参数原样作为 program argv |
 
-`mqb --help` 是 CLI 的权威即时说明。
+`mqb --help` 是 CLI 的权威即时说明，并显示当前二进制内嵌版本。
 
 ---
 
@@ -233,18 +244,16 @@ mqb <source.cpp|module.ixx|module.cppm|module.mpp> <more-sources...> [options]
 ├── obj/     # collision-free object files
 ├── deps/    # /sourceDependencies metadata
 ├── scan/    # /scanDependencies / P1689 metadata
-├── ifc/     # module interface artifacts
+├── ifc/     # named-module / header-unit IFC artifacts
 ├── cache/   # compile/link cache metadata
 └── bin/     # executable
 ```
 
-源文件身份参与 artifact routing，因此跨目录同 basename TU 不会共用同一个 object/cache 路径。
+Windows 上同一物理源文件即使被用户或 MSVC scanner 以不同大小写/路径别名表示，也会归一到稳定 artifact identity，避免一份 source 分裂出两套 cache/IFC。
 
 ---
 
 ## 架构原则
-
-C++ V2 的核心链路是：
 
 ```text
 CLI / mqb.json
@@ -264,52 +273,29 @@ Incremental link
 Optional run
 ```
 
-几个重要边界：
+关键边界：Source discovery 只选候选；`/scanDependencies` 管模块拓扑，`/sourceDependencies` 管实际 header freshness；Planner 与 Executor 分离；shell text 不是构建模型；缓存命中必须由 identity + outputs + dependencies 一起证明；并行度只是 execution policy；未定义 artifact/freshness policy 的能力必须 fail closed。
 
-1. **Source discovery 只选候选**，不替代编译器依赖信息。
-2. **`/scanDependencies` 只负责模块拓扑**，不替代 `/sourceDependencies` 的实际头文件 freshness。
-3. **Planner 与 Executor 分离**；Core 不直接知道 `cl.exe` 命令行细节。
-4. **shell text 不是构建模型**；进程使用 executable + argv + environment 的结构化表示。
-5. **缓存命中必须由 build identity + outputs + dependencies 一起证明**，不能只看源码/EXE mtime。
-6. **并行度是执行策略**，改变 `-j` 不应导致 rebuild。
-7. 未定义 artifact/freshness policy 的能力必须 **fail closed**。
-
-更详细的模块边界、缓存和 orchestration 设计见 [`docs/CPP_V2_ARCHITECTURE.md`](docs/CPP_V2_ARCHITECTURE.md)。
+更详细的模块、缓存和 orchestration 设计见 [`docs/CPP_V2_ARCHITECTURE.md`](docs/CPP_V2_ARCHITECTURE.md)。
 
 ---
 
 ## PowerShell Golden Reference（过渡期）
 
-根目录以下文件仍保留：
+根目录的 `build.ps1`、`install.bat`、`Microsoft.PowerShell_profile.ps1` 仍属于旧 PowerShell 实现。它们继续保持已有用户的稳定入口、作为 C++ 迁移 Golden Reference，并支撑后续 parity campaign。
 
-```text
-build.ps1
-install.bat
-Microsoft.PowerShell_profile.ps1
-```
+**`v5.0.0-rc.1` 不修改这套安装入口。** RC 用户应直接解压 `mqb.exe` 并自行加入 PATH；在 stable v5 的 parity/cutover 通过之前，不应把 `install.bat` 理解为 C++ `mqb.exe` 的安装器。
 
-它们属于旧 PowerShell 实现，目前的作用是：
-
-- 保持已有用户的稳定入口；
-- 为 C++ V2 行为迁移提供 Golden Reference；
-- 支撑后续 PowerShell/C++ parity campaign 与最终 cutover。
-
-因此**现在不应把 `install.bat` 理解为 C++ V2 `mqb.exe` 的正式安装器**。C++ V2 的发布、安装与默认入口切换仍是后续迁移里程碑。
-
-旧 `msvc_list.json` / PowerShell 参数体系也不等于 C++ V2 的 `mqb.json` schema；不要混用两套配置契约。
+旧 `msvc_list.json` / PowerShell 参数体系也不等于 C++ 的 `mqb.json` schema；不要混用两套配置契约。
 
 ---
 
 ## 当前路线
 
-接下来的主要工程方向：
-
-- 完成 Modules 扩展策略：header units、external/prebuilt providers、`import std`；
-- PowerShell ↔ C++ V2 行为 parity campaign；
-- `mqb.exe` 发布/安装/默认入口 cutover；
-- 再逐步删除不再需要的 PowerShell Golden Reference。
-
-当前 Modules 扩展跟踪：Issue #16。
+- `v5.0.0-rc.1`：交付可验证的 C++ standalone candidate；
+- Issue #16：继续 external/prebuilt named-module providers 与 `import std`；
+- PowerShell ↔ C++ 行为 parity campaign；
+- installer/profile/default-entry cutover；
+- 满足上述 stable gate 后发布正式 v5，并逐步删除不再需要的 PowerShell Golden Reference。
 
 ## License
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,10 +1,23 @@
 cmake_minimum_required(VERSION 3.25)
 
-project(mqb VERSION 0.1.0 LANGUAGES CXX)
+if(POLICY CMP0091)
+    cmake_policy(SET CMP0091 NEW)
+endif()
+
+project(mqb VERSION 5.0.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Release candidates are shipped as a standalone mqb.exe. Keep MSVC's runtime
+# linked statically so the package does not depend on a separately installed
+# Visual C++ redistributable. Debug keeps the matching debug static runtime.
+if(MSVC)
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+endif()
+
+set(MQB_VERSION "${PROJECT_VERSION}-dev" CACHE STRING "User-visible MQB version")
 
 option(MQB_BUILD_TESTS "Build MQB tests" ON)
 option(MQB_ENABLE_INSTALLED_MSVC_TESTS "Run tests that require an installed Visual Studio toolchain" OFF)

--- a/cpp/apps/mqb/CMakeLists.txt
+++ b/cpp/apps/mqb/CMakeLists.txt
@@ -19,6 +19,7 @@ target_link_libraries(mqb_cli
 )
 
 target_compile_features(mqb_cli PUBLIC cxx_std_23)
+target_compile_definitions(mqb_cli PRIVATE MQB_VERSION="${MQB_VERSION}")
 
 add_executable(mqb
     main.cpp

--- a/cpp/apps/mqb/Cli.cpp
+++ b/cpp/apps/mqb/Cli.cpp
@@ -10,6 +10,10 @@
 #include <system_error>
 #include <utility>
 
+#ifndef MQB_VERSION
+#define MQB_VERSION "0.0.0-dev"
+#endif
+
 namespace mqb::cli {
 namespace {
 
@@ -273,9 +277,8 @@ parse_arguments(const std::span<const std::string_view> arguments) {
 }
 
 std::string_view usage() noexcept {
-    return R"(MQB - MSVC Quick Build (C++ V2)
-
-Usage:
+    return "MQB " MQB_VERSION " - MSVC Quick Build (C++ refactor)\n\n"
+R"(Usage:
   mqb <entry.cpp> [options] [-- program-args...]
   mqb <source.cpp> <more-sources...|module.ixx...> [options] [-- program-args...]
 
@@ -293,8 +296,10 @@ Source selection:
 
 Single-entry discovery follows reachable project-local named imports to project-local
 module-interface candidates. Discovery selects candidates only; MSVC P1689 scanning remains
-the authority for module topology and provider validation. Header units, external/prebuilt
-provider execution, and import std remain unsupported and fail closed in the module pipeline.
+the authority for module topology and provider validation. Project-local header-unit imports
+stay outside TU discovery but route through the P1689 module pipeline, where their IFCs are
+built and cached automatically. External/prebuilt named-module providers and import std
+remain unsupported and fail closed.
 
 Options:
   --debug                  Explicitly select Debug compile/link preset
@@ -313,7 +318,7 @@ Options:
   --env <auto|vs|portable> Toolchain selection (default: auto)
   --portable-root <dir>    Add a portable_msvc root candidate
   -v, --verbose            Show config, discovery, toolchain, and artifact details
-  -h, --help               Show this help
+  -h, --help               Show this help and the embedded build version
   --                       Pass all remaining argv elements to the program
 
 Job count is execution policy only; changing -j does not invalidate build caches.
@@ -324,7 +329,7 @@ Generated state:
   .mqb/obj/    collision-free object files
   .mqb/deps/   compiler dependency metadata
   .mqb/scan/   module dependency scan metadata
-  .mqb/ifc/    module interface artifacts
+  .mqb/ifc/    module/header-unit interface artifacts
   .mqb/cache/  compile and link cache metadata
   .mqb/bin/    linked executable
 )";

--- a/docs/CPP_V2_ARCHITECTURE.md
+++ b/docs/CPP_V2_ARCHITECTURE.md
@@ -1,15 +1,15 @@
-# C++ V2 Architecture
+# C++ Refactor Architecture
 
-This document defines the architecture for migrating MSVC Quick Build from the PowerShell implementation to a typed C++23 build tool.
+This document defines the current typed C++23 architecture of MSVC Quick Build and the boundary of the v5 release-candidate line.
 
 ## Goals
 
-- Keep the PowerShell implementation as the behavioral reference until parity is proven.
+- Keep the PowerShell implementation as the behavioral reference until parity and cutover are explicitly proven.
 - Separate source selection, build policy, dependency topology, compiler/linker execution, and process execution.
-- Keep MSVC-specific spellings out of the core model.
-- Make compile and link cache invalidation explainable and regression-testable.
+- Keep MSVC-specific switches out of the Core model.
+- Make compile/link cache invalidation explainable and regression-testable.
 - Treat paths and argv as structured data rather than shell command strings.
-- Prefer a conservative rebuild/relink or an explicit unsupported error over reusing uncertain artifacts.
+- Prefer conservative rebuild/relink or an explicit unsupported error over uncertain artifact reuse.
 
 ## Layers
 
@@ -22,20 +22,21 @@ CLI (mqb.exe)
     |
     +--> Source Discovery (mqb_discovery)
     |      ordinary C++ candidate-TU selection
-    |      reachable project-local named-module provider candidates
-    |      module-pipeline routing requirement
+    |      reachable project-local named-module candidates
+    |      module/header-unit routing requirement
     |
     v
 Target routing
     +--> Ordinary target orchestration
-    |      bounded parallel N x compile coordinator -> ordered results -> one link coordinator
+    |      bounded parallel compile -> deterministic ordered results -> incremental link
     |
-    +--> Named-module orchestration
+    +--> Module target orchestration
            parallel /scanDependencies
                -> P1689R5 typed model
-               -> resolved provider graph + compile levels
-               -> level-barrier bounded compile waves
-               -> one incremental link coordinator
+               -> named-module + project-local header-unit graph
+               -> deterministic compile levels
+               -> bounded level-barrier compile waves
+               -> incremental link
     |
     +--------------------+--------------------+
     v                    v                    v
@@ -53,37 +54,32 @@ Core                  Modules              MSVC backend
                                               ProcessSpec { executable, argv, cwd, env }
                                                     |
                                                     v
-                                             Windows platform
                                              WindowsProcessRunner
                                              CreateProcessW
 ```
 
 ## Architectural rules
 
-1. **Core does not know `cl.exe` or `link.exe`.** MSVC switches and schemas belong to the backend.
-2. **Planner does not execute.** `BuildPlanner` only creates typed actions.
+1. **Core does not know `cl.exe` or `link.exe`.** MSVC spelling belongs to the backend.
+2. **Planner does not execute.** `BuildPlanner` produces typed planned actions and outputs.
 3. **Correctness beats cache hit rate.** Uncertain cache state rebuilds or relinks.
-4. **No internal shell command API.** Executable and argv remain separate until the Windows adapter builds the `CreateProcessW` command line.
-5. **UTF-8 at the process abstraction boundary.** Windows converts textual argv/environment data to UTF-16 immediately before `CreateProcessW`.
-6. **Compile state and link state are independent.** A compile cache hit does not imply a link cache hit, and link-only changes must never force unnecessary compilation.
-7. **A fresh compile is an explicit relink signal.** Linking must not depend solely on filesystem timestamp granularity.
-8. **Source identity is not a basename.** Project artifacts preserve relative source identity; external sources receive a stable hashed namespace.
-9. **Writable artifacts are exclusive.** Module target preflight rejects empty or colliding object, dependency, scan, IFC, compile-cache, executable, and link-cache paths before external processes start.
-10. **Run-time argv is not build identity.** `--run` and arguments after `--` are execution state only; changing them must not invalidate compile or link caches.
-11. **Discovery is not dependency freshness.** Smart discovery chooses candidate translation units; MSVC `/sourceDependencies` remains the authority for header freshness after compilation.
-12. **Configuration is typed policy, not shell text.** `mqb.json` decodes into optional typed overrides before MSVC arguments are produced.
-13. **Parallelism is execution policy, not build identity.** Job counts must not invalidate compile or link caches.
-14. **Module topology and header freshness are different data.** `/scanDependencies` determines pre-compile module ordering; `/sourceDependencies` remains the post-compile freshness source for headers.
-15. **Provider selection has one owner.** `ModuleDependencyGraphBuilder` resolves named-module providers once; orchestration consumes those exact resolved edges for `/reference` wiring and downstream rebuild propagation.
-16. **Unsupported module requirements fail closed.** Header units and unresolved external/prebuilt named modules are never silently ignored.
-17. **Discovery does not become a second module compiler.** Its lexical module pass selects project-local candidates and records whether module routing is required; P1689 remains authoritative for topology and provider validation.
-18. **Module routing is explicit execution state, not cache identity.** A discovery result may force the named-module pipeline even when no local interface was selected, preventing import-only targets from silently falling back to ordinary compilation.
+4. **No internal shell-command API.** Executable, argv, cwd, and environment remain structured until the Windows adapter.
+5. **Compile state and link state are independent.** Link-only changes do not force unrelated compilation.
+6. **A fresh compile is an explicit relink signal.** Correctness must not depend only on filesystem timestamp granularity.
+7. **Source identity is not a basename.** Project artifacts preserve source identity and external sources use a stable namespace.
+8. **Windows physical aliases must converge.** Existing sources that are physically equivalent must receive the same artifact identity even when Windows/MSVC spells their paths differently.
+9. **Writable artifacts are exclusive.** Target preflight rejects empty/colliding writable outputs before external processes start.
+10. **Run-time argv and job count are execution policy, not build identity.**
+11. **Discovery is not dependency freshness.** Discovery chooses candidate TUs; `/sourceDependencies` remains the post-compile header-freshness authority.
+12. **Module topology and header freshness are separate.** `/scanDependencies`/P1689 orders module work; `/sourceDependencies` validates real compile dependencies.
+13. **Provider selection has one owner.** `ModuleDependencyGraphBuilder` resolves graph edges; orchestration consumes those resolved edges rather than guessing providers again.
+14. **Header units are typed separately from named modules.** Named-module consumers use `/reference`; header-unit consumers use `/headerUnit:*`; producers use `/exportHeader` + `/headerName:*` + `/ifcOutput`.
+15. **Discovery does not become a second module compiler.** Its lexical pass only selects candidates and records routing state; P1689 remains authoritative.
+16. **Unsupported module requirements fail closed.** External/prebuilt named-module providers and `import std` are never silently ignored or downgraded to the ordinary pipeline.
 
 ## Project configuration
 
-`mqb_config` owns the versioned `mqb.json` contract. The CLI searches upward from the invocation directory for the nearest `mqb.json`.
-
-Path semantics are intentionally split:
+`mqb_config` owns versioned `mqb.json`. The CLI searches upward from the invocation directory for the nearest config.
 
 ```text
 CLI relative path --------> invocation directory
@@ -91,40 +87,29 @@ mqb.json relative path ---> directory containing mqb.json
 artifact project root ----> directory containing mqb.json (when present)
 ```
 
-Scalar option precedence is:
-
-```text
-built-in defaults
-    <- mqb.json fields that are present
-        <- explicitly supplied CLI scalar options
-```
-
-List-like build inputs are additive and deterministic: project-config entries appear first, then CLI entries. The v1 schema and examples are documented in `docs/MQB_CONFIG.md`. Unknown fields, duplicate JSON keys, wrong field types, malformed JSON, and unsupported schema versions are rejected instead of guessed.
+Scalar precedence is `explicit CLI > mqb.json > built-in defaults`. List-like inputs are additive and deterministic. Unknown fields, duplicate keys, wrong types, malformed JSON, and unsupported schema versions are rejected rather than guessed. See `docs/MQB_CONFIG.md`.
 
 ## Smart source discovery
 
-With one positional ordinary source, MQB smart-discovers the connected target by default. Multiple positional sources remain an explicit ordered source set. `--no-discover` disables discovery; `--discover` explicitly enables it and can override project configuration.
+With one positional ordinary source, MQB smart-discovers a target by default. Multiple positional sources remain an explicit ordered source set.
 
-Ordinary discovery uses quoted `#include "..."` connectivity, configured include directories, same-basename ownership, deterministic traversal, built-in directory exclusions, and project-config corrections. A reachable non-entry ordinary source defining `main(...)` is a traversal barrier. Explicitly excluded sources and directories are also traversal barriers.
+Ordinary discovery uses quoted local includes, configured include directories, same-basename ownership, deterministic traversal, project corrections, and a secondary-`main()` traversal barrier.
 
-The discovery index also understands the supported translation-unit extension classes from `mqb_core`: ordinary `.cpp/.cc/.cxx` units and module-interface `.ixx/.cppm/.mpp` units. A lightweight lexical module pass extracts named module declarations/imports only for source selection. It ignores comments, literals, preprocessor directives, and header-unit imports. Reachable named imports connect to all matching project-local interface candidates; discovery deliberately does not choose a winner among duplicate providers.
+The discovery index also classifies `.cpp/.cc/.cxx` ordinary TUs and `.ixx/.cppm/.mpp` module interfaces. Its lexical module pass:
 
-When a selected TU contains named-module syntax, discovery reports that the target requires the module pipeline even if no project-local interface provider was found. The CLI propagates that execution-only state through `MsvcTargetRouter`, so `import std` or an unresolved external/prebuilt named module cannot silently fall back to the ordinary pipeline.
+- extracts named module declarations/imports for candidate selection;
+- follows reachable named imports to all matching project-local interface candidates;
+- does not guess a winner between duplicate providers;
+- recognizes header-unit import syntax only as a **module-pipeline routing signal**;
+- never promotes a header into the translation-unit source set.
 
-Discovery output selects candidate TUs only. Incremental header invalidation continues to use compiler-emitted `/sourceDependencies` metadata, while the real module target pipeline runs `/scanDependencies` and the P1689 graph builder to determine authoritative module topology and provider resolution.
+If discovery observes named-module or header-unit syntax but has no local named interface to add, it still sets execution-only module routing state. Therefore unresolved external modules, `import std`, and header-unit-only entries cannot silently fall back to ordinary compilation.
 
-## Compile identity and cache freshness
+## Build identity and compile cache
 
-`BuildSignature::for_compile` models the versioned compiler recipe identity. Compile signature v3 includes:
+`BuildSignature::for_compile` models a versioned compiler recipe. Relevant identity includes source/TU kind, compiler/toolchain identity, configuration, architecture, language standard, ordered compiler options, typed module/header-unit references, and required planned interface outputs.
 
-- source and translation-unit kind;
-- compiler identity;
-- configuration, architecture, and language standard;
-- ordered defines, include paths, and extra compiler arguments;
-- ordered typed module references (`logical-name -> IFC path`);
-- for a module interface unit, the planned IFC output path.
-
-Ordinary object placement remains outside recipe identity. Module IFC placement is different: a provider's planned IFC path is part of the recipe because consumers reference that exact interface artifact.
+Artifact placement and freshness are separate concepts:
 
 ```text
 compiler recipe identity ----> BuildSignature
@@ -132,38 +117,60 @@ source/header/IFC freshness --> CompileCacheValidator
 artifact placement -----------> ProjectArtifactLayout
 ```
 
-`CompileCacheValidator` is pure and returns typed `BuildReason` values; it does not touch the filesystem or launch a process. It validates all planned compile outputs, not only the object. Therefore a provider with an existing object but a missing IFC is stale.
+`CompileCacheValidator` validates the complete planned output set. Compile actions are not object-only: a header-unit producer is a valid **IFC-only** action. This is why deleting only an IFC makes a provider stale even when no object is expected.
 
-Consumer cache metadata records imported IFC files alongside compiler-discovered header dependencies. A provider that actually recompiles in the current module wave also propagates an explicit downstream rebuild signal, preventing timestamp-granularity races from producing a false consumer hit.
+Consumer cache metadata records relevant compiler-discovered dependencies and interface artifacts. A provider that actually recompiles in the current dependency wave also sends an explicit downstream rebuild signal, avoiding false hits caused by timestamp granularity.
 
-`CompileCacheFile` persists compile metadata in a versioned binary format. Missing metadata is a normal cold-cache condition; corrupt/truncated/unsupported metadata is rejected and conservatively rebuilt.
+## Named modules and header units
 
-Ordinary Debug and Release compilation use MSVC `/Z7`, keeping compiler debug information inside each TU's object instead of sharing a compiler PDB between concurrent `cl.exe` processes.
-
-## Link identity and cache freshness
-
-Linking has its own state machine rather than piggybacking on object timestamps.
+The implemented module target supports project-local named modules and project-local header units:
 
 ```text
-ordered object inputs --------+
-resolved library identities --+
-link.exe identity ------------+
-link options -----------------+--> BuildSignature::for_link
-output identity --------------+
-
-output/object/library freshness ---> LinkCacheValidator
-fresh compile ---------------------> force_relink
+selected TU requests
+      -> target-wide writable-artifact preflight
+      -> bounded parallel /scanDependencies
+      -> P1689 typed rules
+      -> ModuleDependencyGraphBuilder
+             named-provider resolution
+             project-local header-unit nodes
+             deterministic compile levels
+      -> dynamic header-unit artifact assignment from P1689 source-path
+      -> dependency-level compile waves
+             named provider: /interface /ifcOutput
+             named consumer: /reference logical-name=ifc
+             header producer: /exportHeader /headerName:* /ifcOutput
+             header consumer: /headerUnit:* header=ifc
+             provider rebuilt -> downstream explicit rebuild
+      -> incremental final link using ordinary/module TU objects only
 ```
 
-`LinkerIdentity` stamps `link.exe` independently from `cl.exe`. User-requested libraries are resolved deterministically to exact `.lib` files before invoking `link.exe`; link-cache metadata persists those resolved inputs.
+Header-unit producers are IFC-only and never become link object inputs. P1689 lookup method (`include-quote` / `include-angle`) and header spelling remain typed identity used by the MSVC backend.
 
-Current boundary: explicitly requested libraries are tracked precisely. Indirect `/DEFAULTLIB` dependencies embedded in objects or libraries are still resolved by `link.exe` and are not claimed as fully tracked transitive link inputs.
+Warm module targets still repeat topology scanning. The current cache guarantee is **compile 0 / link 0**, not scan 0; scan caching is a future optimization.
+
+### Supported module behavior
+
+- strict P1689 parsing and schema validation;
+- project-local named-module interfaces, partitions, implementation units, and consumers;
+- single-entry discovery of reachable project-local named providers;
+- project-local quote/angle header units discovered by the real scanner;
+- source-identity IFC routing and Windows physical-path alias convergence;
+- bounded same-level parallelism with dependency barriers;
+- incremental compile/link caches;
+- provider/header-unit mutation propagation;
+- missing named-provider IFC and header-unit IFC repair;
+- public `mqb main.cpp --run` VS2026 E2E for named modules and header units.
+
+### Deliberate fail-closed boundary
+
+- external/prebuilt named-module provider execution;
+- `import std`.
+
+The P1689 type model may recognize requirements that execution policy does not yet support. Parsing a requirement is not permission to compile it incorrectly.
 
 ## Project artifact layout
 
-Without `mqb.json`, the invocation directory is the project root. With `mqb.json`, its directory becomes the project root. Sources inside the root preserve relative source identity; sources outside it are isolated under `.external/<stable-path-hash>/`.
-
-For a source such as `src/foo.cpp` or `modules/math.ixx`, the layout owns separate namespaces:
+Without `mqb.json`, the invocation directory is the project root. With `mqb.json`, its directory becomes the project root.
 
 ```text
 project/
@@ -179,196 +186,49 @@ project/
       <target>.exe
 ```
 
-IFCs are keyed by source identity rather than logical module spelling. This avoids Windows filename problems such as partition `:` characters and avoids same-basename collisions. The module target coordinator additionally validates global writable-artifact exclusivity before scanning.
+IFCs are keyed by physical/source identity rather than logical module spelling. For existing Windows sources, artifact identity uses physical ancestry/equivalence and case-insensitive keys so scanner path aliases converge. Non-existing planned paths retain a conservative lexical fallback.
 
-## Dependency graphs and planning
-
-`DependencyGraph` stores `node depends on dependency` edges. It rejects duplicate/missing nodes, makes duplicate edges idempotent, returns deterministic topological levels, and fails cycles explicitly.
-
-`ModuleDependencyGraphBuilder` consumes typed P1689 rules and produces one `ModuleDependencyPlan` containing:
-
-```text
-compile_levels
-resolved_dependencies {
-    consumer_source,
-    provider_source,
-    logical_name
-}
-unresolved_requirements
-```
-
-Named-provider selection prefers the unique `is-interface=true` provider when same-name module units exist. Multiple interface providers fail explicitly. Header-unit identity remains typed but unresolved until the dedicated header-unit milestone.
-
-The exact resolved dependency edges are reused for both compile ordering and MSVC `/reference logical-name=ifc` wiring. Orchestration does not run a second provider-selection algorithm.
-
-## Named-module MSVC pipeline
-
-The implemented named-module pipeline supports project-local named-module interfaces and consumers through both explicit CLI target sets and single-entry module-aware discovery:
-
-```text
-selected source requests
-      -> preflight all writable artifacts
-      -> bounded parallel MsvcModuleDependencyScanner
-             cl.exe /scanDependencies <per-source P1689 JSON>
-      -> exactly one P1689 rule per one-source scan
-      -> ModuleDependencyGraphBuilder
-             provider resolution
-             deterministic topological compile levels
-      -> MsvcModuleCompileCoordinator
-             for each level:
-                 bounded parallel incremental compile
-                 module interface: /interface /TP /ifcOutput
-                 consumer: /reference logical-name=<planned-ifc>
-             barrier between levels
-             provider compiled this run -> downstream explicit_rebuild
-      -> MsvcIncrementalLinkCoordinator
-             any TU compiled -> force_relink
-      -> target executable
-```
-
-`/scanDependencies` is topology-only; it does not produce `.obj` or `.ifc`. The real compile remains responsible for `/sourceDependencies`, object output, and IFC output.
-
-Warm module target builds currently repeat topology scanning. The proven cache guarantee is **compile 0 / link 0**, not scan 0. Scan-result caching is a future optimization and must not change build identity semantics.
-
-### Current module capability boundary
-
-Supported and regression-tested:
-
-- P1689R5 parsing and strict schema validation;
-- project-local named-module interface providers;
-- named consumers resolved to exact provider sources;
-- source-identity IFC routing;
-- bounded same-level parallelism with dependency-level barriers;
-- module-aware compile signatures and cache freshness;
-- downstream rebuild propagation when a provider recompiles;
-- incremental final linking;
-- explicit public CLI module-interface targets;
-- single-entry public CLI discovery of reachable project-local named-module providers;
-- real VS2026 provider/consumer executable E2E, including warm builds, provider-only mutation, and missing-IFC repair.
-
-Not yet supported by the execution policy:
-
-- header units;
-- unresolved external/prebuilt named-module providers;
-- `import std` (currently appears as an unresolved external named module and fails closed).
-
-The P1689 model can represent more cases than the current execution policy accepts. That is intentional: parsing a requirement is not permission to compile it incorrectly.
-
-## Ordinary orchestration
-
-### Incremental compile
-
-```text
-CompileCacheFile
-      -> file snapshots
-      -> CompileCacheValidator
-      -> BuildPlanner::plan_compile
-      -> MsvcCompileExecutor
-      -> /sourceDependencies reader
-      -> CompileCacheFile::save
-```
-
-`force_rebuild` is a request-local execution signal represented by `BuildReason::explicit_rebuild`. It does not enter the compile signature and is not persisted into the cache.
-
-### Incremental link
-
-```text
-requested libraries -> MsvcLibraryResolver -> exact .lib inputs
-LinkCacheFile
-      -> output/object/library snapshots
-      -> LinkCacheValidator
-      -> BuildPlanner::plan_link
-      -> MsvcLinker
-      -> LinkCacheFile::save
-```
-
-### Ordinary incremental target
+## Ordinary incremental target
 
 ```text
 ordered source requests
-      -> preflight unique source/object/deps/cache artifacts
+      -> preflight unique writable artifacts
       -> BoundedWorkScheduler(max_parallel_compiles)
-      -> parallel IncrementalCompileCoordinator per ordinary TU
-      -> join every in-flight compile
-      -> deterministic failure selection
-      -> collect collision-free objects in original source order
-      -> any TU compiled? -------- yes ----> force_relink
+      -> parallel IncrementalCompileCoordinator
+      -> deterministic result/failure ordering
+      -> collect objects in source order
+      -> any TU compiled? ---- yes ----> force_relink
       -> IncrementalLinkCoordinator
-      -> one target executable
+      -> target executable
 ```
 
-The scheduler assigns indices monotonically and at most once, joins all work that was already assigned, and quenches dispatch after stop publication. Target results are reassembled in source order.
+Link identity tracks ordered objects, resolved explicit libraries, linker identity, link options, and output identity. Explicit libraries are resolved to exact `.lib` inputs before link execution.
 
-## Process boundary
+## Process and toolchain boundary
 
-`mqb_process` defines a platform-neutral `ProcessSpec` with executable, argv, working directory, structured environment overrides, inheritance choice, and stdout/stderr capture controls.
+`mqb_process` carries executable, argv, working directory, environment overrides, and capture policy. `mqb_platform_windows` owns Windows quoting and `CreateProcessW` execution.
 
-`mqb_platform_windows` isolates Windows command-line quoting and the real `CreateProcessW` runner. Captured child processes use `STARTUPINFOEXW` with `PROC_THREAD_ATTRIBUTE_HANDLE_LIST`, so unrelated pipe handles from concurrent compiler launches are not inherited by sibling children.
+`MsvcToolchainLocator` supports automatic, forced Visual Studio, and forced portable toolchain tracks. Toolchain identity participates in build/cache correctness. GitHub CI opts into real installed-MSVC tests explicitly.
 
-`--run` uses the same structured process boundary. Arguments after `--` remain distinct argv elements and do not participate in build signatures.
+## Verification and release-candidate gate
 
-## MSVC toolchain boundary
+The main C++ workflow runs the installed Visual Studio 2026 suite in Debug. The `v5.0.0-rc.1` release pipeline additionally creates a fresh x64 **Release** build, runs the complete installed-MSVC CTest suite, verifies the embedded user-visible version, stages a standalone package, calculates SHA-256, and uploads the exact validated package as an Actions artifact.
 
-`MsvcToolchainLocator` preserves automatic, forced Visual Studio, and forced portable tracks. The Visual Studio track uses `vswhere`/fallback discovery and isolated `vcvarsall.bat` environment capture. The portable track resolves VC Tools and Windows Kit layout without mutating MQB's own process environment.
+Only the push-to-`main` publish job has release write permission. It downloads the artifact produced by the successful Release test job and creates the GitHub prerelease; pull-request runs cannot publish.
 
-GitHub CI enables installed-MSVC integration tests explicitly; local tests keep them opt-in.
-
-## Current verification milestone
-
-The VS2026 PR suite verifies ordinary CLI behavior plus the named-module backend, routing, and source-discovery path.
-
-Among the real installed-MSVC cases are:
-
-- ordinary single/multi-TU compile and incremental link behavior;
-- same-directory four-TU cold `-j4` and warm `-j1`, proving job count is not build identity;
-- real `/scanDependencies` P1689 output before IFCs exist;
-- real module provider IFC creation and consumer `/reference` compilation;
-- full named-module target cold build and executable launch;
-- warm named-module target with compile 0 / link 0;
-- single-entry `mqb main.cpp` discovery of a reachable project-local module provider;
-- provider-source mutation causing provider + consumer + link rebuild;
-- provider IFC deletion with source/object otherwise warm, causing provider + consumer + link repair;
-- artifact collision/empty-artifact validation before any external process starts.
-
-The named-module target E2E uses the installed Visual Studio 2026 compiler and linker, not a fake process runner.
-
-## Current CLI milestone
-
-The public `mqb.exe` CLI now owns both the ordinary-C++ path and the supported project-local named-module path: project config, smart source discovery, bounded `-j/--jobs` execution, independent link caching, library resolution, structured `--run` argv, explicit module-interface target routing, and single-entry discovery of reachable project-local named-module providers.
-
-This is not full C++ Modules parity. Header units, external/prebuilt provider execution, and `import std` remain explicit fail-closed gaps, and PowerShell/C++ parity testing still precedes cutover.
+The release candidate uses static MSVC runtime linkage. It intentionally does **not** change the legacy `build.ps1` installer/profile entry.
 
 ## Migration sequence
 
-1. **Scaffold** — CMake, `mqb_core`, CLI executable, CTest. ✅
-2. **Pure core** — artifacts, signatures, plan model, dependency graph, compile cache validation/planning. ✅
-3. **Process abstraction** — typed process spec, Windows quoting, Win32 runner. ✅
-4. **MSVC toolchain backend** — portable discovery plus `vswhere/vcvarsall` environment capture. ✅
-5. **Ordinary single TU** — typed compiler arguments, `/sourceDependencies`, cache persistence, real incremental CLI. ✅
-6. **Link state** — independent linker identity/signature/cache/planning/backend/orchestration. ✅
-7. **Explicit multi-TU target** — collision-free layout, per-TU incremental compile, one independently cached link. ✅
-8. **Target UX** — `-o/--output`, `--run`, structured `--` argv passthrough, child exit propagation. ✅
-9. **Explicit libraries** — exact resolution, link-cache v2, `.lib` freshness, `-L/-l`. ✅
-10. **Smart source discovery** — single-entry graph selection, secondary-entry barriers, corrections. ✅
-11. **Project config v1** — upward `mqb.json`, typed schema, path semantics, CLI precedence, config E2E. ✅
-12. **Parallel ordinary-TU scheduling** — bounded concurrency with deterministic reporting/failure semantics. ✅
-13. **Named Modules core/orchestration** — P1689 scan, provider graph, IFC artifacts, module-aware cache, dependency waves, incremental link, real VS2026 E2E. ✅
-14. **Modules expansion/UX** — public CLI routing and project-local module-aware source selection ✅; header units, external/prebuilt provider policy, and `import std` remain.
-15. **Parity** — run PowerShell and C++ against the same E2E fixtures.
-16. **Cutover** — make `mqb.exe` primary only after parity tests pass.
+1. Scaffold / typed Core / process / MSVC backend — complete.
+2. Incremental compile/link and project artifact layout — complete.
+3. Public CLI, project config, smart discovery, bounded parallelism — complete for the C++ target scope.
+4. Project-local named-module pipeline and source discovery — complete.
+5. Project-local header units through public CLI — complete (#19–#24).
+6. **C++ standalone Release Candidate** — `v5.0.0-rc.1` release gate.
+7. External/prebuilt module providers and `import std` — tracked in Issue #16.
+8. PowerShell ↔ C++ behavioral parity campaign.
+9. Installer/profile/default-entry cutover.
+10. Stable v5 and retirement of superseded PowerShell code only after parity is proven.
 
-## Local build
-
-```powershell
-cmake -S cpp -B cpp/build -G Ninja
-cmake --build cpp/build
-ctest --test-dir cpp/build --output-on-failure
-```
-
-To opt into tests that require a registered Visual Studio installation:
-
-```powershell
-cmake -S cpp -B cpp/build -DMQB_ENABLE_INSTALLED_MSVC_TESTS=ON
-```
-
-GitHub Windows CI currently uses the Visual Studio 2026 CMake generator and enables those integration tests.
+The RC is therefore a real distributable C++ build, but not a declaration that migration is finished.

--- a/release/v5.0.0-rc.1.md
+++ b/release/v5.0.0-rc.1.md
@@ -1,0 +1,33 @@
+# v5.0.0-rc.1 — C++ Refactor Release Candidate
+
+This prerelease is the first distributable build of the C++ rewrite: a standalone Windows x64 `mqb.exe` built and tested on the Visual Studio 2026 GitHub runner.
+
+## What is ready
+
+- native C++ executable with no PowerShell runtime dependency for the new CLI path
+- automatic Visual Studio / portable MSVC discovery
+- single-entry smart source discovery and explicit multi-source targets
+- incremental compile and link caches under `.mqb/`
+- bounded parallel scanning/compilation via `--jobs`
+- project configuration through `mqb.json`
+- project-local C++ named modules, including provider discovery and partitions
+- project-local header units (`import "header.hpp";` / `import <header>;`) with P1689 topology, generated IFCs, incremental freshness, rebuild propagation, and missing-IFC repair
+- structured `--run` arguments and library/include/define options
+- real VS2026 cold/warm/mutation/repair coverage in the C++ test suite
+
+## Install this RC
+
+1. Download `vscode-msvc-quick-build-v5.0.0-rc.1-windows-x64.zip` and its `.sha256` file from this prerelease.
+2. Verify the SHA-256 checksum, extract the archive, and place its directory on `PATH`.
+3. Run `mqb --help`; the first line must report `MQB 5.0.0-rc.1 - MSVC Quick Build (C++ refactor)`.
+4. In a project directory, try `mqb main.cpp --run`.
+
+The executable is built with the static MSVC runtime so the package does not require a separate Visual C++ Redistributable installation.
+
+## RC boundary
+
+This is deliberately a **release candidate**, not the final PowerShell-to-C++ cutover. The existing `build.ps1` / `build` installation remains the stable legacy entry and is not replaced by this package.
+
+The C++ rewrite still fails closed for external/prebuilt named-module providers and `import std`. The full PowerShell↔C++ behavioral parity campaign, installer/profile cutover, and any remaining legacy-only switches are also intentionally deferred before a stable v5 release.
+
+Please report a minimal reproducer when an RC build differs from the legacy PowerShell behavior in a workflow that the C++ CLI is intended to support.


### PR DESCRIPTION
Prepares the first distributable C++ refactor release candidate from `main@a20cd1b` without replacing the legacy PowerShell `build` entry.

## Release contract

- target prerelease: `v5.0.0-rc.1`
- Windows x64 standalone `mqb.exe`
- CMake project version moves to 5.0.0; user-visible build version is an explicit `MQB_VERSION` cache input (`5.0.0-dev` by default, `5.0.0-rc.1` in the release gate)
- MSVC runtime is linked statically for the distributable executable
- `mqb --help` embeds the exact build version in its first line
- project-local named modules and project-local header units are included in the RC capability boundary
- external/prebuilt named-module providers and `import std` remain fail-closed
- legacy PowerShell installer/profile remains unchanged; final parity/cutover is not claimed by this prerelease

## Release gate

Adds a dedicated `C++ Release Candidate` workflow. On PR it:

1. configures a fresh VS2026 x64 Release build with `MQB_VERSION=5.0.0-rc.1`
2. builds the full C++ tree with the static MSVC runtime
3. runs the complete installed-MSVC CTest suite in Release mode
4. verifies the embedded version through `mqb --help`
5. stages `mqb.exe`, license, current README/config/architecture docs, and release notes
6. creates `vscode-msvc-quick-build-v5.0.0-rc.1-windows-x64.zip` + SHA-256
7. uploads exactly those validated assets as an Actions artifact

After this PR merges, the release-note marker addition triggers the same build/test/package job on `main`. Only then does a separate job with `contents: write` download the validated artifact and create the GitHub prerelease using the runner's GitHub CLI. Pull-request jobs have read-only repository permission and cannot publish.

## Documentation / migration boundary

- README now documents direct RC installation and project-local header units
- architecture docs reflect typed header-unit producer/consumer execution, dynamic artifact assignment, Windows physical-path identity, and the RC gate
- `build.ps1`, `install.bat`, and the PowerShell profile remain the Golden Reference/stable legacy entry
- stable v5 remains gated on the remaining module policies plus PowerShell↔C++ parity and installer/default-entry cutover

## Final verification

Final exact head: `998d38c044838bd6a2c6751ec0b7eb791d524273`.

- C++ V2 Debug workflow #223: **success** (Configure / Build / complete CTest / cleanup)
- C++ Release Candidate workflow #4: **success**
  - Release Configure / Build succeeded
  - all **56/56** installed-MSVC CTests passed
  - embedded binary version verified exactly as `MQB 5.0.0-rc.1 - MSVC Quick Build (C++ refactor)`
  - validated package and SHA-256 were created and uploaded as an Actions artifact
  - release zip SHA-256: `a803ebda242021e1ab4e958c4a6c74f4b63da641ded46d61ac0d4fef05e18195`
  - publish job was skipped by design because this was a pull-request run

No release is created from pull-request runs. The same Release gate must pass again on the merge commit before publication.