### PR TITLE
feat: expose raw compiler and linker build policy

### DIFF
--- a/cpp/apps/mqb/Cli.cpp
+++ b/cpp/apps/mqb/Cli.cpp
@@ -215,6 +215,30 @@ parse_arguments(const std::span<const std::string_view> arguments) {
             options.standard_override = *standard;
             continue;
         }
+        if (argument == "--compiler-arg" || argument == "-flags") {
+            auto value = require_value(arguments, index, argument);
+            if (!value) return std::unexpected(value.error());
+            options.compiler_arguments.emplace_back(*value);
+            continue;
+        }
+        if (argument.starts_with("--compiler-arg=")) {
+            auto value = long_equals_value(argument, "--compiler-arg=");
+            if (!value) return std::unexpected(value.error());
+            options.compiler_arguments.emplace_back(*value);
+            continue;
+        }
+        if (argument == "--linker-arg" || argument == "-link_flags") {
+            auto value = require_value(arguments, index, argument);
+            if (!value) return std::unexpected(value.error());
+            options.linker_arguments.emplace_back(*value);
+            continue;
+        }
+        if (argument.starts_with("--linker-arg=")) {
+            auto value = long_equals_value(argument, "--linker-arg=");
+            if (!value) return std::unexpected(value.error());
+            options.linker_arguments.emplace_back(*value);
+            continue;
+        }
         if (argument == "--env" || argument == "-env") {
             auto value = require_value(arguments, index, argument);
             if (!value) return std::unexpected(value.error());
@@ -353,11 +377,18 @@ Options:
   --lib-path <dir>         Add a library search directory
   -l <name>, -l<name>      Link a library ('.lib' is optional)
   --lib <name>             Link a library (legacy -libs accepted; repeat for multiple values)
+  --compiler-arg <arg>     Append one raw cl.exe argument (legacy -flags accepted; repeatable)
+  --linker-arg <arg>       Append one raw link.exe argument (legacy -link_flags accepted; repeatable)
   --env <auto|vs|portable> Toolchain selection (legacy -env and portable/port/p accepted)
   --portable-root <dir>    Add a portable_msvc root candidate
   -v, --verbose            Show config, discovery, toolchain, and artifact details
   -h, --help               Show this help and the embedded build version (-help/-? accepted)
   --                       Pass all remaining argv elements to the program
+
+Raw compiler/linker arguments are one argv element per option occurrence; MQB does not split a
+quoted string into multiple switches. Project config entries are applied first and CLI raw args
+append afterward. Structured artifact routing such as /Fo, /scanDependencies, /MACHINE and /OUT
+is emitted after raw arguments so the BuildPlan remains authoritative.
 
 Legacy compatibility aliases intentionally cover spelling only. Legacy-only semantics such as
 -a string splitting, DLL/static output kinds, and MSVC tuning switches remain tracked by the

--- a/cpp/apps/mqb/Cli.hpp
+++ b/cpp/apps/mqb/Cli.hpp
@@ -23,6 +23,8 @@ struct Options {
     std::vector<std::filesystem::path> include_directories;
     std::vector<std::filesystem::path> library_directories;
     std::vector<std::string> libraries;
+    std::vector<std::string> compiler_arguments;
+    std::vector<std::string> linker_arguments;
     msvc::ToolchainPreference toolchain_preference{msvc::ToolchainPreference::automatic};
     std::vector<std::filesystem::path> portable_roots;
     std::optional<bool> discovery_override;

--- a/cpp/apps/mqb/main.cpp
+++ b/cpp/apps/mqb/main.cpp
@@ -340,6 +340,8 @@ int main(const int argc, char* argv[]) {
     cli_overrides.build.include_directories = options.include_directories;
     cli_overrides.build.library_directories = options.library_directories;
     cli_overrides.build.libraries = options.libraries;
+    cli_overrides.build.compiler_arguments = options.compiler_arguments;
+    cli_overrides.build.linker_arguments = options.linker_arguments;
     cli_overrides.discovery.enabled = options.discovery_override;
 
     auto effective = mqb::config::resolve_project_options(
@@ -354,6 +356,8 @@ int main(const int argc, char* argv[]) {
     options.include_directories = effective.include_directories;
     options.library_directories = effective.library_directories;
     options.libraries = effective.libraries;
+    options.compiler_arguments = effective.compiler_arguments;
+    options.linker_arguments = effective.linker_arguments;
 
     std::vector<fs::path> sources = requested_sources;
     bool discovery_requires_module_pipeline = false;
@@ -470,6 +474,7 @@ int main(const int argc, char* argv[]) {
     compiler_options.standard = options.build.standard;
     compiler_options.defines = std::move(options.defines);
     compiler_options.include_directories = std::move(options.include_directories);
+    compiler_options.additional_arguments = std::move(options.compiler_arguments);
 
     mqb::LinkOptions link_options;
     link_options.configuration = options.build.configuration;
@@ -477,6 +482,7 @@ int main(const int argc, char* argv[]) {
     link_options.subsystem = mqb::LinkSubsystem::console;
     link_options.library_directories = std::move(options.library_directories);
     link_options.libraries = std::move(options.libraries);
+    link_options.additional_arguments = std::move(options.linker_arguments);
 
     const bool module_target = discovery_requires_module_pipeline || std::any_of(
         target_sources.begin(),
@@ -528,6 +534,12 @@ int main(const int argc, char* argv[]) {
         }
         for (const auto& library : link_options.libraries) {
             std::cout << "  lib:     " << library << '\n';
+        }
+        for (const auto& argument : compiler_options.additional_arguments) {
+            std::cout << "  cl-arg:  " << argument << '\n';
+        }
+        for (const auto& argument : link_options.additional_arguments) {
+            std::cout << "  link-arg:" << argument << '\n';
         }
         std::cout << "  exe:     " << path_text(target_artifacts->executable) << '\n'
                   << "  cache:   " << path_text(target_artifacts->link_cache) << '\n';

--- a/cpp/config/include/mqb/config/ProjectConfig.hpp
+++ b/cpp/config/include/mqb/config/ProjectConfig.hpp
@@ -19,6 +19,8 @@ struct BuildOverrides {
     std::vector<std::filesystem::path> include_directories;
     std::vector<std::filesystem::path> library_directories;
     std::vector<std::string> libraries;
+    std::vector<std::string> compiler_arguments;
+    std::vector<std::string> linker_arguments;
 };
 
 struct DiscoveryOverrides {

--- a/cpp/config/include/mqb/config/ProjectOptions.hpp
+++ b/cpp/config/include/mqb/config/ProjectOptions.hpp
@@ -23,6 +23,8 @@ struct EffectiveProjectOptions {
     std::vector<std::filesystem::path> include_directories;
     std::vector<std::filesystem::path> library_directories;
     std::vector<std::string> libraries;
+    std::vector<std::string> compiler_arguments;
+    std::vector<std::string> linker_arguments;
 
     bool discovery_enabled{true};
     std::vector<std::filesystem::path> discovery_exclude_directories;

--- a/cpp/config/src/ProjectConfig.cpp
+++ b/cpp/config/src/ProjectConfig.cpp
@@ -397,6 +397,8 @@ require_paths(const fs::path& file, const fs::path& root, const JsonValue& value
     return std::nullopt;
 }
 [[nodiscard]] std::optional<CppStandard> standard(std::string_view value) {
+    if (value == "14" || value == "c++14") return CppStandard::cpp14;
+    if (value == "17" || value == "c++17") return CppStandard::cpp17;
     if (value == "20" || value == "c++20") return CppStandard::cpp20;
     if (value == "23" || value == "c++23") return CppStandard::cpp23;
     if (value == "latest" || value == "c++latest") return CppStandard::latest;
@@ -408,7 +410,8 @@ decode_build(const fs::path& file, const fs::path& root, const JsonValue& value,
     auto object = require_object(file, value, "build");
     if (!object) return std::unexpected(object.error());
     auto known = reject_unknown(file, **object,
-        {"configuration", "architecture", "standard", "output", "defines", "include_dirs", "library_dirs", "libraries"},
+        {"configuration", "architecture", "standard", "output", "defines", "include_dirs",
+         "library_dirs", "libraries", "compiler_args", "linker_args"},
         "build");
     if (!known) return std::unexpected(known.error());
 
@@ -430,7 +433,7 @@ decode_build(const fs::path& file, const fs::path& root, const JsonValue& value,
         auto text = require_string(file, it->second, "build.standard");
         if (!text) return std::unexpected(text.error());
         auto parsed = standard(*text);
-        if (!parsed) return std::unexpected(schema_error(file, it->second, "build.standard must be '20', '23', or 'latest'"));
+        if (!parsed) return std::unexpected(schema_error(file, it->second, "build.standard must be '14', '17', '20', '23', or 'latest'"));
         out.standard = *parsed;
     }
     if (auto it = (**object).find("output"); it != (**object).end()) {
@@ -457,6 +460,16 @@ decode_build(const fs::path& file, const fs::path& root, const JsonValue& value,
         auto values = require_strings(file, it->second, "build.libraries");
         if (!values) return std::unexpected(values.error());
         out.libraries = std::move(*values);
+    }
+    if (auto it = (**object).find("compiler_args"); it != (**object).end()) {
+        auto values = require_strings(file, it->second, "build.compiler_args");
+        if (!values) return std::unexpected(values.error());
+        out.compiler_arguments = std::move(*values);
+    }
+    if (auto it = (**object).find("linker_args"); it != (**object).end()) {
+        auto values = require_strings(file, it->second, "build.linker_args");
+        if (!values) return std::unexpected(values.error());
+        out.linker_arguments = std::move(*values);
     }
     return {};
 }

--- a/cpp/config/src/ProjectOptions.cpp
+++ b/cpp/config/src/ProjectOptions.cpp
@@ -21,6 +21,8 @@ void apply_build(
     append_all(effective.include_directories, overrides.include_directories);
     append_all(effective.library_directories, overrides.library_directories);
     append_all(effective.libraries, overrides.libraries);
+    append_all(effective.compiler_arguments, overrides.compiler_arguments);
+    append_all(effective.linker_arguments, overrides.linker_arguments);
 }
 
 void apply_discovery(

--- a/cpp/config/tests/build_policy_config_tests.cpp
+++ b/cpp/config/tests/build_policy_config_tests.cpp
@@ -1,0 +1,103 @@
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string_view>
+#include <system_error>
+
+#include "mqb/config/ProjectConfig.hpp"
+#include "mqb/config/ProjectOptions.hpp"
+
+namespace {
+namespace fs = std::filesystem;
+int failures = 0;
+
+void expect(bool condition, std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+void write_text(const fs::path& path, std::string_view text) {
+    fs::create_directories(path.parent_path());
+    std::ofstream stream{path, std::ios::binary | std::ios::trunc};
+    stream << text;
+}
+
+struct TempTree {
+    fs::path root;
+    ~TempTree() {
+        std::error_code ignored;
+        fs::remove_all(root, ignored);
+    }
+};
+} // namespace
+
+int main() {
+    const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
+    TempTree tree{.root = fs::temp_directory_path() / ("mqb_build_policy_config_" + std::to_string(unique))};
+    const fs::path file = tree.root / "mqb.json";
+
+    write_text(file, R"json({
+  "version": 1,
+  "build": {
+    "standard": "17",
+    "compiler_args": ["/W4", "/DCONFIG_POLICY=1"],
+    "linker_args": ["/OPT:NOREF"]
+  }
+})json");
+
+    auto loaded = mqb::config::ProjectConfigLoader::load(file);
+    expect(loaded.has_value(), "build-policy config should load");
+    if (loaded) {
+        expect(loaded->build.standard == mqb::CppStandard::cpp17,
+               "mqb.json should accept C++17");
+        expect(loaded->build.compiler_arguments.size() == 2
+                   && loaded->build.compiler_arguments[0] == "/W4"
+                   && loaded->build.compiler_arguments[1] == "/DCONFIG_POLICY=1",
+               "compiler_args should preserve config order");
+        expect(loaded->build.linker_arguments.size() == 1
+                   && loaded->build.linker_arguments[0] == "/OPT:NOREF",
+               "linker_args should decode");
+
+        mqb::config::ProjectOverrides cli;
+        cli.build.standard = mqb::CppStandard::cpp14;
+        cli.build.compiler_arguments = {"/WX"};
+        cli.build.linker_arguments = {"/MAP:cli.map"};
+        const auto effective = mqb::config::resolve_project_options(&*loaded, cli);
+        expect(effective.standard == mqb::CppStandard::cpp14,
+               "CLI scalar standard should override project config");
+        expect(effective.compiler_arguments.size() == 3
+                   && effective.compiler_arguments[0] == "/W4"
+                   && effective.compiler_arguments[1] == "/DCONFIG_POLICY=1"
+                   && effective.compiler_arguments[2] == "/WX",
+               "CLI compiler arguments should append after config arguments");
+        expect(effective.linker_arguments.size() == 2
+                   && effective.linker_arguments[0] == "/OPT:NOREF"
+                   && effective.linker_arguments[1] == "/MAP:cli.map",
+               "CLI linker arguments should append after config arguments");
+    }
+
+    write_text(file, R"json({"version":1,"build":{"standard":"14"}})json");
+    auto cpp14 = mqb::config::ProjectConfigLoader::load(file);
+    expect(cpp14.has_value() && cpp14->build.standard == mqb::CppStandard::cpp14,
+           "mqb.json should accept C++14");
+
+    write_text(file, R"json({"version":1,"build":{"compiler_args":[""]}})json");
+    auto empty = mqb::config::ProjectConfigLoader::load(file);
+    expect(!empty && empty.error().code == mqb::config::ErrorCode::schema_error,
+           "empty compiler_args entry should fail strict schema validation");
+
+    write_text(file, R"json({"version":1,"build":{"linker_args":"/MAP"}})json");
+    auto wrong_type = mqb::config::ProjectConfigLoader::load(file);
+    expect(!wrong_type && wrong_type.error().code == mqb::config::ErrorCode::schema_error,
+           "linker_args must be a JSON string array");
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+    std::cout << "mqb_build_policy_config_tests passed\n";
+    return 0;
+}

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -46,6 +46,10 @@ add_executable(mqb_process_model_tests process_model_tests.cpp)
 target_link_libraries(mqb_process_model_tests PRIVATE mqb_process)
 target_compile_features(mqb_process_model_tests PRIVATE cxx_std_23)
 
+add_executable(mqb_build_policy_config_tests ../config/tests/build_policy_config_tests.cpp)
+target_link_libraries(mqb_build_policy_config_tests PRIVATE mqb_config)
+target_compile_features(mqb_build_policy_config_tests PRIVATE cxx_std_23)
+
 set(MQB_TEST_TARGETS
     mqb_core_tests
     mqb_build_plan_tests
@@ -59,6 +63,7 @@ set(MQB_TEST_TARGETS
     mqb_project_artifact_layout_tests
     mqb_translation_unit_classifier_tests
     mqb_process_model_tests
+    mqb_build_policy_config_tests
 )
 
 if(WIN32)
@@ -101,6 +106,10 @@ if(WIN32)
     target_link_libraries(mqb_cli_argument_tests PRIVATE mqb_cli)
     target_compile_features(mqb_cli_argument_tests PRIVATE cxx_std_23)
 
+    add_executable(mqb_build_policy_cli_tests build_policy_cli_tests.cpp)
+    target_link_libraries(mqb_build_policy_cli_tests PRIVATE mqb_cli)
+    target_compile_features(mqb_build_policy_cli_tests PRIVATE cxx_std_23)
+
     list(APPEND MQB_TEST_TARGETS
         mqb_windows_command_line_tests
         mqb_process_echo_helper
@@ -112,6 +121,7 @@ if(WIN32)
         mqb_msvc_compile_executor_tests
         mqb_msvc_source_dependencies_tests
         mqb_cli_argument_tests
+        mqb_build_policy_cli_tests
     )
 
     if(MQB_ENABLE_INSTALLED_MSVC_TESTS)
@@ -147,6 +157,10 @@ if(WIN32)
         target_link_libraries(mqb_module_cli_e2e_tests PRIVATE mqb_platform_windows)
         target_compile_features(mqb_module_cli_e2e_tests PRIVATE cxx_std_23)
 
+        add_executable(mqb_build_policy_e2e_tests mqb_build_policy_e2e_tests.cpp)
+        target_link_libraries(mqb_build_policy_e2e_tests PRIVATE mqb_platform_windows)
+        target_compile_features(mqb_build_policy_e2e_tests PRIVATE cxx_std_23)
+
         list(APPEND MQB_TEST_TARGETS
             mqb_msvc_visual_studio_tests
             mqb_msvc_compile_integration_tests
@@ -156,6 +170,7 @@ if(WIN32)
             mqb_project_config_e2e_tests
             mqb_parallel_cli_e2e_tests
             mqb_module_cli_e2e_tests
+            mqb_build_policy_e2e_tests
         )
     endif()
 endif()
@@ -180,6 +195,7 @@ add_test(NAME mqb.core.link_cache_file COMMAND mqb_link_cache_file_tests)
 add_test(NAME mqb.core.project_artifact_layout COMMAND mqb_project_artifact_layout_tests)
 add_test(NAME mqb.core.translation_unit_classifier COMMAND mqb_translation_unit_classifier_tests)
 add_test(NAME mqb.process.model COMMAND mqb_process_model_tests)
+add_test(NAME mqb.config.build_policy COMMAND mqb_build_policy_config_tests)
 
 if(WIN32)
     add_test(NAME mqb.windows.command_line COMMAND mqb_windows_command_line_tests)
@@ -194,6 +210,7 @@ if(WIN32)
     add_test(NAME mqb.msvc.compile_executor COMMAND mqb_msvc_compile_executor_tests)
     add_test(NAME mqb.msvc.source_dependencies COMMAND mqb_msvc_source_dependencies_tests)
     add_test(NAME mqb.cli.arguments COMMAND mqb_cli_argument_tests)
+    add_test(NAME mqb.cli.build_policy COMMAND mqb_build_policy_cli_tests)
 
     if(MQB_ENABLE_INSTALLED_MSVC_TESTS)
         add_test(NAME mqb.msvc.visual_studio COMMAND mqb_msvc_visual_studio_tests)
@@ -215,6 +232,10 @@ if(WIN32)
         add_test(
             NAME mqb.cli.module_e2e
             COMMAND mqb_module_cli_e2e_tests $<TARGET_FILE:mqb>
+        )
+        add_test(
+            NAME mqb.cli.build_policy_e2e
+            COMMAND mqb_build_policy_e2e_tests $<TARGET_FILE:mqb>
         )
     endif()
 endif()

--- a/cpp/tests/build_policy_cli_tests.cpp
+++ b/cpp/tests/build_policy_cli_tests.cpp
@@ -1,0 +1,80 @@
+#include <iostream>
+#include <string_view>
+#include <vector>
+
+#include "Cli.hpp"
+
+namespace {
+int failures = 0;
+void expect(bool condition, std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+} // namespace
+
+int main() {
+    using namespace std::string_view_literals;
+
+    {
+        const std::vector arguments{
+            "main.cpp"sv,
+            "--compiler-arg"sv, "/W4"sv,
+            "--compiler-arg=/WX"sv,
+            "--linker-arg"sv, "/MAP:one.map"sv,
+            "--linker-arg=/OPT:NOREF"sv,
+        };
+        auto parsed = mqb::cli::parse_arguments(arguments);
+        expect(parsed.has_value(), "native raw build-policy options should parse");
+        if (parsed) {
+            expect(parsed->compiler_arguments.size() == 2
+                       && parsed->compiler_arguments[0] == "/W4"
+                       && parsed->compiler_arguments[1] == "/WX",
+                   "compiler arguments should preserve occurrence order");
+            expect(parsed->linker_arguments.size() == 2
+                       && parsed->linker_arguments[0] == "/MAP:one.map"
+                       && parsed->linker_arguments[1] == "/OPT:NOREF",
+                   "linker arguments should preserve occurrence order");
+        }
+    }
+
+    {
+        const std::vector arguments{
+            "main.cpp"sv,
+            "-flags"sv, "/DPOLICY_VALUE=7"sv,
+            "-flags"sv, "/volatile:iso"sv,
+            "-link_flags"sv, "/MAP:legacy.map"sv,
+        };
+        auto parsed = mqb::cli::parse_arguments(arguments);
+        expect(parsed.has_value(), "legacy raw build-policy aliases should parse");
+        if (parsed) {
+            expect(parsed->compiler_arguments.size() == 2
+                       && parsed->compiler_arguments[0] == "/DPOLICY_VALUE=7"
+                       && parsed->compiler_arguments[1] == "/volatile:iso",
+                   "legacy -flags should mean one raw argv element per occurrence");
+            expect(parsed->linker_arguments.size() == 1
+                       && parsed->linker_arguments[0] == "/MAP:legacy.map",
+                   "legacy -link_flags should map to ordered linker arguments");
+        }
+    }
+
+    {
+        const std::vector arguments{"main.cpp"sv, "--compiler-arg"sv};
+        auto parsed = mqb::cli::parse_arguments(arguments);
+        expect(!parsed, "missing raw compiler argument should be rejected");
+    }
+
+    {
+        const std::vector arguments{"main.cpp"sv, "--linker-arg="sv};
+        auto parsed = mqb::cli::parse_arguments(arguments);
+        expect(!parsed, "empty raw linker argument should be rejected");
+    }
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+    std::cout << "mqb_build_policy_cli_tests passed\n";
+    return 0;
+}

--- a/cpp/tests/mqb_build_policy_e2e_tests.cpp
+++ b/cpp/tests/mqb_build_policy_e2e_tests.cpp
@@ -1,0 +1,249 @@
+#include <chrono>
+#include <expected>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <vector>
+
+#include "mqb/platform/windows/WindowsProcessRunner.hpp"
+#include "mqb/process/Process.hpp"
+
+namespace {
+namespace fs = std::filesystem;
+int failures = 0;
+
+void expect(bool condition, std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+[[nodiscard]] std::string path_text(const fs::path& path) {
+    const auto bytes = path.generic_u8string();
+    return std::string{reinterpret_cast<const char*>(bytes.data()), bytes.size()};
+}
+
+void write_text(const fs::path& path, std::string_view text) {
+    fs::create_directories(path.parent_path());
+    std::ofstream stream{path, std::ios::binary | std::ios::trunc};
+    stream << text;
+}
+
+void dump_failure(const mqb::process::ProcessResult& result) {
+    std::cerr << "exit: " << result.exit_code << '\n'
+              << "stdout:\n" << result.stdout_text << '\n'
+              << "stderr:\n" << result.stderr_text << '\n';
+}
+
+[[nodiscard]] bool contains_line(std::string_view output, std::string_view expected) {
+    std::size_t begin = 0;
+    while (begin <= output.size()) {
+        const std::size_t newline = output.find('\n', begin);
+        const std::size_t end = newline == std::string_view::npos ? output.size() : newline;
+        std::string_view line = output.substr(begin, end - begin);
+        if (!line.empty() && line.back() == '\r') line.remove_suffix(1);
+        if (line == expected) return true;
+        if (newline == std::string_view::npos) break;
+        begin = newline + 1;
+    }
+    return false;
+}
+
+struct TempTree {
+    fs::path root;
+    ~TempTree() {
+        std::error_code ignored;
+        fs::remove_all(root, ignored);
+    }
+};
+
+[[nodiscard]] std::expected<mqb::process::ProcessResult, std::string> run_mqb(
+    mqb::platform::windows::WindowsProcessRunner& runner,
+    const fs::path& mqb,
+    const fs::path& root,
+    const std::vector<std::string>& extra_arguments) {
+    mqb::process::ProcessSpec spec;
+    spec.executable = mqb;
+    spec.arguments = {"main.cpp", "--env", "vs", "--no-discover"};
+    spec.arguments.insert(spec.arguments.end(), extra_arguments.begin(), extra_arguments.end());
+    spec.working_directory = root;
+    spec.capture_stdout = true;
+    spec.capture_stderr = true;
+    auto result = runner.run(spec);
+    if (!result) return std::unexpected("failed to launch mqb: " + result.error().message);
+    return std::move(*result);
+}
+
+[[nodiscard]] std::expected<mqb::process::ProcessResult, std::string> run_executable(
+    mqb::platform::windows::WindowsProcessRunner& runner,
+    const fs::path& executable,
+    const fs::path& root) {
+    mqb::process::ProcessSpec spec;
+    spec.executable = executable;
+    spec.working_directory = root;
+    spec.capture_stdout = true;
+    spec.capture_stderr = true;
+    auto result = runner.run(spec);
+    if (!result) return std::unexpected("failed to launch built executable: " + result.error().message);
+    return std::move(*result);
+}
+
+[[nodiscard]] std::vector<std::string> raw_policy(
+    int value,
+    const fs::path& map_file) {
+    return {
+        "-o", "policy",
+        "--compiler-arg", "/DPOLICY_VALUE=" + std::to_string(value),
+        "--linker-arg", "/MAP:" + path_text(map_file),
+    };
+}
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    if (argc != 2) {
+        std::cerr << "usage: mqb_build_policy_e2e_tests <mqb-executable>\n";
+        return 2;
+    }
+
+    const fs::path mqb_executable{argv[1]};
+    const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
+    TempTree tree{.root = fs::temp_directory_path() / ("mqb_build_policy_e2e_" + std::to_string(unique))};
+    fs::create_directories(tree.root);
+
+    write_text(tree.root / "main.cpp", R"cpp(#include <cstdio>
+#ifndef POLICY_VALUE
+#error POLICY_VALUE must be supplied by raw build policy
+#endif
+int main() {
+    std::printf("policy=%d\n", POLICY_VALUE);
+    return 0;
+}
+)cpp");
+
+    mqb::platform::windows::WindowsProcessRunner runner;
+    const fs::path map_one = tree.root / "policy-one.map";
+    const fs::path map_two = tree.root / "policy-two.map";
+    const fs::path executable = tree.root / ".mqb" / "bin" / "policy.exe";
+
+    auto cold = run_mqb(runner, mqb_executable, tree.root, raw_policy(1, map_one));
+    expect(cold.has_value(), "cold raw-policy invocation should launch");
+    if (cold) {
+        if (cold->exit_code != 0) dump_failure(*cold);
+        expect(cold->exit_code == 0, "cold raw-policy build should succeed");
+        expect(cold->stdout_text.find("[compile] main.cpp") != std::string::npos,
+               "cold raw compiler policy should compile the TU");
+        expect(cold->stdout_text.find("[link] policy.exe") != std::string::npos,
+               "cold raw linker policy should link the target");
+    }
+    expect(fs::is_regular_file(map_one), "raw /MAP linker argument should produce its side artifact");
+
+    auto cold_run = run_executable(runner, executable, tree.root);
+    expect(cold_run.has_value() && cold_run->exit_code == 0,
+           "cold raw-policy executable should run");
+    if (cold_run) {
+        expect(cold_run->stdout_text.find("policy=1") != std::string::npos,
+               "raw compiler define should affect executable behavior");
+    }
+
+    auto warm = run_mqb(runner, mqb_executable, tree.root, raw_policy(1, map_one));
+    expect(warm.has_value(), "warm raw-policy invocation should launch");
+    if (warm) {
+        if (warm->exit_code != 0) dump_failure(*warm);
+        expect(warm->exit_code == 0, "warm raw-policy build should succeed");
+        expect(contains_line(warm->stdout_text, "[up-to-date] main.cpp"),
+               "unchanged raw compiler policy should reuse compile cache");
+        expect(contains_line(warm->stdout_text, "[up-to-date] policy.exe"),
+               "unchanged raw linker policy should reuse link cache");
+    }
+
+    auto compiler_changed = run_mqb(runner, mqb_executable, tree.root, raw_policy(2, map_one));
+    expect(compiler_changed.has_value(), "compiler-policy change invocation should launch");
+    if (compiler_changed) {
+        if (compiler_changed->exit_code != 0) dump_failure(*compiler_changed);
+        expect(compiler_changed->exit_code == 0, "compiler-policy changed build should succeed");
+        expect(compiler_changed->stdout_text.find("[compile] main.cpp") != std::string::npos
+                   && compiler_changed->stdout_text.find("compiler options changed") != std::string::npos,
+               "raw compiler argument change should invalidate compile recipe identity");
+        expect(compiler_changed->stdout_text.find("[link] policy.exe") != std::string::npos,
+               "fresh compile from raw compiler change should force relink");
+    }
+
+    auto compiler_changed_run = run_executable(runner, executable, tree.root);
+    expect(compiler_changed_run.has_value() && compiler_changed_run->exit_code == 0,
+           "compiler-policy changed executable should run");
+    if (compiler_changed_run) {
+        expect(compiler_changed_run->stdout_text.find("policy=2") != std::string::npos,
+               "changed raw compiler argument should affect executable behavior");
+    }
+
+    auto linker_changed = run_mqb(runner, mqb_executable, tree.root, raw_policy(2, map_two));
+    expect(linker_changed.has_value(), "linker-policy change invocation should launch");
+    if (linker_changed) {
+        if (linker_changed->exit_code != 0) dump_failure(*linker_changed);
+        expect(linker_changed->exit_code == 0, "linker-policy changed build should succeed");
+        expect(contains_line(linker_changed->stdout_text, "[up-to-date] main.cpp"),
+               "linker-only policy change must not recompile the TU");
+        expect(linker_changed->stdout_text.find("[link] policy.exe") != std::string::npos
+                   && linker_changed->stdout_text.find("linker options changed") != std::string::npos,
+               "raw linker argument change should invalidate link recipe identity only");
+    }
+    expect(fs::is_regular_file(map_two), "changed raw linker /MAP argument should be honored");
+
+    const fs::path config_map = tree.root / "config-policy.map";
+    const std::string config = std::string{R"json({
+  "version": 1,
+  "build": {
+    "standard": "17",
+    "output": "config_policy",
+    "compiler_args": ["/DPOLICY_VALUE=3"],
+    "linker_args": ["/MAP:)json"}
+        + path_text(config_map)
+        + R"json("]
+  }
+})json";
+    write_text(tree.root / "mqb.json", config);
+
+    auto config_cold = run_mqb(runner, mqb_executable, tree.root, {});
+    expect(config_cold.has_value(), "config build-policy invocation should launch");
+    if (config_cold) {
+        if (config_cold->exit_code != 0) dump_failure(*config_cold);
+        expect(config_cold->exit_code == 0, "C++17 config build-policy target should succeed");
+        expect(config_cold->stdout_text.find("[compile] main.cpp") != std::string::npos,
+               "config standard/compiler policy should produce a fresh compile");
+        expect(config_cold->stdout_text.find("[link] config_policy.exe") != std::string::npos,
+               "config linker policy should produce the configured target");
+    }
+    expect(fs::is_regular_file(config_map), "mqb.json linker_args should reach link.exe");
+
+    const fs::path config_executable = tree.root / ".mqb" / "bin" / "config_policy.exe";
+    auto config_run = run_executable(runner, config_executable, tree.root);
+    expect(config_run.has_value() && config_run->exit_code == 0,
+           "config build-policy executable should run");
+    if (config_run) {
+        expect(config_run->stdout_text.find("policy=3") != std::string::npos,
+               "mqb.json compiler_args should affect executable behavior");
+    }
+
+    auto config_warm = run_mqb(runner, mqb_executable, tree.root, {});
+    expect(config_warm.has_value(), "warm config build-policy invocation should launch");
+    if (config_warm) {
+        if (config_warm->exit_code != 0) dump_failure(*config_warm);
+        expect(config_warm->exit_code == 0, "warm config build-policy target should succeed");
+        expect(contains_line(config_warm->stdout_text, "[up-to-date] main.cpp"),
+               "unchanged config compiler policy should be reusable");
+        expect(contains_line(config_warm->stdout_text, "[up-to-date] config_policy.exe"),
+               "unchanged config linker policy should be reusable");
+    }
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+    std::cout << "mqb_build_policy_e2e_tests passed\n";
+    return 0;
+}

--- a/cpp/tests/mqb_build_policy_e2e_tests.cpp
+++ b/cpp/tests/mqb_build_policy_e2e_tests.cpp
@@ -126,11 +126,10 @@ int main() {
 )cpp");
 
     mqb::platform::windows::WindowsProcessRunner runner;
-    const fs::path map_one = tree.root / "policy-one.map";
-    const fs::path map_two = tree.root / "policy-two.map";
+    const fs::path map_file = tree.root / "policy.map";
     const fs::path executable = tree.root / ".mqb" / "bin" / "policy.exe";
 
-    auto cold = run_mqb(runner, mqb_executable, tree.root, raw_policy(1, map_one));
+    auto cold = run_mqb(runner, mqb_executable, tree.root, raw_policy(1, map_file));
     expect(cold.has_value(), "cold raw-policy invocation should launch");
     if (cold) {
         if (cold->exit_code != 0) dump_failure(*cold);
@@ -140,7 +139,7 @@ int main() {
         expect(cold->stdout_text.find("[link] policy.exe") != std::string::npos,
                "cold raw linker policy should link the target");
     }
-    expect(fs::is_regular_file(map_one), "raw /MAP linker argument should produce its side artifact");
+    expect(fs::is_regular_file(map_file), "raw /MAP linker argument should produce its side artifact");
 
     auto cold_run = run_executable(runner, executable, tree.root);
     expect(cold_run.has_value() && cold_run->exit_code == 0,
@@ -150,7 +149,7 @@ int main() {
                "raw compiler define should affect executable behavior");
     }
 
-    auto warm = run_mqb(runner, mqb_executable, tree.root, raw_policy(1, map_one));
+    auto warm = run_mqb(runner, mqb_executable, tree.root, raw_policy(1, map_file));
     expect(warm.has_value(), "warm raw-policy invocation should launch");
     if (warm) {
         if (warm->exit_code != 0) dump_failure(*warm);
@@ -161,7 +160,7 @@ int main() {
                "unchanged raw linker policy should reuse link cache");
     }
 
-    auto compiler_changed = run_mqb(runner, mqb_executable, tree.root, raw_policy(2, map_one));
+    auto compiler_changed = run_mqb(runner, mqb_executable, tree.root, raw_policy(2, map_file));
     expect(compiler_changed.has_value(), "compiler-policy change invocation should launch");
     if (compiler_changed) {
         if (compiler_changed->exit_code != 0) dump_failure(*compiler_changed);
@@ -181,7 +180,20 @@ int main() {
                "changed raw compiler argument should affect executable behavior");
     }
 
-    auto linker_changed = run_mqb(runner, mqb_executable, tree.root, raw_policy(2, map_two));
+    // Change link recipe identity independently from the compiler recipe while
+    // retaining the already-proven /MAP argument. Delete the map first so the
+    // relink must recreate it; this verifies the changed linker invocation was
+    // actually executed without depending on link.exe's semantics for swapping
+    // /MAP output filenames across consecutive links.
+    std::error_code remove_error;
+    fs::remove(map_file, remove_error);
+    expect(!remove_error && !fs::exists(map_file),
+           "test should remove the first map artifact before linker-only rebuild");
+
+    auto linker_policy = raw_policy(2, map_file);
+    linker_policy.emplace_back("--linker-arg");
+    linker_policy.emplace_back("/INCREMENTAL:NO");
+    auto linker_changed = run_mqb(runner, mqb_executable, tree.root, linker_policy);
     expect(linker_changed.has_value(), "linker-policy change invocation should launch");
     if (linker_changed) {
         if (linker_changed->exit_code != 0) dump_failure(*linker_changed);
@@ -192,7 +204,8 @@ int main() {
                    && linker_changed->stdout_text.find("linker options changed") != std::string::npos,
                "raw linker argument change should invalidate link recipe identity only");
     }
-    expect(fs::is_regular_file(map_two), "changed raw linker /MAP argument should be honored");
+    expect(fs::is_regular_file(map_file),
+           "linker-only rebuild should execute raw /MAP policy and recreate its side artifact");
 
     const fs::path config_map = tree.root / "config-policy.map";
     const std::string config = std::string{R"json({

--- a/docs/MQB_CONFIG.md
+++ b/docs/MQB_CONFIG.md
@@ -12,7 +12,7 @@ MQB searches upward from the directory where it is invoked and uses the nearest 
 }
 ```
 
-`version` is required. Version 1 uses strict JSON: comments, trailing commas, duplicate keys, unknown schema fields, and incorrect field types are rejected.
+`version` is required. Version 1 uses strict JSON: comments, trailing commas, duplicate keys, unknown schema fields, incorrect field types, and empty entries in string arrays are rejected.
 
 ## Full example
 
@@ -22,7 +22,7 @@ MQB searches upward from the directory where it is invoked and uses the nearest 
   "build": {
     "configuration": "release",
     "architecture": "x64",
-    "standard": "23",
+    "standard": "17",
     "output": "game",
     "defines": [
       "GAME_BUILD=1"
@@ -37,6 +37,12 @@ MQB searches upward from the directory where it is invoked and uses the nearest 
     "libraries": [
       "math",
       "codec.lib"
+    ],
+    "compiler_args": [
+      "/W4"
+    ],
+    "linker_args": [
+      "/OPT:NOREF"
     ]
   },
   "discovery": {
@@ -61,14 +67,26 @@ MQB searches upward from the directory where it is invoked and uses the nearest 
 |---|---|---|
 | `configuration` | string | `debug` or `release` |
 | `architecture` | string | `x86` or `x64` |
-| `standard` | string | `20`, `23`, or `latest` (`c++20`, `c++23`, `c++latest` are also accepted) |
+| `standard` | string | `14`, `17`, `20`, `23`, or `latest` (`c++14`, `c++17`, `c++20`, `c++23`, `c++latest` are also accepted) |
 | `output` | string | target name under `.mqb/bin/` |
 | `defines` | string array | preprocessor definitions, without `/D` |
 | `include_dirs` | string array | include search directories |
 | `library_dirs` | string array | library search directories |
 | `libraries` | string array | requested libraries; `.lib` is optional for ordinary names |
+| `compiler_args` | string array | ordered raw `cl.exe` argv elements |
+| `linker_args` | string array | ordered raw `link.exe` argv elements |
 
 All path-valued config entries are resolved relative to the directory containing `mqb.json`, not the shell's current working directory.
+
+Raw compiler/linker arguments are literal argv elements. MQB does not split one JSON string containing spaces into several switches. For example:
+
+```json
+"compiler_args": ["/W4", "/WX"]
+```
+
+represents two compiler arguments, while `"/W4 /WX"` is one argument and is not rewritten by MQB.
+
+Backend-owned structured routing remains authoritative. Raw arguments are emitted before MQB's planned output/topology switches such as `/Fo`, `/ifcOutput`, `/scanDependencies`, `/MACHINE`, `/SUBSYSTEM`, and `/OUT`.
 
 ## Discovery fields
 
@@ -92,9 +110,9 @@ An ordinary `extra_sources` entry may not define another `main()`. The entry TU 
 
 Built-in directory exclusions such as `.mqb`, `.git`, `.vs`, `build`, `out`, and `cmake-build-*` remain active in addition to configured exclusions.
 
-### Named modules and discovery
+### Named modules and header units
 
-Project-local named modules do **not** require a separate v1 config section.
+Project-local named modules and project-local header units do **not** require separate v1 config sections.
 
 For a single ordinary entry such as:
 
@@ -105,9 +123,11 @@ int main() { return answer(); }
 
 smart discovery may select a reachable local `.ixx/.cppm/.mpp` provider candidate. Discovery does not decide which candidate is authoritative; MSVC `/scanDependencies` P1689 metadata remains responsible for provider selection, dependency ordering, ambiguity/cycle diagnostics, and unresolved requirements.
 
-If a selected source contains named-module syntax but no supported local provider is found, the target still routes through the module pipeline and fails closed. It does not silently fall back to an ordinary compile.
+Header-unit lexical syntax stays out of ordinary TU discovery edges, but it routes the target through the same authoritative P1689 module pipeline. Project-local header-unit IFCs are allocated, built, freshness-tracked, and repaired automatically.
 
-Header units, external/prebuilt providers, and `import std` do not yet have execution/artifact policy and remain unsupported.
+Modules and header units require C++20 or newer. Selecting `standard: "14"` or `"17"` for an ordinary target is supported; if that target requires module/header-unit scanning, MQB fails closed before launching the unsupported module operation.
+
+If a selected source contains named-module syntax but no supported local provider is found, the target fails closed. External/prebuilt named-module providers and `import std` remain tracked separately in issue #16.
 
 ## Precedence
 
@@ -138,7 +158,7 @@ List-like options are additive rather than replacing the config list. The effect
 mqb.json entries, then CLI entries
 ```
 
-This applies to defines, include directories, library directories, and libraries. For example, `-I local` adds a CLI include directory after the project's `include_dirs` entries.
+This applies to defines, include directories, library directories, libraries, `compiler_args`, and `linker_args`. For example, a CLI `--compiler-arg /WX` is appended after project `compiler_args` entries.
 
 ## Path bases
 
@@ -171,23 +191,11 @@ still loads `project/mqb.json`, places artifacts under `project/.mqb/`, and inte
 
 The config file timestamp itself is not a special global rebuild trigger. Instead, the effective typed build options produced from the file participate in the existing compile/link signatures.
 
-For example, changing only:
-
-```json
-"defines": ["VALUE=1"]
-```
-
-to:
-
-```json
-"defines": ["VALUE=2"]
-```
-
-changes compiler recipe identity and recompiles affected TUs even if no source file timestamp changed.
+Changing a compiler argument changes compiler recipe identity and recompiles affected TUs even if no source timestamp changed. The resulting fresh objects force the downstream link. Changing only a linker argument changes link recipe identity and relinks without recompiling otherwise-fresh TUs.
 
 Likewise, library names/search paths affect link recipe identity, while exact resolved `.lib` files are separately tracked as link freshness inputs.
 
-For named modules, compile identity also includes typed module references and planned module-interface output identity. Imported IFC files participate in consumer freshness validation, and a missing provider IFC invalidates the provider's cached compile outputs.
+For named modules and header units, compile identity also includes typed provider/reference and interface-output identity. Imported IFC files participate in consumer freshness validation, and a missing provider IFC invalidates the provider's cached outputs.
 
 ## Parallelism
 
@@ -201,10 +209,10 @@ Changing the job count does not alter compile or link signatures and therefore m
 
 ## Current boundaries
 
-- v1 config has no header-unit, external/prebuilt module-provider, or `import std` policy.
+- v1 config has no external/prebuilt module-provider or `import std` policy.
 - v1 config does not store parallel job count.
 - `exclude_dirs`, `extra_sources`, and `exclude_sources` are exact paths, not globs.
 - Explicit user libraries are freshness-tracked; indirect `/DEFAULTLIB` transitive dependencies are not claimed as fully tracked.
 - C++ V2 currently classifies C++ translation units only; `.c` is not supported by the V2 source classifier.
 
-For the broader build/module/cache architecture, see [`CPP_V2_ARCHITECTURE.md`](CPP_V2_ARCHITECTURE.md).
+For stable-v5 migration decisions, see [`V5_PARITY.md`](V5_PARITY.md). For the broader build/module/cache architecture, see [`CPP_V2_ARCHITECTURE.md`](CPP_V2_ARCHITECTURE.md).

--- a/docs/V5_PARITY.md
+++ b/docs/V5_PARITY.md
@@ -23,7 +23,7 @@ Status meanings:
 | project-local header units | native pipeline is ready | **ready** |
 | `.c` translation units | rejected by native CLI today | **implement** |
 | `.hpp` / `.h` as positional legacy discovery seeds | native CLI treats headers as non-TU inputs | **migrate** unless a real user workflow requires positional header seeds |
-| C++14 / C++17 | ordinary native targets map to `/std:c++14` / `/std:c++17`; module pipeline remains C++20+ | **ready** for ordinary non-module targets |
+| C++14 / C++17 | ordinary native targets map to `/std:c++14` / `/std:c++17`; CLI and `mqb.json` accept both; module pipeline remains C++20+ | **ready** for ordinary non-module targets |
 | C++20 / C++23 / latest | ready | **ready** |
 
 ## Common command-line options
@@ -37,11 +37,13 @@ Status meanings:
 | default x64 | `--x64` / x64 default; legacy `-x64` accepted | **compat** |
 | `-I`, `-include` | `-I`; legacy `-include` accepted | **compat** |
 | `-L`, `-libpath` | `-L`, `--lib-path`; legacy `-libpath` accepted | **compat** |
-| `-libs` | `-l`, `--lib`; legacy `-libs <value>` accepted and repeatable | **compat** for scalar/repeated values; document that shell array tokenization is not emulated |
+| `-libs` | `-l`, `--lib`; legacy `-libs <value>` accepted and repeatable | **compat** for scalar/repeated values; shell-array tokenization is not emulated |
 | `-D`, `-defines` | `-D`; legacy `-defines` accepted | **compat** |
 | `-config debug/release` | `--debug`, `--release`, `--config`; legacy `-config` accepted | **compat** |
 | `-env vs/portable/port/p/auto` | `--env auto/vs/portable`; legacy spelling and portable aliases accepted | **compat** |
 | `-help`, `-?` | `--help`, `-h`; legacy help aliases accepted | **compat** |
+| `-flags` | `--compiler-arg <one argv>`; legacy `-flags <one argv>` accepted and repeatable | **compat** with explicit one-argv-per-occurrence semantics |
+| `-link_flags` | `--linker-arg <one argv>`; legacy alias accepted and repeatable | **compat** with explicit one-argv-per-occurrence semantics |
 | `-a "..."` single-string program arguments | structured `-- program-args...` | **migrate**: keep structured argv semantics; decide whether a compatibility tokenizer is worth the ambiguity |
 
 ## Target/output kinds
@@ -57,36 +59,39 @@ Status meanings:
 
 ## Compiler and linker policy
 
-The native backend already has typed `CompilerOptions` / `LinkOptions`, including ordered additional argument vectors. Compile and link signatures include those vectors, so future pass-through flags can remain incrementally correct.
+The native backend has typed `CompilerOptions` / `LinkOptions` plus ordered additional argument vectors. CLI and `mqb.json` expose those vectors, and compile/link signatures hash them in order. Config arguments are applied first and CLI arguments append afterward. Backend-owned artifact/topology switches are emitted after raw arguments so the BuildPlan remains authoritative.
 
 | Legacy option | Native C++ status | Stable-v5 decision |
 | --- | --- | --- |
-| `-optimize Od/O1/O2/Ox` | debug/release presets cover common cases, no first-class override | **implement** or explicitly migrate to raw compiler flags after parity E2E |
-| `-runtime MD/MDd/MT/MTd` | presets choose MDd/MD; release package itself uses static CRT only for MQB | **implement** target runtime selection |
-| `-warnings W0/W1/W3/W4/Wall` | fixed W3 today | **implement** |
-| `-WX` | not exposed | **implement** |
-| `-debug_info off/Zi/ZI/Z7` | presets use Z7 | **implement** or migrate to raw compiler flags with documented precedence |
-| `-exceptions EHsc/EHa/off` | fixed EHsc today | **implement** or migrate to raw compiler flags |
-| `-rtc1` | not exposed | **implement** or migrate to raw compiler flags |
-| `-jmc` | not exposed | **implement** or migrate to raw compiler flags |
-| `-sdl` | not exposed | **implement** or migrate to raw compiler flags |
-| `-permissive` | native currently always uses `/permissive-` | **migrate**: strict conformance is the native baseline; add an escape hatch only if parity fixtures require it |
-| `-fp precise/strict/fast` | not exposed | **implement** or migrate to raw compiler flags |
-| `-charset unicode/mbcs` | native uses UTF-8 source/execution compile policy; Windows macro charset is not exposed | **implement** if legacy projects rely on `_UNICODE/UNICODE` vs `_MBCS` macros |
-| `-ltcg` | not exposed | **implement** because it couples compile `/GL` and link `/LTCG` |
-| `-incremental` linker switch | native build engine is always incrementally cached, but linker `/INCREMENTAL` is not exposed | **migrate** terminology; expose linker incremental only if required |
-| `-flags` | Core already supports ordered compiler additional args but CLI/config do not expose them | **implement next** |
-| `-link_flags` | Core already supports ordered linker additional args but CLI/config do not expose them | **implement next** |
+| `-optimize Od/O1/O2/Ox` | debug/release presets cover common cases; raw compiler args can express an override | **migrate** long-tail override to `--compiler-arg`; typed option remains optional unless parity fixtures justify it |
+| `-runtime MD/MDd/MT/MTd` | presets choose MDd/MD | **implement** typed target runtime selection because CRT policy affects the supported target contract |
+| `-warnings W0/W1/W3/W4/Wall` | fixed W3 baseline; raw compiler args can override later in argv | **migrate** long-tail override to `--compiler-arg` |
+| `-WX` | raw compiler args support `/WX` | **migrate** to `--compiler-arg /WX` |
+| `-debug_info off/Zi/ZI/Z7` | presets use Z7; raw compiler args exist | **migrate** long-tail override, but preserve parallel-safe default recipe |
+| `-exceptions EHsc/EHa/off` | fixed EHsc baseline; raw compiler args exist | **migrate** long-tail override |
+| `-rtc1` | raw compiler args exist | **migrate** to raw build policy |
+| `-jmc` | raw compiler args exist | **migrate** to raw build policy |
+| `-sdl` | raw compiler args exist | **migrate** to raw build policy |
+| `-permissive` | native baseline is `/permissive-`; raw args can add a later MSVC conformance switch where supported | **migrate** strict conformance remains default |
+| `-fp precise/strict/fast` | raw compiler args exist | **migrate** to raw build policy |
+| `-charset unicode/mbcs` | UTF-8 source/execution is native baseline; Windows macro charset is not typed | **implement** only if parity fixtures show `_UNICODE/UNICODE` vs `_MBCS` is a required stable contract |
+| `-ltcg` | requires coupled compile `/GL` + link `/LTCG` policy | **implement** typed/coupled policy; do not rely on users manually keeping two raw lists coherent |
+| `-incremental` linker switch | native build engine is incrementally cached; linker `/INCREMENTAL` can be passed raw | **migrate** terminology; expose raw linker switch if specifically desired |
+| `-flags` / arbitrary compiler switches | ordered CLI/config pass-through is wired and cache-safe | **ready/compat** |
+| `-link_flags` / arbitrary linker switches | ordered CLI/config pass-through is wired and cache-safe | **ready/compat** |
 
 ## Project configuration
 
 | Legacy behavior | Native C++ status | Stable-v5 decision |
 | --- | --- | --- |
 | `msvc_list.json`, upward search up to five levels | native uses nearest upward `mqb.json` | **migrate** to `mqb.json`; provide upgrade guidance/tooling rather than keeping two authoritative schemas forever |
-| CLI overrides config | ready | **ready** |
+| CLI overrides scalar config | ready | **ready** |
+| additive list precedence | config lists first, CLI lists append | **ready** |
+| 14/17/20/23/latest standard config | ready | **ready** |
 | include/lib/define/library config | ready in `mqb.json` | **ready** |
+| `compiler_args` / `linker_args` | ready in strict `mqb.json` v1 schema | **ready** |
 | source discovery excludes | ready with the native discovery schema | **ready** |
-| legacy config keys for tuning/target kind | not all represented | **implement** only for capabilities accepted into the stable parity surface |
+| legacy config keys for target kind/coupled policies | not all represented | **implement** only for capabilities accepted into the stable parity surface |
 
 ## Toolchain/environment behavior
 
@@ -101,22 +106,24 @@ The native backend already has typed `CompilerOptions` / `LinkOptions`, includin
 
 ## Incremental/artifact behavior
 
-Stable v5 does not require byte-for-byte artifact layout parity with PowerShell. It requires equivalent observable correctness: cold build succeeds, warm no-op avoids unnecessary work, source/header/library/config/toolchain changes invalidate the right work, missing required artifacts repair correctly, and outputs are collision-free.
+Stable v5 does not require byte-for-byte artifact layout parity with PowerShell. It requires equivalent observable correctness: cold build succeeds, warm no-op avoids unnecessary work, source/header/library/config/toolchain/build-policy changes invalidate the right work, missing required artifacts repair correctly, and outputs are collision-free.
 
-The native `.mqb/obj`, `.mqb/deps`, `.mqb/scan`, `.mqb/ifc`, `.mqb/cache`, and `.mqb/bin` layout is therefore the stable direction rather than the old PowerShell temporary layout.
+Raw compiler argument changes are compile-recipe identity and therefore force affected compile + downstream link. Raw linker argument changes are link-recipe identity and therefore relink without recompiling otherwise-fresh TUs.
+
+The native `.mqb/obj`, `.mqb/deps`, `.mqb/scan`, `.mqb/ifc`, `.mqb/cache`, and `.mqb/bin` layout is the stable direction rather than the old PowerShell temporary layout.
 
 ## C++ Modules boundary (#16)
 
-Project-local named modules and project-local header units are in the RC/stable-capable surface, but they require C++20 or newer. C++14/17 are ordinary-target compatibility modes only; attempting to scan or compile a module/header-unit contract below C++20 fails before MSVC is launched. External/prebuilt named-module providers and `import std` remain tracked in #16. Stable v5 may ship with those cases still fail-closed if the release notes keep that boundary explicit; they must not be accidentally accepted through compatibility parsing.
+Project-local named modules and project-local header units are in the RC/stable-capable surface, but they require C++20 or newer. C++14/17 are ordinary-target compatibility modes only; attempting to scan or compile a module/header-unit contract below C++20 fails before MSVC is launched. External/prebuilt named-module providers and `import std` remain tracked in #16. Stable v5 may ship with those cases still fail-closed if release notes keep that boundary explicit; they must not be accidentally accepted through compatibility parsing.
 
 ## Parity campaign order
 
 1. Legacy CLI spelling compatibility for behaviors the native engine already supports. **Done in #27.**
 2. Restore C++14/17 ordinary-target modes while preserving the C++20+ module boundary. **Done in #28.**
-3. Raw compiler/linker pass-through with cache-invalidation E2E.
+3. Raw compiler/linker pass-through plus config build-policy expansion and cache-invalidation E2E. **Done in #29.**
 4. Add `.c` translation units.
 5. Target kinds: DLL/static plus subsystem/runtime policy.
-6. First-class/high-value MSVC tuning options; use raw flags for the long tail where that produces an explicit, testable contract.
+6. Close the remaining high-value typed/coupled MSVC policy gaps (notably runtime/LTCG and any charset requirement proven by parity fixtures).
 7. Shared PowerShell-vs-C++ fixtures for ordinary targets, config precedence, incremental rebuilds, libraries, run argv, x86/x64, Debug/Release, and failure behavior.
 8. Installer/profile/`build` command cutover and clean-machine upgrade/rollback validation.
 9. Generalize the release workflow and publish stable v5 only from the exact validated artifact.


### PR DESCRIPTION
Continues the stable-v5 parity campaign in #26 after #27/#28.

## Scope

- expose ordered raw compiler arguments through `--compiler-arg <arg>` and legacy `-flags <arg>`; repeat one option per argv element
- expose ordered raw linker arguments through `--linker-arg <arg>` and legacy `-link_flags <arg>`
- extend strict `mqb.json` v1 build policy with `compiler_args` and `linker_args` string arrays
- extend `mqb.json build.standard` to C++14/C++17, completing the config half of #28
- preserve deterministic merge order: config list first, then CLI list
- route effective raw policy into the existing Core `CompilerOptions.additional_arguments` / `LinkOptions.additional_arguments`; those ordered vectors are already part of compile/link recipe identity
- preserve structured backend routing after raw args so `/Fo`, `/ifcOutput`, `/scanDependencies`, `/MACHINE`, `/SUBSYSTEM`, and `/OUT` remain BuildPlan-owned

## Verification

- focused CLI parser regression for native and legacy raw-argument spellings
- focused strict-config/resolver regression for 14/17, raw arrays, invalid empty/type inputs, and config->CLI append order
- real installed-VS E2E for cold/warm reuse, compiler-arg invalidation (compile + link), linker-arg invalidation (link only), `/MAP` side output, and `mqb.json` C++17 + raw compiler/linker policy

The first E2E head exposed an over-specific test assertion around swapping `/MAP:` output filenames between consecutive links. Product behavior had already reached 58/59 tests; the final test keeps the actual `/MAP` execution proof, deletes that side artifact, changes only linker recipe identity by appending `/INCREMENTAL:NO`, and requires the TU to remain up-to-date while relink recreates the map.

## Final verification

Final exact head: `d05bc9652f8e1f528fbc7c29bbb12870c8de9b78`.

- C++ V2 Debug workflow #236: **success** (Configure / Build / all 59 CTests / cleanup)
- C++ Release Candidate workflow #15: **success**
  - Release Configure / Build / all tests succeeded
  - embedded RC version verification succeeded
  - validated zip + SHA-256 staging/upload succeeded
  - publish job skipped by design for the PR run

This PR is intentionally an escape-hatch/build-policy slice, not a replacement for high-value typed/coupled options such as runtime, target kind, LTCG, or subsystem. Those remain tracked separately in `docs/V5_PARITY.md` / #26.