### PR TITLE
feat: restore ordinary C++14 and C++17 target modes

### DIFF
--- a/cpp/apps/mqb/Cli.cpp
+++ b/cpp/apps/mqb/Cli.cpp
@@ -38,12 +38,14 @@ require_value(
 
 [[nodiscard]] std::expected<CppStandard, Error>
 parse_standard(const std::string_view value) {
+    if (value == "14" || value == "c++14") return CppStandard::cpp14;
+    if (value == "17" || value == "c++17") return CppStandard::cpp17;
     if (value == "20" || value == "c++20") return CppStandard::cpp20;
     if (value == "23" || value == "c++23") return CppStandard::cpp23;
     if (value == "latest" || value == "c++latest") return CppStandard::latest;
     return std::unexpected(error(
         "unsupported C++ standard '" + std::string{value}
-        + "' (expected 20, 23, or latest)"));
+        + "' (expected 14, 17, 20, 23, or latest)"));
 }
 
 [[nodiscard]] std::expected<BuildConfiguration, Error>
@@ -331,14 +333,16 @@ Single-entry discovery follows reachable project-local named imports to project-
 module-interface candidates. Discovery selects candidates only; MSVC P1689 scanning remains
 the authority for module topology and provider validation. Project-local header-unit imports
 stay outside TU discovery but route through the P1689 module pipeline, where their IFCs are
-built and cached automatically. External/prebuilt named-module providers and import std
-remain unsupported and fail closed.
+built and cached automatically. Modules and header units require C++20 or newer; selecting
+C++14/17 for a target that requires the module pipeline fails closed before MSVC is invoked.
+External/prebuilt named-module providers and import std remain unsupported and fail closed.
 
 Options:
   --debug                  Explicitly select Debug compile/link preset
   --release                Explicitly select Release compile/link preset
   --config <debug|release> Select compile/link preset (legacy -config alias accepted)
-  --std <20|23|latest>     Explicitly select C++ language standard (legacy -std accepted)
+  --std <14|17|20|23|latest>
+                           Explicitly select C++ language standard (legacy -std accepted)
   --x86 | --x64            Explicitly select target architecture (legacy -x86/-x64 accepted)
   -j, --jobs <N>           Maximum concurrent TU scans/compiles (default: hardware concurrency)
   -o, --output <name>      Set target executable name under .mqb/bin/ (legacy -output accepted)
@@ -356,8 +360,8 @@ Options:
   --                       Pass all remaining argv elements to the program
 
 Legacy compatibility aliases intentionally cover spelling only. Legacy-only semantics such as
--a string splitting, DLL/static output kinds, C++14/17, and MSVC tuning switches remain tracked
-by the stable-v5 parity inventory and are not silently accepted here.
+-a string splitting, DLL/static output kinds, and MSVC tuning switches remain tracked by the
+stable-v5 parity inventory and are not silently accepted here.
 
 Job count is execution policy only; changing -j does not invalidate build caches.
 Discovery is source selection only. Incremental header freshness continues to use

--- a/cpp/backends/msvc/include/mqb/msvc/MsvcCompiler.hpp
+++ b/cpp/backends/msvc/include/mqb/msvc/MsvcCompiler.hpp
@@ -13,6 +13,7 @@
 
 namespace mqb::msvc {
 
+using HeaderUnitLookupMethod = mqb::HeaderUnitLookupMethod;
 using HeaderUnitReference = mqb::HeaderUnitReference;
 using ModuleReference = mqb::ModuleReference;
 

--- a/cpp/backends/msvc/src/MsvcCompiler.cpp
+++ b/cpp/backends/msvc/src/MsvcCompiler.cpp
@@ -27,8 +27,16 @@ namespace fs = std::filesystem;
         bytes.size()};
 }
 
