### PR TITLE
feat: add first stable-v5 CLI compatibility slice

### DIFF
--- a/cpp/apps/mqb/Cli.cpp
+++ b/cpp/apps/mqb/Cli.cpp
@@ -46,6 +46,15 @@ parse_standard(const std::string_view value) {
         + "' (expected 20, 23, or latest)"));
 }
 
+[[nodiscard]] std::expected<BuildConfiguration, Error>
+parse_configuration(const std::string_view value) {
+    if (value == "debug") return BuildConfiguration::debug;
+    if (value == "release") return BuildConfiguration::release;
+    return std::unexpected(error(
+        "unsupported build configuration '" + std::string{value}
+        + "' (expected debug or release)"));
+}
+
 [[nodiscard]] std::expected<std::size_t, Error>
 parse_jobs(const std::string_view value) {
     std::size_t jobs = 0;
@@ -64,7 +73,9 @@ parse_jobs(const std::string_view value) {
 parse_toolchain_preference(const std::string_view value) {
     if (value == "auto") return msvc::ToolchainPreference::automatic;
     if (value == "vs") return msvc::ToolchainPreference::visual_studio;
-    if (value == "portable") return msvc::ToolchainPreference::portable;
+    if (value == "portable" || value == "port" || value == "p") {
+        return msvc::ToolchainPreference::portable;
+    }
     return std::unexpected(error(
         "unsupported toolchain preference '" + std::string{value}
         + "' (expected auto, vs, or portable)"));
@@ -107,7 +118,8 @@ parse_arguments(const std::span<const std::string_view> arguments) {
             }
             break;
         }
-        if (argument == "-h" || argument == "--help") {
+        if (argument == "-h" || argument == "--help"
+            || argument == "-help" || argument == "-?") {
             options.show_help = true;
             continue;
         }
@@ -125,7 +137,7 @@ parse_arguments(const std::span<const std::string_view> arguments) {
             options.discovery_override = false;
             continue;
         }
-        if (argument == "--run") {
+        if (argument == "--run" || argument == "-run") {
             options.build.run_after_build = true;
             continue;
         }
@@ -151,7 +163,7 @@ parse_arguments(const std::span<const std::string_view> arguments) {
             options.jobs = *jobs;
             continue;
         }
-        if (argument == "-o" || argument == "--output") {
+        if (argument == "-o" || argument == "--output" || argument == "-output") {
             auto value = require_value(arguments, index, argument);
             if (!value) return std::unexpected(value.error());
             options.build.output_name = std::string{*value};
@@ -173,17 +185,26 @@ parse_arguments(const std::span<const std::string_view> arguments) {
             options.configuration_override = BuildConfiguration::release;
             continue;
         }
-        if (argument == "--x86") {
+        if (argument == "--config" || argument == "-config") {
+            auto value = require_value(arguments, index, argument);
+            if (!value) return std::unexpected(value.error());
+            auto configuration = parse_configuration(*value);
+            if (!configuration) return std::unexpected(configuration.error());
+            options.build.configuration = *configuration;
+            options.configuration_override = *configuration;
+            continue;
+        }
+        if (argument == "--x86" || argument == "-x86") {
             options.build.architecture = Architecture::x86;
             options.architecture_override = Architecture::x86;
             continue;
         }
-        if (argument == "--x64") {
+        if (argument == "--x64" || argument == "-x64") {
             options.build.architecture = Architecture::x64;
             options.architecture_override = Architecture::x64;
             continue;
         }
-        if (argument == "--std") {
+        if (argument == "--std" || argument == "-std") {
             auto value = require_value(arguments, index, argument);
             if (!value) return std::unexpected(value.error());
             auto standard = parse_standard(*value);
@@ -192,7 +213,7 @@ parse_arguments(const std::span<const std::string_view> arguments) {
             options.standard_override = *standard;
             continue;
         }
-        if (argument == "--env") {
+        if (argument == "--env" || argument == "-env") {
             auto value = require_value(arguments, index, argument);
             if (!value) return std::unexpected(value.error());
             auto preference = parse_toolchain_preference(*value);
@@ -206,7 +227,7 @@ parse_arguments(const std::span<const std::string_view> arguments) {
             options.portable_roots.emplace_back(std::string{*value});
             continue;
         }
-        if (argument == "--lib-path") {
+        if (argument == "--lib-path" || argument == "-libpath") {
             auto value = require_value(arguments, index, argument);
             if (!value) return std::unexpected(value.error());
             options.library_directories.emplace_back(std::string{*value});
@@ -218,7 +239,7 @@ parse_arguments(const std::span<const std::string_view> arguments) {
             options.library_directories.emplace_back(std::string{*value});
             continue;
         }
-        if (argument == "--lib") {
+        if (argument == "--lib" || argument == "-libs") {
             auto value = require_value(arguments, index, argument);
             if (!value) return std::unexpected(value.error());
             options.libraries.emplace_back(*value);
@@ -228,6 +249,18 @@ parse_arguments(const std::span<const std::string_view> arguments) {
             auto value = long_equals_value(argument, "--lib=");
             if (!value) return std::unexpected(value.error());
             options.libraries.emplace_back(*value);
+            continue;
+        }
+        if (argument == "-include") {
+            auto value = require_value(arguments, index, argument);
+            if (!value) return std::unexpected(value.error());
+            options.include_directories.emplace_back(std::string{*value});
+            continue;
+        }
+        if (argument == "-defines") {
+            auto value = require_value(arguments, index, argument);
+            if (!value) return std::unexpected(value.error());
+            options.defines.emplace_back(*value);
             continue;
         }
         if (argument == "-I" || argument.starts_with("-I")) {
@@ -304,22 +337,27 @@ remain unsupported and fail closed.
 Options:
   --debug                  Explicitly select Debug compile/link preset
   --release                Explicitly select Release compile/link preset
-  --std <20|23|latest>     Explicitly select C++ language standard
-  --x86 | --x64            Explicitly select target architecture
+  --config <debug|release> Select compile/link preset (legacy -config alias accepted)
+  --std <20|23|latest>     Explicitly select C++ language standard (legacy -std accepted)
+  --x86 | --x64            Explicitly select target architecture (legacy -x86/-x64 accepted)
   -j, --jobs <N>           Maximum concurrent TU scans/compiles (default: hardware concurrency)
-  -o, --output <name>      Set target executable name under .mqb/bin/
-  --run                    Run the executable after a successful build
-  -I <dir>, -I<dir>        Add an include directory
-  -D <value>, -D<value>    Add a preprocessor definition
-  -L <dir>, -L<dir>        Add a library search directory
+  -o, --output <name>      Set target executable name under .mqb/bin/ (legacy -output accepted)
+  --run                    Run the executable after a successful build (legacy -run accepted)
+  -I <dir>, -I<dir>        Add an include directory (legacy -include accepted)
+  -D <value>, -D<value>    Add a preprocessor definition (legacy -defines accepted)
+  -L <dir>, -L<dir>        Add a library search directory (legacy -libpath accepted)
   --lib-path <dir>         Add a library search directory
   -l <name>, -l<name>      Link a library ('.lib' is optional)
-  --lib <name>             Link a library (name or explicit path)
-  --env <auto|vs|portable> Toolchain selection (default: auto)
+  --lib <name>             Link a library (legacy -libs accepted; repeat for multiple values)
+  --env <auto|vs|portable> Toolchain selection (legacy -env and portable/port/p accepted)
   --portable-root <dir>    Add a portable_msvc root candidate
   -v, --verbose            Show config, discovery, toolchain, and artifact details
-  -h, --help               Show this help and the embedded build version
+  -h, --help               Show this help and the embedded build version (-help/-? accepted)
   --                       Pass all remaining argv elements to the program
+
+Legacy compatibility aliases intentionally cover spelling only. Legacy-only semantics such as
+-a string splitting, DLL/static output kinds, C++14/17, and MSVC tuning switches remain tracked
+by the stable-v5 parity inventory and are not silently accepted here.
 
 Job count is execution policy only; changing -j does not invalidate build caches.
 Discovery is source selection only. Incremental header freshness continues to use

--- a/cpp/tests/cli_argument_tests.cpp
+++ b/cpp/tests/cli_argument_tests.cpp
@@ -213,6 +213,69 @@ int main() {
     {
         const std::vector arguments{
             "main.cpp"sv,
+            "-config"sv,
+            "release"sv,
+            "-std"sv,
+            "20"sv,
+            "-x86"sv,
+            "-output"sv,
+            "legacy-product"sv,
+            "-run"sv,
+            "-env"sv,
+            "p"sv,
+            "-include"sv,
+            "legacy include"sv,
+            "-defines"sv,
+            "LEGACY=1"sv,
+            "-libpath"sv,
+            "legacy libs"sv,
+            "-libs"sv,
+            "legacy_math"sv,
+        };
+        auto parsed = mqb::cli::parse_arguments(arguments);
+        expect(parsed.has_value(), "legacy PowerShell-style aliases should parse");
+        if (parsed) {
+            expect(parsed->configuration_override == mqb::BuildConfiguration::release,
+                   "legacy -config release should map to the typed release override");
+            expect(parsed->standard_override == mqb::CppStandard::cpp20,
+                   "legacy -std should map to the typed standard override");
+            expect(parsed->architecture_override == mqb::Architecture::x86,
+                   "legacy -x86 should map to the typed architecture override");
+            expect(parsed->build.output_name == "legacy-product",
+                   "legacy -output should map to the output name");
+            expect(parsed->build.run_after_build,
+                   "legacy -run should map to run-after-build");
+            expect(parsed->toolchain_preference == mqb::msvc::ToolchainPreference::portable,
+                   "legacy -env p should map to portable toolchain preference");
+            expect(parsed->include_directories.size() == 1
+                       && parsed->include_directories.front() == "legacy include",
+                   "legacy -include should preserve the include path");
+            expect(parsed->defines.size() == 1 && parsed->defines.front() == "LEGACY=1",
+                   "legacy -defines should preserve the preprocessor definition");
+            expect(parsed->library_directories.size() == 1
+                       && parsed->library_directories.front() == "legacy libs",
+                   "legacy -libpath should preserve the library directory");
+            expect(parsed->libraries.size() == 1 && parsed->libraries.front() == "legacy_math",
+                   "legacy -libs should preserve one repeatable library value");
+        }
+    }
+
+    {
+        const std::vector arguments{"main.cpp"sv, "-config"sv, "profile"sv};
+        auto parsed = mqb::cli::parse_arguments(arguments);
+        expect(!parsed, "legacy -config should reject unknown preset names");
+    }
+
+    {
+        const std::vector arguments{"-?"sv};
+        auto parsed = mqb::cli::parse_arguments(arguments);
+        expect(parsed.has_value() && parsed->show_help,
+               "legacy -? help alias should not require a source file");
+    }
+
+    {
+        const std::vector arguments{
+            "main.cpp"sv,
             "--output=demo"sv,
             "--jobs=3"sv,
             "--lib-path=vendor"sv,

--- a/docs/V5_PARITY.md
+++ b/docs/V5_PARITY.md
@@ -1,0 +1,121 @@
+# Stable v5 PowerShell -> C++ parity inventory
+
+This document is the contract inventory for issue #26. It separates behavior required for the stable C++ cutover from optional legacy syntax and from C++ Modules expansion tracked independently in #16.
+
+Status meanings:
+
+- **ready**: native `mqb.exe` already owns the behavior and has C++ test coverage.
+- **compat**: native behavior exists and the legacy command spelling is accepted by the C++ parser.
+- **implement**: required before the stable v5 cutover unless explicitly reclassified with rationale.
+- **migrate**: stable v5 intentionally changes the interface; migration/diagnostics must be documented and tested instead of pretending to be byte-for-byte compatible.
+- **legacy-only**: intentionally not part of the stable native contract; must remain available through an explicitly retained legacy path if still promised.
+- **#16**: module policy is tracked independently by issue #16 and is not silently folded into parity work.
+
+## Baseline command and source contract
+
+| Legacy PowerShell surface | Native C++ status | Stable-v5 decision |
+| --- | --- | --- |
+| `build <sources...>` | `mqb <sources...>` is ready | **implement** installer/command cutover; decide whether `build` remains a compatibility command |
+| one focused source with smart dependency discovery | ready | **ready** |
+| multiple explicit source files | ready | **ready** |
+| `.cpp`, `.cc`, `.cxx` | ready | **ready** |
+| `.ixx` / named modules | ready for project-local providers | **ready**, with #16 boundaries documented |
+| project-local header units | native pipeline is ready | **ready** |
+| `.c` translation units | rejected by native CLI today | **implement** |
+| `.hpp` / `.h` as positional legacy discovery seeds | native CLI treats headers as non-TU inputs | **migrate** unless a real user workflow requires positional header seeds |
+| C++14 / C++17 | native CLI currently supports 20/23/latest | **implement** for ordinary non-module targets |
+| C++20 / C++23 / latest | ready | **ready** |
+
+## Common command-line options
+
+| Legacy spelling / behavior | Native equivalent | Stable-v5 decision |
+| --- | --- | --- |
+| `-o`, `-output` | `-o`, `--output`; legacy `-output` accepted | **compat** |
+| `-run` | `--run`; legacy `-run` accepted | **compat** |
+| `-std` | `--std`; legacy `-std` accepted for current native standards | **compat**, plus C++14/17 work above |
+| `-x86` | `--x86`; legacy spelling accepted | **compat** |
+| default x64 | `--x64` / x64 default; legacy `-x64` accepted | **compat** |
+| `-I`, `-include` | `-I`; legacy `-include` accepted | **compat** |
+| `-L`, `-libpath` | `-L`, `--lib-path`; legacy `-libpath` accepted | **compat** |
+| `-libs` | `-l`, `--lib`; legacy `-libs <value>` accepted and repeatable | **compat** for scalar/repeated values; document that shell array tokenization is not emulated |
+| `-D`, `-defines` | `-D`; legacy `-defines` accepted | **compat** |
+| `-config debug/release` | `--debug`, `--release`, `--config`; legacy `-config` accepted | **compat** |
+| `-env vs/portable/port/p/auto` | `--env auto/vs/portable`; legacy spelling and portable aliases accepted | **compat** |
+| `-help`, `-?` | `--help`, `-h`; legacy help aliases accepted | **compat** |
+| `-a "..."` single-string program arguments | structured `-- program-args...` | **migrate**: keep structured argv semantics; decide whether a compatibility tokenizer is worth the ambiguity |
+
+## Target/output kinds
+
+| Legacy behavior | Native C++ status | Stable-v5 decision |
+| --- | --- | --- |
+| executable target | ready | **ready** |
+| DLL target (`-type dll`) | not exposed by native target model | **implement** |
+| static library target (`-type static`) | not exposed by native target model | **implement** |
+| automatic `.exe/.dll/.lib` suffix by target kind | executable only today | **implement** with target-kind work |
+| console subsystem | native default | **ready** |
+| windows subsystem | link model has typed subsystem but CLI does not expose it | **implement** |
+
+## Compiler and linker policy
+
+The native backend already has typed `CompilerOptions` / `LinkOptions`, including ordered additional argument vectors. Compile and link signatures include those vectors, so future pass-through flags can remain incrementally correct.
+
+| Legacy option | Native C++ status | Stable-v5 decision |
+| --- | --- | --- |
+| `-optimize Od/O1/O2/Ox` | debug/release presets cover common cases, no first-class override | **implement** or explicitly migrate to raw compiler flags after parity E2E |
+| `-runtime MD/MDd/MT/MTd` | presets choose MDd/MD; release package itself uses static CRT only for MQB | **implement** target runtime selection |
+| `-warnings W0/W1/W3/W4/Wall` | fixed W3 today | **implement** |
+| `-WX` | not exposed | **implement** |
+| `-debug_info off/Zi/ZI/Z7` | presets use Z7 | **implement** or migrate to raw compiler flags with documented precedence |
+| `-exceptions EHsc/EHa/off` | fixed EHsc today | **implement** or migrate to raw compiler flags |
+| `-rtc1` | not exposed | **implement** or migrate to raw compiler flags |
+| `-jmc` | not exposed | **implement** or migrate to raw compiler flags |
+| `-sdl` | not exposed | **implement** or migrate to raw compiler flags |
+| `-permissive` | native currently always uses `/permissive-` | **migrate**: strict conformance is the native baseline; add an escape hatch only if parity fixtures require it |
+| `-fp precise/strict/fast` | not exposed | **implement** or migrate to raw compiler flags |
+| `-charset unicode/mbcs` | native uses UTF-8 source/execution compile policy; Windows macro charset is not exposed | **implement** if legacy projects rely on `_UNICODE/UNICODE` vs `_MBCS` macros |
+| `-ltcg` | not exposed | **implement** because it couples compile `/GL` and link `/LTCG` |
+| `-incremental` linker switch | native build engine is always incrementally cached, but linker `/INCREMENTAL` is not exposed | **migrate** terminology; expose linker incremental only if required |
+| `-flags` | Core already supports ordered compiler additional args but CLI/config do not expose them | **implement next** |
+| `-link_flags` | Core already supports ordered linker additional args but CLI/config do not expose them | **implement next** |
+
+## Project configuration
+
+| Legacy behavior | Native C++ status | Stable-v5 decision |
+| --- | --- | --- |
+| `msvc_list.json`, upward search up to five levels | native uses nearest upward `mqb.json` | **migrate** to `mqb.json`; provide upgrade guidance/tooling rather than keeping two authoritative schemas forever |
+| CLI overrides config | ready | **ready** |
+| include/lib/define/library config | ready in `mqb.json` | **ready** |
+| source discovery excludes | ready with the native discovery schema | **ready** |
+| legacy config keys for tuning/target kind | not all represented | **implement** only for capabilities accepted into the stable parity surface |
+
+## Toolchain/environment behavior
+
+| Legacy behavior | Native C++ status | Stable-v5 decision |
+| --- | --- | --- |
+| Visual Studio discovery | ready | **ready** |
+| portable MSVC discovery | ready | **ready** |
+| automatic preference | ready | **ready** |
+| environment aliases `portable/port/p` | parser compatibility added | **compat** |
+| legacy `.msvc_build_env` preference file | native does not use it | **migrate** to explicit CLI/config/environment contract; document upgrade |
+| cached vcvars environment text file | native locator owns process environment differently | **migrate** implementation detail; no parity requirement |
+
+## Incremental/artifact behavior
+
+Stable v5 does not require byte-for-byte artifact layout parity with PowerShell. It requires equivalent observable correctness: cold build succeeds, warm no-op avoids unnecessary work, source/header/library/config/toolchain changes invalidate the right work, missing required artifacts repair correctly, and outputs are collision-free.
+
+The native `.mqb/obj`, `.mqb/deps`, `.mqb/scan`, `.mqb/ifc`, `.mqb/cache`, and `.mqb/bin` layout is therefore the stable direction rather than the old PowerShell temporary layout.
+
+## C++ Modules boundary (#16)
+
+Project-local named modules and project-local header units are in the RC/stable-capable surface. External/prebuilt named-module providers and `import std` remain tracked in #16. Stable v5 may ship with those cases still fail-closed if the release notes keep that boundary explicit; they must not be accidentally accepted through compatibility parsing.
+
+## Parity campaign order
+
+1. Legacy CLI spelling compatibility for behaviors the native engine already supports.
+2. Raw compiler/linker pass-through with cache-invalidation E2E.
+3. C++14/17 ordinary-target support and `.c` translation units.
+4. Target kinds: DLL/static plus subsystem/runtime policy.
+5. First-class/high-value MSVC tuning options; use raw flags for the long tail where that produces an explicit, testable contract.
+6. Shared PowerShell-vs-C++ fixtures for ordinary targets, config precedence, incremental rebuilds, libraries, run argv, x86/x64, Debug/Release, and failure behavior.
+7. Installer/profile/`build` command cutover and clean-machine upgrade/rollback validation.
+8. Generalize the release workflow and publish stable v5 only from the exact validated artifact.


### PR DESCRIPTION
Starts the #26 stable-v5 parity campaign from `main@902b4a6`.

## Scope

- add a committed `docs/V5_PARITY.md` inventory that classifies the legacy PowerShell surface into ready / compat / implement / migrate / legacy-only / #16
- accept legacy command spellings for native behaviors that already exist: `-config`, `-std`, `-x86/-x64`, `-output`, `-run`, `-env`, `-include`, `-defines`, `-libpath`, `-libs`, `-help`, `-?`
- preserve `portable/port/p` legacy environment aliases
- map all aliases into the existing typed C++ options; no second compatibility execution path
- explicitly do **not** accept unsupported legacy semantics such as `-a`, DLL/static target kinds, C++14/17, or MSVC tuning flags yet
- add parser regression coverage for the compatibility surface and invalid legacy config values

## Why this is first

The stable cutover eventually needs an installed `build` compatibility story. Syntax aliases are a low-risk first step because they reuse already-tested native semantics rather than reimplementing build behavior. The inventory prevents later parity decisions from being made ad hoc.

## Follow-up order

The inventory identifies raw compiler/linker pass-through as the next slice because Core already models and hashes `additional_arguments`; then C++14/17 + `.c`, target kinds/runtime/subsystem, the higher-value MSVC policy controls, shared PowerShell-vs-C++ fixtures, and finally installer/default-command cutover.

Closes no issue; this is the first incremental slice of #26.