### PR TITLE
release: prepare v5.0.0-rc.2 C++ refactor candidate

### DIFF
--- a/.github/workflows/cpp-release.yml
+++ b/.github/workflows/cpp-release.yml
@@ -12,7 +12,7 @@ on:
     branches:
       - main
     paths:
-      - 'release/v5.0.0-rc.1.md'
+      - 'release/v5.0.0-rc.2.md'
 
 jobs:
   build-test-package:
@@ -20,8 +20,8 @@ jobs:
     permissions:
       contents: read
     env:
-      MQB_RELEASE_VERSION: 5.0.0-rc.1
-      MQB_PACKAGE_NAME: vscode-msvc-quick-build-v5.0.0-rc.1-windows-x64
+      MQB_RELEASE_VERSION: 5.0.0-rc.2
+      MQB_PACKAGE_NAME: vscode-msvc-quick-build-v5.0.0-rc.2-windows-x64
 
     steps:
       - name: Checkout
@@ -71,7 +71,7 @@ jobs:
           Copy-Item 'LICENSE' (Join-Path $stage 'LICENSE')
           Copy-Item 'docs/MQB_CONFIG.md' (Join-Path $stage 'MQB_CONFIG.md')
           Copy-Item 'docs/CPP_V2_ARCHITECTURE.md' (Join-Path $stage 'CPP_V2_ARCHITECTURE.md')
-          Copy-Item 'release/v5.0.0-rc.1.md' (Join-Path $stage 'RELEASE_NOTES.md')
+          Copy-Item 'release/v5.0.0-rc.2.md' (Join-Path $stage 'RELEASE_NOTES.md')
 
           $zip = Join-Path $dist ($env:MQB_PACKAGE_NAME + '.zip')
           if (Test-Path $zip) { Remove-Item $zip -Force }
@@ -102,8 +102,8 @@ jobs:
       contents: write
     env:
       GH_TOKEN: ${{ github.token }}
-      MQB_RELEASE_VERSION: 5.0.0-rc.1
-      MQB_PACKAGE_NAME: vscode-msvc-quick-build-v5.0.0-rc.1-windows-x64
+      MQB_RELEASE_VERSION: 5.0.0-rc.2
+      MQB_PACKAGE_NAME: vscode-msvc-quick-build-v5.0.0-rc.2-windows-x64
 
     steps:
       - name: Checkout release notes
@@ -134,6 +134,6 @@ jobs:
             --repo $env:GITHUB_REPOSITORY `
             --target $env:GITHUB_SHA `
             --title "$tag — C++ Refactor Release Candidate" `
-            --notes-file 'release/v5.0.0-rc.1.md' `
+            --notes-file 'release/v5.0.0-rc.2.md' `
             --prerelease
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
 # MQB — MSVC Quick Build
 
-面向 Windows + MSVC 的轻量 C++ 构建工具。目标是让普通 C++ 项目在**不维护 `.sln` / `.vcxproj` / CMakeLists.txt** 的情况下，直接从源文件完成发现、增量编译、模块拓扑、链接和运行。
+面向 Windows + MSVC 的轻量 C/C++ 构建工具。目标是让普通 C/C++ 项目在**不维护 `.sln` / `.vcxproj` / CMakeLists.txt** 的情况下，直接从源文件完成发现、增量编译、模块拓扑、链接和运行。
 
 > **当前迁移状态**
 >
-> - `cpp/` 中的 **C++23 重构版 (`mqb.exe`)** 已具备普通 C++、project-local named modules 与 project-local header units 的端到端构建链，并由 Visual Studio 2026 真实工具链 E2E 持续验证。
-> - `v5.0.0-rc.1` 是 C++ 重构版的首个可分发 Release Candidate；它是独立的 `mqb.exe`，**尚不代表 PowerShell → C++ 的最终 cutover**。
+> - `cpp/` 中的 **C++23 重构版 (`mqb.exe`)** 已具备普通 C/C++、project-local named modules 与 project-local header units 的端到端构建链，并由 Visual Studio 2026 真实工具链 E2E 持续验证。
+> - `v5.0.0-rc.2` 是 C++ 重构版的第二个可分发 Release Candidate；它新增原生 `.c`、typed runtime/subsystem CLI 与 `mqb.json` policy，**尚不代表 PowerShell → C++ 的最终 cutover**。
 > - `build.ps1` 仍保留为 **PowerShell Golden Reference / 过渡期稳定入口**；现有 `install.bat` 和 PowerShell profile 不会被 RC 静默替换。
 > - MQB 不宣称与 MSBuild “1:1 等价”。当前原则是：显式建模已支持的常用 MSVC 语义，并用真实编译器回归测试证明行为。
 
-## v5.0.0-rc.1 C++ Release Candidate
+## v5.0.0-rc.2 C++ Release Candidate
 
 RC 的 Windows x64 包由 GitHub Actions 在 **Release 配置**下构建；同一条 workflow 会先运行完整 VS2026 CTest，再生成 zip 和 SHA-256，最后才允许创建 prerelease。
 
 发布资产：
 
 ```text
