### PR TITLE
fix: isolate C discovery from C++ module syntax

### DIFF
--- a/cpp/discovery/src/SourceDiscovery.cpp
+++ b/cpp/discovery/src/SourceDiscovery.cpp
@@ -539,7 +539,9 @@ SourceDiscovery::discover(const Request& request) {
             const std::string comment_free = strip_comments_preserve_literals(*text);
             record.local_includes = parse_local_includes(comment_free);
             if (record.kind == FileKind::translation_unit) {
-                record.module_syntax = ModuleSyntaxParser::parse(*text);
+                if (is_cpp_translation_unit_path(record.path)) {
+                    record.module_syntax = ModuleSyntaxParser::parse(*text);
+                }
                 record.defines_main = ordinary_translation_unit(record)
                     && contains_main(comment_free);
             }

--- a/cpp/discovery/tests/CMakeLists.txt
+++ b/cpp/discovery/tests/CMakeLists.txt
@@ -22,11 +22,18 @@ add_executable(mqb_module_source_discovery_tests
 target_link_libraries(mqb_module_source_discovery_tests PRIVATE mqb_discovery)
 target_compile_features(mqb_module_source_discovery_tests PRIVATE cxx_std_23)
 
+add_executable(mqb_c_source_discovery_tests
+    c_source_discovery_tests.cpp
+)
+target_link_libraries(mqb_c_source_discovery_tests PRIVATE mqb_discovery)
+target_compile_features(mqb_c_source_discovery_tests PRIVATE cxx_std_23)
+
 foreach(target IN ITEMS
     mqb_source_discovery_tests
     mqb_source_discovery_corrections_tests
     mqb_module_syntax_tests
     mqb_module_source_discovery_tests
+    mqb_c_source_discovery_tests
 )
     if(MSVC)
         target_compile_options(${target} PRIVATE /W4 /permissive-)
@@ -39,3 +46,4 @@ add_test(NAME mqb.discovery.source_graph COMMAND mqb_source_discovery_tests)
 add_test(NAME mqb.discovery.corrections COMMAND mqb_source_discovery_corrections_tests)
 add_test(NAME mqb.discovery.module_syntax COMMAND mqb_module_syntax_tests)
 add_test(NAME mqb.discovery.module_graph COMMAND mqb_module_source_discovery_tests)
+add_test(NAME mqb.discovery.c_language_isolation COMMAND mqb_c_source_discovery_tests)

--- a/cpp/discovery/tests/c_source_discovery_tests.cpp
+++ b/cpp/discovery/tests/c_source_discovery_tests.cpp
@@ -1,0 +1,90 @@
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string_view>
+#include <system_error>
+
+#include "mqb/discovery/SourceDiscovery.hpp"
+
+namespace {
+namespace fs = std::filesystem;
+int failures = 0;
+
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+void write_text(const fs::path& path, const std::string_view text) {
+    fs::create_directories(path.parent_path());
+    std::ofstream stream{path, std::ios::binary | std::ios::trunc};
+    stream << text;
+}
+
+struct TempTree {
+    fs::path root;
+    ~TempTree() {
+        std::error_code ignored;
+        fs::remove_all(root, ignored);
+    }
+};
+
+[[nodiscard]] bool same_path(const fs::path& left, const fs::path& right) {
+    std::error_code error;
+    return fs::equivalent(left, right, error) && !error;
+}
+} // namespace
+
+int main() {
+    const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
+    TempTree tree{
+        .root = fs::temp_directory_path() / ("mqb_c_discovery_" + std::to_string(unique)),
+    };
+
+    const fs::path header = tree.root / "shared.h";
+    const fs::path main_c = tree.root / "main.c";
+    const fs::path helper_c = tree.root / "helper.c";
+
+    write_text(header, "#pragma once\nint helper(void);\n");
+    write_text(main_c, R"c(#include "shared.h"
+typedef int module;
+module local_module_identifier;
+typedef int import;
+import local_import_identifier;
+int main(void) { return helper() == 42 ? 0 : 1; }
+)c");
+    write_text(helper_c, R"c(#include "shared.h"
+typedef int export;
+export local_export_identifier;
+int helper(void) { return 42; }
+)c");
+
+    mqb::discovery::Request request{
+        .project_root = tree.root,
+        .entry = main_c,
+    };
+    auto result = mqb::discovery::SourceDiscovery::discover(request);
+    expect(result.has_value(), "C entry should participate in ordinary smart discovery");
+    if (result) {
+        expect(result->sources.size() == 2,
+               "shared local header should connect main.c and helper.c");
+        if (result->sources.size() == 2) {
+            expect(same_path(result->sources[0], main_c),
+                   "C entry should remain first in deterministic discovery order");
+            expect(same_path(result->sources[1], helper_c),
+                   "connected C helper should be selected as an ordinary TU");
+        }
+        expect(!result->requires_module_pipeline,
+               "legal C identifiers named module/import/export must not route into the C++ module pipeline");
+    }
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+    std::cout << "mqb_c_source_discovery_tests passed\n";
+    return 0;
+}


### PR DESCRIPTION
Follows #30/#31 and closes the small C discovery correctness debt left after native `.c` support.

## Scope

- keep `.c` files fully indexed for ordinary smart discovery, local include edges, same-basename ownership, and `main()` handling
- only invoke `ModuleSyntaxParser` for C++ translation units via the existing `is_cpp_translation_unit_path()` classifier
- leave C `NamedModuleSyntax` empty so legal identifiers resembling `module`, `import`, or `export` cannot route a C target into the C++ P1689 module pipeline
- preserve all existing C++ named-module/header-unit discovery behavior unchanged

## Regression

A focused discovery CTest builds a pure-C fixture whose source contains legal identifiers named `module`, `import`, and `export`. It requires:

- `main.c` + connected `helper.c` are selected through the ordinary include graph
- entry ordering remains deterministic
- `requires_module_pipeline == false`

## Final verification

Final exact head: `cea2471ff6fd6583a7b8c80e9643ca998029b32a`.

- C++ V2 workflow #261: **success** (Configure / Build / complete CTest suite / cleanup)
- C++ Release Candidate workflow #37: **success**
  - Release Configure / Build / complete CTest suite succeeded
  - embedded RC version verification succeeded
  - validated package staging/upload succeeded
  - publish job skipped by design for the PR run

This deliberately remains a 3-file correctness fix; no module graph/orchestration behavior is changed.