+[[nodiscard]] bool predates_cpp20(const CppStandard standard) noexcept {
+    return standard == CppStandard::cpp14 || standard == CppStandard::cpp17;
+}
+
 [[nodiscard]] std::string standard_argument(const CppStandard standard) {
     switch (standard) {
+    case CppStandard::cpp14:
+        return "/std:c++14";
+    case CppStandard::cpp17:
+        return "/std:c++17";
     case CppStandard::cpp20:
         return "/std:c++20";
     case CppStandard::cpp23:
@@ -126,6 +134,15 @@ void append_configuration_arguments(
 
 [[nodiscard]] std::expected<void, CompilerError> validate_module_contract(
     const CompileInvocation& invocation) {
+    const bool uses_module_contract = invocation.kind == TranslationUnitKind::module_interface
+        || invocation.module_interface_output.has_value()
+        || !invocation.module_references.empty()
+        || !invocation.header_unit_references.empty();
+    if (uses_module_contract && predates_cpp20(invocation.options.standard)) {
+        return std::unexpected(invalid_request(
+            "module and header-unit compilation requires C++20 or newer"));
+    }
+
     if (invocation.kind == TranslationUnitKind::module_interface) {
         if (!invocation.module_interface_output
             || invocation.module_interface_output->empty()) {
@@ -295,6 +312,10 @@ MsvcCompiler::build_header_unit_arguments(const HeaderUnitCompileInvocation& inv
     }
     if (invocation.source_dependencies && invocation.source_dependencies->empty()) {
         return std::unexpected(invalid_request("sourceDependencies output path is empty"));
+    }
+    if (predates_cpp20(invocation.options.standard)) {
+        return std::unexpected(invalid_request(
+            "header-unit compilation requires C++20 or newer"));
     }
 
     std::vector<std::string> arguments;

--- a/cpp/backends/msvc/src/MsvcModuleDependencyScanner.cpp
+++ b/cpp/backends/msvc/src/MsvcModuleDependencyScanner.cpp
@@ -27,8 +27,16 @@ namespace fs = std::filesystem;
         bytes.size()};
 }
 
+[[nodiscard]] bool predates_cpp20(const CppStandard standard) noexcept {
+    return standard == CppStandard::cpp14 || standard == CppStandard::cpp17;
+}
+
 [[nodiscard]] std::string standard_argument(const CppStandard standard) {
     switch (standard) {
+    case CppStandard::cpp14:
+        return "/std:c++14";
+    case CppStandard::cpp17:
+        return "/std:c++17";
     case CppStandard::cpp20:
         return "/std:c++20";
     case CppStandard::cpp23:
@@ -108,6 +116,11 @@ MsvcModuleDependencyScanner::build_arguments(const ModuleScanInvocation& invocat
         return std::unexpected(failure(
             ModuleScanErrorCode::invalid_request,
             "module scan output path is empty"));
+    }
+    if (predates_cpp20(invocation.options.standard)) {
+        return std::unexpected(failure(
+            ModuleScanErrorCode::invalid_request,
+            "module dependency scanning requires C++20 or newer"));
     }
 
     std::vector<std::string> arguments;

--- a/cpp/backends/msvc/tests/module_dependency_scanner_tests.cpp
+++ b/cpp/backends/msvc/tests/module_dependency_scanner_tests.cpp
@@ -134,6 +134,20 @@ int main() {
         }
     }
 
+    {
+        ModuleScanInvocation pre20;
+        pre20.source = "src/legacy.cpp";
+        pre20.output_file = "scan/legacy.json";
+        pre20.options.standard = CppStandard::cpp17;
+        auto rejected = MsvcModuleDependencyScanner::build_arguments(pre20);
+        expect(!rejected && rejected.error().code == ModuleScanErrorCode::invalid_request,
+               "P1689 module scanning should reject C++17 before cl.exe is launched");
+        if (!rejected) {
+            expect(rejected.error().message.find("C++20") != std::string::npos,
+                   "pre-C++20 scan rejection should explain the minimum standard");
+        }
+    }
+
     const fs::path root = make_temp_root();
     const fs::path output = root / "scan" / "module.json";
     const fs::path source = root / "module.ixx";

--- a/cpp/core/include/mqb/core/BuildTypes.hpp
+++ b/cpp/core/include/mqb/core/BuildTypes.hpp
@@ -15,9 +15,14 @@ enum class Architecture {
 };
 
 enum class CppStandard {
+    // Keep the existing values first: BuildSignature hashes the enum value and
+    // existing C++20/23/latest caches must not be invalidated just because
+    // stable-v5 parity adds older ordinary-TU modes.
     cpp20,
     cpp23,
     latest,
+    cpp14,
+    cpp17,
 };
 
 enum class BuildReason {

--- a/cpp/core/include/mqb/core/BuildTypes.hpp
+++ b/cpp/core/include/mqb/core/BuildTypes.hpp
@@ -15,14 +15,13 @@ enum class Architecture {
 };
 
 enum class CppStandard {
-    // Keep the existing values first: BuildSignature hashes the enum value and
-    // existing C++20/23/latest caches must not be invalidated just because
-    // stable-v5 parity adds older ordinary-TU modes.
-    cpp20,
-    cpp23,
-    latest,
-    cpp14,
-    cpp17,
+    // BuildSignature hashes these numeric values. Keep existing identities
+    // stable across parity expansion so old C++20/23/latest caches remain valid.
+    cpp20 = 0,
+    cpp23 = 1,
+    latest = 2,
+    cpp14 = 3,
+    cpp17 = 4,
 };
 
 enum class BuildReason {

--- a/cpp/core/src/BuildTypes.cpp
+++ b/cpp/core/src/BuildTypes.cpp
@@ -24,6 +24,10 @@ std::string_view to_string(const Architecture value) noexcept {
 
 std::string_view to_string(const CppStandard value) noexcept {
     switch (value) {
+    case CppStandard::cpp14:
+        return "c++14";
+    case CppStandard::cpp17:
+        return "c++17";
     case CppStandard::cpp20:
         return "c++20";
     case CppStandard::cpp23:

--- a/cpp/tests/cli_argument_tests.cpp
+++ b/cpp/tests/cli_argument_tests.cpp
@@ -211,12 +211,26 @@ int main() {
     }
 
     {
+        const std::vector arguments{"main.cpp"sv, "--std"sv, "14"sv};
+        auto parsed = mqb::cli::parse_arguments(arguments);
+        expect(parsed.has_value() && parsed->standard_override == mqb::CppStandard::cpp14,
+               "--std 14 should select the typed C++14 mode");
+    }
+
+    {
+        const std::vector arguments{"main.cpp"sv, "--std"sv, "c++17"sv};
+        auto parsed = mqb::cli::parse_arguments(arguments);
+        expect(parsed.has_value() && parsed->standard_override == mqb::CppStandard::cpp17,
+               "--std c++17 should select the typed C++17 mode");
+    }
+
+    {
         const std::vector arguments{
             "main.cpp"sv,
             "-config"sv,
             "release"sv,
             "-std"sv,
-            "20"sv,
+            "17"sv,
             "-x86"sv,
             "-output"sv,
             "legacy-product"sv,
@@ -237,8 +251,8 @@ int main() {
         if (parsed) {
             expect(parsed->configuration_override == mqb::BuildConfiguration::release,
                    "legacy -config release should map to the typed release override");
-            expect(parsed->standard_override == mqb::CppStandard::cpp20,
-                   "legacy -std should map to the typed standard override");
+            expect(parsed->standard_override == mqb::CppStandard::cpp17,
+                   "legacy -std 17 should map to the typed C++17 override");
             expect(parsed->architecture_override == mqb::Architecture::x86,
                    "legacy -x86 should map to the typed architecture override");
             expect(parsed->build.output_name == "legacy-product",

--- a/cpp/tests/msvc_compile_integration_tests.cpp
+++ b/cpp/tests/msvc_compile_integration_tests.cpp
@@ -148,6 +148,33 @@ int main() {
         }
     }
 
+    for (const auto standard : {mqb::CppStandard::cpp14, mqb::CppStandard::cpp17}) {
+        auto legacy = invocation;
+        legacy.object = fixture.path() / "object dir"
+            / (standard == mqb::CppStandard::cpp14 ? "cpp14.obj" : "cpp17.obj");
+        legacy.source_dependencies = fixture.path() / "dependency dir"
+            / (standard == mqb::CppStandard::cpp14 ? "cpp14.json" : "cpp17.json");
+        legacy.options.standard = standard;
+
+        const auto legacy_result = compiler.compile(legacy);
+        expect(legacy_result.has_value(),
+               standard == mqb::CppStandard::cpp14
+                   ? "installed MSVC should compile the ordinary fixture in C++14 mode"
+                   : "installed MSVC should compile the ordinary fixture in C++17 mode");
+        if (!legacy_result) {
+            std::cerr << "legacy-standard compiler error: " << legacy_result.error().message << '\n';
+            if (legacy_result.error().process_result) {
+                std::cerr << legacy_result.error().process_result->stdout_text;
+                std::cerr << legacy_result.error().process_result->stderr_text;
+            }
+        } else {
+            expect(fs::is_regular_file(legacy.object),
+                   "legacy standard compile should create its requested object");
+            expect(fs::is_regular_file(*legacy.source_dependencies),
+                   "legacy standard compile should keep source dependency metadata enabled");
+        }
+    }
+
     const fs::path broken_source = fixture.path() / "source dir" / "broken.cpp";
     const fs::path broken_object = fixture.path() / "object dir" / "broken.obj";
     write_text(broken_source, "int broken( { return 0; }\n");

--- a/cpp/tests/msvc_compiler_arguments_tests.cpp
+++ b/cpp/tests/msvc_compiler_arguments_tests.cpp
@@ -82,6 +82,24 @@ int main() {
                "structured object routing should win by appearing after a raw /Fo");
     }
 
+    auto cpp14 = invocation;
+    cpp14.options.standard = mqb::CppStandard::cpp14;
+    cpp14.options.additional_arguments.clear();
+    const auto cpp14_result = mqb::msvc::MsvcCompiler::build_arguments(cpp14);
+    expect(cpp14_result.has_value(), "ordinary C++14 compile invocation should be supported");
+    if (cpp14_result) {
+        expect(contains(*cpp14_result, "/std:c++14"), "C++14 should map correctly");
+    }
+
+    auto cpp17 = invocation;
+    cpp17.options.standard = mqb::CppStandard::cpp17;
+    cpp17.options.additional_arguments.clear();
+    const auto cpp17_result = mqb::msvc::MsvcCompiler::build_arguments(cpp17);
+    expect(cpp17_result.has_value(), "ordinary C++17 compile invocation should be supported");
+    if (cpp17_result) {
+        expect(contains(*cpp17_result, "/std:c++17"), "C++17 should map correctly");
+    }
+
     auto cpp20 = invocation;
     cpp20.options.standard = mqb::CppStandard::cpp20;
     cpp20.options.additional_arguments.clear();
@@ -161,6 +179,38 @@ int main() {
                    "structured module object routing should follow raw /Fo arguments");
             expect(module_result->back() == "modules/math.ixx",
                    "module source should remain the final argv element");
+        }
+    }
+
+    {
+        auto pre20_module = invocation;
+        pre20_module.kind = mqb::TranslationUnitKind::module_interface;
+        pre20_module.module_interface_output = "ifc/legacy.ifc";
+        pre20_module.options.standard = mqb::CppStandard::cpp17;
+        pre20_module.options.additional_arguments.clear();
+        auto rejected = mqb::msvc::MsvcCompiler::build_arguments(pre20_module);
+        expect(!rejected
+                   && rejected.error().code == mqb::msvc::CompilerErrorCode::invalid_request,
+               "module interface should fail closed below C++20");
+        if (!rejected) {
+            expect(rejected.error().message.find("C++20") != std::string::npos,
+                   "pre-C++20 module rejection should explain the minimum standard");
+        }
+    }
+
+    {
+        mqb::msvc::HeaderUnitCompileInvocation header;
+        header.header_name = "legacy.hpp";
+        header.lookup_method = mqb::msvc::HeaderUnitLookupMethod::quote;
+        header.interface_output = "ifc/legacy.hpp.ifc";
+        header.options.standard = mqb::CppStandard::cpp14;
+        auto rejected = mqb::msvc::MsvcCompiler::build_header_unit_arguments(header);
+        expect(!rejected
+                   && rejected.error().code == mqb::msvc::CompilerErrorCode::invalid_request,
+               "header-unit producer should fail closed below C++20");
+        if (!rejected) {
+            expect(rejected.error().message.find("C++20") != std::string::npos,
+                   "pre-C++20 header-unit rejection should explain the minimum standard");
         }
     }
 

--- a/docs/V5_PARITY.md
+++ b/docs/V5_PARITY.md
@@ -23,7 +23,7 @@ Status meanings:
 | project-local header units | native pipeline is ready | **ready** |
 | `.c` translation units | rejected by native CLI today | **implement** |
 | `.hpp` / `.h` as positional legacy discovery seeds | native CLI treats headers as non-TU inputs | **migrate** unless a real user workflow requires positional header seeds |
-| C++14 / C++17 | native CLI currently supports 20/23/latest | **implement** for ordinary non-module targets |
+| C++14 / C++17 | ordinary native targets map to `/std:c++14` / `/std:c++17`; module pipeline remains C++20+ | **ready** for ordinary non-module targets |
 | C++20 / C++23 / latest | ready | **ready** |
 
 ## Common command-line options
@@ -32,7 +32,7 @@ Status meanings:
 | --- | --- | --- |
 | `-o`, `-output` | `-o`, `--output`; legacy `-output` accepted | **compat** |
 | `-run` | `--run`; legacy `-run` accepted | **compat** |
-| `-std` | `--std`; legacy `-std` accepted for current native standards | **compat**, plus C++14/17 work above |
+| `-std` | `--std`; legacy `-std` accepts 14/17/20/23/latest | **compat** |
 | `-x86` | `--x86`; legacy spelling accepted | **compat** |
 | default x64 | `--x64` / x64 default; legacy `-x64` accepted | **compat** |
 | `-I`, `-include` | `-I`; legacy `-include` accepted | **compat** |
@@ -107,15 +107,16 @@ The native `.mqb/obj`, `.mqb/deps`, `.mqb/scan`, `.mqb/ifc`, `.mqb/cache`, and `
 
 ## C++ Modules boundary (#16)
 
-Project-local named modules and project-local header units are in the RC/stable-capable surface. External/prebuilt named-module providers and `import std` remain tracked in #16. Stable v5 may ship with those cases still fail-closed if the release notes keep that boundary explicit; they must not be accidentally accepted through compatibility parsing.
+Project-local named modules and project-local header units are in the RC/stable-capable surface, but they require C++20 or newer. C++14/17 are ordinary-target compatibility modes only; attempting to scan or compile a module/header-unit contract below C++20 fails before MSVC is launched. External/prebuilt named-module providers and `import std` remain tracked in #16. Stable v5 may ship with those cases still fail-closed if the release notes keep that boundary explicit; they must not be accidentally accepted through compatibility parsing.
 
 ## Parity campaign order
 
-1. Legacy CLI spelling compatibility for behaviors the native engine already supports.
-2. Raw compiler/linker pass-through with cache-invalidation E2E.
-3. C++14/17 ordinary-target support and `.c` translation units.
-4. Target kinds: DLL/static plus subsystem/runtime policy.
-5. First-class/high-value MSVC tuning options; use raw flags for the long tail where that produces an explicit, testable contract.
-6. Shared PowerShell-vs-C++ fixtures for ordinary targets, config precedence, incremental rebuilds, libraries, run argv, x86/x64, Debug/Release, and failure behavior.
-7. Installer/profile/`build` command cutover and clean-machine upgrade/rollback validation.
-8. Generalize the release workflow and publish stable v5 only from the exact validated artifact.
+1. Legacy CLI spelling compatibility for behaviors the native engine already supports. **Done in #27.**
+2. Restore C++14/17 ordinary-target modes while preserving the C++20+ module boundary. **Done in #28.**
+3. Raw compiler/linker pass-through with cache-invalidation E2E.
+4. Add `.c` translation units.
+5. Target kinds: DLL/static plus subsystem/runtime policy.
+6. First-class/high-value MSVC tuning options; use raw flags for the long tail where that produces an explicit, testable contract.
+7. Shared PowerShell-vs-C++ fixtures for ordinary targets, config precedence, incremental rebuilds, libraries, run argv, x86/x64, Debug/Release, and failure behavior.
+8. Installer/profile/`build` command cutover and clean-machine upgrade/rollback validation.
+9. Generalize the release workflow and publish stable v5 only from the exact validated artifact.


### PR DESCRIPTION
Continues #26 stable-v5 parity after #27.

## Scope

- add C++14 and C++17 as explicit `CppStandard` values without changing the existing numeric identities of C++20/C++23/latest (compile signatures hash the enum value)
- map ordinary MSVC compiles to `/std:c++14` and `/std:c++17`
- accept `--std/-std 14|17` in the native CLI, including legacy `-std 17`
- preserve the C++20+ boundary for the module pipeline: P1689 scans, module/interface contracts, and Header Unit producers reject pre-C++20 standards before launching MSVC
- add parser/backend regression coverage for both old-standard mappings and fail-closed module/header-unit cases
- extend the existing installed-MSVC compile integration to compile the same real fixture in C++14 and C++17 while still producing `/sourceDependencies` metadata
- update `docs/V5_PARITY.md` so ordinary C++14/17 are a ready compatibility mode and the module boundary remains explicit

This deliberately restores old-standard support only for ordinary C++ translation units. It does not weaken the C++20+ contract of named modules or Header Units.

## Cache compatibility

`CppStandard` values used by already-shipped recipes are explicitly pinned: C++20=0, C++23=1, latest=2. New C++14/C++17 identities are appended as 3/4, so this feature does not invalidate existing C++20/23/latest compile caches merely because the enum expanded.

## Toolchain contract

Microsoft documents `/std:c++14` and `/std:c++17` as supported MSVC modes, while `/scanDependencies` and C++ modules require C++20 or newer. MQB reflects that distinction explicitly.

## Deliberate follow-up boundary

`mqb.json` still accepts the existing 20/23/latest standard values in this slice. The next build-policy/config slice will extend that schema together with raw compiler/linker pass-through, rather than churn the same configuration object in two adjacent migrations.

## Final verification

Final exact head: `838150b66af07629f407c85b75131c4af2e817b6`.

- C++ V2 Debug workflow #231: **success** (Configure / Build / complete CTest / cleanup)
- C++ Release Candidate workflow #11: **success**
  - Release Configure / Build / complete CTest succeeded
  - embedded RC version verification succeeded
  - validated zip + SHA-256 package staging/upload succeeded
  - publish job skipped by design for the PR run

The first exact-head attempt correctly failed on a test-only namespace qualification (`HeaderUnitLookupMethod`); the final head explicitly re-exports the Core lookup enum alongside the existing MSVC Header Unit reference aliases and passes both gates.