-vscode-msvc-quick-build-v5.0.0-rc.1-windows-x64.zip
-vscode-msvc-quick-build-v5.0.0-rc.1-windows-x64.zip.sha256
+vscode-msvc-quick-build-v5.0.0-rc.2-windows-x64.zip
+vscode-msvc-quick-build-v5.0.0-rc.2-windows-x64.zip.sha256
 ```
 
 安装/试用：
@@ -26,40 +26,44 @@ vscode-msvc-quick-build-v5.0.0-rc.1-windows-x64.zip.sha256
 # 解压后，将 mqb.exe 所在目录加入 PATH
 mqb --help
 mqb main.cpp --run
+mqb main.c --run
 ```
 
 `mqb --help` 第一行会携带二进制内嵌版本；RC 包应显示：
 
 ```text
-MQB 5.0.0-rc.1 - MSVC Quick Build (C++ refactor)
+MQB 5.0.0-rc.2 - MSVC Quick Build (C++ refactor)
 ```
 
-发布二进制使用静态 MSVC runtime，避免要求用户额外安装 Visual C++ Redistributable。Release Candidate 的完整边界见 [`release/v5.0.0-rc.1.md`](release/v5.0.0-rc.1.md)。
+发布二进制使用静态 MSVC runtime，避免要求用户额外安装 Visual C++ Redistributable。Release Candidate 的完整边界见 [`release/v5.0.0-rc.2.md`](release/v5.0.0-rc.2.md)。
 
 ---
 
 ## C++ 重构版现在能做什么
 
 - **结构化 MSVC 调用**：直接执行 `cl.exe` / `link.exe`，不通过 shell 拼接命令字符串。
+- **C 与 C++ translation units**：原生支持 `.c`、`.cpp`、`.cc`、`.cxx`；C discovery 不会把合法的 `module/import/export` 标识符误识别成 C++ Modules 语法。
 - **工具链发现**：支持 Visual Studio 与 portable MSVC 路径，工具链身份进入缓存判断。
-- **单入口智能发现**：`mqb main.cpp` 会从项目内 include / named-import 连接关系选择相关 translation units。
+- **单入口智能发现**：`mqb main.cpp` / `mqb main.c` 会从项目内 include / named-import 连接关系选择相关 translation units。
 - **Project-local named modules**：支持 `.ixx` / `.cppm` / `.mpp` interface providers、partitions 与 implementation units，使用 `/scanDependencies` + P1689 建立真实拓扑。
 - **Project-local header units**：`import "header.hpp";` / `import <header>;` 会进入 P1689 模块管线；header 本身不会被伪装成普通 TU，IFC 由 target 动态分配、增量生成与修复。
 - **增量编译**：使用 `/sourceDependencies` 跟踪实际头文件 freshness；编译参数、工具链、模块引用和计划输出参与 compile identity。
+- **Typed MSVC runtime**：`--runtime MD|MDd|MT|MTd`（以及兼容 `-runtime`）由 backend 统一映射，参与 compile identity，并保持 typed policy 对冲突 raw flag 的最终权威。
+- **Typed subsystem**：`--subsystem console|windows`（以及兼容 `-subsystem`）进入 link identity；仅 subsystem 改变时不会误重编 fresh TUs。
 - **IFC 增量正确性**：provider IFC 缺失、provider/header-unit 重编或引用变化会可靠传导到 consumer。
 - **增量链接**：对象、显式库、linker identity 与 link options 共同决定是否重新链接。
 - **有界并行**：`-j/--jobs` 控制 TU scan/compile 并发；job count 是 execution policy，不污染 build cache identity。
