### PR TITLE
feat: support DLL targets in native MQB

### DIFF
--- a/cpp/apps/mqb/Cli.cpp
+++ b/cpp/apps/mqb/Cli.cpp
@@ -57,6 +57,19 @@ parse_configuration(const std::string_view value) {
         + "' (expected debug or release)"));
 }
 
+[[nodiscard]] std::expected<TargetKind, Error>
+parse_target_kind(const std::string_view value) {
+    if (value == "exe" || value == "executable") return TargetKind::executable;
+    if (value == "dll" || value == "dynamic") return TargetKind::dynamic_library;
+    if (value == "static" || value == "lib") {
+        return std::unexpected(error(
+            "static-library targets require the upcoming MSVC librarian pipeline"));
+    }
+    return std::unexpected(error(
+        "unsupported target kind '" + std::string{value}
+        + "' (expected exe or dll)"));
+}
+
 [[nodiscard]] std::expected<RuntimeLibrary, Error>
 parse_runtime(const std::string_view value) {
     if (value == "MD" || value == "md") return RuntimeLibrary::md;
@@ -195,6 +208,24 @@ parse_arguments(const std::span<const std::string_view> arguments) {
             auto value = long_equals_value(argument, "--output=");
             if (!value) return std::unexpected(value.error());
             options.build.output_name = std::string{*value};
+            continue;
+        }
+        if (argument == "--type" || argument == "-type") {
+            auto value = require_value(arguments, index, argument);
+            if (!value) return std::unexpected(value.error());
+            auto target_kind = parse_target_kind(*value);
+            if (!target_kind) return std::unexpected(target_kind.error());
+            options.build.target_kind = *target_kind;
+            options.target_kind_override = *target_kind;
+            continue;
+        }
+        if (argument.starts_with("--type=")) {
+            auto value = long_equals_value(argument, "--type=");
+            if (!value) return std::unexpected(value.error());
+            auto target_kind = parse_target_kind(*value);
+            if (!target_kind) return std::unexpected(target_kind.error());
+            options.build.target_kind = *target_kind;
+            options.target_kind_override = *target_kind;
             continue;
         }
         if (argument == "--debug") {
@@ -352,7 +383,7 @@ parse_arguments(const std::span<const std::string_view> arguments) {
             auto value = attached_or_next(arguments, index, argument, "-D");
             if (!value) return std::unexpected(value.error());
             if (value->empty()) return std::unexpected(error("empty preprocessor define"));
-            options.defines.emplace_back(*value);
+            options.defines.emplace_back(std::string{*value});
             continue;
         }
         if (argument == "-L" || argument.starts_with("-L")) {
@@ -366,7 +397,7 @@ parse_arguments(const std::span<const std::string_view> arguments) {
             auto value = attached_or_next(arguments, index, argument, "-l");
             if (!value) return std::unexpected(value.error());
             if (value->empty()) return std::unexpected(error("empty library name"));
-            options.libraries.emplace_back(*value);
+            options.libraries.emplace_back(std::string{*value});
             continue;
         }
         if (!argument.empty() && argument.front() == '-') {
@@ -419,14 +450,15 @@ Options:
   --config <debug|release> Select compile/link preset (legacy -config alias accepted)
   --std <14|17|20|23|latest>
                            Explicitly select C++ language standard (legacy -std accepted)
+  --type <exe|dll>         Select executable or DLL output kind (legacy -type accepted)
   --runtime <MD|MDd|MT|MTd>
                            Explicitly select MSVC CRT runtime (legacy -runtime accepted)
   --subsystem <console|windows>
-                           Explicitly select executable subsystem (legacy -subsystem accepted)
+                           Explicitly select PE subsystem (legacy -subsystem accepted)
   --x86 | --x64            Explicitly select target architecture (legacy -x86/-x64 accepted)
   -j, --jobs <N>           Maximum concurrent TU scans/compiles (default: hardware concurrency)
-  -o, --output <name>      Set target executable name under .mqb/bin/ (legacy -output accepted)
-  --run                    Run the executable after a successful build (legacy -run accepted)
+  -o, --output <name>      Set target name under .mqb/bin/ (legacy -output accepted)
+  --run                    Run an executable after a successful build (legacy -run accepted)
   -I <dir>, -I<dir>        Add an include directory (legacy -include accepted)
   -D <value>, -D<value>    Add a preprocessor definition (legacy -defines accepted)
   -L <dir>, -L<dir>        Add a library search directory (legacy -libpath accepted)
@@ -439,15 +471,15 @@ Options:
   --portable-root <dir>    Add a portable_msvc root candidate
   -v, --verbose            Show config, discovery, toolchain, and artifact details
   -h, --help               Show this help and the embedded build version (-help/-? accepted)
-  --                       Pass all remaining argv elements to the program
+  --                       Pass all remaining argv elements to an executable program
 
 Raw compiler/linker arguments are one argv element per option occurrence; MQB does not split a
 quoted string into multiple switches. Project config entries are applied first and CLI raw args
-append afterward. Structured artifact routing such as /Fo, /scanDependencies, /MACHINE and /OUT
-is emitted after raw arguments so the BuildPlan remains authoritative.
+append afterward. Structured artifact routing such as /Fo, /scanDependencies, /DLL, /IMPLIB,
+/MACHINE and /OUT is emitted after raw arguments so the BuildPlan remains authoritative.
 
 Legacy compatibility aliases intentionally cover spelling only. Legacy-only semantics such as
--a string splitting and DLL/static output kinds remain tracked by the stable-v5 parity inventory
+-a string splitting and static-library output remain tracked by the stable-v5 parity inventory
 and are not silently accepted here.
 
 Job count is execution policy only; changing -j does not invalidate build caches.
@@ -460,7 +492,7 @@ Generated state:
   .mqb/scan/   module dependency scan metadata
   .mqb/ifc/    module/header-unit interface artifacts
   .mqb/cache/  compile and link cache metadata
-  .mqb/bin/    linked executable
+  .mqb/bin/    linked executable/DLL and DLL import-library artifacts
 )";
 }
 

--- a/cpp/apps/mqb/Cli.hpp
+++ b/cpp/apps/mqb/Cli.hpp
@@ -21,6 +21,7 @@ struct Options {
     std::optional<BuildConfiguration> configuration_override;
     std::optional<Architecture> architecture_override;
     std::optional<CppStandard> standard_override;
+    std::optional<TargetKind> target_kind_override;
     std::optional<RuntimeLibrary> runtime_override;
     std::optional<LinkSubsystem> subsystem_override;
     std::vector<std::string> defines;

--- a/cpp/apps/mqb/ModuleCliTarget.cpp
+++ b/cpp/apps/mqb/ModuleCliTarget.cpp
@@ -174,6 +174,7 @@ int run_module_target(
                   << "  project: " << path_text(request.project_root) << '\n';
         if (request.config_file) std::cout << "  config:  " << path_text(*request.config_file) << '\n';
         std::cout << "  pipeline: named-modules\n"
+                  << "  type:    " << to_string(request.link_options.target_kind) << '\n'
                   << "  jobs:    " << request.max_parallel_jobs
                   << (request.jobs_explicit ? "" : " (auto)") << '\n'
                   << "  cl:      " << path_text(toolchain.identity.compiler) << '\n'
@@ -193,7 +194,7 @@ int run_module_target(
             std::cout << "  libpath: " << path_text(directory) << '\n';
         }
         for (const auto& library : request.link_options.libraries) std::cout << "  lib:     " << library << '\n';
-        std::cout << "  exe:     " << path_text(request.target.executable) << '\n'
+        std::cout << "  output:  " << path_text(request.target.executable) << '\n'
                   << "  cache:   " << path_text(request.target.link_cache) << '\n';
     }
 
@@ -264,7 +265,7 @@ int run_module_target(
     } else {
         std::cout << "[up-to-date] " << path_text(target_request.target.executable.filename()) << '\n';
     }
-    std::cout << "executable: " << path_text(target_request.target.executable) << '\n';
+    std::cout << "output: " << path_text(target_request.target.executable) << '\n';
 
     if (!request.run_after_build) return 0;
     std::cout << "[run] " << path_text(target_request.target.executable.filename()) << '\n';

--- a/cpp/apps/mqb/main.cpp
+++ b/cpp/apps/mqb/main.cpp
@@ -335,6 +335,7 @@ int main(const int argc, char* argv[]) {
     cli_overrides.build.configuration = options.configuration_override;
     cli_overrides.build.architecture = options.architecture_override;
     cli_overrides.build.standard = options.standard_override;
+    cli_overrides.build.target_kind = options.target_kind_override;
     cli_overrides.build.runtime_library = options.runtime_override;
     cli_overrides.build.subsystem = options.subsystem_override;
     cli_overrides.build.output_name = options.build.output_name;
@@ -352,6 +353,7 @@ int main(const int argc, char* argv[]) {
     options.build.configuration = effective.configuration;
     options.build.architecture = effective.architecture;
     options.build.standard = effective.standard;
+    options.build.target_kind = effective.target_kind;
     options.runtime_override = effective.runtime_library;
     options.subsystem_override = effective.subsystem;
     options.build.output_name = effective.output_name;
@@ -362,6 +364,12 @@ int main(const int argc, char* argv[]) {
     options.libraries = effective.libraries;
     options.compiler_arguments = effective.compiler_arguments;
     options.linker_arguments = effective.linker_arguments;
+
+    if (options.build.run_after_build
+        && options.build.target_kind != mqb::TargetKind::executable) {
+        std::cerr << "error: --run is only valid for executable targets\n";
+        return 2;
+    }
 
     std::vector<fs::path> sources = requested_sources;
     bool discovery_requires_module_pipeline = false;
@@ -443,7 +451,7 @@ int main(const int argc, char* argv[]) {
 
     const std::string target_name = options.build.output_name.value_or(
         requested_sources.front().stem().string());
-    auto target_artifacts = layout->for_target(target_name);
+    auto target_artifacts = layout->for_target(target_name, options.build.target_kind);
     if (!target_artifacts) {
         std::cerr << "error: " << target_artifacts.error().message << '\n';
         return 2;
@@ -484,6 +492,7 @@ int main(const int argc, char* argv[]) {
     mqb::LinkOptions link_options;
     link_options.configuration = options.build.configuration;
     link_options.architecture = options.build.architecture;
+    link_options.target_kind = options.build.target_kind;
     link_options.subsystem = options.subsystem_override.value_or(mqb::LinkSubsystem::console);
     link_options.library_directories = std::move(options.library_directories);
     link_options.libraries = std::move(options.libraries);
@@ -524,7 +533,8 @@ int main(const int argc, char* argv[]) {
         if (project_config) {
             std::cout << "  config:  " << path_text(project_config->file) << '\n';
         }
-        std::cout << "  jobs:    " << compile_jobs
+        std::cout << "  type:    " << mqb::to_string(options.build.target_kind) << '\n'
+                  << "  jobs:    " << compile_jobs
                   << (options.jobs ? "" : " (auto)") << '\n'
                   << "  cl:      " << path_text(toolchain->identity.compiler) << '\n'
                   << "  link:    " << path_text(toolchain->linker) << '\n';
@@ -546,7 +556,7 @@ int main(const int argc, char* argv[]) {
         for (const auto& argument : link_options.additional_arguments) {
             std::cout << "  link-arg:" << argument << '\n';
         }
-        std::cout << "  exe:     " << path_text(target_artifacts->executable) << '\n'
+        std::cout << "  output:  " << path_text(target_artifacts->executable) << '\n'
                   << "  cache:   " << path_text(target_artifacts->link_cache) << '\n';
     }
 
@@ -602,7 +612,7 @@ int main(const int argc, char* argv[]) {
         std::cout << "[up-to-date] " << path_text(request.target.executable.filename()) << '\n';
     }
 
-    std::cout << "executable: " << path_text(request.target.executable) << '\n';
+    std::cout << "output: " << path_text(request.target.executable) << '\n';
 
     if (!options.build.run_after_build) {
         return 0;

--- a/cpp/backends/msvc/include/mqb/msvc/MsvcLinker.hpp
+++ b/cpp/backends/msvc/include/mqb/msvc/MsvcLinker.hpp
@@ -45,6 +45,12 @@ public:
     [[nodiscard]] static std::expected<LinkerIdentity, LinkerError>
     identity(const MsvcToolchain& toolchain);
 
+    [[nodiscard]] static std::filesystem::path
+    import_library_path(const std::filesystem::path& output);
+
+    [[nodiscard]] static std::filesystem::path
+    export_file_path(const std::filesystem::path& output);
+
     [[nodiscard]] static std::expected<std::vector<std::string>, LinkerError>
     build_arguments(const LinkInvocation& invocation);
 

--- a/cpp/backends/msvc/src/MsvcLinker.cpp
+++ b/cpp/backends/msvc/src/MsvcLinker.cpp
@@ -95,8 +95,25 @@ MsvcLinker::identity(const MsvcToolchain& toolchain) {
     };
 }
 
+fs::path MsvcLinker::import_library_path(const fs::path& output) {
+    fs::path import_library = output;
+    import_library.replace_extension(".lib");
+    return import_library;
+}
+
+fs::path MsvcLinker::export_file_path(const fs::path& output) {
+    fs::path export_file = output;
+    export_file.replace_extension(".exp");
+    return export_file;
+}
+
 std::expected<std::vector<std::string>, LinkerError>
 MsvcLinker::build_arguments(const LinkInvocation& invocation) {
+    if (invocation.options.target_kind == TargetKind::static_library) {
+        return std::unexpected(failure(
+            LinkerErrorCode::invalid_request,
+            "static-library targets require the MSVC librarian pipeline"));
+    }
     if (invocation.objects.empty()) {
         return std::unexpected(failure(
             LinkerErrorCode::invalid_request,
@@ -129,7 +146,7 @@ MsvcLinker::build_arguments(const LinkInvocation& invocation) {
 
     std::vector<std::string> arguments;
     arguments.reserve(
-        12
+        14
         + invocation.objects.size()
         + invocation.options.library_directories.size()
         + invocation.libraries.size()
@@ -167,6 +184,10 @@ MsvcLinker::build_arguments(const LinkInvocation& invocation) {
 
     // Structured routing is emitted after raw flags so the BuildPlan owns the
     // final target identity even if a user supplied a conflicting raw switch.
+    if (invocation.options.target_kind == TargetKind::dynamic_library) {
+        arguments.emplace_back("/DLL");
+        arguments.push_back("/IMPLIB:" + path_to_utf8(import_library_path(invocation.output)));
+    }
     arguments.push_back(architecture_argument(invocation.options.architecture));
     arguments.push_back(subsystem_argument(invocation.options.subsystem));
     arguments.push_back("/OUT:" + path_to_utf8(invocation.output));

--- a/cpp/config/include/mqb/config/ProjectConfig.hpp
+++ b/cpp/config/include/mqb/config/ProjectConfig.hpp
@@ -17,6 +17,7 @@ struct BuildOverrides {
     std::optional<CppStandard> standard;
     std::optional<RuntimeLibrary> runtime_library;
     std::optional<LinkSubsystem> subsystem;
+    std::optional<TargetKind> target_kind;
     std::optional<std::string> output_name;
     std::vector<std::string> defines;
     std::vector<std::filesystem::path> include_directories;

--- a/cpp/config/include/mqb/config/ProjectOptions.hpp
+++ b/cpp/config/include/mqb/config/ProjectOptions.hpp
@@ -20,6 +20,7 @@ struct EffectiveProjectOptions {
     CppStandard standard{CppStandard::cpp23};
     std::optional<RuntimeLibrary> runtime_library;
     LinkSubsystem subsystem{LinkSubsystem::console};
+    TargetKind target_kind{TargetKind::executable};
     std::optional<std::string> output_name;
     std::vector<std::string> defines;
     std::vector<std::filesystem::path> include_directories;

--- a/cpp/config/src/ProjectConfig.cpp
+++ b/cpp/config/src/ProjectConfig.cpp
@@ -416,13 +416,18 @@ require_paths(const fs::path& file, const fs::path& root, const JsonValue& value
     if (value == "windows") return LinkSubsystem::windows;
     return std::nullopt;
 }
+[[nodiscard]] std::optional<TargetKind> target_kind(std::string_view value) {
+    if (value == "exe" || value == "executable") return TargetKind::executable;
+    if (value == "dll" || value == "dynamic") return TargetKind::dynamic_library;
+    return std::nullopt;
+}
 
 [[nodiscard]] std::expected<void, Error>
 decode_build(const fs::path& file, const fs::path& root, const JsonValue& value, BuildOverrides& out) {
     auto object = require_object(file, value, "build");
     if (!object) return std::unexpected(object.error());
     auto known = reject_unknown(file, **object,
-        {"configuration", "architecture", "standard", "runtime", "subsystem", "output", "defines", "include_dirs",
+        {"configuration", "architecture", "standard", "runtime", "subsystem", "type", "output", "defines", "include_dirs",
          "library_dirs", "libraries", "compiler_args", "linker_args"},
         "build");
     if (!known) return std::unexpected(known.error());
@@ -461,6 +466,15 @@ decode_build(const fs::path& file, const fs::path& root, const JsonValue& value,
         auto parsed = subsystem(*text);
         if (!parsed) return std::unexpected(schema_error(file, it->second, "build.subsystem must be 'console' or 'windows'"));
         out.subsystem = *parsed;
+    }
+    if (auto it = (**object).find("type"); it != (**object).end()) {
+        auto text = require_string(file, it->second, "build.type");
+        if (!text) return std::unexpected(text.error());
+        auto parsed = target_kind(*text);
+        if (!parsed) return std::unexpected(schema_error(
+            file, it->second,
+            "build.type must be 'exe' or 'dll'; static libraries require the librarian milestone"));
+        out.target_kind = *parsed;
     }
     if (auto it = (**object).find("output"); it != (**object).end()) {
         auto text = require_string(file, it->second, "build.output");

--- a/cpp/config/src/ProjectOptions.cpp
+++ b/cpp/config/src/ProjectOptions.cpp
@@ -18,6 +18,7 @@ void apply_build(
     if (overrides.standard) effective.standard = *overrides.standard;
     if (overrides.runtime_library) effective.runtime_library = overrides.runtime_library;
     if (overrides.subsystem) effective.subsystem = *overrides.subsystem;
+    if (overrides.target_kind) effective.target_kind = *overrides.target_kind;
     if (overrides.output_name) effective.output_name = overrides.output_name;
     append_all(effective.defines, overrides.defines);
     append_all(effective.include_directories, overrides.include_directories);

--- a/cpp/config/tests/build_policy_config_tests.cpp
+++ b/cpp/config/tests/build_policy_config_tests.cpp
@@ -43,6 +43,7 @@ int main() {
   "version": 1,
   "build": {
     "standard": "17",
+    "type": "dll",
     "runtime": "MT",
     "subsystem": "windows",
     "compiler_args": ["/W4", "/DCONFIG_POLICY=1"],
@@ -55,6 +56,8 @@ int main() {
     if (loaded) {
         expect(loaded->build.standard == mqb::CppStandard::cpp17,
                "mqb.json should accept C++17");
+        expect(loaded->build.target_kind == mqb::TargetKind::dynamic_library,
+               "mqb.json should decode typed DLL output");
         expect(loaded->build.runtime_library == mqb::RuntimeLibrary::mt,
                "mqb.json should decode typed MT runtime");
         expect(loaded->build.subsystem == mqb::LinkSubsystem::windows,
@@ -69,6 +72,7 @@ int main() {
 
         mqb::config::ProjectOverrides cli;
         cli.build.standard = mqb::CppStandard::cpp14;
+        cli.build.target_kind = mqb::TargetKind::executable;
         cli.build.runtime_library = mqb::RuntimeLibrary::mdd;
         cli.build.subsystem = mqb::LinkSubsystem::console;
         cli.build.compiler_arguments = {"/WX"};
@@ -76,6 +80,8 @@ int main() {
         const auto effective = mqb::config::resolve_project_options(&*loaded, cli);
         expect(effective.standard == mqb::CppStandard::cpp14,
                "CLI scalar standard should override project config");
+        expect(effective.target_kind == mqb::TargetKind::executable,
+               "CLI scalar target kind should override DLL project config");
         expect(effective.runtime_library == mqb::RuntimeLibrary::mdd,
                "CLI scalar runtime should override project config");
         expect(effective.subsystem == mqb::LinkSubsystem::console,
@@ -95,6 +101,11 @@ int main() {
     auto cpp14 = mqb::config::ProjectConfigLoader::load(file);
     expect(cpp14.has_value() && cpp14->build.standard == mqb::CppStandard::cpp14,
            "mqb.json should accept C++14");
+
+    write_text(file, R"json({"version":1,"build":{"type":"static"}})json");
+    auto static_target = mqb::config::ProjectConfigLoader::load(file);
+    expect(!static_target && static_target.error().code == mqb::config::ErrorCode::schema_error,
+           "static target must remain fail-closed before librarian support");
 
     write_text(file, R"json({"version":1,"build":{"runtime":"dynamic"}})json");
     auto bad_runtime = mqb::config::ProjectConfigLoader::load(file);

--- a/cpp/core/include/mqb/core/BuildRequest.hpp
+++ b/cpp/core/include/mqb/core/BuildRequest.hpp
@@ -15,6 +15,7 @@ struct BuildRequest {
     BuildConfiguration configuration{BuildConfiguration::debug};
     Architecture architecture{Architecture::x64};
     CppStandard standard{CppStandard::cpp23};
+    TargetKind target_kind{TargetKind::executable};
     bool run_after_build{false};
     std::vector<std::string> run_arguments;
 };

--- a/cpp/core/include/mqb/core/BuildTypes.hpp
+++ b/cpp/core/include/mqb/core/BuildTypes.hpp
@@ -24,6 +24,14 @@ enum class CppStandard {
     cpp17 = 4,
 };
 
+enum class TargetKind {
+    executable,
+    dynamic_library,
+    // Reserved for the librarian-backed target slice. The public CLI/config
+    // will not accept static until the lib.exe pipeline is implemented.
+    static_library,
+};
+
 enum class BuildReason {
     missing_cache_entry,
     missing_output,
@@ -39,6 +47,7 @@ enum class BuildReason {
 [[nodiscard]] std::string_view to_string(BuildConfiguration value) noexcept;
 [[nodiscard]] std::string_view to_string(Architecture value) noexcept;
 [[nodiscard]] std::string_view to_string(CppStandard value) noexcept;
+[[nodiscard]] std::string_view to_string(TargetKind value) noexcept;
 [[nodiscard]] std::string_view to_string(BuildReason value) noexcept;
 
 } // namespace mqb

--- a/cpp/core/include/mqb/core/LinkCache.hpp
+++ b/cpp/core/include/mqb/core/LinkCache.hpp
@@ -19,6 +19,7 @@ struct LinkCacheEntry {
     std::vector<std::filesystem::path> objects;
     std::filesystem::path output;
     std::vector<std::filesystem::path> libraries;
+    std::vector<std::filesystem::path> side_outputs;
 };
 
 struct LinkCacheValidation {
@@ -51,6 +52,19 @@ public:
         const FileSnapshot& output_snapshot,
         std::span<const FileSnapshot> object_snapshots,
         std::span<const FileSnapshot> library_snapshots,
+        bool force_relink = false);
+
+    [[nodiscard]] static LinkCacheValidation validate(
+        std::span<const std::filesystem::path> current_objects,
+        std::span<const std::filesystem::path> current_libraries,
+        const std::filesystem::path& current_output,
+        const LinkerIdentity& current_linker,
+        const LinkOptions& current_options,
+        const std::optional<LinkCacheEntry>& cached_entry,
+        const FileSnapshot& output_snapshot,
+        std::span<const FileSnapshot> object_snapshots,
+        std::span<const FileSnapshot> library_snapshots,
+        std::span<const FileSnapshot> side_output_snapshots,
         bool force_relink = false);
 };
 

--- a/cpp/core/include/mqb/core/LinkOptions.hpp
+++ b/cpp/core/include/mqb/core/LinkOptions.hpp
@@ -16,6 +16,7 @@ enum class LinkSubsystem {
 struct LinkOptions {
     BuildConfiguration configuration{BuildConfiguration::debug};
     Architecture architecture{Architecture::x64};
+    TargetKind target_kind{TargetKind::executable};
     LinkSubsystem subsystem{LinkSubsystem::console};
     std::vector<std::filesystem::path> library_directories;
     std::vector<std::string> libraries;

--- a/cpp/core/include/mqb/core/ProjectArtifactLayout.hpp
+++ b/cpp/core/include/mqb/core/ProjectArtifactLayout.hpp
@@ -5,6 +5,8 @@
 #include <string>
 #include <string_view>
 
+#include "mqb/core/BuildTypes.hpp"
+
 namespace mqb {
 
 struct SourceArtifacts {
@@ -16,6 +18,9 @@ struct SourceArtifacts {
 };
 
 struct TargetArtifacts {
+    // Existing field name is retained through the executable/DLL slice to keep
+    // the incremental target API stable. Static-library work will generalize the
+    // final-artifact/cache vocabulary when the librarian pipeline lands.
     std::filesystem::path executable;
     std::filesystem::path link_cache;
 };
@@ -42,7 +47,9 @@ public:
     for_source(const std::filesystem::path& source) const;
 
     [[nodiscard]] std::expected<TargetArtifacts, ArtifactLayoutError>
-    for_target(std::string_view target_name) const;
+    for_target(
+        std::string_view target_name,
+        TargetKind target_kind = TargetKind::executable) const;
 
     [[nodiscard]] const std::filesystem::path& project_root() const noexcept {
         return project_root_;

--- a/cpp/core/src/BuildSignature.cpp
+++ b/cpp/core/src/BuildSignature.cpp
@@ -70,9 +70,6 @@ public:
         if (!identity) {
             return;
         }
-        // Preserve the exact v4 byte stream for all pre-header-unit recipes so
-        // #19 caches remain reusable. Only the new producer shape appends a
-        // versioned domain marker and its lookup identity.
         add_string("mqb.header-unit.producer.v1");
         add_string(identity->header_name);
         add_enum(identity->lookup_method);
@@ -170,22 +167,14 @@ BuildSignature BuildSignature::for_compile(
     hasher.add_enum(options.configuration);
     hasher.add_enum(options.architecture);
     if (is_c_translation_unit_path(unit.source)) {
-        // .c did not exist in any previous valid v4 recipe, so a C-only domain
-        // marker can be added without invalidating old C++ caches. The target
-        // C++ standard is intentionally absent because the C backend recipe does
-        // not emit a C++ /std switch; raw C standard switches remain represented
-        // through additional_arguments when users opt into them explicitly.
         hasher.add_string("mqb.c.language.v1");
     } else {
-        // Preserve the exact pre-C v4 byte stream for every existing C++ recipe.
         hasher.add_enum(options.standard);
     }
     hasher.add_strings(options.defines);
     hasher.add_paths(options.include_directories);
     hasher.add_strings(options.additional_arguments);
     if (options.runtime_library) {
-        // Keep all historical default v4 byte streams intact. Explicit runtime
-        // selection is a new optional recipe domain layered after old fields.
         hasher.add_string("mqb.runtime-library.v1");
         hasher.add_enum(*options.runtime_library);
     }
@@ -226,6 +215,12 @@ BuildSignature BuildSignature::for_link(
     hasher.add_paths(options.library_directories);
     hasher.add_strings(options.libraries);
     hasher.add_strings(options.additional_arguments);
+    if (options.target_kind != TargetKind::executable) {
+        // Preserve the exact historical v2 byte stream for executable links.
+        // New executable-style targets append a versioned kind domain only.
+        hasher.add_string("mqb.link.target-kind.v1");
+        hasher.add_enum(options.target_kind);
+    }
     return BuildSignature{hasher.finish()};
 }
 

--- a/cpp/core/src/BuildTypes.cpp
+++ b/cpp/core/src/BuildTypes.cpp
@@ -38,6 +38,18 @@ std::string_view to_string(const CppStandard value) noexcept {
     return "unknown";
 }
 
+std::string_view to_string(const TargetKind value) noexcept {
+    switch (value) {
+    case TargetKind::executable:
+        return "exe";
+    case TargetKind::dynamic_library:
+        return "dll";
+    case TargetKind::static_library:
+        return "static";
+    }
+    return "unknown";
+}
+
 std::string_view to_string(const BuildReason value) noexcept {
     switch (value) {
     case BuildReason::missing_cache_entry:

--- a/cpp/core/src/LinkCache.cpp
+++ b/cpp/core/src/LinkCache.cpp
@@ -70,6 +70,18 @@ void validate_freshness(
     }
 }
 
+void validate_side_outputs(
+    const std::span<const std::filesystem::path> cached_side_outputs,
+    const std::span<const FileSnapshot> snapshots,
+    std::vector<BuildReason>& reasons) {
+    for (const auto& output : cached_side_outputs) {
+        const auto* snapshot = find_snapshot(snapshots, output);
+        if (snapshot == nullptr || !snapshot->exists) {
+            add_reason(reasons, BuildReason::missing_output);
+        }
+    }
+}
+
 } // namespace
 
 LinkCacheValidation LinkCacheValidator::validate(
@@ -91,6 +103,7 @@ LinkCacheValidation LinkCacheValidator::validate(
         output_snapshot,
         object_snapshots,
         std::span<const FileSnapshot>{},
+        std::span<const FileSnapshot>{},
         force_relink);
 }
 
@@ -104,6 +117,32 @@ LinkCacheValidation LinkCacheValidator::validate(
     const FileSnapshot& output_snapshot,
     const std::span<const FileSnapshot> object_snapshots,
     const std::span<const FileSnapshot> library_snapshots,
+    const bool force_relink) {
+    return validate(
+        current_objects,
+        current_libraries,
+        current_output,
+        current_linker,
+        current_options,
+        cached_entry,
+        output_snapshot,
+        object_snapshots,
+        library_snapshots,
+        std::span<const FileSnapshot>{},
+        force_relink);
+}
+
+LinkCacheValidation LinkCacheValidator::validate(
+    const std::span<const std::filesystem::path> current_objects,
+    const std::span<const std::filesystem::path> current_libraries,
+    const std::filesystem::path& current_output,
+    const LinkerIdentity& current_linker,
+    const LinkOptions& current_options,
+    const std::optional<LinkCacheEntry>& cached_entry,
+    const FileSnapshot& output_snapshot,
+    const std::span<const FileSnapshot> object_snapshots,
+    const std::span<const FileSnapshot> library_snapshots,
+    const std::span<const FileSnapshot> side_output_snapshots,
     const bool force_relink) {
     LinkCacheValidation result;
 
@@ -149,6 +188,7 @@ LinkCacheValidation LinkCacheValidator::validate(
     if (!output_snapshot.exists) {
         add_reason(result.reasons, BuildReason::missing_output);
     }
+    validate_side_outputs(cached.side_outputs, side_output_snapshots, result.reasons);
 
     validate_freshness(current_objects, object_snapshots, output_snapshot, result.reasons);
     validate_freshness(current_libraries, library_snapshots, output_snapshot, result.reasons);

--- a/cpp/core/src/LinkCacheFile.cpp
+++ b/cpp/core/src/LinkCacheFile.cpp
@@ -25,7 +25,8 @@ namespace fs = std::filesystem;
 
 constexpr std::array<std::uint8_t, 8> magic{
     'M', 'Q', 'B', 'L', 'I', 'N', 'K', 'C'};
-constexpr std::uint32_t format_version = 2;
+constexpr std::uint32_t legacy_format_version = 2;
+constexpr std::uint32_t format_version = 3;
 constexpr std::size_t max_cache_file_size = 64u * 1024u * 1024u;
 constexpr std::uint32_t max_string_size = 4u * 1024u * 1024u;
 constexpr std::uint32_t max_link_input_count = 100000u;
@@ -255,6 +256,8 @@ serialize(const fs::path& file, const LinkCacheEntry& entry) {
     if (!objects) return std::unexpected(objects.error());
     auto libraries = write_paths(writer, file, entry.libraries, "library input");
     if (!libraries) return std::unexpected(libraries.error());
+    auto side_outputs = write_paths(writer, file, entry.side_outputs, "side output");
+    if (!side_outputs) return std::unexpected(side_outputs.error());
 
     return writer.bytes();
 }
@@ -285,7 +288,7 @@ deserialize(const fs::path& file, const std::span<const std::uint8_t> bytes) {
     }
     auto version = reader.read_u32();
     if (!version) return std::unexpected(version.error());
-    if (*version != format_version) {
+    if (*version != legacy_format_version && *version != format_version) {
         return std::unexpected(make_error(
             LinkCacheFileErrorCode::unsupported_version,
             file,
@@ -312,6 +315,13 @@ deserialize(const fs::path& file, const std::span<const std::uint8_t> bytes) {
     auto libraries = read_paths(reader, "library input");
     if (!libraries) return std::unexpected(libraries.error());
 
+    std::vector<fs::path> side_outputs;
+    if (*version == format_version) {
+        auto loaded_side_outputs = read_paths(reader, "side output");
+        if (!loaded_side_outputs) return std::unexpected(loaded_side_outputs.error());
+        side_outputs = std::move(*loaded_side_outputs);
+    }
+
     if (!reader.at_end()) {
         return std::unexpected(reader.corrupt("unexpected trailing bytes in link cache file"));
     }
@@ -329,6 +339,7 @@ deserialize(const fs::path& file, const std::span<const std::uint8_t> bytes) {
         .objects = std::move(*objects),
         .output = std::move(*output),
         .libraries = std::move(*libraries),
+        .side_outputs = std::move(side_outputs),
     };
 }
 

--- a/cpp/core/src/ProjectArtifactLayout.cpp
+++ b/cpp/core/src/ProjectArtifactLayout.cpp
@@ -110,17 +110,12 @@ namespace fs = std::filesystem;
     const fs::path& source) {
     const fs::path normalized_source = normalize_existing_identity(source);
 
-    // For existing inputs, prefer physical ancestry over textual prefixes.
-    // Windows scanners may return a case/8.3/canonical spelling different from
-    // the caller while still naming the same file under the same project root.
     if (auto relative = physical_relative(project_root, normalized_source)) {
         return *relative;
     }
 
     fs::path relative = normalized_source.lexically_relative(project_root);
 #ifdef _WIN32
-    // Non-existing planned inputs cannot use fs::equivalent. Keep Windows
-    // identity case-insensitive so textual aliases still converge.
     relative = windows_identity_casefold(std::move(relative));
 #endif
     if (safe_relative(relative)) {
@@ -146,6 +141,18 @@ namespace fs = std::filesystem;
 [[nodiscard]] fs::path append_suffix(fs::path path, const std::string_view suffix) {
     path += std::string{suffix};
     return path;
+}
+
+[[nodiscard]] std::string_view target_suffix(const TargetKind target_kind) {
+    switch (target_kind) {
+    case TargetKind::executable:
+        return ".exe";
+    case TargetKind::dynamic_library:
+        return ".dll";
+    case TargetKind::static_library:
+        return ".lib";
+    }
+    return ".exe";
 }
 
 } // namespace
@@ -193,7 +200,9 @@ ProjectArtifactLayout::for_source(const fs::path& source) const {
 }
 
 std::expected<TargetArtifacts, ArtifactLayoutError>
-ProjectArtifactLayout::for_target(const std::string_view target_name) const {
+ProjectArtifactLayout::for_target(
+    const std::string_view target_name,
+    const TargetKind target_kind) const {
     if (!valid_target_name(target_name)) {
         return std::unexpected(failure(
             ArtifactLayoutErrorCode::invalid_target_name,
@@ -202,7 +211,7 @@ ProjectArtifactLayout::for_target(const std::string_view target_name) const {
     }
 
     fs::path executable = artifact_root_ / "bin" / std::string{target_name};
-    executable += ".exe";
+    executable += target_suffix(target_kind);
     fs::path link_cache = artifact_root_ / "cache" / "link" / std::string{target_name};
     link_cache += ".linkcache";
     return TargetArtifacts{

--- a/cpp/orchestration/src/MsvcIncrementalLinkCoordinator.cpp
+++ b/cpp/orchestration/src/MsvcIncrementalLinkCoordinator.cpp
@@ -63,6 +63,25 @@ void snapshot_inputs(
     }
 }
 
+void collect_existing_side_output(
+    const fs::path& path,
+    std::vector<fs::path>& outputs,
+    std::vector<IncrementalLinkWarning>& warnings) {
+    std::error_code error_code;
+    const bool exists = fs::exists(path, error_code);
+    if (error_code) {
+        warnings.push_back(IncrementalLinkWarning{
+            .code = IncrementalLinkWarningCode::file_snapshot_failed,
+            .path = path,
+            .message = "failed to query linker side output: " + error_code.message(),
+        });
+        return;
+    }
+    if (exists) {
+        outputs.push_back(path);
+    }
+}
+
 [[nodiscard]] IncrementalLinkError link_failure(
     const IncrementalLinkErrorCode code,
     std::string message,
@@ -131,6 +150,11 @@ MsvcIncrementalLinkCoordinator::run(const IncrementalLinkRequest& request) const
     std::vector<FileSnapshot> library_snapshots;
     snapshot_inputs(resolved_libraries->files, library_snapshots, result.warnings);
 
+    std::vector<FileSnapshot> side_output_snapshots;
+    if (cached_entry) {
+        snapshot_inputs(cached_entry->side_outputs, side_output_snapshots, result.warnings);
+    }
+
     result.validation = LinkCacheValidator::validate(
         request.objects,
         resolved_libraries->files,
@@ -141,6 +165,7 @@ MsvcIncrementalLinkCoordinator::run(const IncrementalLinkRequest& request) const
         output_snapshot,
         object_snapshots,
         library_snapshots,
+        side_output_snapshots,
         request.force_relink);
 
     const LinkPlanItem plan_item{
@@ -195,6 +220,18 @@ MsvcIncrementalLinkCoordinator::run(const IncrementalLinkRequest& request) const
     result.linked = true;
     result.process = std::move(*linked);
 
+    std::vector<fs::path> side_outputs;
+    if (request.options.target_kind == TargetKind::dynamic_library) {
+        collect_existing_side_output(
+            msvc::MsvcLinker::import_library_path(action->output),
+            side_outputs,
+            result.warnings);
+        collect_existing_side_output(
+            msvc::MsvcLinker::export_file_path(action->output),
+            side_outputs,
+            result.warnings);
+    }
+
     const LinkCacheEntry new_entry{
         .linker = *linker_identity,
         .signature = BuildSignature::for_link(
@@ -206,6 +243,7 @@ MsvcIncrementalLinkCoordinator::run(const IncrementalLinkRequest& request) const
         .objects = action->objects,
         .output = action->output,
         .libraries = action->libraries,
+        .side_outputs = std::move(side_outputs),
     };
     auto saved = LinkCacheFile::save(request.cache_file, new_entry);
     if (!saved) {

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -179,6 +179,10 @@ if(WIN32)
         target_link_libraries(mqb_runtime_subsystem_config_e2e_tests PRIVATE mqb_platform_windows)
         target_compile_features(mqb_runtime_subsystem_config_e2e_tests PRIVATE cxx_std_23)
 
+        add_executable(mqb_dll_target_e2e_tests mqb_dll_target_e2e_tests.cpp)
+        target_link_libraries(mqb_dll_target_e2e_tests PRIVATE mqb_platform_windows)
+        target_compile_features(mqb_dll_target_e2e_tests PRIVATE cxx_std_23)
+
         list(APPEND MQB_TEST_TARGETS
             mqb_msvc_visual_studio_tests
             mqb_msvc_compile_integration_tests
@@ -191,6 +195,7 @@ if(WIN32)
             mqb_build_policy_e2e_tests
             mqb_c_source_e2e_tests
             mqb_runtime_subsystem_config_e2e_tests
+            mqb_dll_target_e2e_tests
         )
     endif()
 endif()
@@ -266,6 +271,10 @@ if(WIN32)
         add_test(
             NAME mqb.cli.runtime_subsystem_config_e2e
             COMMAND mqb_runtime_subsystem_config_e2e_tests $<TARGET_FILE:mqb>
+        )
+        add_test(
+            NAME mqb.cli.dll_target_e2e
+            COMMAND mqb_dll_target_e2e_tests $<TARGET_FILE:mqb>
         )
     endif()
 endif()

--- a/cpp/tests/build_policy_cli_tests.cpp
+++ b/cpp/tests/build_policy_cli_tests.cpp
@@ -42,12 +42,17 @@ int main() {
     {
         const std::vector arguments{
             "main.cpp"sv,
+            "--type"sv, "dll"sv,
             "--runtime"sv, "MT"sv,
             "--subsystem=windows"sv,
         };
         auto parsed = mqb::cli::parse_arguments(arguments);
-        expect(parsed.has_value(), "typed native runtime/subsystem options should parse");
+        expect(parsed.has_value(), "typed native target/runtime/subsystem options should parse");
         if (parsed) {
+            expect(parsed->target_kind_override == mqb::TargetKind::dynamic_library,
+                   "--type dll should select typed DLL output");
+            expect(parsed->build.target_kind == mqb::TargetKind::dynamic_library,
+                   "typed DLL selection should also update BuildRequest");
             expect(parsed->runtime_override == mqb::RuntimeLibrary::mt,
                    "--runtime MT should select static release CRT");
             expect(parsed->subsystem_override == mqb::LinkSubsystem::windows,
@@ -58,17 +63,33 @@ int main() {
     {
         const std::vector arguments{
             "main.cpp"sv,
+            "-type"sv, "dll"sv,
             "-runtime"sv, "MDd"sv,
             "-subsystem"sv, "console"sv,
         };
         auto parsed = mqb::cli::parse_arguments(arguments);
-        expect(parsed.has_value(), "legacy runtime/subsystem aliases should parse");
+        expect(parsed.has_value(), "legacy type/runtime/subsystem aliases should parse");
         if (parsed) {
+            expect(parsed->target_kind_override == mqb::TargetKind::dynamic_library,
+                   "legacy -type dll should map to typed DLL output");
             expect(parsed->runtime_override == mqb::RuntimeLibrary::mdd,
                    "legacy -runtime MDd should map to typed runtime");
             expect(parsed->subsystem_override == mqb::LinkSubsystem::console,
                    "legacy -subsystem console should map to typed subsystem");
         }
+    }
+
+    {
+        const std::vector arguments{"main.cpp"sv, "--type=exe"sv};
+        auto parsed = mqb::cli::parse_arguments(arguments);
+        expect(parsed.has_value() && parsed->target_kind_override == mqb::TargetKind::executable,
+               "--type=exe should explicitly select executable output");
+    }
+
+    {
+        const std::vector arguments{"main.cpp"sv, "--type"sv, "static"sv};
+        auto parsed = mqb::cli::parse_arguments(arguments);
+        expect(!parsed, "static-library target should remain fail-closed before librarian support");
     }
 
     {

--- a/cpp/tests/link_cache_file_tests.cpp
+++ b/cpp/tests/link_cache_file_tests.cpp
@@ -44,13 +44,15 @@ int main() {
 
     const std::vector<fs::path> objects{"obj/main.cpp.obj", "obj/math.cpp.obj"};
     const std::vector<fs::path> libraries{"vendor/math.lib", "vendor/codec.lib"};
-    const fs::path output{"bin/app.exe"};
+    const fs::path output{"bin/plugin.dll"};
+    const std::vector<fs::path> side_outputs{"bin/plugin.lib", "bin/plugin.exp"};
     const mqb::LinkerIdentity linker{
         .linker = "C:/msvc/link.exe",
         .version = "14.51",
         .binary_stamp = "stamp-a",
     };
     mqb::LinkOptions options;
+    options.target_kind = mqb::TargetKind::dynamic_library;
     options.library_directories = {"vendor"};
     options.libraries = {"math.lib", "codec.lib"};
     const auto signature = mqb::BuildSignature::for_link(
@@ -61,9 +63,10 @@ int main() {
         .objects = objects,
         .output = output,
         .libraries = libraries,
+        .side_outputs = side_outputs,
     };
 
-    const fs::path file = tree.root / "cache" / "app.linkcache";
+    const fs::path file = tree.root / "cache" / "plugin.linkcache";
     const auto missing = mqb::LinkCacheFile::load(file);
     expect(missing.has_value() && !missing->has_value(),
            "missing link cache should be a normal cache miss");
@@ -80,6 +83,8 @@ int main() {
         expect((*loaded)->objects == objects, "object inputs should round-trip");
         expect((*loaded)->libraries == libraries, "resolved library inputs should round-trip");
         expect((*loaded)->output == output, "link output should round-trip");
+        expect((*loaded)->side_outputs == side_outputs,
+               "observed linker side outputs should round-trip in cache v3");
     }
 
     {
@@ -89,10 +94,10 @@ int main() {
         stream.write(old_version, 4);
     }
     const auto old_version = mqb::LinkCacheFile::load(file);
-    expect(!old_version.has_value(), "older link-cache format should be rejected safely");
+    expect(!old_version.has_value(), "unsupported link-cache format should be rejected safely");
     if (!old_version) {
         expect(old_version.error().code == mqb::LinkCacheFileErrorCode::unsupported_version,
-               "old cache version should report unsupported_version");
+               "unsupported cache version should report unsupported_version");
     }
 
     const auto restored_after_version = mqb::LinkCacheFile::save(file, entry);

--- a/cpp/tests/mqb_dll_target_e2e_tests.cpp
+++ b/cpp/tests/mqb_dll_target_e2e_tests.cpp
@@ -170,8 +170,9 @@ int main(int argc, char* argv[]) {
         expect(repaired->exit_code == 0, "missing import library should repair successfully");
         expect(contains_line(repaired->stdout_text, "[up-to-date] plugin.cpp"),
                "missing linker side output must not recompile a fresh TU");
-        expect(repaired->stdout_text.find("[link] plugin.dll [missing_output]") != std::string::npos,
-               "missing import library should invalidate only link output freshness");
+        expect(repaired->stdout_text.find("[link] plugin.dll") != std::string::npos
+                   && repaired->stdout_text.find("missing output") != std::string::npos,
+               "missing import library should invalidate link freshness with missing-output reason");
     }
     expect(fs::is_regular_file(import_library), "repair relink should recreate import library");
 

--- a/cpp/tests/mqb_dll_target_e2e_tests.cpp
+++ b/cpp/tests/mqb_dll_target_e2e_tests.cpp
@@ -1,0 +1,220 @@
+#include <windows.h>
+
+#include <chrono>
+#include <expected>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+#include "mqb/platform/windows/WindowsProcessRunner.hpp"
+#include "mqb/process/Process.hpp"
+
+namespace {
+namespace fs = std::filesystem;
+int failures = 0;
+
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+void write_text(const fs::path& path, const std::string_view text) {
+    fs::create_directories(path.parent_path());
+    std::ofstream stream{path, std::ios::binary | std::ios::trunc};
+    stream << text;
+}
+
+void dump_failure(const mqb::process::ProcessResult& result) {
+    std::cerr << "exit: " << result.exit_code << '\n'
+              << "stdout:\n" << result.stdout_text << '\n'
+              << "stderr:\n" << result.stderr_text << '\n';
+}
+
+[[nodiscard]] bool contains_line(std::string_view output, std::string_view expected) {
+    std::size_t begin = 0;
+    while (begin <= output.size()) {
+        const std::size_t newline = output.find('\n', begin);
+        const std::size_t end = newline == std::string_view::npos ? output.size() : newline;
+        std::string_view line = output.substr(begin, end - begin);
+        if (!line.empty() && line.back() == '\r') line.remove_suffix(1);
+        if (line == expected) return true;
+        if (newline == std::string_view::npos) break;
+        begin = newline + 1;
+    }
+    return false;
+}
+
+struct TempTree {
+    fs::path root;
+    ~TempTree() {
+        std::error_code ignored;
+        fs::remove_all(root, ignored);
+    }
+};
+
+[[nodiscard]] std::expected<mqb::process::ProcessResult, std::string> run_mqb(
+    mqb::platform::windows::WindowsProcessRunner& runner,
+    const fs::path& mqb,
+    const fs::path& root,
+    std::vector<std::string> arguments) {
+    mqb::process::ProcessSpec spec;
+    spec.executable = mqb;
+    spec.arguments = std::move(arguments);
+    spec.working_directory = root;
+    spec.capture_stdout = true;
+    spec.capture_stderr = true;
+    auto result = runner.run(spec);
+    if (!result) return std::unexpected("failed to launch mqb: " + result.error().message);
+    return std::move(*result);
+}
+
+[[nodiscard]] std::expected<int, std::string> call_answer(const fs::path& dll) {
+    const HMODULE module = LoadLibraryW(dll.c_str());
+    if (module == nullptr) {
+        return std::unexpected("LoadLibraryW failed: " + std::to_string(GetLastError()));
+    }
+    const FARPROC symbol = GetProcAddress(module, "mqb_answer");
+    if (symbol == nullptr) {
+        const DWORD error = GetLastError();
+        FreeLibrary(module);
+        return std::unexpected("GetProcAddress failed: " + std::to_string(error));
+    }
+    using AnswerFunction = int (*)();
+    const auto answer = reinterpret_cast<AnswerFunction>(symbol);
+    const int value = answer();
+    FreeLibrary(module);
+    return value;
+}
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    if (argc != 2) {
+        std::cerr << "usage: mqb_dll_target_e2e_tests <mqb-executable>\n";
+        return 2;
+    }
+
+    const fs::path mqb_executable{argv[1]};
+    const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
+    TempTree tree{.root = fs::temp_directory_path() / ("mqb_dll_target_e2e_" + std::to_string(unique))};
+    fs::create_directories(tree.root);
+    mqb::platform::windows::WindowsProcessRunner runner;
+
+    write_text(tree.root / "plugin.cpp", R"cpp(extern "C" __declspec(dllexport) int mqb_answer() {
+    return 42;
+}
+)cpp");
+
+    const fs::path dll = tree.root / ".mqb" / "bin" / "plugin.dll";
+    const fs::path import_library = tree.root / ".mqb" / "bin" / "plugin.lib";
+    const fs::path export_file = tree.root / ".mqb" / "bin" / "plugin.exp";
+
+    auto cold = run_mqb(
+        runner,
+        mqb_executable,
+        tree.root,
+        {"plugin.cpp", "--no-discover", "--env", "vs", "--type", "dll",
+         "--runtime", "MT", "-o", "plugin"});
+    expect(cold.has_value(), "cold DLL invocation should launch");
+    if (cold) {
+        if (cold->exit_code != 0) dump_failure(*cold);
+        expect(cold->exit_code == 0, "cold DLL target should build successfully");
+        expect(cold->stdout_text.find("[compile] plugin.cpp") != std::string::npos,
+               "cold DLL target should compile its TU");
+        expect(cold->stdout_text.find("[link] plugin.dll") != std::string::npos,
+               "cold DLL target should link a DLL");
+    }
+    expect(fs::is_regular_file(dll), "DLL output should exist at deterministic .mqb/bin path");
+    expect(fs::is_regular_file(import_library), "exporting DLL should produce deterministic import library");
+    expect(fs::is_regular_file(export_file), "exporting DLL should produce export side file");
+    auto answer = call_answer(dll);
+    expect(answer.has_value() && *answer == 42,
+           "LoadLibrary/GetProcAddress should call exported function from generated DLL");
+
+    auto warm = run_mqb(
+        runner,
+        mqb_executable,
+        tree.root,
+        {"plugin.cpp", "--no-discover", "--env", "vs", "--type=dll",
+         "--runtime", "MT", "-o", "plugin"});
+    expect(warm.has_value(), "warm DLL invocation should launch");
+    if (warm) {
+        if (warm->exit_code != 0) dump_failure(*warm);
+        expect(warm->exit_code == 0, "warm DLL target should succeed");
+        expect(contains_line(warm->stdout_text, "[up-to-date] plugin.cpp"),
+               "unchanged DLL TU should reuse compile cache");
+        expect(contains_line(warm->stdout_text, "[up-to-date] plugin.dll"),
+               "unchanged DLL should reuse link cache");
+    }
+
+    std::error_code error_code;
+    fs::remove(import_library, error_code);
+    expect(!error_code && !fs::exists(import_library),
+           "test should remove generated import library");
+    auto repaired = run_mqb(
+        runner,
+        mqb_executable,
+        tree.root,
+        {"plugin.cpp", "--no-discover", "--env", "vs", "-type", "dll",
+         "--runtime", "MT", "-o", "plugin"});
+    expect(repaired.has_value(), "missing-import-library repair invocation should launch");
+    if (repaired) {
+        if (repaired->exit_code != 0) dump_failure(*repaired);
+        expect(repaired->exit_code == 0, "missing import library should repair successfully");
+        expect(contains_line(repaired->stdout_text, "[up-to-date] plugin.cpp"),
+               "missing linker side output must not recompile a fresh TU");
+        expect(repaired->stdout_text.find("[link] plugin.dll [missing_output]") != std::string::npos,
+               "missing import library should invalidate only link output freshness");
+    }
+    expect(fs::is_regular_file(import_library), "repair relink should recreate import library");
+
+    write_text(tree.root / "plugin.cpp", R"cpp(extern "C" __declspec(dllexport) int mqb_answer() {
+    return 43;
+}
+)cpp");
+    auto mutated = run_mqb(
+        runner,
+        mqb_executable,
+        tree.root,
+        {"plugin.cpp", "--no-discover", "--env", "vs", "--type", "dll",
+         "--runtime", "MT", "-o", "plugin"});
+    expect(mutated.has_value(), "mutated DLL invocation should launch");
+    if (mutated) {
+        if (mutated->exit_code != 0) dump_failure(*mutated);
+        expect(mutated->exit_code == 0, "mutated DLL target should rebuild");
+        expect(mutated->stdout_text.find("[compile] plugin.cpp") != std::string::npos,
+               "mutated DLL source should recompile");
+        expect(mutated->stdout_text.find("[link] plugin.dll") != std::string::npos,
+               "fresh DLL object should relink DLL");
+    }
+    auto mutated_answer = call_answer(dll);
+    expect(mutated_answer.has_value() && *mutated_answer == 43,
+           "relinked DLL should expose mutated exported behavior");
+
+    auto invalid_run = run_mqb(
+        runner,
+        mqb_executable,
+        tree.root,
+        {"plugin.cpp", "--type", "dll", "--run"});
+    expect(invalid_run.has_value(), "DLL --run validation invocation should launch");
+    if (invalid_run) {
+        expect(invalid_run->exit_code == 2,
+               "DLL --run should fail at CLI/orchestration validation boundary");
+        expect(invalid_run->stderr_text.find("--run is only valid for executable targets") != std::string::npos,
+               "DLL --run should explain executable-only run semantics");
+    }
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+    std::cout << "mqb_dll_target_e2e_tests passed\n";
+    return 0;
+}

--- a/cpp/tests/msvc_linker_arguments_tests.cpp
+++ b/cpp/tests/msvc_linker_arguments_tests.cpp
@@ -60,6 +60,32 @@ int main() {
                "planned output must override a conflicting raw /OUT");
     }
 
+    auto dll = invocation;
+    dll.output = "bin/plugin.dll";
+    dll.options.target_kind = mqb::TargetKind::dynamic_library;
+    dll.options.additional_arguments = {"/OUT:ignored.dll", "/IMPLIB:ignored.lib"};
+    const auto dll_result = mqb::msvc::MsvcLinker::build_arguments(dll);
+    expect(dll_result.has_value(), "typed DLL link invocation should produce argv");
+    if (dll_result) {
+        expect(contains(*dll_result, "/DLL"), "DLL target should emit /DLL");
+        expect(contains(*dll_result, "/IMPLIB:bin/plugin.lib"),
+               "DLL target should own deterministic import-library path");
+        expect(contains(*dll_result, "/OUT:bin/plugin.dll"),
+               "DLL target should own structured DLL output path");
+        const auto raw_implib = std::find(dll_result->begin(), dll_result->end(), "/IMPLIB:ignored.lib");
+        const auto planned_implib = std::find(dll_result->begin(), dll_result->end(), "/IMPLIB:bin/plugin.lib");
+        expect(raw_implib != dll_result->end() && planned_implib != dll_result->end()
+                   && raw_implib < planned_implib,
+               "typed DLL import-library path must override conflicting raw /IMPLIB");
+        expect(mqb::msvc::MsvcLinker::export_file_path(dll.output) == std::filesystem::path{"bin/plugin.exp"},
+               "DLL export side-output path should be deterministic");
+    }
+
+    auto static_library = invocation;
+    static_library.options.target_kind = mqb::TargetKind::static_library;
+    const auto static_result = mqb::msvc::MsvcLinker::build_arguments(static_library);
+    expect(!static_result, "static target must fail closed in linker backend");
+
     auto release = invocation;
     release.options.configuration = mqb::BuildConfiguration::release;
     release.options.architecture = mqb::Architecture::x86;

--- a/docs/MQB_CONFIG.md
+++ b/docs/MQB_CONFIG.md
@@ -23,6 +23,7 @@ MQB searches upward from the directory where it is invoked and uses the nearest 
     "configuration": "release",
     "architecture": "x64",
     "standard": "17",
+    "type": "exe",
     "runtime": "MT",
     "subsystem": "console",
     "output": "game",
@@ -70,9 +71,10 @@ MQB searches upward from the directory where it is invoked and uses the nearest 
 | `configuration` | string | `debug` or `release` |
 | `architecture` | string | `x86` or `x64` |
 | `standard` | string | `14`, `17`, `20`, `23`, or `latest` (`c++14`, `c++17`, `c++20`, `c++23`, `c++latest` are also accepted) |
+| `type` | string | `exe` or `dll`; static libraries remain fail-closed until the dedicated librarian pipeline lands |
 | `runtime` | string | MSVC CRT runtime: `MD`, `MDd`, `MT`, or `MTd` |
-| `subsystem` | string | executable subsystem: `console` or `windows` |
-| `output` | string | target name under `.mqb/bin/` |
+| `subsystem` | string | PE subsystem: `console` or `windows` |
+| `output` | string | target name under `.mqb/bin/`; MQB supplies the `.exe` or `.dll` suffix from `type` |
 | `defines` | string array | preprocessor definitions, without `/D` |
 | `include_dirs` | string array | include search directories |
 | `library_dirs` | string array | library search directories |
@@ -82,7 +84,9 @@ MQB searches upward from the directory where it is invoked and uses the nearest 
 
 All path-valued config entries are resolved relative to the directory containing `mqb.json`, not the shell's current working directory.
 
-`runtime` and `subsystem` are typed policy, not shorthand for raw flags. The MSVC backend remains the sole owner of their command-line spelling. An explicit typed runtime is emitted after raw compiler arguments, and the structured subsystem is emitted after raw linker arguments, so a conflicting raw `/MD*` or `/SUBSYSTEM:*` cannot silently override the typed project policy.
+`type`, `runtime`, and `subsystem` are typed policy, not shorthand for raw flags. The MSVC backend remains the sole owner of their command-line spelling. An explicit typed runtime is emitted after raw compiler arguments; typed DLL/output/subsystem routing is emitted after raw linker arguments, so conflicting raw `/MD*`, `/DLL`, `/IMPLIB`, `/SUBSYSTEM:*`, or `/OUT:*` switches cannot silently override the typed project policy.
+
+For a DLL target that exports symbols, MQB supplies a deterministic import-library location beside the DLL (`.mqb/bin/<target>.lib`). Linker side outputs that were actually produced are recorded in the link cache; deleting a recorded import library or export file invalidates link freshness and causes a repair relink without recompiling otherwise-fresh translation units.
 
 Raw compiler/linker arguments are literal argv elements. MQB does not split one JSON string containing spaces into several switches. For example:
 
@@ -92,7 +96,7 @@ Raw compiler/linker arguments are literal argv elements. MQB does not split one 
 
 represents two compiler arguments, while `"/W4 /WX"` is one argument and is not rewritten by MQB.
 
-Backend-owned structured routing remains authoritative. Raw arguments are emitted before MQB's planned output/topology switches such as `/Fo`, `/ifcOutput`, `/scanDependencies`, `/MACHINE`, `/SUBSYSTEM`, and `/OUT`.
+Backend-owned structured routing remains authoritative. Raw arguments are emitted before MQB's planned output/topology switches such as `/Fo`, `/ifcOutput`, `/scanDependencies`, `/DLL`, `/IMPLIB`, `/MACHINE`, `/SUBSYSTEM`, and `/OUT`.
 
 ## Discovery fields
 
@@ -146,7 +150,7 @@ For scalar options:
 explicit CLI option > mqb.json > built-in default
 ```
 
-This includes `configuration`, `architecture`, `standard`, `runtime`, `subsystem`, and `output`.
+This includes `configuration`, `architecture`, `standard`, `type`, `runtime`, `subsystem`, and `output`.
 
 Examples:
 
@@ -154,10 +158,13 @@ Examples:
 # mqb.json says release; this build is debug.
 mqb main.cpp --debug
 
+# mqb.json says DLL; this invocation explicitly builds an executable.
+mqb main.cpp --type exe
+
 # mqb.json says MT; this invocation uses the dynamic CRT.
 mqb main.cpp --runtime MD
 
-# mqb.json says windows; this invocation links a console target.
+# mqb.json says windows; this invocation uses the console subsystem.
 mqb main.cpp --subsystem console
 
 # mqb.json disables discovery; this explicitly turns it back on.
@@ -210,11 +217,13 @@ The config file timestamp itself is not a special global rebuild trigger. Instea
 
 Changing `runtime` changes compiler recipe identity, recompiles affected TUs, and therefore relinks the target. Leaving `runtime` unset preserves the historical Debug `/MDd` and Release `/MD` recipes and their existing signature identity.
 
+Changing `type` changes link recipe/output identity. The historical executable signature byte stream is retained for executable targets; DLL targets add their typed target-kind identity. Changing executable↔DLL relinks without recompiling otherwise-fresh translation units when the compile recipe is unchanged.
+
 Changing only `subsystem` changes link recipe identity and relinks without recompiling otherwise-fresh TUs.
 
 Changing a compiler argument changes compiler recipe identity and recompiles affected TUs even if no source timestamp changed. The resulting fresh objects force the downstream link. Changing only a linker argument changes link recipe identity and relinks without recompiling otherwise-fresh TUs.
 
-Likewise, library names/search paths affect link recipe identity, while exact resolved `.lib` files are separately tracked as link freshness inputs.
+Likewise, library names/search paths affect link recipe identity, while exact resolved `.lib` files are separately tracked as link freshness inputs. Recorded DLL linker side outputs are separately checked for existence and repaired by relinking if missing.
 
 For named modules and header units, compile identity also includes typed provider/reference and interface-output identity. Imported IFC files participate in consumer freshness validation, and a missing provider IFC invalidates the provider's cached outputs.
 
@@ -230,7 +239,8 @@ Changing the job count does not alter compile or link signatures and therefore m
 
 ## Current boundaries
 
-- v1 config has no target-kind field yet; executable targets are the native output contract until DLL/static work lands.
+- v1 `build.type` supports `exe` and `dll`; static libraries remain fail-closed until the dedicated `lib.exe`/librarian pipeline lands.
+- `--run` is executable-only; DLL targets are built artifacts and are not launched as programs.
 - v1 config has no external/prebuilt module-provider or `import std` policy.
 - v1 config does not store parallel job count.
 - `exclude_dirs`, `extra_sources`, and `exclude_sources` are exact paths, not globs.

--- a/docs/V5_PARITY.md
+++ b/docs/V5_PARITY.md
@@ -31,8 +31,9 @@ Status meanings:
 | Legacy spelling / behavior | Native equivalent | Stable-v5 decision |
 | --- | --- | --- |
 | `-o`, `-output` | `-o`, `--output`; legacy `-output` accepted | **compat** |
-| `-run` | `--run`; legacy `-run` accepted | **compat** |
+| `-run` | `--run`; legacy `-run` accepted for executable targets | **compat** |
 | `-std` | `--std`; legacy `-std` accepts 14/17/20/23/latest | **compat** |
+| `-type exe/dll` | `--type exe/dll`; legacy `-type` accepted | **compat** for executable/DLL; static remains pending librarian support |
 | `-x86` | `--x86`; legacy spelling accepted | **compat** |
 | default x64 | `--x64` / x64 default; legacy `-x64` accepted | **compat** |
 | `-I`, `-include` | `-I`; legacy `-include` accepted | **compat** |
@@ -53,15 +54,18 @@ Status meanings:
 | Legacy behavior | Native C++ status | Stable-v5 decision |
 | --- | --- | --- |
 | executable target | ready | **ready** |
-| DLL target (`-type dll`) | not exposed by native target model | **implement** |
-| static library target (`-type static`) | not exposed by native target model | **implement** with an explicit `lib.exe`/librarian owner |
-| automatic `.exe/.dll/.lib` suffix by target kind | executable only today | **implement** with target-kind work |
+| DLL target (`-type dll`) | typed Core/CLI/config target kind, `.dll` layout, `/DLL` + deterministic `/IMPLIB`, cache-correct side-output repair, real DLL load/call E2E | **ready/compat** |
+| static library target (`-type static`) | internal enum reserved; public CLI/config fail closed | **implement** with an explicit `lib.exe`/librarian owner |
+| automatic `.exe/.dll` suffix by target kind | ready | **ready** |
+| automatic `.lib` suffix for static target | layout support is reserved but public static pipeline is not exposed | **implement** with librarian work |
 | console subsystem | typed CLI/config policy; default console | **ready/compat** |
 | windows subsystem | typed CLI/config policy with link-only cache invalidation E2E | **ready/compat** |
 
+DLL link identity is typed and separate from executable identity while preserving the historical executable link-signature byte stream. For exporting DLLs, MQB owns a deterministic `.mqb/bin/<target>.lib` import-library path. Linker side outputs that were observed after a successful link are persisted in link-cache v3; v2 executable caches remain readable. Removing a recorded import library/export file invalidates only the link and repairs it without recompiling fresh translation units.
+
 ## Compiler and linker policy
 
-The native backend has typed `CompilerOptions` / `LinkOptions` plus ordered additional argument vectors. CLI and `mqb.json` expose those vectors, and compile/link signatures hash them in order. Config arguments are applied first and CLI arguments append afterward. High-value typed policy remains authoritative over conflicting raw flags: typed runtime is emitted after raw compiler arguments, while structured subsystem/output routing is emitted after raw linker arguments.
+The native backend has typed `CompilerOptions` / `LinkOptions` plus ordered additional argument vectors. CLI and `mqb.json` expose those vectors, and compile/link signatures hash them in order. Config arguments are applied first and CLI arguments append afterward. High-value typed policy remains authoritative over conflicting raw flags: typed runtime is emitted after raw compiler arguments, while structured target-kind/subsystem/output routing is emitted after raw linker arguments.
 
 | Legacy option | Native C++ status | Stable-v5 decision |
 | --- | --- | --- |
@@ -87,14 +91,15 @@ The native backend has typed `CompilerOptions` / `LinkOptions` plus ordered addi
 | Legacy behavior | Native C++ status | Stable-v5 decision |
 | --- | --- | --- |
 | `msvc_list.json`, upward search up to five levels | native uses nearest upward `mqb.json` | **migrate** to `mqb.json`; provide upgrade guidance/tooling rather than keeping two authoritative schemas forever |
-| CLI overrides scalar config | ready, including runtime/subsystem | **ready** |
+| CLI overrides scalar config | ready, including type/runtime/subsystem | **ready** |
 | additive list precedence | config lists first, CLI lists append | **ready** |
 | 14/17/20/23/latest standard config | ready | **ready** |
+| target-kind config | strict `build.type` supports `exe`/`dll`; static remains fail-closed | **ready** for exe/DLL |
 | runtime/subsystem config | typed strict-schema fields with real cache-invalidation E2E | **ready** |
 | include/lib/define/library config | ready in `mqb.json` | **ready** |
 | `compiler_args` / `linker_args` | ready in strict `mqb.json` v1 schema | **ready** |
 | source discovery excludes | ready with the native discovery schema | **ready** |
-| legacy config keys for target kind/coupled policies | not all represented | **implement** only for capabilities accepted into the stable parity surface |
+| legacy config keys for remaining coupled policies | not all represented | **implement** only for capabilities accepted into the stable parity surface |
 
 ## Toolchain/environment behavior
 
@@ -111,7 +116,7 @@ The native backend has typed `CompilerOptions` / `LinkOptions` plus ordered addi
 
 Stable v5 does not require byte-for-byte artifact layout parity with PowerShell. It requires equivalent observable correctness: cold build succeeds, warm no-op avoids unnecessary work, source/header/library/config/toolchain/build-policy changes invalidate the right work, missing required artifacts repair correctly, and outputs are collision-free.
 
-Typed runtime changes are compile-recipe identity and therefore force affected compile + downstream link. Typed subsystem changes are link-recipe identity and relink without recompiling otherwise-fresh TUs. The same semantics hold whether policy comes from CLI or `mqb.json`.
+Typed runtime changes are compile-recipe identity and therefore force affected compile + downstream link. Typed target-kind/subsystem changes are link-recipe identity and relink without recompiling otherwise-fresh TUs. The same semantics hold whether policy comes from CLI or `mqb.json`.
 
 Raw compiler argument changes are compile-recipe identity and therefore force affected compile + downstream link. Raw linker argument changes are link-recipe identity and therefore relink without recompiling otherwise-fresh TUs.
 
@@ -130,8 +135,9 @@ Project-local named modules and project-local header units are in the RC/stable-
 5. Typed runtime/subsystem CLI policy and cache semantics. **Done in #31.**
 6. Isolate C smart discovery from C++ module lexical syntax. **Done in #32.**
 7. Typed `mqb.json` runtime/subsystem policy with CLI precedence and real invalidation E2E. **Done in #33.**
-8. Target kinds: DLL and static library; static must have an explicit `lib.exe`/librarian backend rather than being modeled as `link.exe`.
-9. Close the remaining high-value coupled MSVC policy gap (notably LTCG and any charset requirement proven by parity fixtures).
-10. Shared PowerShell-vs-C++ fixtures for ordinary targets, config precedence, incremental rebuilds, libraries, run argv, x86/x64, Debug/Release, and failure behavior.
-11. Installer/profile/`build` command cutover and clean-machine upgrade/rollback validation.
-12. Generalize the release workflow and publish stable v5 only from the exact validated artifact.
+8. Native DLL target kind with typed linker routing, deterministic import library, and side-output repair. **Done in #35 once merged.**
+9. Static-library target with an explicit `lib.exe`/librarian backend and archive cache owner.
+10. Close the remaining high-value coupled MSVC policy gap (notably LTCG and any charset requirement proven by parity fixtures).
+11. Shared PowerShell-vs-C++ fixtures for ordinary targets, config precedence, incremental rebuilds, libraries, run argv, x86/x64, Debug/Release, and failure behavior.
+12. Installer/profile/`build` command cutover and clean-machine upgrade/rollback validation.
+13. Generalize the release workflow and publish stable v5 only from the exact validated artifact.


### PR DESCRIPTION
Implements the first native target-kind expansion after `v5.0.0-rc.2`.

## Scope

- add typed `TargetKind` ownership to Core build/link policy
- preserve the historical executable link signature byte stream; DLL links append a versioned target-kind domain
- select `.exe` / `.dll` target artifacts from `ProjectArtifactLayout`
- add strict `mqb.json build.type` support for `exe` / `dll`
- add native `--type <exe|dll>` and legacy-compatible `-type` routing
- emit structured MSVC `/DLL` and deterministic `/IMPLIB:<target>.lib` after raw linker arguments
- persist observed DLL linker side outputs in backward-compatible link-cache v3 and repair missing `.lib/.exp` via link-only rebuild
- keep static libraries fail-closed until the dedicated `lib.exe` librarian pipeline lands
- reject `--run` for non-executable targets
- route ordinary and module/header-unit targets through the same typed link policy

## Final validation

Final exact head: `468b3f8d77a94abcc385806248ee9fc5e7d81b22`.

- C++ V2 workflow #284: **success** — full Debug build and **65/65 CTest**
- C++ Release Candidate workflow #58: **success** — Release build, **65/65 CTest**, embedded rc.2 version gate, package/checksum staging and artifact upload; publish skipped by design on PR
- real VS2026 DLL E2E proves:
  - cold DLL compile/link
  - deterministic `.dll`, import `.lib`, and export `.exp`
  - `LoadLibraryW` / `GetProcAddress` calls an exported function
  - warm compile/link cache reuse
  - deleting recorded import `.lib` keeps TU up-to-date and triggers link-only `missing output` repair
  - source mutation recompiles/relinks and changes exported behavior
  - DLL `--run` fails at the executable-only validation boundary

Static-library support remains intentionally outside this PR and is the next librarian-backed mainline slice.