### PR TITLE
feat: add runtime and subsystem project config policy

### DIFF
--- a/cpp/apps/mqb/main.cpp
+++ b/cpp/apps/mqb/main.cpp
@@ -335,6 +335,8 @@ int main(const int argc, char* argv[]) {
     cli_overrides.build.configuration = options.configuration_override;
     cli_overrides.build.architecture = options.architecture_override;
     cli_overrides.build.standard = options.standard_override;
+    cli_overrides.build.runtime_library = options.runtime_override;
+    cli_overrides.build.subsystem = options.subsystem_override;
     cli_overrides.build.output_name = options.build.output_name;
     cli_overrides.build.defines = options.defines;
     cli_overrides.build.include_directories = options.include_directories;
@@ -350,6 +352,8 @@ int main(const int argc, char* argv[]) {
     options.build.configuration = effective.configuration;
     options.build.architecture = effective.architecture;
     options.build.standard = effective.standard;
+    options.runtime_override = effective.runtime_library;
+    options.subsystem_override = effective.subsystem;
     options.build.output_name = effective.output_name;
     options.discover_sources = effective.discovery_enabled;
     options.defines = effective.defines;

--- a/cpp/config/include/mqb/config/ProjectConfig.hpp
+++ b/cpp/config/include/mqb/config/ProjectConfig.hpp
@@ -6,7 +6,8 @@
 #include <string>
 #include <vector>
 
-#include "mqb/core/BuildTypes.hpp"
+#include "mqb/core/CompilerOptions.hpp"
+#include "mqb/core/LinkOptions.hpp"
 
 namespace mqb::config {
 
@@ -14,6 +15,8 @@ struct BuildOverrides {
     std::optional<BuildConfiguration> configuration;
     std::optional<Architecture> architecture;
     std::optional<CppStandard> standard;
+    std::optional<RuntimeLibrary> runtime_library;
+    std::optional<LinkSubsystem> subsystem;
     std::optional<std::string> output_name;
     std::vector<std::string> defines;
     std::vector<std::filesystem::path> include_directories;

--- a/cpp/config/include/mqb/config/ProjectOptions.hpp
+++ b/cpp/config/include/mqb/config/ProjectOptions.hpp
@@ -18,6 +18,8 @@ struct EffectiveProjectOptions {
     BuildConfiguration configuration{BuildConfiguration::debug};
     Architecture architecture{Architecture::x64};
     CppStandard standard{CppStandard::cpp23};
+    std::optional<RuntimeLibrary> runtime_library;
+    LinkSubsystem subsystem{LinkSubsystem::console};
     std::optional<std::string> output_name;
     std::vector<std::string> defines;
     std::vector<std::filesystem::path> include_directories;

--- a/cpp/config/src/ProjectConfig.cpp
+++ b/cpp/config/src/ProjectConfig.cpp
@@ -404,13 +404,25 @@ require_paths(const fs::path& file, const fs::path& root, const JsonValue& value
     if (value == "latest" || value == "c++latest") return CppStandard::latest;
     return std::nullopt;
 }
+[[nodiscard]] std::optional<RuntimeLibrary> runtime_library(std::string_view value) {
+    if (value == "MD" || value == "md") return RuntimeLibrary::md;
+    if (value == "MDd" || value == "mdd") return RuntimeLibrary::mdd;
+    if (value == "MT" || value == "mt") return RuntimeLibrary::mt;
+    if (value == "MTd" || value == "mtd") return RuntimeLibrary::mtd;
+    return std::nullopt;
+}
+[[nodiscard]] std::optional<LinkSubsystem> subsystem(std::string_view value) {
+    if (value == "console") return LinkSubsystem::console;
+    if (value == "windows") return LinkSubsystem::windows;
+    return std::nullopt;
+}
 
 [[nodiscard]] std::expected<void, Error>
 decode_build(const fs::path& file, const fs::path& root, const JsonValue& value, BuildOverrides& out) {
     auto object = require_object(file, value, "build");
     if (!object) return std::unexpected(object.error());
     auto known = reject_unknown(file, **object,
-        {"configuration", "architecture", "standard", "output", "defines", "include_dirs",
+        {"configuration", "architecture", "standard", "runtime", "subsystem", "output", "defines", "include_dirs",
          "library_dirs", "libraries", "compiler_args", "linker_args"},
         "build");
     if (!known) return std::unexpected(known.error());
@@ -435,6 +447,20 @@ decode_build(const fs::path& file, const fs::path& root, const JsonValue& value,
         auto parsed = standard(*text);
         if (!parsed) return std::unexpected(schema_error(file, it->second, "build.standard must be '14', '17', '20', '23', or 'latest'"));
         out.standard = *parsed;
+    }
+    if (auto it = (**object).find("runtime"); it != (**object).end()) {
+        auto text = require_string(file, it->second, "build.runtime");
+        if (!text) return std::unexpected(text.error());
+        auto parsed = runtime_library(*text);
+        if (!parsed) return std::unexpected(schema_error(file, it->second, "build.runtime must be 'MD', 'MDd', 'MT', or 'MTd'"));
+        out.runtime_library = *parsed;
+    }
+    if (auto it = (**object).find("subsystem"); it != (**object).end()) {
+        auto text = require_string(file, it->second, "build.subsystem");
+        if (!text) return std::unexpected(text.error());
+        auto parsed = subsystem(*text);
+        if (!parsed) return std::unexpected(schema_error(file, it->second, "build.subsystem must be 'console' or 'windows'"));
+        out.subsystem = *parsed;
     }
     if (auto it = (**object).find("output"); it != (**object).end()) {
         auto text = require_string(file, it->second, "build.output");

--- a/cpp/config/src/ProjectOptions.cpp
+++ b/cpp/config/src/ProjectOptions.cpp
@@ -16,6 +16,8 @@ void apply_build(
     if (overrides.configuration) effective.configuration = *overrides.configuration;
     if (overrides.architecture) effective.architecture = *overrides.architecture;
     if (overrides.standard) effective.standard = *overrides.standard;
+    if (overrides.runtime_library) effective.runtime_library = overrides.runtime_library;
+    if (overrides.subsystem) effective.subsystem = *overrides.subsystem;
     if (overrides.output_name) effective.output_name = overrides.output_name;
     append_all(effective.defines, overrides.defines);
     append_all(effective.include_directories, overrides.include_directories);

--- a/cpp/config/tests/build_policy_config_tests.cpp
+++ b/cpp/config/tests/build_policy_config_tests.cpp
@@ -43,6 +43,8 @@ int main() {
   "version": 1,
   "build": {
     "standard": "17",
+    "runtime": "MT",
+    "subsystem": "windows",
     "compiler_args": ["/W4", "/DCONFIG_POLICY=1"],
     "linker_args": ["/OPT:NOREF"]
   }
@@ -53,6 +55,10 @@ int main() {
     if (loaded) {
         expect(loaded->build.standard == mqb::CppStandard::cpp17,
                "mqb.json should accept C++17");
+        expect(loaded->build.runtime_library == mqb::RuntimeLibrary::mt,
+               "mqb.json should decode typed MT runtime");
+        expect(loaded->build.subsystem == mqb::LinkSubsystem::windows,
+               "mqb.json should decode typed Windows subsystem");
         expect(loaded->build.compiler_arguments.size() == 2
                    && loaded->build.compiler_arguments[0] == "/W4"
                    && loaded->build.compiler_arguments[1] == "/DCONFIG_POLICY=1",
@@ -63,11 +69,17 @@ int main() {
 
         mqb::config::ProjectOverrides cli;
         cli.build.standard = mqb::CppStandard::cpp14;
+        cli.build.runtime_library = mqb::RuntimeLibrary::mdd;
+        cli.build.subsystem = mqb::LinkSubsystem::console;
         cli.build.compiler_arguments = {"/WX"};
         cli.build.linker_arguments = {"/MAP:cli.map"};
         const auto effective = mqb::config::resolve_project_options(&*loaded, cli);
         expect(effective.standard == mqb::CppStandard::cpp14,
                "CLI scalar standard should override project config");
+        expect(effective.runtime_library == mqb::RuntimeLibrary::mdd,
+               "CLI scalar runtime should override project config");
+        expect(effective.subsystem == mqb::LinkSubsystem::console,
+               "CLI scalar subsystem should override project config");
         expect(effective.compiler_arguments.size() == 3
                    && effective.compiler_arguments[0] == "/W4"
                    && effective.compiler_arguments[1] == "/DCONFIG_POLICY=1"
@@ -83,6 +95,21 @@ int main() {
     auto cpp14 = mqb::config::ProjectConfigLoader::load(file);
     expect(cpp14.has_value() && cpp14->build.standard == mqb::CppStandard::cpp14,
            "mqb.json should accept C++14");
+
+    write_text(file, R"json({"version":1,"build":{"runtime":"dynamic"}})json");
+    auto bad_runtime = mqb::config::ProjectConfigLoader::load(file);
+    expect(!bad_runtime && bad_runtime.error().code == mqb::config::ErrorCode::schema_error,
+           "unknown runtime must fail strict schema validation");
+
+    write_text(file, R"json({"version":1,"build":{"subsystem":"gui"}})json");
+    auto bad_subsystem = mqb::config::ProjectConfigLoader::load(file);
+    expect(!bad_subsystem && bad_subsystem.error().code == mqb::config::ErrorCode::schema_error,
+           "unknown subsystem must fail strict schema validation");
+
+    write_text(file, R"json({"version":1,"build":{"runtime":17}})json");
+    auto runtime_type = mqb::config::ProjectConfigLoader::load(file);
+    expect(!runtime_type && runtime_type.error().code == mqb::config::ErrorCode::schema_error,
+           "runtime must be a JSON string");
 
     write_text(file, R"json({"version":1,"build":{"compiler_args":[""]}})json");
     auto empty = mqb::config::ProjectConfigLoader::load(file);

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -175,6 +175,10 @@ if(WIN32)
         target_link_libraries(mqb_c_source_e2e_tests PRIVATE mqb_platform_windows)
         target_compile_features(mqb_c_source_e2e_tests PRIVATE cxx_std_23)
 
+        add_executable(mqb_runtime_subsystem_config_e2e_tests mqb_runtime_subsystem_config_e2e_tests.cpp)
+        target_link_libraries(mqb_runtime_subsystem_config_e2e_tests PRIVATE mqb_platform_windows)
+        target_compile_features(mqb_runtime_subsystem_config_e2e_tests PRIVATE cxx_std_23)
+
         list(APPEND MQB_TEST_TARGETS
             mqb_msvc_visual_studio_tests
             mqb_msvc_compile_integration_tests
@@ -186,6 +190,7 @@ if(WIN32)
             mqb_module_cli_e2e_tests
             mqb_build_policy_e2e_tests
             mqb_c_source_e2e_tests
+            mqb_runtime_subsystem_config_e2e_tests
         )
     endif()
 endif()
@@ -257,6 +262,10 @@ if(WIN32)
         add_test(
             NAME mqb.cli.c_source_e2e
             COMMAND mqb_c_source_e2e_tests $<TARGET_FILE:mqb>
+        )
+        add_test(
+            NAME mqb.cli.runtime_subsystem_config_e2e
+            COMMAND mqb_runtime_subsystem_config_e2e_tests $<TARGET_FILE:mqb>
         )
     endif()
 endif()

--- a/cpp/tests/mqb_runtime_subsystem_config_e2e_tests.cpp
+++ b/cpp/tests/mqb_runtime_subsystem_config_e2e_tests.cpp
@@ -1,0 +1,189 @@
+#include <chrono>
+#include <expected>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <vector>
+
+#include "mqb/platform/windows/WindowsProcessRunner.hpp"
+#include "mqb/process/Process.hpp"
+
+namespace {
+namespace fs = std::filesystem;
+int failures = 0;
+
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+void write_text(const fs::path& path, const std::string_view text) {
+    fs::create_directories(path.parent_path());
+    std::ofstream stream{path, std::ios::binary | std::ios::trunc};
+    stream << text;
+}
+
+void write_config(
+    const fs::path& root,
+    const std::string_view runtime,
+    const std::string_view subsystem) {
+    const std::string config =
+        "{\n"
+        "  \"version\": 1,\n"
+        "  \"build\": {\n"
+        "    \"standard\": \"17\",\n"
+        "    \"runtime\": \"" + std::string{runtime} + "\",\n"
+        "    \"subsystem\": \"" + std::string{subsystem} + "\",\n"
+        "    \"output\": \"config_policy\"\n"
+        "  }\n"
+        "}\n";
+    write_text(root / "mqb.json", config);
+}
+
+[[nodiscard]] bool contains_line(
+    const std::string_view output,
+    const std::string_view expected) {
+    std::size_t begin = 0;
+    while (begin <= output.size()) {
+        const std::size_t newline = output.find('\n', begin);
+        const std::size_t end = newline == std::string_view::npos ? output.size() : newline;
+        std::string_view line = output.substr(begin, end - begin);
+        if (!line.empty() && line.back() == '\r') line.remove_suffix(1);
+        if (line == expected) return true;
+        if (newline == std::string_view::npos) break;
+        begin = newline + 1;
+    }
+    return false;
+}
+
+void dump_failure(const mqb::process::ProcessResult& result) {
+    std::cerr << "exit: " << result.exit_code << '\n'
+              << "stdout:\n" << result.stdout_text << '\n'
+              << "stderr:\n" << result.stderr_text << '\n';
+}
+
+struct TempTree {
+    fs::path root;
+    ~TempTree() {
+        std::error_code ignored;
+        fs::remove_all(root, ignored);
+    }
+};
+
+[[nodiscard]] std::expected<mqb::process::ProcessResult, std::string> run_mqb(
+    mqb::platform::windows::WindowsProcessRunner& runner,
+    const fs::path& mqb,
+    const fs::path& root) {
+    mqb::process::ProcessSpec spec;
+    spec.executable = mqb;
+    spec.arguments = {"main.cpp", "--env", "vs", "--no-discover"};
+    spec.working_directory = root;
+    spec.capture_stdout = true;
+    spec.capture_stderr = true;
+    auto result = runner.run(spec);
+    if (!result) return std::unexpected("failed to launch mqb: " + result.error().message);
+    return std::move(*result);
+}
+
+void expect_success(
+    const std::expected<mqb::process::ProcessResult, std::string>& result,
+    const std::string_view message) {
+    expect(result.has_value(), message);
+    if (result && result->exit_code != 0) dump_failure(*result);
+    if (result) expect(result->exit_code == 0, message);
+}
+
+} // namespace
+
+int main(const int argc, char* argv[]) {
+    if (argc != 2) {
+        std::cerr << "usage: mqb_runtime_subsystem_config_e2e_tests <mqb-executable>\n";
+        return 2;
+    }
+
+    const fs::path mqb_executable{argv[1]};
+    const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
+    TempTree tree{
+        .root = fs::temp_directory_path()
+            / ("mqb_runtime_subsystem_config_" + std::to_string(unique)),
+    };
+    fs::create_directories(tree.root);
+
+    write_text(tree.root / "main.cpp", R"cpp(#include <windows.h>
+int main() { return 0; }
+int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) { return 0; }
+)cpp");
+
+    mqb::platform::windows::WindowsProcessRunner runner;
+
+    write_config(tree.root, "MT", "console");
+    auto cold = run_mqb(runner, mqb_executable, tree.root);
+    expect_success(cold, "cold MT/console config build should succeed");
+    if (cold) {
+        expect(cold->stdout_text.find("[compile] main.cpp") != std::string::npos,
+               "cold config should compile the TU");
+        expect(cold->stdout_text.find("[link] config_policy.exe") != std::string::npos,
+               "cold config should link the configured target");
+    }
+
+    auto warm = run_mqb(runner, mqb_executable, tree.root);
+    expect_success(warm, "warm MT/console config build should succeed");
+    if (warm) {
+        expect(contains_line(warm->stdout_text, "[up-to-date] main.cpp"),
+               "unchanged config runtime should reuse compile cache");
+        expect(contains_line(warm->stdout_text, "[up-to-date] config_policy.exe"),
+               "unchanged config subsystem should reuse link cache");
+    }
+
+    write_config(tree.root, "MD", "console");
+    auto runtime_changed = run_mqb(runner, mqb_executable, tree.root);
+    expect_success(runtime_changed, "runtime-only config change should succeed");
+    if (runtime_changed) {
+        expect(runtime_changed->stdout_text.find("[compile] main.cpp") != std::string::npos
+                   && runtime_changed->stdout_text.find("compiler options changed") != std::string::npos,
+               "config runtime change should invalidate compile identity");
+        expect(runtime_changed->stdout_text.find("[link] config_policy.exe") != std::string::npos,
+               "config runtime change should relink after recompilation");
+    }
+
+    auto runtime_warm = run_mqb(runner, mqb_executable, tree.root);
+    expect_success(runtime_warm, "warm MD/console config build should succeed");
+    if (runtime_warm) {
+        expect(contains_line(runtime_warm->stdout_text, "[up-to-date] main.cpp"),
+               "unchanged MD runtime should keep compile cache warm");
+        expect(contains_line(runtime_warm->stdout_text, "[up-to-date] config_policy.exe"),
+               "unchanged console subsystem should keep link cache warm");
+    }
+
+    write_config(tree.root, "MD", "windows");
+    auto subsystem_changed = run_mqb(runner, mqb_executable, tree.root);
+    expect_success(subsystem_changed, "subsystem-only config change should succeed");
+    if (subsystem_changed) {
+        expect(contains_line(subsystem_changed->stdout_text, "[up-to-date] main.cpp"),
+               "config subsystem-only change must not recompile the TU");
+        expect(subsystem_changed->stdout_text.find("[link] config_policy.exe") != std::string::npos
+                   && subsystem_changed->stdout_text.find("linker options changed") != std::string::npos,
+               "config subsystem change should invalidate link identity only");
+    }
+
+    auto subsystem_warm = run_mqb(runner, mqb_executable, tree.root);
+    expect_success(subsystem_warm, "warm MD/windows config build should succeed");
+    if (subsystem_warm) {
+        expect(contains_line(subsystem_warm->stdout_text, "[up-to-date] main.cpp"),
+               "unchanged windows subsystem should keep compile cache warm");
+        expect(contains_line(subsystem_warm->stdout_text, "[up-to-date] config_policy.exe"),
+               "unchanged windows subsystem should keep link cache warm");
+    }
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+    std::cout << "mqb_runtime_subsystem_config_e2e_tests passed\n";
+    return 0;
+}

--- a/docs/MQB_CONFIG.md
+++ b/docs/MQB_CONFIG.md
@@ -23,6 +23,8 @@ MQB searches upward from the directory where it is invoked and uses the nearest 
     "configuration": "release",
     "architecture": "x64",
     "standard": "17",
+    "runtime": "MT",
+    "subsystem": "console",
     "output": "game",
     "defines": [
       "GAME_BUILD=1"
@@ -68,6 +70,8 @@ MQB searches upward from the directory where it is invoked and uses the nearest 
 | `configuration` | string | `debug` or `release` |
 | `architecture` | string | `x86` or `x64` |
 | `standard` | string | `14`, `17`, `20`, `23`, or `latest` (`c++14`, `c++17`, `c++20`, `c++23`, `c++latest` are also accepted) |
+| `runtime` | string | MSVC CRT runtime: `MD`, `MDd`, `MT`, or `MTd` |
+| `subsystem` | string | executable subsystem: `console` or `windows` |
 | `output` | string | target name under `.mqb/bin/` |
 | `defines` | string array | preprocessor definitions, without `/D` |
 | `include_dirs` | string array | include search directories |
@@ -77,6 +81,8 @@ MQB searches upward from the directory where it is invoked and uses the nearest 
 | `linker_args` | string array | ordered raw `link.exe` argv elements |
 
 All path-valued config entries are resolved relative to the directory containing `mqb.json`, not the shell's current working directory.
+
+`runtime` and `subsystem` are typed policy, not shorthand for raw flags. The MSVC backend remains the sole owner of their command-line spelling. An explicit typed runtime is emitted after raw compiler arguments, and the structured subsystem is emitted after raw linker arguments, so a conflicting raw `/MD*` or `/SUBSYSTEM:*` cannot silently override the typed project policy.
 
 Raw compiler/linker arguments are literal argv elements. MQB does not split one JSON string containing spaces into several switches. For example:
 
@@ -94,15 +100,18 @@ Backend-owned structured routing remains authoritative. Raw arguments are emitte
 |---|---|---|
 | `enabled` | boolean | enable or disable single-entry smart source discovery |
 | `exclude_dirs` | string array | exact project directories to prune before discovery graph construction |
-| `extra_sources` | string array | exact supported C++ translation units to add even when disconnected from the entry graph |
-| `exclude_sources` | string array | exact supported C++ translation units to exclude and treat as traversal barriers |
+| `extra_sources` | string array | exact supported C/C++ translation units to add even when disconnected from the entry graph |
+| `exclude_sources` | string array | exact supported C/C++ translation units to exclude and treat as traversal barriers |
 
-Supported C++ translation-unit extensions in the current V2 source classifier are:
+Supported translation-unit extensions in the current V2 source classifier are:
 
 ```text
-ordinary source:   .cpp .cc .cxx
-module interface:  .ixx .cppm .mpp
+C ordinary source:     .c
+C++ ordinary source:   .cpp .cc .cxx
+module interface:      .ixx .cppm .mpp
 ```
+
+C sources participate in ordinary include/main smart discovery but are never parsed as C++ module syntax. This keeps legal C identifiers such as `module`, `import`, or `export` from routing a C target into the P1689 module pipeline.
 
 Version 1 intentionally uses exact paths rather than a glob language. This keeps correction semantics deterministic while the discovery model is still being stabilized.
 
@@ -137,11 +146,19 @@ For scalar options:
 explicit CLI option > mqb.json > built-in default
 ```
 
+This includes `configuration`, `architecture`, `standard`, `runtime`, `subsystem`, and `output`.
+
 Examples:
 
 ```powershell
 # mqb.json says release; this build is debug.
 mqb main.cpp --debug
+
+# mqb.json says MT; this invocation uses the dynamic CRT.
+mqb main.cpp --runtime MD
+
+# mqb.json says windows; this invocation links a console target.
+mqb main.cpp --subsystem console
 
 # mqb.json disables discovery; this explicitly turns it back on.
 mqb main.cpp --discover
@@ -191,6 +208,10 @@ still loads `project/mqb.json`, places artifacts under `project/.mqb/`, and inte
 
 The config file timestamp itself is not a special global rebuild trigger. Instead, the effective typed build options produced from the file participate in the existing compile/link signatures.
 
+Changing `runtime` changes compiler recipe identity, recompiles affected TUs, and therefore relinks the target. Leaving `runtime` unset preserves the historical Debug `/MDd` and Release `/MD` recipes and their existing signature identity.
+
+Changing only `subsystem` changes link recipe identity and relinks without recompiling otherwise-fresh TUs.
+
 Changing a compiler argument changes compiler recipe identity and recompiles affected TUs even if no source timestamp changed. The resulting fresh objects force the downstream link. Changing only a linker argument changes link recipe identity and relinks without recompiling otherwise-fresh TUs.
 
 Likewise, library names/search paths affect link recipe identity, while exact resolved `.lib` files are separately tracked as link freshness inputs.
@@ -209,10 +230,10 @@ Changing the job count does not alter compile or link signatures and therefore m
 
 ## Current boundaries
 
+- v1 config has no target-kind field yet; executable targets are the native output contract until DLL/static work lands.
 - v1 config has no external/prebuilt module-provider or `import std` policy.
 - v1 config does not store parallel job count.
 - `exclude_dirs`, `extra_sources`, and `exclude_sources` are exact paths, not globs.
 - Explicit user libraries are freshness-tracked; indirect `/DEFAULTLIB` transitive dependencies are not claimed as fully tracked.
-- C++ V2 currently classifies C++ translation units only; `.c` is not supported by the V2 source classifier.
 
 For stable-v5 migration decisions, see [`V5_PARITY.md`](V5_PARITY.md). For the broader build/module/cache architecture, see [`CPP_V2_ARCHITECTURE.md`](CPP_V2_ARCHITECTURE.md).

--- a/docs/V5_PARITY.md
+++ b/docs/V5_PARITY.md
@@ -18,10 +18,10 @@ Status meanings:
 | `build <sources...>` | `mqb <sources...>` is ready | **implement** installer/command cutover; decide whether `build` remains a compatibility command |
 | one focused source with smart dependency discovery | ready | **ready** |
 | multiple explicit source files | ready | **ready** |
+| `.c` | native C recipe, smart discovery, mixed C/C++, and language-isolated discovery are covered | **ready** |
 | `.cpp`, `.cc`, `.cxx` | ready | **ready** |
 | `.ixx` / named modules | ready for project-local providers | **ready**, with #16 boundaries documented |
 | project-local header units | native pipeline is ready | **ready** |
-| `.c` translation units | rejected by native CLI today | **implement** |
 | `.hpp` / `.h` as positional legacy discovery seeds | native CLI treats headers as non-TU inputs | **migrate** unless a real user workflow requires positional header seeds |
 | C++14 / C++17 | ordinary native targets map to `/std:c++14` / `/std:c++17`; CLI and `mqb.json` accept both; module pipeline remains C++20+ | **ready** for ordinary non-module targets |
 | C++20 / C++23 / latest | ready | **ready** |
@@ -40,6 +40,8 @@ Status meanings:
 | `-libs` | `-l`, `--lib`; legacy `-libs <value>` accepted and repeatable | **compat** for scalar/repeated values; shell-array tokenization is not emulated |
 | `-D`, `-defines` | `-D`; legacy `-defines` accepted | **compat** |
 | `-config debug/release` | `--debug`, `--release`, `--config`; legacy `-config` accepted | **compat** |
+| `-runtime MD/MDd/MT/MTd` | `--runtime`; legacy `-runtime` accepted | **compat** |
+| `-subsystem console/windows` | `--subsystem`; legacy `-subsystem` accepted | **compat** |
 | `-env vs/portable/port/p/auto` | `--env auto/vs/portable`; legacy spelling and portable aliases accepted | **compat** |
 | `-help`, `-?` | `--help`, `-h`; legacy help aliases accepted | **compat** |
 | `-flags` | `--compiler-arg <one argv>`; legacy `-flags <one argv>` accepted and repeatable | **compat** with explicit one-argv-per-occurrence semantics |
@@ -52,19 +54,19 @@ Status meanings:
 | --- | --- | --- |
 | executable target | ready | **ready** |
 | DLL target (`-type dll`) | not exposed by native target model | **implement** |
-| static library target (`-type static`) | not exposed by native target model | **implement** |
+| static library target (`-type static`) | not exposed by native target model | **implement** with an explicit `lib.exe`/librarian owner |
 | automatic `.exe/.dll/.lib` suffix by target kind | executable only today | **implement** with target-kind work |
-| console subsystem | native default | **ready** |
-| windows subsystem | link model has typed subsystem but CLI does not expose it | **implement** |
+| console subsystem | typed CLI/config policy; default console | **ready/compat** |
+| windows subsystem | typed CLI/config policy with link-only cache invalidation E2E | **ready/compat** |
 
 ## Compiler and linker policy
 
-The native backend has typed `CompilerOptions` / `LinkOptions` plus ordered additional argument vectors. CLI and `mqb.json` expose those vectors, and compile/link signatures hash them in order. Config arguments are applied first and CLI arguments append afterward. Backend-owned artifact/topology switches are emitted after raw arguments so the BuildPlan remains authoritative.
+The native backend has typed `CompilerOptions` / `LinkOptions` plus ordered additional argument vectors. CLI and `mqb.json` expose those vectors, and compile/link signatures hash them in order. Config arguments are applied first and CLI arguments append afterward. High-value typed policy remains authoritative over conflicting raw flags: typed runtime is emitted after raw compiler arguments, while structured subsystem/output routing is emitted after raw linker arguments.
 
 | Legacy option | Native C++ status | Stable-v5 decision |
 | --- | --- | --- |
 | `-optimize Od/O1/O2/Ox` | debug/release presets cover common cases; raw compiler args can express an override | **migrate** long-tail override to `--compiler-arg`; typed option remains optional unless parity fixtures justify it |
-| `-runtime MD/MDd/MT/MTd` | presets choose MDd/MD | **implement** typed target runtime selection because CRT policy affects the supported target contract |
+| `-runtime MD/MDd/MT/MTd` | typed CLI/config policy; unset preserves Debug `/MDd` and Release `/MD`; explicit runtime is compile identity | **ready/compat** |
 | `-warnings W0/W1/W3/W4/Wall` | fixed W3 baseline; raw compiler args can override later in argv | **migrate** long-tail override to `--compiler-arg` |
 | `-WX` | raw compiler args support `/WX` | **migrate** to `--compiler-arg /WX` |
 | `-debug_info off/Zi/ZI/Z7` | presets use Z7; raw compiler args exist | **migrate** long-tail override, but preserve parallel-safe default recipe |
@@ -85,9 +87,10 @@ The native backend has typed `CompilerOptions` / `LinkOptions` plus ordered addi
 | Legacy behavior | Native C++ status | Stable-v5 decision |
 | --- | --- | --- |
 | `msvc_list.json`, upward search up to five levels | native uses nearest upward `mqb.json` | **migrate** to `mqb.json`; provide upgrade guidance/tooling rather than keeping two authoritative schemas forever |
-| CLI overrides scalar config | ready | **ready** |
+| CLI overrides scalar config | ready, including runtime/subsystem | **ready** |
 | additive list precedence | config lists first, CLI lists append | **ready** |
 | 14/17/20/23/latest standard config | ready | **ready** |
+| runtime/subsystem config | typed strict-schema fields with real cache-invalidation E2E | **ready** |
 | include/lib/define/library config | ready in `mqb.json` | **ready** |
 | `compiler_args` / `linker_args` | ready in strict `mqb.json` v1 schema | **ready** |
 | source discovery excludes | ready with the native discovery schema | **ready** |
@@ -108,6 +111,8 @@ The native backend has typed `CompilerOptions` / `LinkOptions` plus ordered addi
 
 Stable v5 does not require byte-for-byte artifact layout parity with PowerShell. It requires equivalent observable correctness: cold build succeeds, warm no-op avoids unnecessary work, source/header/library/config/toolchain/build-policy changes invalidate the right work, missing required artifacts repair correctly, and outputs are collision-free.
 
+Typed runtime changes are compile-recipe identity and therefore force affected compile + downstream link. Typed subsystem changes are link-recipe identity and relink without recompiling otherwise-fresh TUs. The same semantics hold whether policy comes from CLI or `mqb.json`.
+
 Raw compiler argument changes are compile-recipe identity and therefore force affected compile + downstream link. Raw linker argument changes are link-recipe identity and therefore relink without recompiling otherwise-fresh TUs.
 
 The native `.mqb/obj`, `.mqb/deps`, `.mqb/scan`, `.mqb/ifc`, `.mqb/cache`, and `.mqb/bin` layout is the stable direction rather than the old PowerShell temporary layout.
@@ -121,9 +126,12 @@ Project-local named modules and project-local header units are in the RC/stable-
 1. Legacy CLI spelling compatibility for behaviors the native engine already supports. **Done in #27.**
 2. Restore C++14/17 ordinary-target modes while preserving the C++20+ module boundary. **Done in #28.**
 3. Raw compiler/linker pass-through plus config build-policy expansion and cache-invalidation E2E. **Done in #29.**
-4. Add `.c` translation units.
-5. Target kinds: DLL/static plus subsystem/runtime policy.
-6. Close the remaining high-value typed/coupled MSVC policy gaps (notably runtime/LTCG and any charset requirement proven by parity fixtures).
-7. Shared PowerShell-vs-C++ fixtures for ordinary targets, config precedence, incremental rebuilds, libraries, run argv, x86/x64, Debug/Release, and failure behavior.
-8. Installer/profile/`build` command cutover and clean-machine upgrade/rollback validation.
-9. Generalize the release workflow and publish stable v5 only from the exact validated artifact.
+4. Native `.c` translation units and mixed-language execution. **Done in #30.**
+5. Typed runtime/subsystem CLI policy and cache semantics. **Done in #31.**
+6. Isolate C smart discovery from C++ module lexical syntax. **Done in #32.**
+7. Typed `mqb.json` runtime/subsystem policy with CLI precedence and real invalidation E2E. **Done in #33.**
+8. Target kinds: DLL and static library; static must have an explicit `lib.exe`/librarian backend rather than being modeled as `link.exe`.
+9. Close the remaining high-value coupled MSVC policy gap (notably LTCG and any charset requirement proven by parity fixtures).
+10. Shared PowerShell-vs-C++ fixtures for ordinary targets, config precedence, incremental rebuilds, libraries, run argv, x86/x64, Debug/Release, and failure behavior.
+11. Installer/profile/`build` command cutover and clean-machine upgrade/rollback validation.
+12. Generalize the release workflow and publish stable v5 only from the exact validated artifact.


### PR DESCRIPTION
Completes the project-config half of #31 without expanding target kinds.

## Scope

- extend strict `mqb.json` v1 `build` schema with typed scalar `runtime` (`MD`, `MDd`, `MT`, `MTd`) and `subsystem` (`console`, `windows`)
- reuse the existing #31 Core types; no duplicate runtime/subsystem enums or raw-flag translation layer
- preserve scalar precedence: explicit CLI > `mqb.json` > built-in/default policy
- route effective config values through `CompilerOptions.runtime_library` and `LinkOptions.subsystem`
- keep typed policy authoritative over conflicting raw compiler/linker flags
- keep invalid value/type/unknown-field behavior fail-closed
- keep DLL/static target kinds out of this PR

## Verification

Focused config regression covers:

- valid runtime/subsystem decode
- CLI-over-config scalar precedence
- invalid runtime value, invalid subsystem value, and wrong runtime JSON type
- existing ordered raw compiler/linker config behavior

Real installed-MSVC config E2E covers:

- `runtime: MT` cold + warm
- config runtime `MT -> MD` => compile + downstream link
- unchanged `MD` => compile 0 / link 0
- config subsystem `console -> windows` with unchanged runtime => compile 0 / link 1
- unchanged Windows subsystem => compile 0 / link 0

Documentation updates `MQB_CONFIG.md` and the stable-v5 parity inventory, including C discovery language isolation from #32.

## Final verification

Final exact head: `cae446486509c820a7a3479505771d6400ff0a62`.

- C++ V2 workflow #267: **success** (Configure / Build / complete CTest suite / cleanup)
- C++ Release Candidate workflow #42: **success**
  - Release Configure / Build / complete CTest suite succeeded
  - embedded RC version verification succeeded
  - validated package staging/upload succeeded
  - publish job skipped by design for the PR run

Next parity slice: typed executable/DLL target kind through the existing linker. Static libraries remain a separate librarian-backed slice so `lib.exe` is not modeled as `link.exe`.