-- **`mqb.json`**：严格、带版本的项目配置，遵循 `explicit CLI > mqb.json > built-in defaults`。
+- **`mqb.json`**：严格、带版本的项目配置，遵循 `explicit CLI > mqb.json > built-in defaults`，并支持 `build.runtime` / `build.subsystem`。
 - **结构化运行参数**：`--run -- arg1 "arg 2"` 保持 argv 边界。
 - **隔离构建产物**：全部 C++ 中间产物放在项目 `.mqb/` 下，不在源码目录通配删除 `.obj/.ifc`。
 
 ### 当前明确不支持
 
-以下能力目前**故意 fail closed**，不会为了“看起来能编译”而偷偷退回普通 TU 路径：
+以下能力目前**故意 fail closed**，不会为了“看起来能编译”而偷偷退回错误管线：
 
 - external / prebuilt named-module providers；
 - `import std;`；
-- C (`.c`) translation units；
+- DLL target 与 static-library target（正在 stable-v5 parity 主线中分别接入 linker / librarian pipeline）；
 - 将 C++ RC 宣称为 PowerShell 版本的完整行为替代品。
 
 Modules 剩余扩展策略跟踪在 Issue #16；最终 stable v5 还需要 PowerShell ↔ C++ parity / installer / default-entry cutover 的独立验收。
@@ -76,7 +80,7 @@ cmake --build cpp/build --config Release --target mqb
 .\cpp\build\apps\mqb\Release\mqb.exe --help
 ```
 
-默认开发构建版本为 `5.0.0-dev`。发布流水线会显式传入 `-DMQB_VERSION=5.0.0-rc.1`，因此开发二进制不会冒充已发布版本。
+默认开发构建版本为 `5.0.0-dev`。发布流水线会显式传入 `-DMQB_VERSION=5.0.0-rc.2`，因此开发二进制不会冒充已发布版本。
 
 ### 运行完整测试
 
@@ -97,9 +101,10 @@ Release Candidate 还会在独立 build tree 中以 `Release` 配置重复完整
 
 ```powershell
 mqb main.cpp --env vs --std latest --run
+mqb main.c --env vs --run
 ```
 
-单个 positional source 默认启用 smart discovery。若 `main.cpp` 通过本地 include / named import 连接到其他 C++ TU，MQB 会选择相关源文件再构建。
+单个 positional source 默认启用 smart discovery。若入口通过本地 include / named import 连接到其他 translation units，MQB 会选择相关源文件再构建。C translation units 参与普通 include/main discovery，但不会进入 C++ module lexical parser。
 
 显式关闭：
 
@@ -114,6 +119,30 @@ mqb main.cpp src/math.cpp src/io.cpp --release -j 8 -o app
 ```
 
 多个 positional sources 表示**精确 source set**，不再自动扩大集合。
+
+### Runtime / subsystem
+
+```powershell
+# 静态 CRT Release 风格 runtime policy
+mqb main.cpp --runtime MT
+
+# Windows GUI subsystem；只改变 link policy，不应让 fresh TU 重编
+mqb winmain.cpp --subsystem windows
+```
+
+同样的 policy 可写入 `mqb.json`：
+
+```json
+{
+  "version": 1,
+  "build": {
+    "runtime": "MT",
+    "subsystem": "console"
+  }
+}
+```
+
+显式 CLI scalar 始终覆盖 config scalar。
 
 ### 运行时参数
 
@@ -189,6 +218,8 @@ C++ 重构版使用根目录 `mqb.json`，不是 PowerShell 版本的 `msvc_list
     "configuration": "release",
     "architecture": "x64",
     "standard": "latest",
+    "runtime": "MT",
+    "subsystem": "console",
     "output": "game",
     "defines": ["GAME_BUILD=1"],
     "include_dirs": ["include"],
@@ -211,15 +242,17 @@ MQB 从 invocation directory 向上查找最近的 `mqb.json`；配置文件所�
 ## 常用 CLI
 
 ```text
-mqb <entry.cpp> [options] [-- program-args...]
-mqb <source.cpp|module.ixx|module.cppm|module.mpp> <more-sources...> [options]
+mqb <entry.c|entry.cpp> [options] [-- program-args...]
+mqb <source.c|source.cpp|module.ixx|module.cppm|module.mpp> <more-sources...> [options]
 ```
 
 | 选项 | 作用 |
 |---|---|
 | `--debug` / `--release` | 选择构建配置 |
-| `--std <20|23|latest>` | 选择 C++ 标准 |
+| `--std <14|17|20|23|latest>` | 选择 C++ 标准（C TU 不发 C++ `/std`） |
 | `--x86` / `--x64` | 选择目标架构 |
+| `--runtime <MD|MDd|MT|MTd>` | 选择 MSVC runtime library |
+| `--subsystem <console|windows>` | 选择 executable subsystem |
 | `-j, --jobs <N>` | 最大并发 scan/compile 数量 |
 | `-o, --output <name>` | `.mqb/bin/` 下的目标名 |
 | `--run` | 构建成功后运行 |
@@ -228,6 +261,8 @@ mqb <source.cpp|module.ixx|module.cppm|module.mpp> <more-sources...> [options]
 | `-D <value>` | preprocessor definition |
 | `-L <dir>` / `--lib-path <dir>` | library search directory |
 | `-l <name>` / `--lib <name>` | 显式链接库 |
+| `--compiler-arg <arg>` | 追加一个原样 `cl.exe` argv 元素 |
+| `--linker-arg <arg>` | 追加一个原样 `link.exe` argv 元素 |
 | `--env <auto|vs|portable>` | 工具链选择 |
 | `--portable-root <dir>` | 增加 portable toolchain root 候选 |
 | `-v, --verbose` | 输出 project/config/toolchain/artifact/pipeline 信息 |
@@ -246,7 +281,7 @@ mqb <source.cpp|module.ixx|module.cppm|module.mpp> <more-sources...> [options]
 ├── scan/    # /scanDependencies / P1689 metadata
 ├── ifc/     # named-module / header-unit IFC artifacts
 ├── cache/   # compile/link cache metadata
-└── bin/     # executable
+└── bin/     # current target output
 ```
 
 Windows 上同一物理源文件即使被用户或 MSVC scanner 以不同大小写/路径别名表示，也会归一到稳定 artifact identity，避免一份 source 分裂出两套 cache/IFC。
@@ -283,7 +318,7 @@ Optional run
 
 根目录的 `build.ps1`、`install.bat`、`Microsoft.PowerShell_profile.ps1` 仍属于旧 PowerShell 实现。它们继续保持已有用户的稳定入口、作为 C++ 迁移 Golden Reference，并支撑后续 parity campaign。
 
-**`v5.0.0-rc.1` 不修改这套安装入口。** RC 用户应直接解压 `mqb.exe` 并自行加入 PATH；在 stable v5 的 parity/cutover 通过之前，不应把 `install.bat` 理解为 C++ `mqb.exe` 的安装器。
+**`v5.0.0-rc.2` 不修改这套安装入口。** RC 用户应直接解压 `mqb.exe` 并自行加入 PATH；在 stable v5 的 parity/cutover 通过之前，不应把 `install.bat` 理解为 C++ `mqb.exe` 的安装器。
 
 旧 `msvc_list.json` / PowerShell 参数体系也不等于 C++ 的 `mqb.json` schema；不要混用两套配置契约。
 
@@ -291,9 +326,9 @@ Optional run
 
 ## 当前路线
 
-- `v5.0.0-rc.1`：交付可验证的 C++ standalone candidate；
+- `v5.0.0-rc.2`：交付新增 C translation units 与 typed runtime/subsystem policy 的 C++ standalone candidate；
+- stable-v5 parity：继续 DLL target、static librarian pipeline、必要 coupled policy 与 shared PowerShell↔C++ fixtures；
 - Issue #16：继续 external/prebuilt named-module providers 与 `import std`；
-- PowerShell ↔ C++ 行为 parity campaign；
 - installer/profile/default-entry cutover；
 - 满足上述 stable gate 后发布正式 v5，并逐步删除不再需要的 PowerShell Golden Reference。
 

--- a/release/v5.0.0-rc.2.md
+++ b/release/v5.0.0-rc.2.md
@@ -1,0 +1,45 @@
+# v5.0.0-rc.2 — C++ Refactor Release Candidate
+
+This prerelease advances the standalone Windows x64 C++ rewrite after `v5.0.0-rc.1`. It is built and tested on the Visual Studio 2026 GitHub runner and keeps the PowerShell implementation as the legacy/default installation path while stable-v5 parity work continues.
+
+## What changed since rc.1
+
+- native C (`.c`) translation units are now supported alongside C++ sources
+- C discovery is language-isolated: legal C identifiers such as `module`, `import`, and `export` do not enter the C++ module pipeline
+- typed MSVC runtime selection through `--runtime MD|MDd|MT|MTd` and legacy-compatible `-runtime`
+- typed executable subsystem selection through `--subsystem console|windows` and legacy-compatible `-subsystem`
+- strict `mqb.json` v1 now supports `build.runtime` and `build.subsystem`
+- runtime changes participate in compile identity and force the required downstream link; subsystem-only changes invalidate link identity without recompiling fresh translation units
+- the runtime policy remains backend-owned, so a conflicting raw compiler argument cannot override the typed runtime choice
+
+## Existing C++ RC capabilities
+
+- standalone native `mqb.exe` with no PowerShell runtime dependency on the new CLI path
+- Visual Studio / portable MSVC discovery
+- single-entry smart source discovery and explicit multi-source targets
+- incremental compile/link caches under `.mqb/`
+- bounded parallel scanning/compilation via `--jobs`
+- strict project configuration through `mqb.json`
+- project-local named modules, including provider discovery and partitions
+- project-local header units with P1689 topology, generated IFCs, freshness/rebuild propagation, and missing-IFC repair
+- structured `--run` arguments and library/include/define/raw build-policy options
+- real installed-MSVC cold/warm/mutation/repair coverage in the test suite
+
+## Install this RC
+
+1. Download `vscode-msvc-quick-build-v5.0.0-rc.2-windows-x64.zip` and its `.sha256` file from this prerelease.
+2. Verify the SHA-256 checksum, extract the archive, and place its directory on `PATH`.
+3. Run `mqb --help`; the first line must report `MQB 5.0.0-rc.2 - MSVC Quick Build (C++ refactor)`.
+4. Try `mqb main.cpp --run` or `mqb main.c --run` in a project directory.
+
+The packaged executable uses the static MSVC runtime, so the RC does not require a separate Visual C++ Redistributable installation.
+
+## RC boundary
+
+This remains a **release candidate**, not the final PowerShell-to-C++ cutover. The repository's existing `build.ps1`, `install.bat`, and PowerShell profile remain the legacy/default installation path.
+
+DLL and static-library target kinds are not part of rc.2. Work on DLL target routing continues separately, and static libraries require a dedicated `lib.exe`/librarian pipeline rather than pretending they are linker targets.
+
+External/prebuilt named-module providers and `import std` also remain intentionally unsupported/fail-closed. Stable v5 still requires the explicit parity campaign, installer/default-command cutover, and stable release engineering gates tracked in issue #26.
+
+Please report a minimal reproducer when this RC differs from the legacy PowerShell behavior in a workflow that the native C++ CLI is intended to support.


### PR DESCRIPTION
Prepares the second distributable C++ refactor candidate from the current stable-v5 parity mainline.

## Release scope

`v5.0.0-rc.2` advances the already-published `rc.1` with capabilities that are merged to `main` and covered by real installed-MSVC tests:

- native `.c` translation units
- C discovery language isolation from C++ module lexical syntax
- typed `--runtime MD|MDd|MT|MTd` / legacy `-runtime`
- typed `--subsystem console|windows` / legacy `-subsystem`
- strict `mqb.json` `build.runtime` and `build.subsystem`
- cache-correct compile-vs-link invalidation for runtime/subsystem changes

## Deliberate RC boundary

This PR does **not** claim stable-v5 cutover. DLL/static target kinds, shared PowerShell↔C++ parity fixtures, installer/default-command cutover, and remaining stable release engineering are still tracked separately. External/prebuilt named-module providers and `import std` remain outside this release boundary.

## Release engineering

- retarget release workflow to embed `5.0.0-rc.2`
- package `vscode-msvc-quick-build-v5.0.0-rc.2-windows-x64.zip` plus SHA-256
- stage the exact tested binary and docs into the published artifact
- create the GitHub prerelease only on the `main` push after the PR gate succeeds
- keep PR runs publication-safe: build/test/package only, publish job skipped

## Final verification

Final exact head: `ca7b1dfa79c78a83620108e45038275e21d7a95d`.

- C++ V2 workflow #269: **success** (Configure / Build / complete CTest suite / cleanup)
- C++ Release Candidate workflow #43: **success**
  - Release Configure / Build / complete installed-MSVC CTest suite succeeded
  - embedded version `MQB 5.0.0-rc.2 - MSVC Quick Build (C++ refactor)` verified
  - rc.2 package + checksum staged and uploaded
  - publish job skipped by design for the PR run

The PR Actions artifact digest is not treated as the final release zip checksum; the main push rebuild/publish run and GitHub Release asset digest will be verified separately after merge.