### PR TITLE
feat: add native static-library targets

### DIFF
--- a/cpp/apps/mqb/CMakeLists.txt
+++ b/cpp/apps/mqb/CMakeLists.txt
@@ -24,6 +24,7 @@ target_compile_definitions(mqb_cli PRIVATE MQB_VERSION="${MQB_VERSION}")
 add_executable(mqb
     main.cpp
     ModuleCliTarget.cpp
+    StaticCliTarget.cpp
 )
 
 target_link_libraries(mqb

--- a/cpp/apps/mqb/Cli.cpp
+++ b/cpp/apps/mqb/Cli.cpp
@@ -17,73 +17,104 @@
 namespace mqb::cli {
 namespace {
 
-[[nodiscard]] Error error(std::string message) { return Error{.message = std::move(message)}; }
+[[nodiscard]] Error error(std::string message) {
+    return Error{.message = std::move(message)};
+}
 
-[[nodiscard]] std::expected<std::string_view, Error> require_value(
+[[nodiscard]] std::expected<std::string_view, Error>
+require_value(
     const std::span<const std::string_view> arguments,
     std::size_t& index,
     const std::string_view option) {
-    if (index + 1 >= arguments.size()) return std::unexpected(error("missing value for " + std::string{option}));
+    if (index + 1 >= arguments.size()) {
+        return std::unexpected(error("missing value for " + std::string{option}));
+    }
     ++index;
-    if (arguments[index].empty()) return std::unexpected(error("empty value for " + std::string{option}));
+    if (arguments[index].empty()) {
+        return std::unexpected(error("empty value for " + std::string{option}));
+    }
     return arguments[index];
 }
 
-[[nodiscard]] std::expected<CppStandard, Error> parse_standard(const std::string_view value) {
+[[nodiscard]] std::expected<CppStandard, Error>
+parse_standard(const std::string_view value) {
     if (value == "14" || value == "c++14") return CppStandard::cpp14;
     if (value == "17" || value == "c++17") return CppStandard::cpp17;
     if (value == "20" || value == "c++20") return CppStandard::cpp20;
     if (value == "23" || value == "c++23") return CppStandard::cpp23;
     if (value == "latest" || value == "c++latest") return CppStandard::latest;
-    return std::unexpected(error("unsupported C++ standard '" + std::string{value} + "' (expected 14, 17, 20, 23, or latest)"));
+    return std::unexpected(error(
+        "unsupported C++ standard '" + std::string{value}
+        + "' (expected 14, 17, 20, 23, or latest)"));
 }
 
-[[nodiscard]] std::expected<BuildConfiguration, Error> parse_configuration(const std::string_view value) {
+[[nodiscard]] std::expected<BuildConfiguration, Error>
+parse_configuration(const std::string_view value) {
     if (value == "debug") return BuildConfiguration::debug;
     if (value == "release") return BuildConfiguration::release;
-    return std::unexpected(error("unsupported build configuration '" + std::string{value} + "' (expected debug or release)"));
+    return std::unexpected(error(
+        "unsupported build configuration '" + std::string{value}
+        + "' (expected debug or release)"));
 }
 
-[[nodiscard]] std::expected<TargetKind, Error> parse_target_kind(const std::string_view value) {
+[[nodiscard]] std::expected<TargetKind, Error>
+parse_target_kind(const std::string_view value) {
     if (value == "exe" || value == "executable") return TargetKind::executable;
     if (value == "dll" || value == "dynamic") return TargetKind::dynamic_library;
     if (value == "static" || value == "lib") return TargetKind::static_library;
-    return std::unexpected(error("unsupported target kind '" + std::string{value} + "' (expected exe, dll, or static)"));
+    return std::unexpected(error(
+        "unsupported target kind '" + std::string{value}
+        + "' (expected exe, dll, or static)"));
 }
 
-[[nodiscard]] std::expected<RuntimeLibrary, Error> parse_runtime(const std::string_view value) {
+[[nodiscard]] std::expected<RuntimeLibrary, Error>
+parse_runtime(const std::string_view value) {
     if (value == "MD" || value == "md") return RuntimeLibrary::md;
     if (value == "MDd" || value == "mdd") return RuntimeLibrary::mdd;
     if (value == "MT" || value == "mt") return RuntimeLibrary::mt;
     if (value == "MTd" || value == "mtd") return RuntimeLibrary::mtd;
-    return std::unexpected(error("unsupported runtime library '" + std::string{value} + "' (expected MD, MDd, MT, or MTd)"));
+    return std::unexpected(error(
+        "unsupported runtime library '" + std::string{value}
+        + "' (expected MD, MDd, MT, or MTd)"));
 }
 
-[[nodiscard]] std::expected<LinkSubsystem, Error> parse_subsystem(const std::string_view value) {
+[[nodiscard]] std::expected<LinkSubsystem, Error>
+parse_subsystem(const std::string_view value) {
     if (value == "console") return LinkSubsystem::console;
     if (value == "windows") return LinkSubsystem::windows;
-    return std::unexpected(error("unsupported subsystem '" + std::string{value} + "' (expected console or windows)"));
+    return std::unexpected(error(
+        "unsupported subsystem '" + std::string{value}
+        + "' (expected console or windows)"));
 }
 
-[[nodiscard]] std::expected<std::size_t, Error> parse_jobs(const std::string_view value) {
+[[nodiscard]] std::expected<std::size_t, Error>
+parse_jobs(const std::string_view value) {
     std::size_t jobs = 0;
     const char* const begin = value.data();
     const char* const end = value.data() + value.size();
     const auto [parsed_end, parse_error] = std::from_chars(begin, end, jobs);
     if (parse_error != std::errc{} || parsed_end != end || jobs == 0) {
-        return std::unexpected(error("invalid compile job count '" + std::string{value} + "' (expected a positive integer)"));
+        return std::unexpected(error(
+            "invalid compile job count '" + std::string{value}
+            + "' (expected a positive integer)"));
     }
     return jobs;
 }
 
-[[nodiscard]] std::expected<msvc::ToolchainPreference, Error> parse_toolchain_preference(const std::string_view value) {
+[[nodiscard]] std::expected<msvc::ToolchainPreference, Error>
+parse_toolchain_preference(const std::string_view value) {
     if (value == "auto") return msvc::ToolchainPreference::automatic;
     if (value == "vs") return msvc::ToolchainPreference::visual_studio;
-    if (value == "portable" || value == "port" || value == "p") return msvc::ToolchainPreference::portable;
-    return std::unexpected(error("unsupported toolchain preference '" + std::string{value} + "' (expected auto, vs, or portable)"));
+    if (value == "portable" || value == "port" || value == "p") {
+        return msvc::ToolchainPreference::portable;
+    }
+    return std::unexpected(error(
+        "unsupported toolchain preference '" + std::string{value}
+        + "' (expected auto, vs, or portable)"));
 }
 
-[[nodiscard]] std::expected<std::string_view, Error> attached_or_next(
+[[nodiscard]] std::expected<std::string_view, Error>
+attached_or_next(
     const std::span<const std::string_view> arguments,
     std::size_t& index,
     const std::string_view argument,
@@ -92,143 +123,295 @@ namespace {
     return require_value(arguments, index, option);
 }
 
-[[nodiscard]] std::expected<std::string_view, Error> long_equals_value(
+[[nodiscard]] std::expected<std::string_view, Error>
+long_equals_value(
     const std::string_view argument,
     const std::string_view prefix) {
     const std::string_view value = argument.substr(prefix.size());
-    if (value.empty()) return std::unexpected(error("empty value for " + std::string{prefix.substr(0, prefix.size() - 1)}));
+    if (value.empty()) {
+        return std::unexpected(error(
+            "empty value for " + std::string{prefix.substr(0, prefix.size() - 1)}));
+    }
     return value;
 }
 
 } // namespace
 
-std::expected<Options, Error> parse_arguments(const std::span<const std::string_view> arguments) {
+std::expected<Options, Error>
+parse_arguments(const std::span<const std::string_view> arguments) {
     Options options;
+
     for (std::size_t index = 0; index < arguments.size(); ++index) {
         const std::string_view argument = arguments[index];
+
         if (argument == "--") {
-            for (++index; index < arguments.size(); ++index) options.build.run_arguments.emplace_back(arguments[index]);
+            for (++index; index < arguments.size(); ++index) {
+                options.build.run_arguments.emplace_back(arguments[index]);
+            }
             break;
         }
-        if (argument == "-h" || argument == "--help" || argument == "-help" || argument == "-?") { options.show_help = true; continue; }
-        if (argument == "--verbose" || argument == "-v") { options.verbose = true; continue; }
-        if (argument == "--discover") { options.discover_sources = true; options.discovery_override = true; continue; }
-        if (argument == "--no-discover") { options.discover_sources = false; options.discovery_override = false; continue; }
-        if (argument == "--run" || argument == "-run") { options.build.run_after_build = true; continue; }
+        if (argument == "-h" || argument == "--help"
+            || argument == "-help" || argument == "-?") {
+            options.show_help = true;
+            continue;
+        }
+        if (argument == "--verbose" || argument == "-v") {
+            options.verbose = true;
+            continue;
+        }
+        if (argument == "--discover") {
+            options.discover_sources = true;
+            options.discovery_override = true;
+            continue;
+        }
+        if (argument == "--no-discover") {
+            options.discover_sources = false;
+            options.discovery_override = false;
+            continue;
+        }
+        if (argument == "--run" || argument == "-run") {
+            options.build.run_after_build = true;
+            continue;
+        }
         if (argument == "-j" || argument == "--jobs") {
-            auto value = require_value(arguments, index, argument); if (!value) return std::unexpected(value.error());
-            auto jobs = parse_jobs(*value); if (!jobs) return std::unexpected(jobs.error()); options.jobs = *jobs; continue;
+            auto value = require_value(arguments, index, argument);
+            if (!value) return std::unexpected(value.error());
+            auto jobs = parse_jobs(*value);
+            if (!jobs) return std::unexpected(jobs.error());
+            options.jobs = *jobs;
+            continue;
         }
         if (argument.starts_with("--jobs=")) {
-            auto value = long_equals_value(argument, "--jobs="); if (!value) return std::unexpected(value.error());
-            auto jobs = parse_jobs(*value); if (!jobs) return std::unexpected(jobs.error()); options.jobs = *jobs; continue;
+            auto value = long_equals_value(argument, "--jobs=");
+            if (!value) return std::unexpected(value.error());
+            auto jobs = parse_jobs(*value);
+            if (!jobs) return std::unexpected(jobs.error());
+            options.jobs = *jobs;
+            continue;
         }
         if (argument.starts_with("-j") && argument.size() > 2) {
-            auto jobs = parse_jobs(argument.substr(2)); if (!jobs) return std::unexpected(jobs.error()); options.jobs = *jobs; continue;
+            auto jobs = parse_jobs(argument.substr(2));
+            if (!jobs) return std::unexpected(jobs.error());
+            options.jobs = *jobs;
+            continue;
         }
         if (argument == "-o" || argument == "--output" || argument == "-output") {
-            auto value = require_value(arguments, index, argument); if (!value) return std::unexpected(value.error()); options.build.output_name = std::string{*value}; continue;
+            auto value = require_value(arguments, index, argument);
+            if (!value) return std::unexpected(value.error());
+            options.build.output_name = std::string{*value};
+            continue;
         }
         if (argument.starts_with("--output=")) {
-            auto value = long_equals_value(argument, "--output="); if (!value) return std::unexpected(value.error()); options.build.output_name = std::string{*value}; continue;
+            auto value = long_equals_value(argument, "--output=");
+            if (!value) return std::unexpected(value.error());
+            options.build.output_name = std::string{*value};
+            continue;
         }
         if (argument == "--type" || argument == "-type") {
-            auto value = require_value(arguments, index, argument); if (!value) return std::unexpected(value.error());
-            auto target_kind = parse_target_kind(*value); if (!target_kind) return std::unexpected(target_kind.error());
-            options.build.target_kind = *target_kind; options.target_kind_override = *target_kind; continue;
+            auto value = require_value(arguments, index, argument);
+            if (!value) return std::unexpected(value.error());
+            auto target_kind = parse_target_kind(*value);
+            if (!target_kind) return std::unexpected(target_kind.error());
+            options.build.target_kind = *target_kind;
+            options.target_kind_override = *target_kind;
+            continue;
         }
         if (argument.starts_with("--type=")) {
-            auto value = long_equals_value(argument, "--type="); if (!value) return std::unexpected(value.error());
-            auto target_kind = parse_target_kind(*value); if (!target_kind) return std::unexpected(target_kind.error());
-            options.build.target_kind = *target_kind; options.target_kind_override = *target_kind; continue;
+            auto value = long_equals_value(argument, "--type=");
+            if (!value) return std::unexpected(value.error());
+            auto target_kind = parse_target_kind(*value);
+            if (!target_kind) return std::unexpected(target_kind.error());
+            options.build.target_kind = *target_kind;
+            options.target_kind_override = *target_kind;
+            continue;
         }
-        if (argument == "--debug") { options.build.configuration = BuildConfiguration::debug; options.configuration_override = BuildConfiguration::debug; continue; }
-        if (argument == "--release") { options.build.configuration = BuildConfiguration::release; options.configuration_override = BuildConfiguration::release; continue; }
+        if (argument == "--debug") {
+            options.build.configuration = BuildConfiguration::debug;
+            options.configuration_override = BuildConfiguration::debug;
+            continue;
+        }
+        if (argument == "--release") {
+            options.build.configuration = BuildConfiguration::release;
+            options.configuration_override = BuildConfiguration::release;
+            continue;
+        }
         if (argument == "--config" || argument == "-config") {
-            auto value = require_value(arguments, index, argument); if (!value) return std::unexpected(value.error());
-            auto configuration = parse_configuration(*value); if (!configuration) return std::unexpected(configuration.error());
-            options.build.configuration = *configuration; options.configuration_override = *configuration; continue;
+            auto value = require_value(arguments, index, argument);
+            if (!value) return std::unexpected(value.error());
+            auto configuration = parse_configuration(*value);
+            if (!configuration) return std::unexpected(configuration.error());
+            options.build.configuration = *configuration;
+            options.configuration_override = *configuration;
+            continue;
         }
-        if (argument == "--x86" || argument == "-x86") { options.build.architecture = Architecture::x86; options.architecture_override = Architecture::x86; continue; }
-        if (argument == "--x64" || argument == "-x64") { options.build.architecture = Architecture::x64; options.architecture_override = Architecture::x64; continue; }
+        if (argument == "--x86" || argument == "-x86") {
+            options.build.architecture = Architecture::x86;
+            options.architecture_override = Architecture::x86;
+            continue;
+        }
+        if (argument == "--x64" || argument == "-x64") {
+            options.build.architecture = Architecture::x64;
+            options.architecture_override = Architecture::x64;
+            continue;
+        }
         if (argument == "--std" || argument == "-std") {
-            auto value = require_value(arguments, index, argument); if (!value) return std::unexpected(value.error());
-            auto standard = parse_standard(*value); if (!standard) return std::unexpected(standard.error()); options.build.standard = *standard; options.standard_override = *standard; continue;
+            auto value = require_value(arguments, index, argument);
+            if (!value) return std::unexpected(value.error());
+            auto standard = parse_standard(*value);
+            if (!standard) return std::unexpected(standard.error());
+            options.build.standard = *standard;
+            options.standard_override = *standard;
+            continue;
         }
         if (argument == "--runtime" || argument == "-runtime") {
-            auto value = require_value(arguments, index, argument); if (!value) return std::unexpected(value.error());
-            auto runtime = parse_runtime(*value); if (!runtime) return std::unexpected(runtime.error()); options.runtime_override = *runtime; continue;
+            auto value = require_value(arguments, index, argument);
+            if (!value) return std::unexpected(value.error());
+            auto runtime = parse_runtime(*value);
+            if (!runtime) return std::unexpected(runtime.error());
+            options.runtime_override = *runtime;
+            continue;
         }
         if (argument.starts_with("--runtime=")) {
-            auto value = long_equals_value(argument, "--runtime="); if (!value) return std::unexpected(value.error());
-            auto runtime = parse_runtime(*value); if (!runtime) return std::unexpected(runtime.error()); options.runtime_override = *runtime; continue;
+            auto value = long_equals_value(argument, "--runtime=");
+            if (!value) return std::unexpected(value.error());
+            auto runtime = parse_runtime(*value);
+            if (!runtime) return std::unexpected(runtime.error());
+            options.runtime_override = *runtime;
+            continue;
         }
         if (argument == "--subsystem" || argument == "-subsystem") {
-            auto value = require_value(arguments, index, argument); if (!value) return std::unexpected(value.error());
-            auto subsystem = parse_subsystem(*value); if (!subsystem) return std::unexpected(subsystem.error()); options.subsystem_override = *subsystem; continue;
+            auto value = require_value(arguments, index, argument);
+            if (!value) return std::unexpected(value.error());
+            auto subsystem = parse_subsystem(*value);
+            if (!subsystem) return std::unexpected(subsystem.error());
+            options.subsystem_override = *subsystem;
+            continue;
         }
         if (argument.starts_with("--subsystem=")) {
-            auto value = long_equals_value(argument, "--subsystem="); if (!value) return std::unexpected(value.error());
-            auto subsystem = parse_subsystem(*value); if (!subsystem) return std::unexpected(subsystem.error()); options.subsystem_override = *subsystem; continue;
+            auto value = long_equals_value(argument, "--subsystem=");
+            if (!value) return std::unexpected(value.error());
+            auto subsystem = parse_subsystem(*value);
+            if (!subsystem) return std::unexpected(subsystem.error());
+            options.subsystem_override = *subsystem;
+            continue;
         }
         if (argument == "--compiler-arg" || argument == "-flags") {
-            auto value = require_value(arguments, index, argument); if (!value) return std::unexpected(value.error()); options.compiler_arguments.emplace_back(*value); continue;
+            auto value = require_value(arguments, index, argument);
+            if (!value) return std::unexpected(value.error());
+            options.compiler_arguments.emplace_back(*value);
+            continue;
         }
         if (argument.starts_with("--compiler-arg=")) {
-            auto value = long_equals_value(argument, "--compiler-arg="); if (!value) return std::unexpected(value.error()); options.compiler_arguments.emplace_back(*value); continue;
+            auto value = long_equals_value(argument, "--compiler-arg=");
+            if (!value) return std::unexpected(value.error());
+            options.compiler_arguments.emplace_back(*value);
+            continue;
         }
         if (argument == "--linker-arg" || argument == "-link_flags") {
-            auto value = require_value(arguments, index, argument); if (!value) return std::unexpected(value.error()); options.linker_arguments.emplace_back(*value); continue;
+            auto value = require_value(arguments, index, argument);
+            if (!value) return std::unexpected(value.error());
+            options.linker_arguments.emplace_back(*value);
+            continue;
         }
         if (argument.starts_with("--linker-arg=")) {
-            auto value = long_equals_value(argument, "--linker-arg="); if (!value) return std::unexpected(value.error()); options.linker_arguments.emplace_back(*value); continue;
+            auto value = long_equals_value(argument, "--linker-arg=");
+            if (!value) return std::unexpected(value.error());
+            options.linker_arguments.emplace_back(*value);
+            continue;
         }
         if (argument == "--env" || argument == "-env") {
-            auto value = require_value(arguments, index, argument); if (!value) return std::unexpected(value.error());
-            auto preference = parse_toolchain_preference(*value); if (!preference) return std::unexpected(preference.error()); options.toolchain_preference = *preference; continue;
+            auto value = require_value(arguments, index, argument);
+            if (!value) return std::unexpected(value.error());
+            auto preference = parse_toolchain_preference(*value);
+            if (!preference) return std::unexpected(preference.error());
+            options.toolchain_preference = *preference;
+            continue;
         }
         if (argument == "--portable-root") {
-            auto value = require_value(arguments, index, argument); if (!value) return std::unexpected(value.error()); options.portable_roots.emplace_back(std::string{*value}); continue;
+            auto value = require_value(arguments, index, argument);
+            if (!value) return std::unexpected(value.error());
+            options.portable_roots.emplace_back(std::string{*value});
+            continue;
         }
         if (argument == "--lib-path" || argument == "-libpath") {
-            auto value = require_value(arguments, index, argument); if (!value) return std::unexpected(value.error()); options.library_directories.emplace_back(std::string{*value}); continue;
+            auto value = require_value(arguments, index, argument);
+            if (!value) return std::unexpected(value.error());
+            options.library_directories.emplace_back(std::string{*value});
+            continue;
         }
         if (argument.starts_with("--lib-path=")) {
-            auto value = long_equals_value(argument, "--lib-path="); if (!value) return std::unexpected(value.error()); options.library_directories.emplace_back(std::string{*value}); continue;
+            auto value = long_equals_value(argument, "--lib-path=");
+            if (!value) return std::unexpected(value.error());
+            options.library_directories.emplace_back(std::string{*value});
+            continue;
         }
         if (argument == "--lib" || argument == "-libs") {
-            auto value = require_value(arguments, index, argument); if (!value) return std::unexpected(value.error()); options.libraries.emplace_back(*value); continue;
+            auto value = require_value(arguments, index, argument);
+            if (!value) return std::unexpected(value.error());
+            options.libraries.emplace_back(*value);
+            continue;
         }
         if (argument.starts_with("--lib=")) {
-            auto value = long_equals_value(argument, "--lib="); if (!value) return std::unexpected(value.error()); options.libraries.emplace_back(*value); continue;
+            auto value = long_equals_value(argument, "--lib=");
+            if (!value) return std::unexpected(value.error());
+            options.libraries.emplace_back(*value);
+            continue;
         }
         if (argument == "-include") {
-            auto value = require_value(arguments, index, argument); if (!value) return std::unexpected(value.error()); options.include_directories.emplace_back(std::string{*value}); continue;
+            auto value = require_value(arguments, index, argument);
+            if (!value) return std::unexpected(value.error());
+            options.include_directories.emplace_back(std::string{*value});
+            continue;
         }
         if (argument == "-defines") {
-            auto value = require_value(arguments, index, argument); if (!value) return std::unexpected(value.error()); options.defines.emplace_back(*value); continue;
+            auto value = require_value(arguments, index, argument);
+            if (!value) return std::unexpected(value.error());
+            options.defines.emplace_back(*value);
+            continue;
         }
         if (argument == "-I" || argument.starts_with("-I")) {
-            auto value = attached_or_next(arguments, index, argument, "-I"); if (!value) return std::unexpected(value.error());
-            if (value->empty()) return std::unexpected(error("empty include directory")); options.include_directories.emplace_back(std::string{*value}); continue;
+            auto value = attached_or_next(arguments, index, argument, "-I");
+            if (!value) return std::unexpected(value.error());
+            if (value->empty()) return std::unexpected(error("empty include directory"));
+            options.include_directories.emplace_back(std::string{*value});
+            continue;
         }
         if (argument == "-D" || argument.starts_with("-D")) {
-            auto value = attached_or_next(arguments, index, argument, "-D"); if (!value) return std::unexpected(value.error());
-            if (value->empty()) return std::unexpected(error("empty preprocessor define")); options.defines.emplace_back(std::string{*value}); continue;
+            auto value = attached_or_next(arguments, index, argument, "-D");
+            if (!value) return std::unexpected(value.error());
+            if (value->empty()) return std::unexpected(error("empty preprocessor define"));
+            options.defines.emplace_back(std::string{*value});
+            continue;
         }
         if (argument == "-L" || argument.starts_with("-L")) {
-            auto value = attached_or_next(arguments, index, argument, "-L"); if (!value) return std::unexpected(value.error());
-            if (value->empty()) return std::unexpected(error("empty library directory")); options.library_directories.emplace_back(std::string{*value}); continue;
+            auto value = attached_or_next(arguments, index, argument, "-L");
+            if (!value) return std::unexpected(value.error());
+            if (value->empty()) return std::unexpected(error("empty library directory"));
+            options.library_directories.emplace_back(std::string{*value});
+            continue;
         }
         if (argument == "-l" || argument.starts_with("-l")) {
-            auto value = attached_or_next(arguments, index, argument, "-l"); if (!value) return std::unexpected(value.error());
-            if (value->empty()) return std::unexpected(error("empty library name")); options.libraries.emplace_back(std::string{*value}); continue;
+            auto value = attached_or_next(arguments, index, argument, "-l");
+            if (!value) return std::unexpected(value.error());
+            if (value->empty()) return std::unexpected(error("empty library name"));
+            options.libraries.emplace_back(std::string{*value});
+            continue;
         }
-        if (!argument.empty() && argument.front() == '-') return std::unexpected(error("unknown option '" + std::string{argument} + "'"));
+        if (!argument.empty() && argument.front() == '-') {
+            return std::unexpected(error("unknown option '" + std::string{argument} + "'"));
+        }
+
         options.build.sources.emplace_back(std::string{argument});
     }
-    if (!options.show_help && options.build.sources.empty()) return std::unexpected(error("missing source file"));
-    if (!options.show_help && !options.build.run_after_build && !options.build.run_arguments.empty()) return std::unexpected(error("arguments after -- require --run"));
+
+    if (!options.show_help && options.build.sources.empty()) {
+        return std::unexpected(error("missing source file"));
+    }
+    if (!options.show_help
+        && !options.build.run_after_build
+        && !options.build.run_arguments.empty()) {
+        return std::unexpected(error("arguments after -- require --run"));
+    }
     return options;
 }
 
@@ -295,7 +478,11 @@ archive and is rejected when explicitly supplied for a static target.
 
 Raw compiler/linker arguments are one argv element per option occurrence; MQB does not split a
 quoted string into multiple switches. Project config entries are applied first and CLI raw args
-append afterward. Structured artifact routing remains backend-owned.
+append afterward. Structured artifact routing such as /Fo, /scanDependencies, /DLL, /IMPLIB,
+/MACHINE and /OUT is emitted after raw arguments so the BuildPlan remains authoritative.
+
+Legacy compatibility aliases intentionally cover spelling only. Legacy-only semantics such as
+-a string splitting remain tracked by the stable-v5 parity inventory and are not silently accepted here.
 
 Job count is execution policy only; changing -j does not invalidate build caches.
 Discovery is source selection only. Incremental header freshness continues to use
@@ -306,7 +493,7 @@ Generated state:
   .mqb/deps/   compiler dependency metadata
   .mqb/scan/   module dependency scan metadata
   .mqb/ifc/    module/header-unit interface artifacts
-  .mqb/cache/  compile/link/archive cache metadata
+  .mqb/cache/  compile, link, and archive cache metadata
   .mqb/bin/    executable, DLL/import-library, or static-library target artifacts
 )";
 }

--- a/cpp/apps/mqb/Cli.cpp
+++ b/cpp/apps/mqb/Cli.cpp
@@ -17,107 +17,73 @@
 namespace mqb::cli {
 namespace {
 
-[[nodiscard]] Error error(std::string message) {
-    return Error{.message = std::move(message)};
-}
+[[nodiscard]] Error error(std::string message) { return Error{.message = std::move(message)}; }
 
-[[nodiscard]] std::expected<std::string_view, Error>
-require_value(
+[[nodiscard]] std::expected<std::string_view, Error> require_value(
     const std::span<const std::string_view> arguments,
     std::size_t& index,
     const std::string_view option) {
-    if (index + 1 >= arguments.size()) {
-        return std::unexpected(error("missing value for " + std::string{option}));
-    }
+    if (index + 1 >= arguments.size()) return std::unexpected(error("missing value for " + std::string{option}));
     ++index;
-    if (arguments[index].empty()) {
-        return std::unexpected(error("empty value for " + std::string{option}));
-    }
+    if (arguments[index].empty()) return std::unexpected(error("empty value for " + std::string{option}));
     return arguments[index];
 }
 
-[[nodiscard]] std::expected<CppStandard, Error>
-parse_standard(const std::string_view value) {
+[[nodiscard]] std::expected<CppStandard, Error> parse_standard(const std::string_view value) {
     if (value == "14" || value == "c++14") return CppStandard::cpp14;
     if (value == "17" || value == "c++17") return CppStandard::cpp17;
     if (value == "20" || value == "c++20") return CppStandard::cpp20;
     if (value == "23" || value == "c++23") return CppStandard::cpp23;
     if (value == "latest" || value == "c++latest") return CppStandard::latest;
-    return std::unexpected(error(
-        "unsupported C++ standard '" + std::string{value}
-        + "' (expected 14, 17, 20, 23, or latest)"));
+    return std::unexpected(error("unsupported C++ standard '" + std::string{value} + "' (expected 14, 17, 20, 23, or latest)"));
 }
 
-[[nodiscard]] std::expected<BuildConfiguration, Error>
-parse_configuration(const std::string_view value) {
+[[nodiscard]] std::expected<BuildConfiguration, Error> parse_configuration(const std::string_view value) {
     if (value == "debug") return BuildConfiguration::debug;
     if (value == "release") return BuildConfiguration::release;
-    return std::unexpected(error(
-        "unsupported build configuration '" + std::string{value}
-        + "' (expected debug or release)"));
+    return std::unexpected(error("unsupported build configuration '" + std::string{value} + "' (expected debug or release)"));
 }
 
-[[nodiscard]] std::expected<TargetKind, Error>
-parse_target_kind(const std::string_view value) {
+[[nodiscard]] std::expected<TargetKind, Error> parse_target_kind(const std::string_view value) {
     if (value == "exe" || value == "executable") return TargetKind::executable;
     if (value == "dll" || value == "dynamic") return TargetKind::dynamic_library;
-    if (value == "static" || value == "lib") {
-        return std::unexpected(error(
-            "static-library targets require the upcoming MSVC librarian pipeline"));
-    }
-    return std::unexpected(error(
-        "unsupported target kind '" + std::string{value}
-        + "' (expected exe or dll)"));
+    if (value == "static" || value == "lib") return TargetKind::static_library;
+    return std::unexpected(error("unsupported target kind '" + std::string{value} + "' (expected exe, dll, or static)"));
 }
 
-[[nodiscard]] std::expected<RuntimeLibrary, Error>
-parse_runtime(const std::string_view value) {
+[[nodiscard]] std::expected<RuntimeLibrary, Error> parse_runtime(const std::string_view value) {
     if (value == "MD" || value == "md") return RuntimeLibrary::md;
     if (value == "MDd" || value == "mdd") return RuntimeLibrary::mdd;
     if (value == "MT" || value == "mt") return RuntimeLibrary::mt;
     if (value == "MTd" || value == "mtd") return RuntimeLibrary::mtd;
-    return std::unexpected(error(
-        "unsupported runtime library '" + std::string{value}
-        + "' (expected MD, MDd, MT, or MTd)"));
+    return std::unexpected(error("unsupported runtime library '" + std::string{value} + "' (expected MD, MDd, MT, or MTd)"));
 }
 
-[[nodiscard]] std::expected<LinkSubsystem, Error>
-parse_subsystem(const std::string_view value) {
+[[nodiscard]] std::expected<LinkSubsystem, Error> parse_subsystem(const std::string_view value) {
     if (value == "console") return LinkSubsystem::console;
     if (value == "windows") return LinkSubsystem::windows;
-    return std::unexpected(error(
-        "unsupported subsystem '" + std::string{value}
-        + "' (expected console or windows)"));
+    return std::unexpected(error("unsupported subsystem '" + std::string{value} + "' (expected console or windows)"));
 }
 
-[[nodiscard]] std::expected<std::size_t, Error>
-parse_jobs(const std::string_view value) {
+[[nodiscard]] std::expected<std::size_t, Error> parse_jobs(const std::string_view value) {
     std::size_t jobs = 0;
     const char* const begin = value.data();
     const char* const end = value.data() + value.size();
     const auto [parsed_end, parse_error] = std::from_chars(begin, end, jobs);
     if (parse_error != std::errc{} || parsed_end != end || jobs == 0) {
-        return std::unexpected(error(
-            "invalid compile job count '" + std::string{value}
-            + "' (expected a positive integer)"));
+        return std::unexpected(error("invalid compile job count '" + std::string{value} + "' (expected a positive integer)"));
     }
     return jobs;
 }
 
-[[nodiscard]] std::expected<msvc::ToolchainPreference, Error>
-parse_toolchain_preference(const std::string_view value) {
+[[nodiscard]] std::expected<msvc::ToolchainPreference, Error> parse_toolchain_preference(const std::string_view value) {
     if (value == "auto") return msvc::ToolchainPreference::automatic;
     if (value == "vs") return msvc::ToolchainPreference::visual_studio;
-    if (value == "portable" || value == "port" || value == "p") {
-        return msvc::ToolchainPreference::portable;
-    }
-    return std::unexpected(error(
-        "unsupported toolchain preference '" + std::string{value}
-        + "' (expected auto, vs, or portable)"));
+    if (value == "portable" || value == "port" || value == "p") return msvc::ToolchainPreference::portable;
+    return std::unexpected(error("unsupported toolchain preference '" + std::string{value} + "' (expected auto, vs, or portable)"));
 }
 
-[[nodiscard]] std::expected<std::string_view, Error>
-attached_or_next(
+[[nodiscard]] std::expected<std::string_view, Error> attached_or_next(
     const std::span<const std::string_view> arguments,
     std::size_t& index,
     const std::string_view argument,
@@ -126,295 +92,143 @@ attached_or_next(
     return require_value(arguments, index, option);
 }
 
-[[nodiscard]] std::expected<std::string_view, Error>
-long_equals_value(
+[[nodiscard]] std::expected<std::string_view, Error> long_equals_value(
     const std::string_view argument,
     const std::string_view prefix) {
     const std::string_view value = argument.substr(prefix.size());
-    if (value.empty()) {
-        return std::unexpected(error(
-            "empty value for " + std::string{prefix.substr(0, prefix.size() - 1)}));
-    }
+    if (value.empty()) return std::unexpected(error("empty value for " + std::string{prefix.substr(0, prefix.size() - 1)}));
     return value;
 }
 
 } // namespace
 
-std::expected<Options, Error>
-parse_arguments(const std::span<const std::string_view> arguments) {
+std::expected<Options, Error> parse_arguments(const std::span<const std::string_view> arguments) {
     Options options;
-
     for (std::size_t index = 0; index < arguments.size(); ++index) {
         const std::string_view argument = arguments[index];
-
         if (argument == "--") {
-            for (++index; index < arguments.size(); ++index) {
-                options.build.run_arguments.emplace_back(arguments[index]);
-            }
+            for (++index; index < arguments.size(); ++index) options.build.run_arguments.emplace_back(arguments[index]);
             break;
         }
-        if (argument == "-h" || argument == "--help"
-            || argument == "-help" || argument == "-?") {
-            options.show_help = true;
-            continue;
-        }
-        if (argument == "--verbose" || argument == "-v") {
-            options.verbose = true;
-            continue;
-        }
-        if (argument == "--discover") {
-            options.discover_sources = true;
-            options.discovery_override = true;
-            continue;
-        }
-        if (argument == "--no-discover") {
-            options.discover_sources = false;
-            options.discovery_override = false;
-            continue;
-        }
-        if (argument == "--run" || argument == "-run") {
-            options.build.run_after_build = true;
-            continue;
-        }
+        if (argument == "-h" || argument == "--help" || argument == "-help" || argument == "-?") { options.show_help = true; continue; }
+        if (argument == "--verbose" || argument == "-v") { options.verbose = true; continue; }
+        if (argument == "--discover") { options.discover_sources = true; options.discovery_override = true; continue; }
+        if (argument == "--no-discover") { options.discover_sources = false; options.discovery_override = false; continue; }
+        if (argument == "--run" || argument == "-run") { options.build.run_after_build = true; continue; }
         if (argument == "-j" || argument == "--jobs") {
-            auto value = require_value(arguments, index, argument);
-            if (!value) return std::unexpected(value.error());
-            auto jobs = parse_jobs(*value);
-            if (!jobs) return std::unexpected(jobs.error());
-            options.jobs = *jobs;
-            continue;
+            auto value = require_value(arguments, index, argument); if (!value) return std::unexpected(value.error());
+            auto jobs = parse_jobs(*value); if (!jobs) return std::unexpected(jobs.error()); options.jobs = *jobs; continue;
         }
         if (argument.starts_with("--jobs=")) {
-            auto value = long_equals_value(argument, "--jobs=");
-            if (!value) return std::unexpected(value.error());
-            auto jobs = parse_jobs(*value);
-            if (!jobs) return std::unexpected(jobs.error());
-            options.jobs = *jobs;
-            continue;
+            auto value = long_equals_value(argument, "--jobs="); if (!value) return std::unexpected(value.error());
+            auto jobs = parse_jobs(*value); if (!jobs) return std::unexpected(jobs.error()); options.jobs = *jobs; continue;
         }
         if (argument.starts_with("-j") && argument.size() > 2) {
-            auto jobs = parse_jobs(argument.substr(2));
-            if (!jobs) return std::unexpected(jobs.error());
-            options.jobs = *jobs;
-            continue;
+            auto jobs = parse_jobs(argument.substr(2)); if (!jobs) return std::unexpected(jobs.error()); options.jobs = *jobs; continue;
         }
         if (argument == "-o" || argument == "--output" || argument == "-output") {
-            auto value = require_value(arguments, index, argument);
-            if (!value) return std::unexpected(value.error());
-            options.build.output_name = std::string{*value};
-            continue;
+            auto value = require_value(arguments, index, argument); if (!value) return std::unexpected(value.error()); options.build.output_name = std::string{*value}; continue;
         }
         if (argument.starts_with("--output=")) {
-            auto value = long_equals_value(argument, "--output=");
-            if (!value) return std::unexpected(value.error());
-            options.build.output_name = std::string{*value};
-            continue;
+            auto value = long_equals_value(argument, "--output="); if (!value) return std::unexpected(value.error()); options.build.output_name = std::string{*value}; continue;
         }
         if (argument == "--type" || argument == "-type") {
-            auto value = require_value(arguments, index, argument);
-            if (!value) return std::unexpected(value.error());
-            auto target_kind = parse_target_kind(*value);
-            if (!target_kind) return std::unexpected(target_kind.error());
-            options.build.target_kind = *target_kind;
-            options.target_kind_override = *target_kind;
-            continue;
+            auto value = require_value(arguments, index, argument); if (!value) return std::unexpected(value.error());
+            auto target_kind = parse_target_kind(*value); if (!target_kind) return std::unexpected(target_kind.error());
+            options.build.target_kind = *target_kind; options.target_kind_override = *target_kind; continue;
         }
         if (argument.starts_with("--type=")) {
-            auto value = long_equals_value(argument, "--type=");
-            if (!value) return std::unexpected(value.error());
-            auto target_kind = parse_target_kind(*value);
-            if (!target_kind) return std::unexpected(target_kind.error());
-            options.build.target_kind = *target_kind;
-            options.target_kind_override = *target_kind;
-            continue;
+            auto value = long_equals_value(argument, "--type="); if (!value) return std::unexpected(value.error());
+            auto target_kind = parse_target_kind(*value); if (!target_kind) return std::unexpected(target_kind.error());
+            options.build.target_kind = *target_kind; options.target_kind_override = *target_kind; continue;
         }
-        if (argument == "--debug") {
-            options.build.configuration = BuildConfiguration::debug;
-            options.configuration_override = BuildConfiguration::debug;
-            continue;
-        }
-        if (argument == "--release") {
-            options.build.configuration = BuildConfiguration::release;
-            options.configuration_override = BuildConfiguration::release;
-            continue;
-        }
+        if (argument == "--debug") { options.build.configuration = BuildConfiguration::debug; options.configuration_override = BuildConfiguration::debug; continue; }
+        if (argument == "--release") { options.build.configuration = BuildConfiguration::release; options.configuration_override = BuildConfiguration::release; continue; }
         if (argument == "--config" || argument == "-config") {
-            auto value = require_value(arguments, index, argument);
-            if (!value) return std::unexpected(value.error());
-            auto configuration = parse_configuration(*value);
-            if (!configuration) return std::unexpected(configuration.error());
-            options.build.configuration = *configuration;
-            options.configuration_override = *configuration;
-            continue;
+            auto value = require_value(arguments, index, argument); if (!value) return std::unexpected(value.error());
+            auto configuration = parse_configuration(*value); if (!configuration) return std::unexpected(configuration.error());
+            options.build.configuration = *configuration; options.configuration_override = *configuration; continue;
         }
-        if (argument == "--x86" || argument == "-x86") {
-            options.build.architecture = Architecture::x86;
-            options.architecture_override = Architecture::x86;
-            continue;
-        }
-        if (argument == "--x64" || argument == "-x64") {
-            options.build.architecture = Architecture::x64;
-            options.architecture_override = Architecture::x64;
-            continue;
-        }
+        if (argument == "--x86" || argument == "-x86") { options.build.architecture = Architecture::x86; options.architecture_override = Architecture::x86; continue; }
+        if (argument == "--x64" || argument == "-x64") { options.build.architecture = Architecture::x64; options.architecture_override = Architecture::x64; continue; }
         if (argument == "--std" || argument == "-std") {
-            auto value = require_value(arguments, index, argument);
-            if (!value) return std::unexpected(value.error());
-            auto standard = parse_standard(*value);
-            if (!standard) return std::unexpected(standard.error());
-            options.build.standard = *standard;
-            options.standard_override = *standard;
-            continue;
+            auto value = require_value(arguments, index, argument); if (!value) return std::unexpected(value.error());
+            auto standard = parse_standard(*value); if (!standard) return std::unexpected(standard.error()); options.build.standard = *standard; options.standard_override = *standard; continue;
         }
         if (argument == "--runtime" || argument == "-runtime") {
-            auto value = require_value(arguments, index, argument);
-            if (!value) return std::unexpected(value.error());
-            auto runtime = parse_runtime(*value);
-            if (!runtime) return std::unexpected(runtime.error());
-            options.runtime_override = *runtime;
-            continue;
+            auto value = require_value(arguments, index, argument); if (!value) return std::unexpected(value.error());
+            auto runtime = parse_runtime(*value); if (!runtime) return std::unexpected(runtime.error()); options.runtime_override = *runtime; continue;
         }
         if (argument.starts_with("--runtime=")) {
-            auto value = long_equals_value(argument, "--runtime=");
-            if (!value) return std::unexpected(value.error());
-            auto runtime = parse_runtime(*value);
-            if (!runtime) return std::unexpected(runtime.error());
-            options.runtime_override = *runtime;
-            continue;
+            auto value = long_equals_value(argument, "--runtime="); if (!value) return std::unexpected(value.error());
+            auto runtime = parse_runtime(*value); if (!runtime) return std::unexpected(runtime.error()); options.runtime_override = *runtime; continue;
         }
         if (argument == "--subsystem" || argument == "-subsystem") {
-            auto value = require_value(arguments, index, argument);
-            if (!value) return std::unexpected(value.error());
-            auto subsystem = parse_subsystem(*value);
-            if (!subsystem) return std::unexpected(subsystem.error());
-            options.subsystem_override = *subsystem;
-            continue;
+            auto value = require_value(arguments, index, argument); if (!value) return std::unexpected(value.error());
+            auto subsystem = parse_subsystem(*value); if (!subsystem) return std::unexpected(subsystem.error()); options.subsystem_override = *subsystem; continue;
         }
         if (argument.starts_with("--subsystem=")) {
-            auto value = long_equals_value(argument, "--subsystem=");
-            if (!value) return std::unexpected(value.error());
-            auto subsystem = parse_subsystem(*value);
-            if (!subsystem) return std::unexpected(subsystem.error());
-            options.subsystem_override = *subsystem;
-            continue;
+            auto value = long_equals_value(argument, "--subsystem="); if (!value) return std::unexpected(value.error());
+            auto subsystem = parse_subsystem(*value); if (!subsystem) return std::unexpected(subsystem.error()); options.subsystem_override = *subsystem; continue;
         }
         if (argument == "--compiler-arg" || argument == "-flags") {
-            auto value = require_value(arguments, index, argument);
-            if (!value) return std::unexpected(value.error());
-            options.compiler_arguments.emplace_back(*value);
-            continue;
+            auto value = require_value(arguments, index, argument); if (!value) return std::unexpected(value.error()); options.compiler_arguments.emplace_back(*value); continue;
         }
         if (argument.starts_with("--compiler-arg=")) {
-            auto value = long_equals_value(argument, "--compiler-arg=");
-            if (!value) return std::unexpected(value.error());
-            options.compiler_arguments.emplace_back(*value);
-            continue;
+            auto value = long_equals_value(argument, "--compiler-arg="); if (!value) return std::unexpected(value.error()); options.compiler_arguments.emplace_back(*value); continue;
         }
         if (argument == "--linker-arg" || argument == "-link_flags") {
-            auto value = require_value(arguments, index, argument);
-            if (!value) return std::unexpected(value.error());
-            options.linker_arguments.emplace_back(*value);
-            continue;
+            auto value = require_value(arguments, index, argument); if (!value) return std::unexpected(value.error()); options.linker_arguments.emplace_back(*value); continue;
         }
         if (argument.starts_with("--linker-arg=")) {
-            auto value = long_equals_value(argument, "--linker-arg=");
-            if (!value) return std::unexpected(value.error());
-            options.linker_arguments.emplace_back(*value);
-            continue;
+            auto value = long_equals_value(argument, "--linker-arg="); if (!value) return std::unexpected(value.error()); options.linker_arguments.emplace_back(*value); continue;
         }
         if (argument == "--env" || argument == "-env") {
-            auto value = require_value(arguments, index, argument);
-            if (!value) return std::unexpected(value.error());
-            auto preference = parse_toolchain_preference(*value);
-            if (!preference) return std::unexpected(preference.error());
-            options.toolchain_preference = *preference;
-            continue;
+            auto value = require_value(arguments, index, argument); if (!value) return std::unexpected(value.error());
+            auto preference = parse_toolchain_preference(*value); if (!preference) return std::unexpected(preference.error()); options.toolchain_preference = *preference; continue;
         }
         if (argument == "--portable-root") {
-            auto value = require_value(arguments, index, argument);
-            if (!value) return std::unexpected(value.error());
-            options.portable_roots.emplace_back(std::string{*value});
-            continue;
+            auto value = require_value(arguments, index, argument); if (!value) return std::unexpected(value.error()); options.portable_roots.emplace_back(std::string{*value}); continue;
         }
         if (argument == "--lib-path" || argument == "-libpath") {
-            auto value = require_value(arguments, index, argument);
-            if (!value) return std::unexpected(value.error());
-            options.library_directories.emplace_back(std::string{*value});
-            continue;
+            auto value = require_value(arguments, index, argument); if (!value) return std::unexpected(value.error()); options.library_directories.emplace_back(std::string{*value}); continue;
         }
         if (argument.starts_with("--lib-path=")) {
-            auto value = long_equals_value(argument, "--lib-path=");
-            if (!value) return std::unexpected(value.error());
-            options.library_directories.emplace_back(std::string{*value});
-            continue;
+            auto value = long_equals_value(argument, "--lib-path="); if (!value) return std::unexpected(value.error()); options.library_directories.emplace_back(std::string{*value}); continue;
         }
         if (argument == "--lib" || argument == "-libs") {
-            auto value = require_value(arguments, index, argument);
-            if (!value) return std::unexpected(value.error());
-            options.libraries.emplace_back(*value);
-            continue;
+            auto value = require_value(arguments, index, argument); if (!value) return std::unexpected(value.error()); options.libraries.emplace_back(*value); continue;
         }
         if (argument.starts_with("--lib=")) {
-            auto value = long_equals_value(argument, "--lib=");
-            if (!value) return std::unexpected(value.error());
-            options.libraries.emplace_back(*value);
-            continue;
+            auto value = long_equals_value(argument, "--lib="); if (!value) return std::unexpected(value.error()); options.libraries.emplace_back(*value); continue;
         }
         if (argument == "-include") {
-            auto value = require_value(arguments, index, argument);
-            if (!value) return std::unexpected(value.error());
-            options.include_directories.emplace_back(std::string{*value});
-            continue;
+            auto value = require_value(arguments, index, argument); if (!value) return std::unexpected(value.error()); options.include_directories.emplace_back(std::string{*value}); continue;
         }
         if (argument == "-defines") {
-            auto value = require_value(arguments, index, argument);
-            if (!value) return std::unexpected(value.error());
-            options.defines.emplace_back(*value);
-            continue;
+            auto value = require_value(arguments, index, argument); if (!value) return std::unexpected(value.error()); options.defines.emplace_back(*value); continue;
         }
         if (argument == "-I" || argument.starts_with("-I")) {
-            auto value = attached_or_next(arguments, index, argument, "-I");
-            if (!value) return std::unexpected(value.error());
-            if (value->empty()) return std::unexpected(error("empty include directory"));
-            options.include_directories.emplace_back(std::string{*value});
-            continue;
+            auto value = attached_or_next(arguments, index, argument, "-I"); if (!value) return std::unexpected(value.error());
+            if (value->empty()) return std::unexpected(error("empty include directory")); options.include_directories.emplace_back(std::string{*value}); continue;
         }
         if (argument == "-D" || argument.starts_with("-D")) {
-            auto value = attached_or_next(arguments, index, argument, "-D");
-            if (!value) return std::unexpected(value.error());
-            if (value->empty()) return std::unexpected(error("empty preprocessor define"));
-            options.defines.emplace_back(std::string{*value});
-            continue;
+            auto value = attached_or_next(arguments, index, argument, "-D"); if (!value) return std::unexpected(value.error());
+            if (value->empty()) return std::unexpected(error("empty preprocessor define")); options.defines.emplace_back(std::string{*value}); continue;
         }
         if (argument == "-L" || argument.starts_with("-L")) {
-            auto value = attached_or_next(arguments, index, argument, "-L");
-            if (!value) return std::unexpected(value.error());
-            if (value->empty()) return std::unexpected(error("empty library directory"));
-            options.library_directories.emplace_back(std::string{*value});
-            continue;
+            auto value = attached_or_next(arguments, index, argument, "-L"); if (!value) return std::unexpected(value.error());
+            if (value->empty()) return std::unexpected(error("empty library directory")); options.library_directories.emplace_back(std::string{*value}); continue;
         }
         if (argument == "-l" || argument.starts_with("-l")) {
-            auto value = attached_or_next(arguments, index, argument, "-l");
-            if (!value) return std::unexpected(value.error());
-            if (value->empty()) return std::unexpected(error("empty library name"));
-            options.libraries.emplace_back(std::string{*value});
-            continue;
+            auto value = attached_or_next(arguments, index, argument, "-l"); if (!value) return std::unexpected(value.error());
+            if (value->empty()) return std::unexpected(error("empty library name")); options.libraries.emplace_back(std::string{*value}); continue;
         }
-        if (!argument.empty() && argument.front() == '-') {
-            return std::unexpected(error("unknown option '" + std::string{argument} + "'"));
-        }
-
+        if (!argument.empty() && argument.front() == '-') return std::unexpected(error("unknown option '" + std::string{argument} + "'"));
         options.build.sources.emplace_back(std::string{argument});
     }
-
-    if (!options.show_help && options.build.sources.empty()) {
-        return std::unexpected(error("missing source file"));
-    }
-    if (!options.show_help
-        && !options.build.run_after_build
-        && !options.build.run_arguments.empty()) {
-        return std::unexpected(error("arguments after -- require --run"));
-    }
+    if (!options.show_help && options.build.sources.empty()) return std::unexpected(error("missing source file"));
+    if (!options.show_help && !options.build.run_after_build && !options.build.run_arguments.empty()) return std::unexpected(error("arguments after -- require --run"));
     return options;
 }
 
@@ -443,6 +257,8 @@ stay outside TU discovery but route through the P1689 module pipeline, where the
 built and cached automatically. Modules and header units require C++20 or newer; selecting
 C++14/17 for a target that requires the module pipeline fails closed before MSVC is invoked.
 External/prebuilt named-module providers and import std remain unsupported and fail closed.
+Static-library targets currently accept ordinary C/C++ translation units; static targets that
+require the Modules/Header Unit pipeline fail closed until archive topology is validated.
 
 Options:
   --debug                  Explicitly select Debug compile/link preset
@@ -450,11 +266,11 @@ Options:
   --config <debug|release> Select compile/link preset (legacy -config alias accepted)
   --std <14|17|20|23|latest>
                            Explicitly select C++ language standard (legacy -std accepted)
-  --type <exe|dll>         Select executable or DLL output kind (legacy -type accepted)
+  --type <exe|dll|static>  Select executable, DLL, or static-library output (legacy -type accepted)
   --runtime <MD|MDd|MT|MTd>
                            Explicitly select MSVC CRT runtime (legacy -runtime accepted)
   --subsystem <console|windows>
-                           Explicitly select PE subsystem (legacy -subsystem accepted)
+                           Explicitly select PE subsystem for executable/DLL targets (legacy -subsystem accepted)
   --x86 | --x64            Explicitly select target architecture (legacy -x86/-x64 accepted)
   -j, --jobs <N>           Maximum concurrent TU scans/compiles (default: hardware concurrency)
   -o, --output <name>      Set target name under .mqb/bin/ (legacy -output accepted)
@@ -473,14 +289,13 @@ Options:
   -h, --help               Show this help and the embedded build version (-help/-? accepted)
   --                       Pass all remaining argv elements to an executable program
 
+Static libraries are produced by MSVC lib.exe from the compiled object set. Linker-only policy
+(libraries, library search paths, subsystem, and raw linker arguments) does not apply to a static
+archive and is rejected when explicitly supplied for a static target.
+
 Raw compiler/linker arguments are one argv element per option occurrence; MQB does not split a
 quoted string into multiple switches. Project config entries are applied first and CLI raw args
-append afterward. Structured artifact routing such as /Fo, /scanDependencies, /DLL, /IMPLIB,
-/MACHINE and /OUT is emitted after raw arguments so the BuildPlan remains authoritative.
-
-Legacy compatibility aliases intentionally cover spelling only. Legacy-only semantics such as
--a string splitting and static-library output remain tracked by the stable-v5 parity inventory
-and are not silently accepted here.
+append afterward. Structured artifact routing remains backend-owned.
 
 Job count is execution policy only; changing -j does not invalidate build caches.
 Discovery is source selection only. Incremental header freshness continues to use
@@ -491,8 +306,8 @@ Generated state:
   .mqb/deps/   compiler dependency metadata
   .mqb/scan/   module dependency scan metadata
   .mqb/ifc/    module/header-unit interface artifacts
-  .mqb/cache/  compile and link cache metadata
-  .mqb/bin/    linked executable/DLL and DLL import-library artifacts
+  .mqb/cache/  compile/link/archive cache metadata
+  .mqb/bin/    executable, DLL/import-library, or static-library target artifacts
 )";
 }
 

--- a/cpp/apps/mqb/StaticCliTarget.cpp
+++ b/cpp/apps/mqb/StaticCliTarget.cpp
@@ -1,0 +1,135 @@
+#include "StaticCliTarget.hpp"
+
+#include <filesystem>
+#include <iostream>
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include "mqb/core/BuildTypes.hpp"
+#include "mqb/msvc/MsvcCompileExecutor.hpp"
+#include "mqb/msvc/MsvcLibrarian.hpp"
+#include "mqb/orchestration/MsvcIncrementalArchiveCoordinator.hpp"
+#include "mqb/orchestration/MsvcIncrementalCompileCoordinator.hpp"
+#include "mqb/orchestration/MsvcIncrementalStaticTargetCoordinator.hpp"
+
+namespace mqb::cli {
+namespace {
+
+namespace fs = std::filesystem;
+
+[[nodiscard]] std::string path_text(const fs::path& path) {
+    const auto bytes = path.generic_u8string();
+    return std::string{reinterpret_cast<const char*>(bytes.data()), bytes.size()};
+}
+
+void write_forwarded_text(std::ostream& stream, const std::string_view text) {
+    for (std::size_t index = 0; index < text.size(); ++index) {
+        const char ch = text[index];
+        if (ch == '\r' && index + 1 < text.size() && text[index + 1] == '\n') {
+            stream.put('\n');
+            ++index;
+        } else {
+            stream.put(ch);
+        }
+    }
+}
+
+void print_process_output(const process::ProcessResult& result) {
+    if (!result.stdout_text.empty()) {
+        write_forwarded_text(std::cout, result.stdout_text);
+        if (result.stdout_text.back() != '\n') std::cout << '\n';
+    }
+    if (!result.stderr_text.empty()) {
+        write_forwarded_text(std::cerr, result.stderr_text);
+        if (result.stderr_text.back() != '\n') std::cerr << '\n';
+    }
+}
+
+void print_reasons(const std::vector<BuildReason>& reasons) {
+    if (reasons.empty()) return;
+    std::cout << " [";
+    for (std::size_t index = 0; index < reasons.size(); ++index) {
+        if (index != 0) std::cout << ", ";
+        std::cout << to_string(reasons[index]);
+    }
+    std::cout << ']';
+}
+
+} // namespace
+
+int run_static_target(
+    StaticCliTargetRequest request,
+    const msvc::MsvcToolchain& toolchain,
+    process::ProcessRunner& runner) {
+    if (request.verbose) {
+        std::cout << "[target] " << request.target_name << '\n'
+                  << "  project: " << path_text(request.project_root) << '\n'
+                  << "  type:    static\n"
+                  << "  cl:      " << path_text(toolchain.identity.compiler) << '\n'
+                  << "  lib:     " << path_text(toolchain.librarian) << '\n'
+                  << "  output:  " << path_text(request.target.executable) << '\n'
+                  << "  cache:   " << path_text(request.target.link_cache) << '\n';
+    }
+
+    msvc::MsvcCompileExecutor compile_executor{toolchain, runner};
+    orchestration::MsvcIncrementalCompileCoordinator compile_coordinator{toolchain, compile_executor};
+    msvc::MsvcLibrarian librarian{toolchain, runner};
+    orchestration::MsvcIncrementalArchiveCoordinator archive_coordinator{toolchain, librarian};
+    orchestration::MsvcIncrementalStaticTargetCoordinator target_coordinator{
+        compile_coordinator, archive_coordinator};
+
+    auto result = target_coordinator.run(orchestration::IncrementalStaticTargetRequest{
+        .sources = std::move(request.sources),
+        .target = request.target,
+        .compiler_options = std::move(request.compiler_options),
+        .working_directory = request.project_root,
+        .max_parallel_compiles = request.max_parallel_jobs,
+    });
+    if (!result) {
+        std::cerr << "error: " << result.error().message;
+        if (!result.error().source.empty()) std::cerr << ": " << path_text(result.error().source);
+        std::cerr << '\n';
+        if (result.error().compile_error) {
+            std::cerr << "  " << result.error().compile_error->message << '\n';
+        }
+        if (result.error().archive_error) {
+            std::cerr << "  " << result.error().archive_error->message << '\n';
+            if (result.error().archive_error->librarian_error) {
+                const auto& library_error = *result.error().archive_error->librarian_error;
+                std::cerr << "  " << library_error.message << '\n';
+                if (library_error.process_result) print_process_output(*library_error.process_result);
+            }
+        }
+        return result.error().code == orchestration::IncrementalStaticTargetErrorCode::archive_failed ? 5 : 4;
+    }
+
+    for (const auto& compile : result->compiles) {
+        if (compile.result.compiled) {
+            std::cout << "[compile] " << path_text(compile.source.filename());
+            print_reasons(compile.result.validation.reasons);
+            std::cout << '\n';
+            if (compile.result.process) print_process_output(*compile.result.process);
+        } else {
+            std::cout << "[up-to-date] " << path_text(compile.source.filename()) << '\n';
+        }
+    }
+
+    for (const auto& warning : result->archive.warnings) {
+        std::cerr << "warning: " << warning.message;
+        if (!warning.path.empty()) std::cerr << ": " << path_text(warning.path);
+        std::cerr << '\n';
+    }
+    if (result->archive.archived) {
+        std::cout << "[archive] " << path_text(request.target.executable.filename());
+        print_reasons(result->archive.validation.reasons);
+        std::cout << '\n';
+        if (result->archive.process) print_process_output(*result->archive.process);
+    } else {
+        std::cout << "[up-to-date] " << path_text(request.target.executable.filename()) << '\n';
+    }
+    std::cout << "output: " << path_text(request.target.executable) << '\n';
+    return 0;
+}
+
+} // namespace mqb::cli

--- a/cpp/apps/mqb/StaticCliTarget.hpp
+++ b/cpp/apps/mqb/StaticCliTarget.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <cstddef>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include "mqb/core/CompilerOptions.hpp"
+#include "mqb/core/ProjectArtifactLayout.hpp"
+#include "mqb/msvc/MsvcToolchainLocator.hpp"
+#include "mqb/orchestration/MsvcIncrementalTargetCoordinator.hpp"
+#include "mqb/process/Process.hpp"
+
+namespace mqb::cli {
+
+struct StaticCliTargetRequest {
+    std::vector<orchestration::TargetSourceRequest> sources;
+    TargetArtifacts target;
+    CompilerOptions compiler_options;
+    std::filesystem::path project_root;
+    std::string target_name;
+    std::size_t max_parallel_jobs{1};
+    bool verbose{false};
+};
+
+[[nodiscard]] int run_static_target(
+    StaticCliTargetRequest request,
+    const msvc::MsvcToolchain& toolchain,
+    process::ProcessRunner& runner);
+
+} // namespace mqb::cli

--- a/cpp/apps/mqb/main.cpp
+++ b/cpp/apps/mqb/main.cpp
@@ -13,6 +13,7 @@
 
 #include "Cli.hpp"
 #include "ModuleCliTarget.hpp"
+#include "StaticCliTarget.hpp"
 #include "mqb/config/ProjectConfig.hpp"
 #include "mqb/config/ProjectOptions.hpp"
 #include "mqb/core/BuildTypes.hpp"
@@ -36,13 +37,10 @@ namespace fs = std::filesystem;
 
 [[nodiscard]] std::string path_text(const fs::path& path) {
     const auto bytes = path.generic_u8string();
-    return std::string{
-        reinterpret_cast<const char*>(bytes.data()),
-        bytes.size()};
+    return std::string{reinterpret_cast<const char*>(bytes.data()), bytes.size()};
 }
 
-[[nodiscard]] std::expected<fs::path, std::string>
-absolute_path_from(
+[[nodiscard]] std::expected<fs::path, std::string> absolute_path_from(
     const fs::path& base,
     const fs::path& path,
     const std::string_view description) {
@@ -50,8 +48,7 @@ absolute_path_from(
     const fs::path candidate = path.is_absolute() ? path : base / path;
     fs::path absolute = fs::absolute(candidate, error_code);
     if (error_code) {
-        return std::unexpected(
-            "failed to resolve " + std::string{description} + ": " + error_code.message());
+        return std::unexpected("failed to resolve " + std::string{description} + ": " + error_code.message());
     }
     return absolute.lexically_normal();
 }
@@ -61,40 +58,24 @@ absolute_path_from(
 }
 
 [[nodiscard]] bool safe_relative(const fs::path& relative) {
-    if (relative.empty() || relative.is_absolute() || relative == ".") {
-        return false;
-    }
-    for (const auto& component : relative) {
-        if (component == "..") {
-            return false;
-        }
-    }
+    if (relative.empty() || relative.is_absolute() || relative == ".") return false;
+    for (const auto& component : relative) if (component == "..") return false;
     return true;
 }
 
-[[nodiscard]] bool inside_project(
-    const fs::path& project_root,
-    const fs::path& path) {
+[[nodiscard]] bool inside_project(const fs::path& project_root, const fs::path& path) {
     return safe_relative(path.lexically_normal().lexically_relative(project_root.lexically_normal()));
 }
 
-[[nodiscard]] fs::path display_source(
-    const fs::path& project_root,
-    const fs::path& source) {
+[[nodiscard]] fs::path display_source(const fs::path& project_root, const fs::path& source) {
     const fs::path relative = source.lexically_relative(project_root);
     return safe_relative(relative) ? relative : source;
 }
 
-void add_portable_root_if_missing(
-    std::vector<fs::path>& roots,
-    const fs::path& candidate) {
-    if (candidate.empty()) {
-        return;
-    }
+void add_portable_root_if_missing(std::vector<fs::path>& roots, const fs::path& candidate) {
+    if (candidate.empty()) return;
     const fs::path normalized = candidate.lexically_normal();
-    if (std::find(roots.begin(), roots.end(), normalized) == roots.end()) {
-        roots.push_back(normalized);
-    }
+    if (std::find(roots.begin(), roots.end(), normalized) == roots.end()) roots.push_back(normalized);
 }
 
 void write_forwarded_text(std::ostream& stream, const std::string_view text) {
@@ -112,27 +93,19 @@ void write_forwarded_text(std::ostream& stream, const std::string_view text) {
 void print_process_output(const mqb::process::ProcessResult& process) {
     if (!process.stdout_text.empty()) {
         write_forwarded_text(std::cout, process.stdout_text);
-        if (process.stdout_text.back() != '\n') {
-            std::cout << '\n';
-        }
+        if (process.stdout_text.back() != '\n') std::cout << '\n';
     }
     if (!process.stderr_text.empty()) {
         write_forwarded_text(std::cerr, process.stderr_text);
-        if (process.stderr_text.back() != '\n') {
-            std::cerr << '\n';
-        }
+        if (process.stderr_text.back() != '\n') std::cerr << '\n';
     }
 }
 
 void print_reasons(const std::vector<mqb::BuildReason>& reasons) {
-    if (reasons.empty()) {
-        return;
-    }
+    if (reasons.empty()) return;
     std::cout << " [";
     for (std::size_t index = 0; index < reasons.size(); ++index) {
-        if (index != 0) {
-            std::cout << ", ";
-        }
+        if (index != 0) std::cout << ", ";
         std::cout << mqb::to_string(reasons[index]);
     }
     std::cout << ']';
@@ -142,30 +115,22 @@ void print_config_error(const mqb::config::Error& error) {
     std::cerr << "error: project config: " << error.message;
     if (!error.path.empty()) {
         std::cerr << ": " << path_text(error.path);
-        if (error.line != 0 && error.column != 0) {
-            std::cerr << ':' << error.line << ':' << error.column;
-        }
+        if (error.line != 0 && error.column != 0) std::cerr << ':' << error.line << ':' << error.column;
     }
     std::cerr << '\n';
 }
 
 void print_compile_failure(const mqb::orchestration::IncrementalCompileError& error) {
     std::cerr << "error: " << error.message << '\n';
-    if (!error.compile_error) {
-        return;
-    }
+    if (!error.compile_error) return;
     const auto& compile_error = *error.compile_error;
     std::cerr << "  " << compile_error.message << '\n';
     if (compile_error.compiler_error) {
         const auto& compiler_error = *compile_error.compiler_error;
         std::cerr << "  " << compiler_error.message << '\n';
-        if (compiler_error.process_result) {
-            print_process_output(*compiler_error.process_result);
-        }
+        if (compiler_error.process_result) print_process_output(*compiler_error.process_result);
     }
-    if (compile_error.dependency_error) {
-        std::cerr << "  " << compile_error.dependency_error->message << '\n';
-    }
+    if (compile_error.dependency_error) std::cerr << "  " << compile_error.dependency_error->message << '\n';
 }
 
 void print_link_failure(const mqb::orchestration::IncrementalLinkError& error) {
@@ -173,59 +138,37 @@ void print_link_failure(const mqb::orchestration::IncrementalLinkError& error) {
     if (error.library_resolution_error) {
         const auto& resolution = *error.library_resolution_error;
         std::cerr << "  " << resolution.message;
-        if (!resolution.library.empty()) {
-            std::cerr << ": " << resolution.library;
-        }
-        if (!resolution.path.empty()) {
-            std::cerr << " (" << path_text(resolution.path) << ')';
-        }
+        if (!resolution.library.empty()) std::cerr << ": " << resolution.library;
+        if (!resolution.path.empty()) std::cerr << " (" << path_text(resolution.path) << ')';
         std::cerr << '\n';
     }
-    if (!error.linker_error) {
-        return;
-    }
+    if (!error.linker_error) return;
     const auto& linker_error = *error.linker_error;
     std::cerr << "  " << linker_error.message << '\n';
-    if (linker_error.process_result) {
-        print_process_output(*linker_error.process_result);
-    }
-    if (linker_error.process_error) {
-        std::cerr << "  " << linker_error.process_error->message << '\n';
-    }
+    if (linker_error.process_result) print_process_output(*linker_error.process_result);
+    if (linker_error.process_error) std::cerr << "  " << linker_error.process_error->message << '\n';
 }
 
 void print_target_failure(const mqb::orchestration::IncrementalTargetError& error) {
     std::cerr << "error: " << error.message;
-    if (!error.source.empty()) {
-        std::cerr << ": " << path_text(error.source);
-    }
+    if (!error.source.empty()) std::cerr << ": " << path_text(error.source);
     std::cerr << '\n';
-    if (error.compile_error) {
-        print_compile_failure(*error.compile_error);
-    }
-    if (error.link_error) {
-        print_link_failure(*error.link_error);
-    }
+    if (error.compile_error) print_compile_failure(*error.compile_error);
+    if (error.link_error) print_link_failure(*error.link_error);
 }
 
-void print_compile_warnings(
-    const mqb::orchestration::IncrementalCompileResult& result) {
+void print_compile_warnings(const mqb::orchestration::IncrementalCompileResult& result) {
     for (const auto& warning : result.warnings) {
         std::cerr << "warning: " << warning.message;
-        if (!warning.path.empty()) {
-            std::cerr << ": " << path_text(warning.path);
-        }
+        if (!warning.path.empty()) std::cerr << ": " << path_text(warning.path);
         std::cerr << '\n';
     }
 }
 
-void print_link_warnings(
-    const mqb::orchestration::IncrementalLinkResult& result) {
+void print_link_warnings(const mqb::orchestration::IncrementalLinkResult& result) {
     for (const auto& warning : result.warnings) {
         std::cerr << "warning: " << warning.message;
-        if (!warning.path.empty()) {
-            std::cerr << ": " << path_text(warning.path);
-        }
+        if (!warning.path.empty()) std::cerr << ": " << path_text(warning.path);
         std::cerr << '\n';
     }
 }
@@ -235,9 +178,7 @@ void print_link_warnings(
 int main(const int argc, char* argv[]) {
     std::vector<std::string_view> arguments;
     arguments.reserve(argc > 1 ? static_cast<std::size_t>(argc - 1) : 0u);
-    for (int index = 1; index < argc; ++index) {
-        arguments.emplace_back(argv[index]);
-    }
+    for (int index = 1; index < argc; ++index) arguments.emplace_back(argv[index]);
 
     auto parsed = mqb::cli::parse_arguments(std::span<const std::string_view>{arguments});
     if (!parsed) {
@@ -253,8 +194,7 @@ int main(const int argc, char* argv[]) {
     std::error_code error_code;
     fs::path invocation_directory = fs::current_path(error_code);
     if (error_code) {
-        std::cerr << "error: failed to resolve current working directory: "
-                  << error_code.message() << '\n';
+        std::cerr << "error: failed to resolve current working directory: " << error_code.message() << '\n';
         return 2;
     }
     invocation_directory = invocation_directory.lexically_normal();
@@ -263,24 +203,19 @@ int main(const int argc, char* argv[]) {
     requested_sources.reserve(options.build.sources.size());
     for (const auto& requested_source : options.build.sources) {
         auto source = absolute_path_from(invocation_directory, requested_source, "source file");
-        if (!source) {
-            std::cerr << "error: " << source.error() << '\n';
-            return 2;
-        }
+        if (!source) { std::cerr << "error: " << source.error() << '\n'; return 2; }
         if (!fs::is_regular_file(*source, error_code) || error_code) {
             std::cerr << "error: source file does not exist: " << path_text(*source) << '\n';
             return 2;
         }
         if (!supported_source(*source)) {
-            std::cerr << "error: only .c, .cpp, .cc, .cxx, .ixx, .cppm, and .mpp sources are supported: "
-                      << path_text(*source) << '\n';
+            std::cerr << "error: only .c, .cpp, .cc, .cxx, .ixx, .cppm, and .mpp sources are supported: " << path_text(*source) << '\n';
             return 2;
         }
         for (const auto& previous : requested_sources) {
             error_code.clear();
             if (fs::equivalent(previous, *source, error_code) && !error_code) {
-                std::cerr << "error: source file was provided more than once: "
-                          << path_text(*source) << '\n';
+                std::cerr << "error: source file was provided more than once: " << path_text(*source) << '\n';
                 return 2;
             }
         }
@@ -289,47 +224,32 @@ int main(const int argc, char* argv[]) {
 
     for (auto& include_directory : options.include_directories) {
         auto resolved = absolute_path_from(invocation_directory, include_directory, "include directory");
-        if (!resolved) {
-            std::cerr << "error: " << resolved.error() << '\n';
-            return 2;
-        }
+        if (!resolved) { std::cerr << "error: " << resolved.error() << '\n'; return 2; }
         include_directory = std::move(*resolved);
     }
     for (auto& library_directory : options.library_directories) {
         auto resolved = absolute_path_from(invocation_directory, library_directory, "library directory");
-        if (!resolved) {
-            std::cerr << "error: " << resolved.error() << '\n';
-            return 2;
-        }
+        if (!resolved) { std::cerr << "error: " << resolved.error() << '\n'; return 2; }
         library_directory = std::move(*resolved);
     }
     for (auto& portable_root : options.portable_roots) {
         auto resolved = absolute_path_from(invocation_directory, portable_root, "portable toolchain root");
-        if (!resolved) {
-            std::cerr << "error: " << resolved.error() << '\n';
-            return 2;
-        }
+        if (!resolved) { std::cerr << "error: " << resolved.error() << '\n'; return 2; }
         portable_root = std::move(*resolved);
     }
 
     std::optional<mqb::config::ProjectConfig> project_config;
     auto located_config = mqb::config::ProjectConfigLoader::find_upwards(invocation_directory);
-    if (!located_config) {
-        print_config_error(located_config.error());
-        return 2;
-    }
+    if (!located_config) { print_config_error(located_config.error()); return 2; }
     if (located_config->has_value()) {
         auto loaded = mqb::config::ProjectConfigLoader::load(**located_config);
-        if (!loaded) {
-            print_config_error(loaded.error());
-            return 2;
-        }
+        if (!loaded) { print_config_error(loaded.error()); return 2; }
         project_config = std::move(*loaded);
     }
 
-    const fs::path project_root = project_config
-        ? project_config->project_root
-        : invocation_directory;
+    const bool subsystem_explicit = options.subsystem_override.has_value()
+        || (project_config && project_config->build.subsystem.has_value());
+    const fs::path project_root = project_config ? project_config->project_root : invocation_directory;
 
     mqb::config::ProjectOverrides cli_overrides;
     cli_overrides.build.configuration = options.configuration_override;
@@ -347,9 +267,7 @@ int main(const int argc, char* argv[]) {
     cli_overrides.build.linker_arguments = options.linker_arguments;
     cli_overrides.discovery.enabled = options.discovery_override;
 
-    auto effective = mqb::config::resolve_project_options(
-        project_config ? &*project_config : nullptr,
-        cli_overrides);
+    auto effective = mqb::config::resolve_project_options(project_config ? &*project_config : nullptr, cli_overrides);
     options.build.configuration = effective.configuration;
     options.build.architecture = effective.architecture;
     options.build.standard = effective.standard;
@@ -365,22 +283,18 @@ int main(const int argc, char* argv[]) {
     options.compiler_arguments = effective.compiler_arguments;
     options.linker_arguments = effective.linker_arguments;
 
-    if (options.build.run_after_build
-        && options.build.target_kind != mqb::TargetKind::executable) {
+    if (options.build.run_after_build && options.build.target_kind != mqb::TargetKind::executable) {
         std::cerr << "error: --run is only valid for executable targets\n";
         return 2;
     }
 
     std::vector<fs::path> sources = requested_sources;
     bool discovery_requires_module_pipeline = false;
-    if (options.discover_sources
-        && requested_sources.size() == 1
+    if (options.discover_sources && requested_sources.size() == 1
         && !mqb::cli::is_module_interface_source(requested_sources.front())) {
         const fs::path& entry = requested_sources.front();
         const bool project_scoped = inside_project(project_root, entry);
-        const fs::path discovery_root = project_scoped
-            ? project_root
-            : entry.parent_path();
+        const fs::path discovery_root = project_scoped ? project_root : entry.parent_path();
         mqb::discovery::Request discovery_request{
             .project_root = discovery_root,
             .entry = entry,
@@ -394,26 +308,20 @@ int main(const int argc, char* argv[]) {
         auto discovered = mqb::discovery::SourceDiscovery::discover(discovery_request);
         if (!discovered) {
             std::cerr << "error: source discovery failed: " << discovered.error().message;
-            if (!discovered.error().path.empty()) {
-                std::cerr << ": " << path_text(discovered.error().path);
-            }
+            if (!discovered.error().path.empty()) std::cerr << ": " << path_text(discovered.error().path);
             std::cerr << '\n';
             return 2;
         }
         for (const auto& warning : discovered->warnings) {
             std::cerr << "warning: source discovery: " << warning.message;
-            if (!warning.path.empty()) {
-                std::cerr << ": " << path_text(warning.path);
-            }
+            if (!warning.path.empty()) std::cerr << ": " << path_text(warning.path);
             std::cerr << '\n';
         }
         discovery_requires_module_pipeline = discovered->requires_module_pipeline;
         sources = std::move(discovered->sources);
         if (sources.size() > 1 || options.verbose) {
             std::cout << "[discover] " << sources.size() << " translation units";
-            if (options.verbose) {
-                std::cout << " from " << discovered->indexed_files << " indexed C/C++ files";
-            }
+            if (options.verbose) std::cout << " from " << discovered->indexed_files << " indexed C/C++ files";
             std::cout << '\n';
         }
     }
@@ -421,26 +329,18 @@ int main(const int argc, char* argv[]) {
 
     const unsigned int hardware_threads = std::thread::hardware_concurrency();
     const std::size_t requested_compile_jobs = options.jobs.value_or(
-        hardware_threads == 0
-            ? std::size_t{1}
-            : static_cast<std::size_t>(hardware_threads));
-    const std::size_t compile_jobs = std::max<std::size_t>(
-        1,
-        std::min(requested_compile_jobs, sources.size()));
+        hardware_threads == 0 ? std::size_t{1} : static_cast<std::size_t>(hardware_threads));
+    const std::size_t compile_jobs = std::max<std::size_t>(1, std::min(requested_compile_jobs, sources.size()));
 
     auto layout = mqb::ProjectArtifactLayout::create(project_root);
-    if (!layout) {
-        std::cerr << "error: " << layout.error().message << '\n';
-        return 2;
-    }
+    if (!layout) { std::cerr << "error: " << layout.error().message << '\n'; return 2; }
 
     std::vector<mqb::orchestration::TargetSourceRequest> target_sources;
     target_sources.reserve(sources.size());
     for (const auto& source : sources) {
         auto artifacts = layout->for_source(source);
         if (!artifacts) {
-            std::cerr << "error: " << artifacts.error().message << ": "
-                      << path_text(source) << '\n';
+            std::cerr << "error: " << artifacts.error().message << ": " << path_text(source) << '\n';
             return 2;
         }
         target_sources.push_back(mqb::orchestration::TargetSourceRequest{
@@ -449,18 +349,12 @@ int main(const int argc, char* argv[]) {
         });
     }
 
-    const std::string target_name = options.build.output_name.value_or(
-        requested_sources.front().stem().string());
+    const std::string target_name = options.build.output_name.value_or(requested_sources.front().stem().string());
     auto target_artifacts = layout->for_target(target_name, options.build.target_kind);
-    if (!target_artifacts) {
-        std::cerr << "error: " << target_artifacts.error().message << '\n';
-        return 2;
-    }
+    if (!target_artifacts) { std::cerr << "error: " << target_artifacts.error().message << '\n'; return 2; }
 
     add_portable_root_if_missing(options.portable_roots, project_root / "portable_msvc");
-    for (const auto& source : sources) {
-        add_portable_root_if_missing(options.portable_roots, source.parent_path() / "portable_msvc");
-    }
+    for (const auto& source : sources) add_portable_root_if_missing(options.portable_roots, source.parent_path() / "portable_msvc");
 
     mqb::platform::windows::WindowsProcessRunner runner;
     mqb::msvc::MsvcToolchainLocator locator{runner};
@@ -473,9 +367,7 @@ int main(const int argc, char* argv[]) {
     auto toolchain = locator.discover(toolchain_discovery);
     if (!toolchain) {
         std::cerr << "error: " << toolchain.error().message;
-        if (!toolchain.error().path.empty()) {
-            std::cerr << ": " << path_text(toolchain.error().path);
-        }
+        if (!toolchain.error().path.empty()) std::cerr << ": " << path_text(toolchain.error().path);
         std::cerr << '\n';
         return 3;
     }
@@ -489,6 +381,36 @@ int main(const int argc, char* argv[]) {
     compiler_options.include_directories = std::move(options.include_directories);
     compiler_options.additional_arguments = std::move(options.compiler_arguments);
 
+    const bool module_target = discovery_requires_module_pipeline || std::any_of(
+        target_sources.begin(), target_sources.end(),
+        [](const mqb::orchestration::TargetSourceRequest& source) {
+            return mqb::cli::is_module_interface_source(source.source);
+        });
+
+    if (options.build.target_kind == mqb::TargetKind::static_library) {
+        if (module_target) {
+            std::cerr << "error: static-library targets do not yet support the Modules/Header Unit pipeline\n";
+            return 2;
+        }
+        if (subsystem_explicit || !options.library_directories.empty()
+            || !options.libraries.empty() || !options.linker_arguments.empty()) {
+            std::cerr << "error: static-library targets do not accept linker-only policy (subsystem, library paths/libraries, or linker args)\n";
+            return 2;
+        }
+        return mqb::cli::run_static_target(
+            mqb::cli::StaticCliTargetRequest{
+                .sources = std::move(target_sources),
+                .target = std::move(*target_artifacts),
+                .compiler_options = std::move(compiler_options),
+                .project_root = project_root,
+                .target_name = target_name,
+                .max_parallel_jobs = compile_jobs,
+                .verbose = options.verbose,
+            },
+            *toolchain,
+            runner);
+    }
+
     mqb::LinkOptions link_options;
     link_options.configuration = options.build.configuration;
     link_options.architecture = options.build.architecture;
@@ -498,12 +420,6 @@ int main(const int argc, char* argv[]) {
     link_options.libraries = std::move(options.libraries);
     link_options.additional_arguments = std::move(options.linker_arguments);
 
-    const bool module_target = discovery_requires_module_pipeline || std::any_of(
-        target_sources.begin(),
-        target_sources.end(),
-        [](const mqb::orchestration::TargetSourceRequest& source) {
-            return mqb::cli::is_module_interface_source(source.source);
-        });
     if (module_target) {
         return mqb::cli::run_module_target(
             mqb::cli::ModuleCliTargetRequest{
@@ -512,9 +428,7 @@ int main(const int argc, char* argv[]) {
                 .compiler_options = std::move(compiler_options),
                 .link_options = std::move(link_options),
                 .project_root = project_root,
-                .config_file = project_config
-                    ? std::optional<fs::path>{project_config->file}
-                    : std::nullopt,
+                .config_file = project_config ? std::optional<fs::path>{project_config->file} : std::nullopt,
                 .target_name = target_name,
                 .max_parallel_jobs = compile_jobs,
                 .jobs_explicit = options.jobs.has_value(),
@@ -530,12 +444,9 @@ int main(const int argc, char* argv[]) {
     if (options.verbose) {
         std::cout << "[target] " << target_name << "\n"
                   << "  project: " << path_text(project_root) << '\n';
-        if (project_config) {
-            std::cout << "  config:  " << path_text(project_config->file) << '\n';
-        }
+        if (project_config) std::cout << "  config:  " << path_text(project_config->file) << '\n';
         std::cout << "  type:    " << mqb::to_string(options.build.target_kind) << '\n'
-                  << "  jobs:    " << compile_jobs
-                  << (options.jobs ? "" : " (auto)") << '\n'
+                  << "  jobs:    " << compile_jobs << (options.jobs ? "" : " (auto)") << '\n'
                   << "  cl:      " << path_text(toolchain->identity.compiler) << '\n'
                   << "  link:    " << path_text(toolchain->linker) << '\n';
         for (const auto& source : target_sources) {
@@ -544,31 +455,19 @@ int main(const int argc, char* argv[]) {
                       << "    deps:  " << path_text(source.artifacts.dependencies) << '\n'
                       << "    cache: " << path_text(source.artifacts.compile_cache) << '\n';
         }
-        for (const auto& directory : link_options.library_directories) {
-            std::cout << "  libpath: " << path_text(directory) << '\n';
-        }
-        for (const auto& library : link_options.libraries) {
-            std::cout << "  lib:     " << library << '\n';
-        }
-        for (const auto& argument : compiler_options.additional_arguments) {
-            std::cout << "  cl-arg:  " << argument << '\n';
-        }
-        for (const auto& argument : link_options.additional_arguments) {
-            std::cout << "  link-arg:" << argument << '\n';
-        }
+        for (const auto& directory : link_options.library_directories) std::cout << "  libpath: " << path_text(directory) << '\n';
+        for (const auto& library : link_options.libraries) std::cout << "  lib:     " << library << '\n';
+        for (const auto& argument : compiler_options.additional_arguments) std::cout << "  cl-arg:  " << argument << '\n';
+        for (const auto& argument : link_options.additional_arguments) std::cout << "  link-arg:" << argument << '\n';
         std::cout << "  output:  " << path_text(target_artifacts->executable) << '\n'
                   << "  cache:   " << path_text(target_artifacts->link_cache) << '\n';
     }
 
     mqb::msvc::MsvcCompileExecutor compile_executor{*toolchain, runner};
-    mqb::orchestration::MsvcIncrementalCompileCoordinator compile_coordinator{
-        *toolchain,
-        compile_executor};
+    mqb::orchestration::MsvcIncrementalCompileCoordinator compile_coordinator{*toolchain, compile_executor};
     mqb::msvc::MsvcLinker linker{*toolchain, runner};
     mqb::orchestration::MsvcIncrementalLinkCoordinator link_coordinator{*toolchain, linker};
-    mqb::orchestration::MsvcIncrementalTargetCoordinator target_coordinator{
-        compile_coordinator,
-        link_coordinator};
+    mqb::orchestration::MsvcIncrementalTargetCoordinator target_coordinator{compile_coordinator, link_coordinator};
 
     const mqb::orchestration::IncrementalTargetRequest request{
         .sources = std::move(target_sources),
@@ -592,9 +491,7 @@ int main(const int argc, char* argv[]) {
             std::cout << "[compile] " << path_text(label);
             print_reasons(compile.result.validation.reasons);
             std::cout << '\n';
-            if (compile.result.process) {
-                print_process_output(*compile.result.process);
-            }
+            if (compile.result.process) print_process_output(*compile.result.process);
         } else {
             std::cout << "[up-to-date] " << path_text(label) << '\n';
         }
@@ -605,18 +502,13 @@ int main(const int argc, char* argv[]) {
         std::cout << "[link] " << path_text(request.target.executable.filename());
         print_reasons(result->link.validation.reasons);
         std::cout << '\n';
-        if (result->link.process) {
-            print_process_output(*result->link.process);
-        }
+        if (result->link.process) print_process_output(*result->link.process);
     } else {
         std::cout << "[up-to-date] " << path_text(request.target.executable.filename()) << '\n';
     }
 
     std::cout << "output: " << path_text(request.target.executable) << '\n';
-
-    if (!options.build.run_after_build) {
-        return 0;
-    }
+    if (!options.build.run_after_build) return 0;
 
     std::cout << "[run] " << path_text(request.target.executable.filename()) << '\n';
     mqb::process::ProcessSpec run_spec;
@@ -625,7 +517,6 @@ int main(const int argc, char* argv[]) {
     run_spec.working_directory = project_root;
     run_spec.capture_stdout = true;
     run_spec.capture_stderr = true;
-
     auto run_result = runner.run(run_spec);
     if (!run_result) {
         std::cerr << "error: failed to run executable: " << run_result.error().message << '\n';

--- a/cpp/apps/mqb/main.cpp
+++ b/cpp/apps/mqb/main.cpp
@@ -37,10 +37,13 @@ namespace fs = std::filesystem;
 
 [[nodiscard]] std::string path_text(const fs::path& path) {
     const auto bytes = path.generic_u8string();
-    return std::string{reinterpret_cast<const char*>(bytes.data()), bytes.size()};
+    return std::string{
+        reinterpret_cast<const char*>(bytes.data()),
+        bytes.size()};
 }
 
-[[nodiscard]] std::expected<fs::path, std::string> absolute_path_from(
+[[nodiscard]] std::expected<fs::path, std::string>
+absolute_path_from(
     const fs::path& base,
     const fs::path& path,
     const std::string_view description) {
@@ -48,7 +51,8 @@ namespace fs = std::filesystem;
     const fs::path candidate = path.is_absolute() ? path : base / path;
     fs::path absolute = fs::absolute(candidate, error_code);
     if (error_code) {
-        return std::unexpected("failed to resolve " + std::string{description} + ": " + error_code.message());
+        return std::unexpected(
+            "failed to resolve " + std::string{description} + ": " + error_code.message());
     }
     return absolute.lexically_normal();
 }
@@ -58,24 +62,40 @@ namespace fs = std::filesystem;
 }
 
 [[nodiscard]] bool safe_relative(const fs::path& relative) {
-    if (relative.empty() || relative.is_absolute() || relative == ".") return false;
-    for (const auto& component : relative) if (component == "..") return false;
+    if (relative.empty() || relative.is_absolute() || relative == ".") {
+        return false;
+    }
+    for (const auto& component : relative) {
+        if (component == "..") {
+            return false;
+        }
+    }
     return true;
 }
 
-[[nodiscard]] bool inside_project(const fs::path& project_root, const fs::path& path) {
+[[nodiscard]] bool inside_project(
+    const fs::path& project_root,
+    const fs::path& path) {
     return safe_relative(path.lexically_normal().lexically_relative(project_root.lexically_normal()));
 }
 
-[[nodiscard]] fs::path display_source(const fs::path& project_root, const fs::path& source) {
+[[nodiscard]] fs::path display_source(
+    const fs::path& project_root,
+    const fs::path& source) {
     const fs::path relative = source.lexically_relative(project_root);
     return safe_relative(relative) ? relative : source;
 }
 
-void add_portable_root_if_missing(std::vector<fs::path>& roots, const fs::path& candidate) {
-    if (candidate.empty()) return;
+void add_portable_root_if_missing(
+    std::vector<fs::path>& roots,
+    const fs::path& candidate) {
+    if (candidate.empty()) {
+        return;
+    }
     const fs::path normalized = candidate.lexically_normal();
-    if (std::find(roots.begin(), roots.end(), normalized) == roots.end()) roots.push_back(normalized);
+    if (std::find(roots.begin(), roots.end(), normalized) == roots.end()) {
+        roots.push_back(normalized);
+    }
 }
 
 void write_forwarded_text(std::ostream& stream, const std::string_view text) {
@@ -93,19 +113,27 @@ void write_forwarded_text(std::ostream& stream, const std::string_view text) {
 void print_process_output(const mqb::process::ProcessResult& process) {
     if (!process.stdout_text.empty()) {
         write_forwarded_text(std::cout, process.stdout_text);
-        if (process.stdout_text.back() != '\n') std::cout << '\n';
+        if (process.stdout_text.back() != '\n') {
+            std::cout << '\n';
+        }
     }
     if (!process.stderr_text.empty()) {
         write_forwarded_text(std::cerr, process.stderr_text);
-        if (process.stderr_text.back() != '\n') std::cerr << '\n';
+        if (process.stderr_text.back() != '\n') {
+            std::cerr << '\n';
+        }
     }
 }
 
 void print_reasons(const std::vector<mqb::BuildReason>& reasons) {
-    if (reasons.empty()) return;
+    if (reasons.empty()) {
+        return;
+    }
     std::cout << " [";
     for (std::size_t index = 0; index < reasons.size(); ++index) {
-        if (index != 0) std::cout << ", ";
+        if (index != 0) {
+            std::cout << ", ";
+        }
         std::cout << mqb::to_string(reasons[index]);
     }
     std::cout << ']';
@@ -115,22 +143,30 @@ void print_config_error(const mqb::config::Error& error) {
     std::cerr << "error: project config: " << error.message;
     if (!error.path.empty()) {
         std::cerr << ": " << path_text(error.path);
-        if (error.line != 0 && error.column != 0) std::cerr << ':' << error.line << ':' << error.column;
+        if (error.line != 0 && error.column != 0) {
+            std::cerr << ':' << error.line << ':' << error.column;
+        }
     }
     std::cerr << '\n';
 }
 
 void print_compile_failure(const mqb::orchestration::IncrementalCompileError& error) {
     std::cerr << "error: " << error.message << '\n';
-    if (!error.compile_error) return;
+    if (!error.compile_error) {
+        return;
+    }
     const auto& compile_error = *error.compile_error;
     std::cerr << "  " << compile_error.message << '\n';
     if (compile_error.compiler_error) {
         const auto& compiler_error = *compile_error.compiler_error;
         std::cerr << "  " << compiler_error.message << '\n';
-        if (compiler_error.process_result) print_process_output(*compiler_error.process_result);
+        if (compiler_error.process_result) {
+            print_process_output(*compiler_error.process_result);
+        }
     }
-    if (compile_error.dependency_error) std::cerr << "  " << compile_error.dependency_error->message << '\n';
+    if (compile_error.dependency_error) {
+        std::cerr << "  " << compile_error.dependency_error->message << '\n';
+    }
 }
 
 void print_link_failure(const mqb::orchestration::IncrementalLinkError& error) {
@@ -138,37 +174,59 @@ void print_link_failure(const mqb::orchestration::IncrementalLinkError& error) {
     if (error.library_resolution_error) {
         const auto& resolution = *error.library_resolution_error;
         std::cerr << "  " << resolution.message;
-        if (!resolution.library.empty()) std::cerr << ": " << resolution.library;
-        if (!resolution.path.empty()) std::cerr << " (" << path_text(resolution.path) << ')';
+        if (!resolution.library.empty()) {
+            std::cerr << ": " << resolution.library;
+        }
+        if (!resolution.path.empty()) {
+            std::cerr << " (" << path_text(resolution.path) << ')';
+        }
         std::cerr << '\n';
     }
-    if (!error.linker_error) return;
+    if (!error.linker_error) {
+        return;
+    }
     const auto& linker_error = *error.linker_error;
     std::cerr << "  " << linker_error.message << '\n';
-    if (linker_error.process_result) print_process_output(*linker_error.process_result);
-    if (linker_error.process_error) std::cerr << "  " << linker_error.process_error->message << '\n';
+    if (linker_error.process_result) {
+        print_process_output(*linker_error.process_result);
+    }
+    if (linker_error.process_error) {
+        std::cerr << "  " << linker_error.process_error->message << '\n';
+    }
 }
 
 void print_target_failure(const mqb::orchestration::IncrementalTargetError& error) {
     std::cerr << "error: " << error.message;
-    if (!error.source.empty()) std::cerr << ": " << path_text(error.source);
+    if (!error.source.empty()) {
+        std::cerr << ": " << path_text(error.source);
+    }
     std::cerr << '\n';
-    if (error.compile_error) print_compile_failure(*error.compile_error);
-    if (error.link_error) print_link_failure(*error.link_error);
+    if (error.compile_error) {
+        print_compile_failure(*error.compile_error);
+    }
+    if (error.link_error) {
+        print_link_failure(*error.link_error);
+    }
 }
 
-void print_compile_warnings(const mqb::orchestration::IncrementalCompileResult& result) {
+void print_compile_warnings(
+    const mqb::orchestration::IncrementalCompileResult& result) {
     for (const auto& warning : result.warnings) {
         std::cerr << "warning: " << warning.message;
-        if (!warning.path.empty()) std::cerr << ": " << path_text(warning.path);
+        if (!warning.path.empty()) {
+            std::cerr << ": " << path_text(warning.path);
+        }
         std::cerr << '\n';
     }
 }
 
-void print_link_warnings(const mqb::orchestration::IncrementalLinkResult& result) {
+void print_link_warnings(
+    const mqb::orchestration::IncrementalLinkResult& result) {
     for (const auto& warning : result.warnings) {
         std::cerr << "warning: " << warning.message;
-        if (!warning.path.empty()) std::cerr << ": " << path_text(warning.path);
+        if (!warning.path.empty()) {
+            std::cerr << ": " << path_text(warning.path);
+        }
         std::cerr << '\n';
     }
 }
@@ -178,7 +236,9 @@ void print_link_warnings(const mqb::orchestration::IncrementalLinkResult& result
 int main(const int argc, char* argv[]) {
     std::vector<std::string_view> arguments;
     arguments.reserve(argc > 1 ? static_cast<std::size_t>(argc - 1) : 0u);
-    for (int index = 1; index < argc; ++index) arguments.emplace_back(argv[index]);
+    for (int index = 1; index < argc; ++index) {
+        arguments.emplace_back(argv[index]);
+    }
 
     auto parsed = mqb::cli::parse_arguments(std::span<const std::string_view>{arguments});
     if (!parsed) {
@@ -194,7 +254,8 @@ int main(const int argc, char* argv[]) {
     std::error_code error_code;
     fs::path invocation_directory = fs::current_path(error_code);
     if (error_code) {
-        std::cerr << "error: failed to resolve current working directory: " << error_code.message() << '\n';
+        std::cerr << "error: failed to resolve current working directory: "
+                  << error_code.message() << '\n';
         return 2;
     }
     invocation_directory = invocation_directory.lexically_normal();
@@ -203,19 +264,24 @@ int main(const int argc, char* argv[]) {
     requested_sources.reserve(options.build.sources.size());
     for (const auto& requested_source : options.build.sources) {
         auto source = absolute_path_from(invocation_directory, requested_source, "source file");
-        if (!source) { std::cerr << "error: " << source.error() << '\n'; return 2; }
+        if (!source) {
+            std::cerr << "error: " << source.error() << '\n';
+            return 2;
+        }
         if (!fs::is_regular_file(*source, error_code) || error_code) {
             std::cerr << "error: source file does not exist: " << path_text(*source) << '\n';
             return 2;
         }
         if (!supported_source(*source)) {
-            std::cerr << "error: only .c, .cpp, .cc, .cxx, .ixx, .cppm, and .mpp sources are supported: " << path_text(*source) << '\n';
+            std::cerr << "error: only .c, .cpp, .cc, .cxx, .ixx, .cppm, and .mpp sources are supported: "
+                      << path_text(*source) << '\n';
             return 2;
         }
         for (const auto& previous : requested_sources) {
             error_code.clear();
             if (fs::equivalent(previous, *source, error_code) && !error_code) {
-                std::cerr << "error: source file was provided more than once: " << path_text(*source) << '\n';
+                std::cerr << "error: source file was provided more than once: "
+                          << path_text(*source) << '\n';
                 return 2;
             }
         }
@@ -224,32 +290,49 @@ int main(const int argc, char* argv[]) {
 
     for (auto& include_directory : options.include_directories) {
         auto resolved = absolute_path_from(invocation_directory, include_directory, "include directory");
-        if (!resolved) { std::cerr << "error: " << resolved.error() << '\n'; return 2; }
+        if (!resolved) {
+            std::cerr << "error: " << resolved.error() << '\n';
+            return 2;
+        }
         include_directory = std::move(*resolved);
     }
     for (auto& library_directory : options.library_directories) {
         auto resolved = absolute_path_from(invocation_directory, library_directory, "library directory");
-        if (!resolved) { std::cerr << "error: " << resolved.error() << '\n'; return 2; }
+        if (!resolved) {
+            std::cerr << "error: " << resolved.error() << '\n';
+            return 2;
+        }
         library_directory = std::move(*resolved);
     }
     for (auto& portable_root : options.portable_roots) {
         auto resolved = absolute_path_from(invocation_directory, portable_root, "portable toolchain root");
-        if (!resolved) { std::cerr << "error: " << resolved.error() << '\n'; return 2; }
+        if (!resolved) {
+            std::cerr << "error: " << resolved.error() << '\n';
+            return 2;
+        }
         portable_root = std::move(*resolved);
     }
 
     std::optional<mqb::config::ProjectConfig> project_config;
     auto located_config = mqb::config::ProjectConfigLoader::find_upwards(invocation_directory);
-    if (!located_config) { print_config_error(located_config.error()); return 2; }
+    if (!located_config) {
+        print_config_error(located_config.error());
+        return 2;
+    }
     if (located_config->has_value()) {
         auto loaded = mqb::config::ProjectConfigLoader::load(**located_config);
-        if (!loaded) { print_config_error(loaded.error()); return 2; }
+        if (!loaded) {
+            print_config_error(loaded.error());
+            return 2;
+        }
         project_config = std::move(*loaded);
     }
 
     const bool subsystem_explicit = options.subsystem_override.has_value()
         || (project_config && project_config->build.subsystem.has_value());
-    const fs::path project_root = project_config ? project_config->project_root : invocation_directory;
+    const fs::path project_root = project_config
+        ? project_config->project_root
+        : invocation_directory;
 
     mqb::config::ProjectOverrides cli_overrides;
     cli_overrides.build.configuration = options.configuration_override;
@@ -267,7 +350,9 @@ int main(const int argc, char* argv[]) {
     cli_overrides.build.linker_arguments = options.linker_arguments;
     cli_overrides.discovery.enabled = options.discovery_override;
 
-    auto effective = mqb::config::resolve_project_options(project_config ? &*project_config : nullptr, cli_overrides);
+    auto effective = mqb::config::resolve_project_options(
+        project_config ? &*project_config : nullptr,
+        cli_overrides);
     options.build.configuration = effective.configuration;
     options.build.architecture = effective.architecture;
     options.build.standard = effective.standard;
@@ -283,18 +368,22 @@ int main(const int argc, char* argv[]) {
     options.compiler_arguments = effective.compiler_arguments;
     options.linker_arguments = effective.linker_arguments;
 
-    if (options.build.run_after_build && options.build.target_kind != mqb::TargetKind::executable) {
+    if (options.build.run_after_build
+        && options.build.target_kind != mqb::TargetKind::executable) {
         std::cerr << "error: --run is only valid for executable targets\n";
         return 2;
     }
 
     std::vector<fs::path> sources = requested_sources;
     bool discovery_requires_module_pipeline = false;
-    if (options.discover_sources && requested_sources.size() == 1
+    if (options.discover_sources
+        && requested_sources.size() == 1
         && !mqb::cli::is_module_interface_source(requested_sources.front())) {
         const fs::path& entry = requested_sources.front();
         const bool project_scoped = inside_project(project_root, entry);
-        const fs::path discovery_root = project_scoped ? project_root : entry.parent_path();
+        const fs::path discovery_root = project_scoped
+            ? project_root
+            : entry.parent_path();
         mqb::discovery::Request discovery_request{
             .project_root = discovery_root,
             .entry = entry,
@@ -308,20 +397,26 @@ int main(const int argc, char* argv[]) {
         auto discovered = mqb::discovery::SourceDiscovery::discover(discovery_request);
         if (!discovered) {
             std::cerr << "error: source discovery failed: " << discovered.error().message;
-            if (!discovered.error().path.empty()) std::cerr << ": " << path_text(discovered.error().path);
+            if (!discovered.error().path.empty()) {
+                std::cerr << ": " << path_text(discovered.error().path);
+            }
             std::cerr << '\n';
             return 2;
         }
         for (const auto& warning : discovered->warnings) {
             std::cerr << "warning: source discovery: " << warning.message;
-            if (!warning.path.empty()) std::cerr << ": " << path_text(warning.path);
+            if (!warning.path.empty()) {
+                std::cerr << ": " << path_text(warning.path);
+            }
             std::cerr << '\n';
         }
         discovery_requires_module_pipeline = discovered->requires_module_pipeline;
         sources = std::move(discovered->sources);
         if (sources.size() > 1 || options.verbose) {
             std::cout << "[discover] " << sources.size() << " translation units";
-            if (options.verbose) std::cout << " from " << discovered->indexed_files << " indexed C/C++ files";
+            if (options.verbose) {
+                std::cout << " from " << discovered->indexed_files << " indexed C/C++ files";
+            }
             std::cout << '\n';
         }
     }
@@ -329,18 +424,26 @@ int main(const int argc, char* argv[]) {
 
     const unsigned int hardware_threads = std::thread::hardware_concurrency();
     const std::size_t requested_compile_jobs = options.jobs.value_or(
-        hardware_threads == 0 ? std::size_t{1} : static_cast<std::size_t>(hardware_threads));
-    const std::size_t compile_jobs = std::max<std::size_t>(1, std::min(requested_compile_jobs, sources.size()));
+        hardware_threads == 0
+            ? std::size_t{1}
+            : static_cast<std::size_t>(hardware_threads));
+    const std::size_t compile_jobs = std::max<std::size_t>(
+        1,
+        std::min(requested_compile_jobs, sources.size()));
 
     auto layout = mqb::ProjectArtifactLayout::create(project_root);
-    if (!layout) { std::cerr << "error: " << layout.error().message << '\n'; return 2; }
+    if (!layout) {
+        std::cerr << "error: " << layout.error().message << '\n';
+        return 2;
+    }
 
     std::vector<mqb::orchestration::TargetSourceRequest> target_sources;
     target_sources.reserve(sources.size());
     for (const auto& source : sources) {
         auto artifacts = layout->for_source(source);
         if (!artifacts) {
-            std::cerr << "error: " << artifacts.error().message << ": " << path_text(source) << '\n';
+            std::cerr << "error: " << artifacts.error().message << ": "
+                      << path_text(source) << '\n';
             return 2;
         }
         target_sources.push_back(mqb::orchestration::TargetSourceRequest{
@@ -349,12 +452,18 @@ int main(const int argc, char* argv[]) {
         });
     }
 
-    const std::string target_name = options.build.output_name.value_or(requested_sources.front().stem().string());
+    const std::string target_name = options.build.output_name.value_or(
+        requested_sources.front().stem().string());
     auto target_artifacts = layout->for_target(target_name, options.build.target_kind);
-    if (!target_artifacts) { std::cerr << "error: " << target_artifacts.error().message << '\n'; return 2; }
+    if (!target_artifacts) {
+        std::cerr << "error: " << target_artifacts.error().message << '\n';
+        return 2;
+    }
 
     add_portable_root_if_missing(options.portable_roots, project_root / "portable_msvc");
-    for (const auto& source : sources) add_portable_root_if_missing(options.portable_roots, source.parent_path() / "portable_msvc");
+    for (const auto& source : sources) {
+        add_portable_root_if_missing(options.portable_roots, source.parent_path() / "portable_msvc");
+    }
 
     mqb::platform::windows::WindowsProcessRunner runner;
     mqb::msvc::MsvcToolchainLocator locator{runner};
@@ -367,7 +476,9 @@ int main(const int argc, char* argv[]) {
     auto toolchain = locator.discover(toolchain_discovery);
     if (!toolchain) {
         std::cerr << "error: " << toolchain.error().message;
-        if (!toolchain.error().path.empty()) std::cerr << ": " << path_text(toolchain.error().path);
+        if (!toolchain.error().path.empty()) {
+            std::cerr << ": " << path_text(toolchain.error().path);
+        }
         std::cerr << '\n';
         return 3;
     }
@@ -382,7 +493,8 @@ int main(const int argc, char* argv[]) {
     compiler_options.additional_arguments = std::move(options.compiler_arguments);
 
     const bool module_target = discovery_requires_module_pipeline || std::any_of(
-        target_sources.begin(), target_sources.end(),
+        target_sources.begin(),
+        target_sources.end(),
         [](const mqb::orchestration::TargetSourceRequest& source) {
             return mqb::cli::is_module_interface_source(source.source);
         });
@@ -392,9 +504,12 @@ int main(const int argc, char* argv[]) {
             std::cerr << "error: static-library targets do not yet support the Modules/Header Unit pipeline\n";
             return 2;
         }
-        if (subsystem_explicit || !options.library_directories.empty()
-            || !options.libraries.empty() || !options.linker_arguments.empty()) {
-            std::cerr << "error: static-library targets do not accept linker-only policy (subsystem, library paths/libraries, or linker args)\n";
+        if (subsystem_explicit
+            || !options.library_directories.empty()
+            || !options.libraries.empty()
+            || !options.linker_arguments.empty()) {
+            std::cerr << "error: static-library targets do not accept linker-only policy "
+                         "(subsystem, library paths/libraries, or linker args)\n";
             return 2;
         }
         return mqb::cli::run_static_target(
@@ -428,7 +543,9 @@ int main(const int argc, char* argv[]) {
                 .compiler_options = std::move(compiler_options),
                 .link_options = std::move(link_options),
                 .project_root = project_root,
-                .config_file = project_config ? std::optional<fs::path>{project_config->file} : std::nullopt,
+                .config_file = project_config
+                    ? std::optional<fs::path>{project_config->file}
+                    : std::nullopt,
                 .target_name = target_name,
                 .max_parallel_jobs = compile_jobs,
                 .jobs_explicit = options.jobs.has_value(),
@@ -444,9 +561,12 @@ int main(const int argc, char* argv[]) {
     if (options.verbose) {
         std::cout << "[target] " << target_name << "\n"
                   << "  project: " << path_text(project_root) << '\n';
-        if (project_config) std::cout << "  config:  " << path_text(project_config->file) << '\n';
+        if (project_config) {
+            std::cout << "  config:  " << path_text(project_config->file) << '\n';
+        }
         std::cout << "  type:    " << mqb::to_string(options.build.target_kind) << '\n'
-                  << "  jobs:    " << compile_jobs << (options.jobs ? "" : " (auto)") << '\n'
+                  << "  jobs:    " << compile_jobs
+                  << (options.jobs ? "" : " (auto)") << '\n'
                   << "  cl:      " << path_text(toolchain->identity.compiler) << '\n'
                   << "  link:    " << path_text(toolchain->linker) << '\n';
         for (const auto& source : target_sources) {
@@ -455,19 +575,31 @@ int main(const int argc, char* argv[]) {
                       << "    deps:  " << path_text(source.artifacts.dependencies) << '\n'
                       << "    cache: " << path_text(source.artifacts.compile_cache) << '\n';
         }
-        for (const auto& directory : link_options.library_directories) std::cout << "  libpath: " << path_text(directory) << '\n';
-        for (const auto& library : link_options.libraries) std::cout << "  lib:     " << library << '\n';
-        for (const auto& argument : compiler_options.additional_arguments) std::cout << "  cl-arg:  " << argument << '\n';
-        for (const auto& argument : link_options.additional_arguments) std::cout << "  link-arg:" << argument << '\n';
+        for (const auto& directory : link_options.library_directories) {
+            std::cout << "  libpath: " << path_text(directory) << '\n';
+        }
+        for (const auto& library : link_options.libraries) {
+            std::cout << "  lib:     " << library << '\n';
+        }
+        for (const auto& argument : compiler_options.additional_arguments) {
+            std::cout << "  cl-arg:  " << argument << '\n';
+        }
+        for (const auto& argument : link_options.additional_arguments) {
+            std::cout << "  link-arg:" << argument << '\n';
+        }
         std::cout << "  output:  " << path_text(target_artifacts->executable) << '\n'
                   << "  cache:   " << path_text(target_artifacts->link_cache) << '\n';
     }
 
     mqb::msvc::MsvcCompileExecutor compile_executor{*toolchain, runner};
-    mqb::orchestration::MsvcIncrementalCompileCoordinator compile_coordinator{*toolchain, compile_executor};
+    mqb::orchestration::MsvcIncrementalCompileCoordinator compile_coordinator{
+        *toolchain,
+        compile_executor};
     mqb::msvc::MsvcLinker linker{*toolchain, runner};
     mqb::orchestration::MsvcIncrementalLinkCoordinator link_coordinator{*toolchain, linker};
-    mqb::orchestration::MsvcIncrementalTargetCoordinator target_coordinator{compile_coordinator, link_coordinator};
+    mqb::orchestration::MsvcIncrementalTargetCoordinator target_coordinator{
+        compile_coordinator,
+        link_coordinator};
 
     const mqb::orchestration::IncrementalTargetRequest request{
         .sources = std::move(target_sources),
@@ -491,7 +623,9 @@ int main(const int argc, char* argv[]) {
             std::cout << "[compile] " << path_text(label);
             print_reasons(compile.result.validation.reasons);
             std::cout << '\n';
-            if (compile.result.process) print_process_output(*compile.result.process);
+            if (compile.result.process) {
+                print_process_output(*compile.result.process);
+            }
         } else {
             std::cout << "[up-to-date] " << path_text(label) << '\n';
         }
@@ -502,13 +636,18 @@ int main(const int argc, char* argv[]) {
         std::cout << "[link] " << path_text(request.target.executable.filename());
         print_reasons(result->link.validation.reasons);
         std::cout << '\n';
-        if (result->link.process) print_process_output(*result->link.process);
+        if (result->link.process) {
+            print_process_output(*result->link.process);
+        }
     } else {
         std::cout << "[up-to-date] " << path_text(request.target.executable.filename()) << '\n';
     }
 
     std::cout << "output: " << path_text(request.target.executable) << '\n';
-    if (!options.build.run_after_build) return 0;
+
+    if (!options.build.run_after_build) {
+        return 0;
+    }
 
     std::cout << "[run] " << path_text(request.target.executable.filename()) << '\n';
     mqb::process::ProcessSpec run_spec;
@@ -517,6 +656,7 @@ int main(const int argc, char* argv[]) {
     run_spec.working_directory = project_root;
     run_spec.capture_stdout = true;
     run_spec.capture_stderr = true;
+
     auto run_result = runner.run(run_spec);
     if (!run_result) {
         std::cerr << "error: failed to run executable: " << run_result.error().message << '\n';

--- a/cpp/backends/msvc/CMakeLists.txt
+++ b/cpp/backends/msvc/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(mqb_msvc STATIC
     src/MsvcCompileExecutor.cpp
     src/MsvcCompiler.cpp
+    src/MsvcLibrarian.cpp
     src/MsvcLibraryResolver.cpp
     src/MsvcLinker.cpp
     src/MsvcModuleDependencyScanner.cpp

--- a/cpp/backends/msvc/include/mqb/msvc/MsvcLibrarian.hpp
+++ b/cpp/backends/msvc/include/mqb/msvc/MsvcLibrarian.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <expected>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "mqb/core/LibrarianIdentity.hpp"
+#include "mqb/msvc/MsvcToolchainLocator.hpp"
+#include "mqb/process/Process.hpp"
+
+namespace mqb::msvc {
+
+struct ArchiveInvocation {
+    std::vector<std::filesystem::path> objects;
+    std::filesystem::path output;
+    std::filesystem::path working_directory;
+};
+
+enum class LibrarianErrorCode {
+    invalid_request,
+    identity_failed,
+    output_prepare_failed,
+    process_failed,
+    archive_failed,
+};
+
+struct LibrarianError {
+    LibrarianErrorCode code{LibrarianErrorCode::invalid_request};
+    std::string message;
+    std::filesystem::path path;
+    std::optional<process::ProcessError> process_error;
+    std::optional<process::ProcessResult> process_result;
+};
+
+class MsvcLibrarian {
+public:
+    MsvcLibrarian(const MsvcToolchain& toolchain, process::ProcessRunner& runner)
+        : toolchain_(toolchain), runner_(runner) {}
+
+    [[nodiscard]] static std::expected<LibrarianIdentity, LibrarianError>
+    identity(const MsvcToolchain& toolchain);
+
+    [[nodiscard]] static std::expected<std::vector<std::string>, LibrarianError>
+    build_arguments(const ArchiveInvocation& invocation);
+
+    [[nodiscard]] std::expected<process::ProcessResult, LibrarianError>
+    archive(const ArchiveInvocation& invocation) const;
+
+private:
+    const MsvcToolchain& toolchain_;
+    process::ProcessRunner& runner_;
+};
+
+} // namespace mqb::msvc

--- a/cpp/backends/msvc/include/mqb/msvc/MsvcLibrarian.hpp
+++ b/cpp/backends/msvc/include/mqb/msvc/MsvcLibrarian.hpp
@@ -24,6 +24,7 @@ enum class LibrarianErrorCode {
     output_prepare_failed,
     process_failed,
     archive_failed,
+    output_install_failed,
 };
 
 struct LibrarianError {

--- a/cpp/backends/msvc/src/MsvcLibrarian.cpp
+++ b/cpp/backends/msvc/src/MsvcLibrarian.cpp
@@ -1,0 +1,120 @@
+#include "mqb/msvc/MsvcLibrarian.hpp"
+
+#include <filesystem>
+#include <string>
+#include <system_error>
+#include <utility>
+
+namespace mqb::msvc {
+namespace {
+
+namespace fs = std::filesystem;
+
+[[nodiscard]] LibrarianError failure(
+    const LibrarianErrorCode code,
+    std::string message,
+    fs::path path = {}) {
+    return LibrarianError{.code = code, .message = std::move(message), .path = std::move(path)};
+}
+
+[[nodiscard]] std::string path_to_utf8(const fs::path& path) {
+    const auto bytes = path.generic_u8string();
+    return std::string{reinterpret_cast<const char*>(bytes.data()), bytes.size()};
+}
+
+} // namespace
+
+std::expected<LibrarianIdentity, LibrarianError>
+MsvcLibrarian::identity(const MsvcToolchain& toolchain) {
+    if (toolchain.librarian.empty()) {
+        return std::unexpected(failure(
+            LibrarianErrorCode::identity_failed, "MSVC librarian path is empty"));
+    }
+    std::error_code ec;
+    if (!fs::is_regular_file(toolchain.librarian, ec) || ec) {
+        return std::unexpected(failure(
+            LibrarianErrorCode::identity_failed,
+            "MSVC librarian executable does not exist",
+            toolchain.librarian));
+    }
+    const auto size = fs::file_size(toolchain.librarian, ec);
+    if (ec) return std::unexpected(failure(
+        LibrarianErrorCode::identity_failed, "cannot read MSVC librarian size", toolchain.librarian));
+    const auto modified = fs::last_write_time(toolchain.librarian, ec);
+    if (ec) return std::unexpected(failure(
+        LibrarianErrorCode::identity_failed, "cannot read MSVC librarian timestamp", toolchain.librarian));
+    return LibrarianIdentity{
+        .librarian = toolchain.librarian,
+        .version = toolchain.identity.version,
+        .binary_stamp = std::to_string(size) + ":" + std::to_string(modified.time_since_epoch().count()),
+    };
+}
+
+std::expected<std::vector<std::string>, LibrarianError>
+MsvcLibrarian::build_arguments(const ArchiveInvocation& invocation) {
+    if (invocation.objects.empty()) {
+        return std::unexpected(failure(
+            LibrarianErrorCode::invalid_request, "archive invocation has no object inputs"));
+    }
+    if (invocation.output.empty()) {
+        return std::unexpected(failure(
+            LibrarianErrorCode::invalid_request, "archive output path is empty"));
+    }
+    std::vector<std::string> arguments;
+    arguments.reserve(invocation.objects.size() + 2);
+    arguments.emplace_back("/NOLOGO");
+    arguments.push_back("/OUT:" + path_to_utf8(invocation.output));
+    for (const auto& object : invocation.objects) {
+        if (object.empty()) {
+            return std::unexpected(failure(
+                LibrarianErrorCode::invalid_request, "archive invocation contains an empty object path"));
+        }
+        arguments.push_back(path_to_utf8(object));
+    }
+    return arguments;
+}
+
+std::expected<process::ProcessResult, LibrarianError>
+MsvcLibrarian::archive(const ArchiveInvocation& invocation) const {
+    auto arguments = build_arguments(invocation);
+    if (!arguments) return std::unexpected(arguments.error());
+
+    std::error_code ec;
+    if (!invocation.output.parent_path().empty()) {
+        fs::create_directories(invocation.output.parent_path(), ec);
+        if (ec) return std::unexpected(failure(
+            LibrarianErrorCode::output_prepare_failed,
+            "failed to prepare static-library output directory",
+            invocation.output.parent_path()));
+    }
+
+    process::ProcessSpec spec;
+    spec.executable = toolchain_.librarian;
+    spec.arguments = std::move(*arguments);
+    spec.working_directory = invocation.working_directory;
+    spec.environment = toolchain_.environment;
+    spec.inherit_environment = true;
+    spec.capture_stdout = true;
+    spec.capture_stderr = true;
+
+    auto result = runner_.run(spec);
+    if (!result) {
+        return std::unexpected(LibrarianError{
+            .code = LibrarianErrorCode::process_failed,
+            .message = "failed to launch MSVC librarian",
+            .path = toolchain_.librarian,
+            .process_error = result.error(),
+        });
+    }
+    if (result->exit_code != 0) {
+        return std::unexpected(LibrarianError{
+            .code = LibrarianErrorCode::archive_failed,
+            .message = "MSVC librarian returned a non-zero exit code",
+            .path = toolchain_.librarian,
+            .process_result = std::move(*result),
+        });
+    }
+    return std::move(*result);
+}
+
+} // namespace mqb::msvc

--- a/cpp/backends/msvc/src/MsvcLibrarian.cpp
+++ b/cpp/backends/msvc/src/MsvcLibrarian.cpp
@@ -1,5 +1,6 @@
 #include "mqb/msvc/MsvcLibrarian.hpp"
 
+#include <chrono>
 #include <filesystem>
 #include <string>
 #include <system_error>
@@ -20,6 +21,18 @@ namespace fs = std::filesystem;
 [[nodiscard]] std::string path_to_utf8(const fs::path& path) {
     const auto bytes = path.generic_u8string();
     return std::string{reinterpret_cast<const char*>(bytes.data()), bytes.size()};
+}
+
+[[nodiscard]] fs::path temporary_archive_path(const fs::path& output) {
+    fs::path temporary = output;
+    temporary += ".tmp." + std::to_string(
+        std::chrono::steady_clock::now().time_since_epoch().count());
+    return temporary;
+}
+
+void remove_if_present(const fs::path& path) noexcept {
+    std::error_code ignored;
+    fs::remove(path, ignored);
 }
 
 } // namespace
@@ -76,8 +89,14 @@ MsvcLibrarian::build_arguments(const ArchiveInvocation& invocation) {
 
 std::expected<process::ProcessResult, LibrarianError>
 MsvcLibrarian::archive(const ArchiveInvocation& invocation) const {
-    auto arguments = build_arguments(invocation);
-    if (!arguments) return std::unexpected(arguments.error());
+    if (invocation.objects.empty()) {
+        return std::unexpected(failure(
+            LibrarianErrorCode::invalid_request, "archive invocation has no object inputs"));
+    }
+    if (invocation.output.empty()) {
+        return std::unexpected(failure(
+            LibrarianErrorCode::invalid_request, "archive output path is empty"));
+    }
 
     std::error_code ec;
     if (!invocation.output.parent_path().empty()) {
@@ -87,6 +106,13 @@ MsvcLibrarian::archive(const ArchiveInvocation& invocation) const {
             "failed to prepare static-library output directory",
             invocation.output.parent_path()));
     }
+
+    const fs::path temporary_output = temporary_archive_path(invocation.output);
+    remove_if_present(temporary_output);
+    ArchiveInvocation temporary_invocation = invocation;
+    temporary_invocation.output = temporary_output;
+    auto arguments = build_arguments(temporary_invocation);
+    if (!arguments) return std::unexpected(arguments.error());
 
     process::ProcessSpec spec;
     spec.executable = toolchain_.librarian;
@@ -99,6 +125,7 @@ MsvcLibrarian::archive(const ArchiveInvocation& invocation) const {
 
     auto result = runner_.run(spec);
     if (!result) {
+        remove_if_present(temporary_output);
         return std::unexpected(LibrarianError{
             .code = LibrarianErrorCode::process_failed,
             .message = "failed to launch MSVC librarian",
@@ -107,12 +134,49 @@ MsvcLibrarian::archive(const ArchiveInvocation& invocation) const {
         });
     }
     if (result->exit_code != 0) {
+        remove_if_present(temporary_output);
         return std::unexpected(LibrarianError{
             .code = LibrarianErrorCode::archive_failed,
             .message = "MSVC librarian returned a non-zero exit code",
             .path = toolchain_.librarian,
             .process_result = std::move(*result),
         });
+    }
+
+    ec.clear();
+    if (!fs::is_regular_file(temporary_output, ec) || ec) {
+        remove_if_present(temporary_output);
+        return std::unexpected(failure(
+            LibrarianErrorCode::output_install_failed,
+            "MSVC librarian succeeded without producing the temporary archive",
+            temporary_output));
+    }
+
+    ec.clear();
+    if (fs::exists(invocation.output, ec) && !ec) {
+        fs::remove(invocation.output, ec);
+        if (ec) {
+            remove_if_present(temporary_output);
+            return std::unexpected(failure(
+                LibrarianErrorCode::output_install_failed,
+                "failed to remove previous static archive before replacement",
+                invocation.output));
+        }
+    } else if (ec) {
+        remove_if_present(temporary_output);
+        return std::unexpected(failure(
+            LibrarianErrorCode::output_install_failed,
+            "failed to query previous static archive before replacement",
+            invocation.output));
+    }
+
+    fs::rename(temporary_output, invocation.output, ec);
+    if (ec) {
+        remove_if_present(temporary_output);
+        return std::unexpected(failure(
+            LibrarianErrorCode::output_install_failed,
+            "failed to install completed static archive",
+            invocation.output));
     }
     return std::move(*result);
 }

--- a/cpp/core/CMakeLists.txt
+++ b/cpp/core/CMakeLists.txt
@@ -1,4 +1,6 @@
 add_library(mqb_core STATIC
+    src/ArchiveCache.cpp
+    src/ArchiveCacheFile.cpp
     src/BuildPlanner.cpp
     src/BuildSignature.cpp
     src/BuildTypes.cpp

--- a/cpp/core/include/mqb/core/ArchiveCache.hpp
+++ b/cpp/core/include/mqb/core/ArchiveCache.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <filesystem>
+#include <optional>
+#include <span>
+#include <vector>
+
+#include "mqb/core/BuildSignature.hpp"
+#include "mqb/core/BuildTypes.hpp"
+#include "mqb/core/FileSnapshot.hpp"
+#include "mqb/core/LibrarianIdentity.hpp"
+
+namespace mqb {
+
+struct ArchiveCacheEntry {
+    LibrarianIdentity librarian;
+    BuildSignature signature;
+    std::vector<std::filesystem::path> objects;
+    std::filesystem::path output;
+};
+
+struct ArchiveCacheValidation {
+    std::vector<BuildReason> reasons;
+
+    [[nodiscard]] bool reusable() const noexcept { return reasons.empty(); }
+};
+
+class ArchiveCacheValidator {
+public:
+    [[nodiscard]] static ArchiveCacheValidation validate(
+        std::span<const std::filesystem::path> current_objects,
+        const std::filesystem::path& current_output,
+        const LibrarianIdentity& current_librarian,
+        const std::optional<ArchiveCacheEntry>& cached_entry,
+        const FileSnapshot& output_snapshot,
+        std::span<const FileSnapshot> object_snapshots,
+        bool force_archive = false);
+};
+
+} // namespace mqb

--- a/cpp/core/include/mqb/core/ArchiveCacheFile.hpp
+++ b/cpp/core/include/mqb/core/ArchiveCacheFile.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <expected>
+#include <filesystem>
+#include <optional>
+#include <string>
+
+#include "mqb/core/ArchiveCache.hpp"
+
+namespace mqb {
+
+enum class ArchiveCacheFileErrorCode {
+    file_open_failed,
+    file_read_failed,
+    file_write_failed,
+    corrupt_data,
+    unsupported_version,
+    replace_failed,
+};
+
+struct ArchiveCacheFileError {
+    ArchiveCacheFileErrorCode code{ArchiveCacheFileErrorCode::corrupt_data};
+    std::filesystem::path file;
+    std::string message;
+};
+
+class ArchiveCacheFile {
+public:
+    [[nodiscard]] static std::expected<std::optional<ArchiveCacheEntry>, ArchiveCacheFileError>
+    load(const std::filesystem::path& file);
+
+    [[nodiscard]] static std::expected<void, ArchiveCacheFileError>
+    save(const std::filesystem::path& file, const ArchiveCacheEntry& entry);
+};
+
+} // namespace mqb

--- a/cpp/core/include/mqb/core/BuildAction.hpp
+++ b/cpp/core/include/mqb/core/BuildAction.hpp
@@ -23,11 +23,17 @@ struct LinkAction {
     std::vector<BuildReason> reasons;
 };
 
+struct ArchiveAction {
+    std::vector<std::filesystem::path> objects;
+    std::filesystem::path output;
+    std::vector<BuildReason> reasons;
+};
+
 struct RunAction {
     std::filesystem::path executable;
     std::vector<std::string> arguments;
 };
 
-using BuildAction = std::variant<CompileAction, LinkAction, RunAction>;
+using BuildAction = std::variant<CompileAction, LinkAction, ArchiveAction, RunAction>;
 
 } // namespace mqb

--- a/cpp/core/include/mqb/core/BuildPlanner.hpp
+++ b/cpp/core/include/mqb/core/BuildPlanner.hpp
@@ -6,6 +6,7 @@
 #include <span>
 #include <vector>
 
+#include "mqb/core/ArchiveCache.hpp"
 #include "mqb/core/BuildPlan.hpp"
 #include "mqb/core/CompileCache.hpp"
 #include "mqb/core/LinkCache.hpp"
@@ -19,6 +20,8 @@ enum class BuildPlannerErrorCode {
     invalid_header_unit_outputs,
     missing_link_input,
     missing_link_output,
+    missing_archive_input,
+    missing_archive_output,
 };
 
 struct BuildPlannerError {
@@ -40,6 +43,12 @@ struct LinkPlanItem {
     LinkCacheValidation cache_validation;
 };
 
+struct ArchivePlanItem {
+    std::vector<std::filesystem::path> objects;
+    std::filesystem::path output;
+    ArchiveCacheValidation cache_validation;
+};
+
 class BuildPlanner {
 public:
     [[nodiscard]] static std::expected<BuildPlan, BuildPlannerError> plan_compile(
@@ -47,6 +56,9 @@ public:
 
     [[nodiscard]] static std::expected<BuildPlan, BuildPlannerError> plan_link(
         const LinkPlanItem& item);
+
+    [[nodiscard]] static std::expected<BuildPlan, BuildPlannerError> plan_archive(
+        const ArchivePlanItem& item);
 };
 
 } // namespace mqb

--- a/cpp/core/include/mqb/core/BuildSignature.hpp
+++ b/cpp/core/include/mqb/core/BuildSignature.hpp
@@ -6,6 +6,7 @@
 #include <string>
 
 #include "mqb/core/CompilerOptions.hpp"
+#include "mqb/core/LibrarianIdentity.hpp"
 #include "mqb/core/LinkOptions.hpp"
 #include "mqb/core/LinkerIdentity.hpp"
 #include "mqb/core/ToolchainIdentity.hpp"
@@ -40,6 +41,11 @@ public:
         const std::filesystem::path& output,
         const LinkerIdentity& linker,
         const LinkOptions& options);
+
+    [[nodiscard]] static BuildSignature for_archive(
+        std::span<const std::filesystem::path> objects,
+        const std::filesystem::path& output,
+        const LibrarianIdentity& librarian);
 
     [[nodiscard]] static BuildSignature from_digest(const SignatureDigest digest) noexcept {
         return BuildSignature{digest};

--- a/cpp/core/include/mqb/core/BuildTypes.hpp
+++ b/cpp/core/include/mqb/core/BuildTypes.hpp
@@ -27,8 +27,6 @@ enum class CppStandard {
 enum class TargetKind {
     executable,
     dynamic_library,
-    // Reserved for the librarian-backed target slice. The public CLI/config
-    // will not accept static until the lib.exe pipeline is implemented.
     static_library,
 };
 
@@ -41,6 +39,8 @@ enum class BuildReason {
     compiler_options_changed,
     link_inputs_changed,
     linker_options_changed,
+    archive_inputs_changed,
+    archive_recipe_changed,
     explicit_rebuild,
 };
 

--- a/cpp/core/include/mqb/core/LibrarianIdentity.hpp
+++ b/cpp/core/include/mqb/core/LibrarianIdentity.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+
+namespace mqb {
+
+struct LibrarianIdentity {
+    std::filesystem::path librarian;
+    std::string version;
+    std::string binary_stamp;
+};
+
+} // namespace mqb

--- a/cpp/core/src/ArchiveCache.cpp
+++ b/cpp/core/src/ArchiveCache.cpp
@@ -1,0 +1,100 @@
+#include "mqb/core/ArchiveCache.hpp"
+
+#include <algorithm>
+#include <filesystem>
+#include <span>
+
+namespace mqb {
+namespace {
+
+[[nodiscard]] bool same_path(
+    const std::filesystem::path& left,
+    const std::filesystem::path& right) {
+    return left.lexically_normal() == right.lexically_normal();
+}
+
+[[nodiscard]] bool same_paths(
+    const std::span<const std::filesystem::path> left,
+    const std::span<const std::filesystem::path> right) {
+    if (left.size() != right.size()) return false;
+    for (std::size_t index = 0; index < left.size(); ++index) {
+        if (!same_path(left[index], right[index])) return false;
+    }
+    return true;
+}
+
+[[nodiscard]] bool same_librarian(
+    const LibrarianIdentity& left,
+    const LibrarianIdentity& right) {
+    return same_path(left.librarian, right.librarian)
+        && left.version == right.version
+        && left.binary_stamp == right.binary_stamp;
+}
+
+void add_reason(std::vector<BuildReason>& reasons, const BuildReason reason) {
+    if (std::find(reasons.begin(), reasons.end(), reason) == reasons.end()) {
+        reasons.push_back(reason);
+    }
+}
+
+[[nodiscard]] const FileSnapshot* find_snapshot(
+    const std::span<const FileSnapshot> snapshots,
+    const std::filesystem::path& path) {
+    const auto it = std::find_if(
+        snapshots.begin(), snapshots.end(),
+        [&path](const FileSnapshot& snapshot) { return same_path(snapshot.path, path); });
+    return it == snapshots.end() ? nullptr : &*it;
+}
+
+} // namespace
+
+ArchiveCacheValidation ArchiveCacheValidator::validate(
+    const std::span<const std::filesystem::path> current_objects,
+    const std::filesystem::path& current_output,
+    const LibrarianIdentity& current_librarian,
+    const std::optional<ArchiveCacheEntry>& cached_entry,
+    const FileSnapshot& output_snapshot,
+    const std::span<const FileSnapshot> object_snapshots,
+    const bool force_archive) {
+    ArchiveCacheValidation result;
+
+    if (force_archive) add_reason(result.reasons, BuildReason::explicit_rebuild);
+
+    if (!cached_entry) {
+        add_reason(result.reasons, BuildReason::missing_cache_entry);
+        if (!output_snapshot.exists) add_reason(result.reasons, BuildReason::missing_output);
+        return result;
+    }
+
+    const auto& cached = *cached_entry;
+    const bool librarian_matches = same_librarian(cached.librarian, current_librarian);
+    if (!librarian_matches) add_reason(result.reasons, BuildReason::toolchain_changed);
+
+    const bool inputs_match = same_paths(cached.objects, current_objects);
+    if (!inputs_match) add_reason(result.reasons, BuildReason::archive_inputs_changed);
+
+    const auto signature = BuildSignature::for_archive(
+        current_objects, current_output, current_librarian);
+    if (cached.signature != signature && librarian_matches && inputs_match) {
+        add_reason(result.reasons, BuildReason::archive_recipe_changed);
+    }
+    if (!same_path(cached.output, current_output)) {
+        add_reason(result.reasons, BuildReason::archive_recipe_changed);
+    }
+    if (!output_snapshot.exists) add_reason(result.reasons, BuildReason::missing_output);
+
+    for (const auto& object : current_objects) {
+        const auto* snapshot = find_snapshot(object_snapshots, object);
+        if (snapshot == nullptr || !snapshot->exists) {
+            add_reason(result.reasons, BuildReason::archive_inputs_changed);
+            continue;
+        }
+        if (output_snapshot.exists && snapshot->modified > output_snapshot.modified) {
+            add_reason(result.reasons, BuildReason::archive_inputs_changed);
+        }
+    }
+
+    return result;
+}
+
+} // namespace mqb

--- a/cpp/core/src/ArchiveCacheFile.cpp
+++ b/cpp/core/src/ArchiveCacheFile.cpp
@@ -1,0 +1,196 @@
+#include "mqb/core/ArchiveCacheFile.hpp"
+
+#include <chrono>
+#include <cstdint>
+#include <expected>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <limits>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+namespace mqb {
+namespace {
+
+namespace fs = std::filesystem;
+constexpr std::string_view magic = "MQBARCHIVE";
+constexpr unsigned int format_version = 1;
+constexpr std::size_t max_objects = 100000u;
+
+[[nodiscard]] ArchiveCacheFileError error(
+    const ArchiveCacheFileErrorCode code,
+    const fs::path& file,
+    std::string message) {
+    return ArchiveCacheFileError{.code = code, .file = file, .message = std::move(message)};
+}
+
+[[nodiscard]] std::string path_to_utf8(const fs::path& path) {
+    const auto bytes = path.lexically_normal().generic_u8string();
+    return std::string{reinterpret_cast<const char*>(bytes.data()), bytes.size()};
+}
+
+[[nodiscard]] fs::path path_from_utf8(const std::string_view value) {
+    std::u8string bytes;
+    bytes.assign(
+        reinterpret_cast<const char8_t*>(value.data()),
+        reinterpret_cast<const char8_t*>(value.data() + value.size()));
+    return fs::path{bytes}.lexically_normal();
+}
+
+[[nodiscard]] fs::path temporary_path_for(const fs::path& file) {
+    fs::path temporary = file;
+    temporary += ".tmp." + std::to_string(
+        std::chrono::steady_clock::now().time_since_epoch().count());
+    return temporary;
+}
+
+} // namespace
+
+std::expected<std::optional<ArchiveCacheEntry>, ArchiveCacheFileError>
+ArchiveCacheFile::load(const fs::path& file) {
+    std::error_code ec;
+    if (!fs::exists(file, ec)) {
+        if (ec) return std::unexpected(error(
+            ArchiveCacheFileErrorCode::file_open_failed, file, "failed to query archive cache file"));
+        return std::optional<ArchiveCacheEntry>{};
+    }
+
+    std::ifstream stream{file, std::ios::binary};
+    if (!stream) return std::unexpected(error(
+        ArchiveCacheFileErrorCode::file_open_failed, file, "failed to open archive cache file"));
+
+    std::string loaded_magic;
+    unsigned int version = 0;
+    if (!(stream >> loaded_magic >> version) || loaded_magic != magic) {
+        return std::unexpected(error(
+            ArchiveCacheFileErrorCode::corrupt_data, file, "archive cache header is invalid"));
+    }
+    if (version != format_version) {
+        return std::unexpected(error(
+            ArchiveCacheFileErrorCode::unsupported_version, file, "archive cache version is not supported"));
+    }
+
+    std::string librarian_path;
+    std::string librarian_version;
+    std::string librarian_stamp;
+    std::uint64_t signature_high = 0;
+    std::uint64_t signature_low = 0;
+    std::string output;
+    std::size_t object_count = 0;
+    if (!(stream >> std::quoted(librarian_path)
+                 >> std::quoted(librarian_version)
+                 >> std::quoted(librarian_stamp)
+                 >> signature_high
+                 >> signature_low
+                 >> std::quoted(output)
+                 >> object_count)) {
+        return std::unexpected(error(
+            ArchiveCacheFileErrorCode::corrupt_data, file, "archive cache body is truncated"));
+    }
+    if (object_count > max_objects) {
+        return std::unexpected(error(
+            ArchiveCacheFileErrorCode::corrupt_data, file, "archive cache object count exceeds safety limit"));
+    }
+
+    std::vector<fs::path> objects;
+    objects.reserve(object_count);
+    for (std::size_t index = 0; index < object_count; ++index) {
+        std::string object;
+        if (!(stream >> std::quoted(object))) {
+            return std::unexpected(error(
+                ArchiveCacheFileErrorCode::corrupt_data, file, "archive cache object list is truncated"));
+        }
+        objects.push_back(path_from_utf8(object));
+    }
+
+    std::string trailing;
+    if (stream >> trailing) {
+        return std::unexpected(error(
+            ArchiveCacheFileErrorCode::corrupt_data, file, "archive cache has unexpected trailing data"));
+    }
+
+    return std::optional<ArchiveCacheEntry>{ArchiveCacheEntry{
+        .librarian = LibrarianIdentity{
+            .librarian = path_from_utf8(librarian_path),
+            .version = std::move(librarian_version),
+            .binary_stamp = std::move(librarian_stamp),
+        },
+        .signature = BuildSignature::from_digest(SignatureDigest{
+            .high = signature_high,
+            .low = signature_low,
+        }),
+        .objects = std::move(objects),
+        .output = path_from_utf8(output),
+    }};
+}
+
+std::expected<void, ArchiveCacheFileError>
+ArchiveCacheFile::save(const fs::path& file, const ArchiveCacheEntry& entry) {
+    if (entry.objects.size() > max_objects) {
+        return std::unexpected(error(
+            ArchiveCacheFileErrorCode::file_write_failed, file, "archive cache object count exceeds safety limit"));
+    }
+
+    std::error_code ec;
+    if (!file.parent_path().empty()) {
+        fs::create_directories(file.parent_path(), ec);
+        if (ec) return std::unexpected(error(
+            ArchiveCacheFileErrorCode::file_write_failed, file, "failed to create archive cache directory"));
+    }
+
+    const fs::path temporary = temporary_path_for(file);
+    {
+        std::ofstream stream{temporary, std::ios::binary | std::ios::trunc};
+        if (!stream) return std::unexpected(error(
+            ArchiveCacheFileErrorCode::file_open_failed, temporary, "failed to open temporary archive cache"));
+        stream << magic << ' ' << format_version << '\n'
+               << std::quoted(path_to_utf8(entry.librarian.librarian)) << '\n'
+               << std::quoted(entry.librarian.version) << '\n'
+               << std::quoted(entry.librarian.binary_stamp) << '\n'
+               << entry.signature.digest().high << ' ' << entry.signature.digest().low << '\n'
+               << std::quoted(path_to_utf8(entry.output)) << '\n'
+               << entry.objects.size() << '\n';
+        for (const auto& object : entry.objects) {
+            stream << std::quoted(path_to_utf8(object)) << '\n';
+        }
+        stream.flush();
+        if (!stream) {
+            stream.close();
+            fs::remove(temporary, ec);
+            return std::unexpected(error(
+                ArchiveCacheFileErrorCode::file_write_failed, temporary, "failed to write archive cache"));
+        }
+    }
+
+    ec.clear();
+    if (fs::exists(file, ec) && !ec) {
+        fs::remove(file, ec);
+        if (ec) {
+            std::error_code ignored;
+            fs::remove(temporary, ignored);
+            return std::unexpected(error(
+                ArchiveCacheFileErrorCode::replace_failed, file, "failed to remove previous archive cache"));
+        }
+    } else if (ec) {
+        std::error_code ignored;
+        fs::remove(temporary, ignored);
+        return std::unexpected(error(
+            ArchiveCacheFileErrorCode::replace_failed, file, "failed to query previous archive cache"));
+    }
+
+    fs::rename(temporary, file, ec);
+    if (ec) {
+        std::error_code ignored;
+        fs::remove(temporary, ignored);
+        return std::unexpected(error(
+            ArchiveCacheFileErrorCode::replace_failed, file, "failed to install archive cache"));
+    }
+    return {};
+}
+
+} // namespace mqb

--- a/cpp/core/src/BuildPlanner.cpp
+++ b/cpp/core/src/BuildPlanner.cpp
@@ -12,17 +12,27 @@ namespace mqb {
 std::expected<BuildPlan, BuildPlannerError> BuildPlanner::plan_compile(
     const std::span<const CompilePlanItem> items) {
     BuildPlan plan;
+
     for (const auto& item : items) {
-        if (item.cache_validation.reusable()) continue;
+        if (item.cache_validation.reusable()) {
+            continue;
+        }
+
         std::size_t object_output_count = 0;
         std::size_t module_interface_output_count = 0;
         for (const auto& output : item.unit.outputs) {
-            if (output.kind == ArtifactKind::object) ++object_output_count;
-            else if (output.kind == ArtifactKind::module_interface) ++module_interface_output_count;
+            if (output.kind == ArtifactKind::object) {
+                ++object_output_count;
+            } else if (output.kind == ArtifactKind::module_interface) {
+                ++module_interface_output_count;
+            }
         }
+
         if (item.unit.header_unit) {
-            if (object_output_count != 0 || module_interface_output_count != 1
-                || item.unit.outputs.size() != 1 || item.unit.outputs.front().path.empty()) {
+            if (object_output_count != 0
+                || module_interface_output_count != 1
+                || item.unit.outputs.size() != 1
+                || item.unit.outputs.front().path.empty()) {
                 return std::unexpected(BuildPlannerError{
                     .code = BuildPlannerErrorCode::invalid_header_unit_outputs,
                     .source = item.unit.source,
@@ -33,7 +43,10 @@ std::expected<BuildPlan, BuildPlannerError> BuildPlanner::plan_compile(
         } else {
             const Artifact* object_output = nullptr;
             for (const auto& output : item.unit.outputs) {
-                if (output.kind == ArtifactKind::object) { object_output = &output; break; }
+                if (output.kind == ArtifactKind::object) {
+                    object_output = &output;
+                    break;
+                }
             }
             if (object_output_count == 0 || object_output == nullptr || object_output->path.empty()) {
                 return std::unexpected(BuildPlannerError{
@@ -52,31 +65,49 @@ std::expected<BuildPlan, BuildPlannerError> BuildPlanner::plan_compile(
                 });
             }
         }
+
         plan.actions.emplace_back(CompileAction{
             .source = item.unit.source,
             .outputs = item.unit.outputs,
             .reasons = item.cache_validation.reasons,
         });
     }
+
     return plan;
 }
 
 std::expected<BuildPlan, BuildPlannerError> BuildPlanner::plan_link(
     const LinkPlanItem& item) {
     BuildPlan plan;
-    if (item.cache_validation.reusable()) return plan;
+    if (item.cache_validation.reusable()) {
+        return plan;
+    }
+
     if (item.objects.empty()) {
-        return std::unexpected(BuildPlannerError{.code = BuildPlannerErrorCode::missing_link_input});
+        return std::unexpected(BuildPlannerError{
+            .code = BuildPlannerErrorCode::missing_link_input,
+        });
     }
     for (const auto& object : item.objects) {
-        if (object.empty()) return std::unexpected(BuildPlannerError{.code = BuildPlannerErrorCode::missing_link_input});
+        if (object.empty()) {
+            return std::unexpected(BuildPlannerError{
+                .code = BuildPlannerErrorCode::missing_link_input,
+            });
+        }
     }
     for (const auto& library : item.libraries) {
-        if (library.empty()) return std::unexpected(BuildPlannerError{.code = BuildPlannerErrorCode::missing_link_input});
+        if (library.empty()) {
+            return std::unexpected(BuildPlannerError{
+                .code = BuildPlannerErrorCode::missing_link_input,
+            });
+        }
     }
     if (item.output.empty()) {
-        return std::unexpected(BuildPlannerError{.code = BuildPlannerErrorCode::missing_link_output});
+        return std::unexpected(BuildPlannerError{
+            .code = BuildPlannerErrorCode::missing_link_output,
+        });
     }
+
     plan.actions.emplace_back(LinkAction{
         .objects = item.objects,
         .output = item.output,
@@ -89,16 +120,28 @@ std::expected<BuildPlan, BuildPlannerError> BuildPlanner::plan_link(
 std::expected<BuildPlan, BuildPlannerError> BuildPlanner::plan_archive(
     const ArchivePlanItem& item) {
     BuildPlan plan;
-    if (item.cache_validation.reusable()) return plan;
+    if (item.cache_validation.reusable()) {
+        return plan;
+    }
+
     if (item.objects.empty()) {
-        return std::unexpected(BuildPlannerError{.code = BuildPlannerErrorCode::missing_archive_input});
+        return std::unexpected(BuildPlannerError{
+            .code = BuildPlannerErrorCode::missing_archive_input,
+        });
     }
     for (const auto& object : item.objects) {
-        if (object.empty()) return std::unexpected(BuildPlannerError{.code = BuildPlannerErrorCode::missing_archive_input});
+        if (object.empty()) {
+            return std::unexpected(BuildPlannerError{
+                .code = BuildPlannerErrorCode::missing_archive_input,
+            });
+        }
     }
     if (item.output.empty()) {
-        return std::unexpected(BuildPlannerError{.code = BuildPlannerErrorCode::missing_archive_output});
+        return std::unexpected(BuildPlannerError{
+            .code = BuildPlannerErrorCode::missing_archive_output,
+        });
     }
+
     plan.actions.emplace_back(ArchiveAction{
         .objects = item.objects,
         .output = item.output,

--- a/cpp/core/src/BuildPlanner.cpp
+++ b/cpp/core/src/BuildPlanner.cpp
@@ -12,27 +12,17 @@ namespace mqb {
 std::expected<BuildPlan, BuildPlannerError> BuildPlanner::plan_compile(
     const std::span<const CompilePlanItem> items) {
     BuildPlan plan;
-
     for (const auto& item : items) {
-        if (item.cache_validation.reusable()) {
-            continue;
-        }
-
+        if (item.cache_validation.reusable()) continue;
         std::size_t object_output_count = 0;
         std::size_t module_interface_output_count = 0;
         for (const auto& output : item.unit.outputs) {
-            if (output.kind == ArtifactKind::object) {
-                ++object_output_count;
-            } else if (output.kind == ArtifactKind::module_interface) {
-                ++module_interface_output_count;
-            }
+            if (output.kind == ArtifactKind::object) ++object_output_count;
+            else if (output.kind == ArtifactKind::module_interface) ++module_interface_output_count;
         }
-
         if (item.unit.header_unit) {
-            if (object_output_count != 0
-                || module_interface_output_count != 1
-                || item.unit.outputs.size() != 1
-                || item.unit.outputs.front().path.empty()) {
+            if (object_output_count != 0 || module_interface_output_count != 1
+                || item.unit.outputs.size() != 1 || item.unit.outputs.front().path.empty()) {
                 return std::unexpected(BuildPlannerError{
                     .code = BuildPlannerErrorCode::invalid_header_unit_outputs,
                     .source = item.unit.source,
@@ -43,10 +33,7 @@ std::expected<BuildPlan, BuildPlannerError> BuildPlanner::plan_compile(
         } else {
             const Artifact* object_output = nullptr;
             for (const auto& output : item.unit.outputs) {
-                if (output.kind == ArtifactKind::object) {
-                    object_output = &output;
-                    break;
-                }
+                if (output.kind == ArtifactKind::object) { object_output = &output; break; }
             }
             if (object_output_count == 0 || object_output == nullptr || object_output->path.empty()) {
                 return std::unexpected(BuildPlannerError{
@@ -65,53 +52,56 @@ std::expected<BuildPlan, BuildPlannerError> BuildPlanner::plan_compile(
                 });
             }
         }
-
         plan.actions.emplace_back(CompileAction{
             .source = item.unit.source,
             .outputs = item.unit.outputs,
             .reasons = item.cache_validation.reasons,
         });
     }
-
     return plan;
 }
 
 std::expected<BuildPlan, BuildPlannerError> BuildPlanner::plan_link(
     const LinkPlanItem& item) {
     BuildPlan plan;
-    if (item.cache_validation.reusable()) {
-        return plan;
-    }
-
+    if (item.cache_validation.reusable()) return plan;
     if (item.objects.empty()) {
-        return std::unexpected(BuildPlannerError{
-            .code = BuildPlannerErrorCode::missing_link_input,
-        });
+        return std::unexpected(BuildPlannerError{.code = BuildPlannerErrorCode::missing_link_input});
     }
     for (const auto& object : item.objects) {
-        if (object.empty()) {
-            return std::unexpected(BuildPlannerError{
-                .code = BuildPlannerErrorCode::missing_link_input,
-            });
-        }
+        if (object.empty()) return std::unexpected(BuildPlannerError{.code = BuildPlannerErrorCode::missing_link_input});
     }
     for (const auto& library : item.libraries) {
-        if (library.empty()) {
-            return std::unexpected(BuildPlannerError{
-                .code = BuildPlannerErrorCode::missing_link_input,
-            });
-        }
+        if (library.empty()) return std::unexpected(BuildPlannerError{.code = BuildPlannerErrorCode::missing_link_input});
     }
     if (item.output.empty()) {
-        return std::unexpected(BuildPlannerError{
-            .code = BuildPlannerErrorCode::missing_link_output,
-        });
+        return std::unexpected(BuildPlannerError{.code = BuildPlannerErrorCode::missing_link_output});
     }
-
     plan.actions.emplace_back(LinkAction{
         .objects = item.objects,
         .output = item.output,
         .libraries = item.libraries,
+        .reasons = item.cache_validation.reasons,
+    });
+    return plan;
+}
+
+std::expected<BuildPlan, BuildPlannerError> BuildPlanner::plan_archive(
+    const ArchivePlanItem& item) {
+    BuildPlan plan;
+    if (item.cache_validation.reusable()) return plan;
+    if (item.objects.empty()) {
+        return std::unexpected(BuildPlannerError{.code = BuildPlannerErrorCode::missing_archive_input});
+    }
+    for (const auto& object : item.objects) {
+        if (object.empty()) return std::unexpected(BuildPlannerError{.code = BuildPlannerErrorCode::missing_archive_input});
+    }
+    if (item.output.empty()) {
+        return std::unexpected(BuildPlannerError{.code = BuildPlannerErrorCode::missing_archive_output});
+    }
+    plan.actions.emplace_back(ArchiveAction{
+        .objects = item.objects,
+        .output = item.output,
         .reasons = item.cache_validation.reasons,
     });
     return plan;

--- a/cpp/core/src/BuildSignature.cpp
+++ b/cpp/core/src/BuildSignature.cpp
@@ -32,17 +32,13 @@ class StableHasher {
 public:
     void add_string(const std::string_view value) noexcept {
         add_u64(static_cast<std::uint64_t>(value.size()));
-        for (const unsigned char byte : value) {
-            add_byte(byte);
-        }
+        for (const unsigned char byte : value) add_byte(byte);
     }
 
     void add_path(const std::filesystem::path& value) noexcept {
         const auto normalized = value.lexically_normal().generic_u8string();
         add_u64(static_cast<std::uint64_t>(normalized.size()));
-        for (const char8_t byte : normalized) {
-            add_byte(static_cast<std::uint8_t>(byte));
-        }
+        for (const char8_t byte : normalized) add_byte(static_cast<std::uint8_t>(byte));
     }
 
     template <typename Enum>
@@ -53,23 +49,16 @@ public:
 
     void add_strings(const std::vector<std::string>& values) noexcept {
         add_u64(static_cast<std::uint64_t>(values.size()));
-        for (const auto& value : values) {
-            add_string(value);
-        }
+        for (const auto& value : values) add_string(value);
     }
 
     void add_paths(const std::span<const std::filesystem::path> values) noexcept {
         add_u64(static_cast<std::uint64_t>(values.size()));
-        for (const auto& value : values) {
-            add_path(value);
-        }
+        for (const auto& value : values) add_path(value);
     }
 
-    void add_header_unit_identity(
-        const std::optional<HeaderUnitIdentity>& identity) noexcept {
-        if (!identity) {
-            return;
-        }
+    void add_header_unit_identity(const std::optional<HeaderUnitIdentity>& identity) noexcept {
+        if (!identity) return;
         add_string("mqb.header-unit.producer.v1");
         add_string(identity->header_name);
         add_enum(identity->lookup_method);
@@ -83,8 +72,7 @@ public:
         }
     }
 
-    void add_header_unit_references(
-        const std::vector<HeaderUnitReference>& references) noexcept {
+    void add_header_unit_references(const std::vector<HeaderUnitReference>& references) noexcept {
         add_u64(static_cast<std::uint64_t>(references.size()));
         for (const auto& reference : references) {
             add_string(reference.header_name);
@@ -96,23 +84,16 @@ public:
     void add_module_outputs(const std::vector<Artifact>& outputs) noexcept {
         std::uint64_t count = 0;
         for (const auto& output : outputs) {
-            if (output.kind == ArtifactKind::module_interface) {
-                ++count;
-            }
+            if (output.kind == ArtifactKind::module_interface) ++count;
         }
         add_u64(count);
         for (const auto& output : outputs) {
-            if (output.kind == ArtifactKind::module_interface) {
-                add_path(output.path);
-            }
+            if (output.kind == ArtifactKind::module_interface) add_path(output.path);
         }
     }
 
     [[nodiscard]] SignatureDigest finish() const noexcept {
-        return SignatureDigest{
-            .high = avalanche(primary_),
-            .low = avalanche(secondary_),
-        };
+        return SignatureDigest{.high = avalanche(primary_), .low = avalanche(secondary_)};
     }
 
 private:
@@ -125,7 +106,6 @@ private:
     void add_byte(const std::uint8_t byte) noexcept {
         primary_ ^= byte;
         primary_ *= fnv_prime;
-
         secondary_ ^= static_cast<std::uint64_t>(byte) + secondary_seed
             + (secondary_ << 6u) + (secondary_ >> 2u);
         secondary_ = std::rotl(secondary_, 13);
@@ -152,18 +132,15 @@ BuildSignature BuildSignature::for_compile(
     const CompilerOptions& options) {
     StableHasher hasher;
     hasher.add_string("mqb.compile.signature.v4");
-
     hasher.add_path(unit.source);
     hasher.add_enum(unit.kind);
     hasher.add_module_references(unit.module_references);
     hasher.add_header_unit_references(unit.header_unit_references);
     hasher.add_module_outputs(unit.outputs);
     hasher.add_header_unit_identity(unit.header_unit);
-
     hasher.add_path(toolchain.compiler);
     hasher.add_string(toolchain.version);
     hasher.add_string(toolchain.binary_stamp);
-
     hasher.add_enum(options.configuration);
     hasher.add_enum(options.architecture);
     if (is_c_translation_unit_path(unit.source)) {
@@ -178,7 +155,6 @@ BuildSignature BuildSignature::for_compile(
         hasher.add_string("mqb.runtime-library.v1");
         hasher.add_enum(*options.runtime_library);
     }
-
     return BuildSignature{hasher.finish()};
 }
 
@@ -187,12 +163,7 @@ BuildSignature BuildSignature::for_link(
     const std::filesystem::path& output,
     const LinkerIdentity& linker,
     const LinkOptions& options) {
-    return for_link(
-        objects,
-        std::span<const std::filesystem::path>{},
-        output,
-        linker,
-        options);
+    return for_link(objects, std::span<const std::filesystem::path>{}, output, linker, options);
 }
 
 BuildSignature BuildSignature::for_link(
@@ -216,11 +187,23 @@ BuildSignature BuildSignature::for_link(
     hasher.add_strings(options.libraries);
     hasher.add_strings(options.additional_arguments);
     if (options.target_kind != TargetKind::executable) {
-        // Preserve the exact historical v2 byte stream for executable links.
-        // New executable-style targets append a versioned kind domain only.
         hasher.add_string("mqb.link.target-kind.v1");
         hasher.add_enum(options.target_kind);
     }
+    return BuildSignature{hasher.finish()};
+}
+
+BuildSignature BuildSignature::for_archive(
+    const std::span<const std::filesystem::path> objects,
+    const std::filesystem::path& output,
+    const LibrarianIdentity& librarian) {
+    StableHasher hasher;
+    hasher.add_string("mqb.archive.signature.v1");
+    hasher.add_paths(objects);
+    hasher.add_path(output);
+    hasher.add_path(librarian.librarian);
+    hasher.add_string(librarian.version);
+    hasher.add_string(librarian.binary_stamp);
     return BuildSignature{hasher.finish()};
 }
 

--- a/cpp/core/src/BuildSignature.cpp
+++ b/cpp/core/src/BuildSignature.cpp
@@ -32,13 +32,17 @@ class StableHasher {
 public:
     void add_string(const std::string_view value) noexcept {
         add_u64(static_cast<std::uint64_t>(value.size()));
-        for (const unsigned char byte : value) add_byte(byte);
+        for (const unsigned char byte : value) {
+            add_byte(byte);
+        }
     }
 
     void add_path(const std::filesystem::path& value) noexcept {
         const auto normalized = value.lexically_normal().generic_u8string();
         add_u64(static_cast<std::uint64_t>(normalized.size()));
-        for (const char8_t byte : normalized) add_byte(static_cast<std::uint8_t>(byte));
+        for (const char8_t byte : normalized) {
+            add_byte(static_cast<std::uint8_t>(byte));
+        }
     }
 
     template <typename Enum>
@@ -49,16 +53,23 @@ public:
 
     void add_strings(const std::vector<std::string>& values) noexcept {
         add_u64(static_cast<std::uint64_t>(values.size()));
-        for (const auto& value : values) add_string(value);
+        for (const auto& value : values) {
+            add_string(value);
+        }
     }
 
     void add_paths(const std::span<const std::filesystem::path> values) noexcept {
         add_u64(static_cast<std::uint64_t>(values.size()));
-        for (const auto& value : values) add_path(value);
+        for (const auto& value : values) {
+            add_path(value);
+        }
     }
 
-    void add_header_unit_identity(const std::optional<HeaderUnitIdentity>& identity) noexcept {
-        if (!identity) return;
+    void add_header_unit_identity(
+        const std::optional<HeaderUnitIdentity>& identity) noexcept {
+        if (!identity) {
+            return;
+        }
         add_string("mqb.header-unit.producer.v1");
         add_string(identity->header_name);
         add_enum(identity->lookup_method);
@@ -72,7 +83,8 @@ public:
         }
     }
 
-    void add_header_unit_references(const std::vector<HeaderUnitReference>& references) noexcept {
+    void add_header_unit_references(
+        const std::vector<HeaderUnitReference>& references) noexcept {
         add_u64(static_cast<std::uint64_t>(references.size()));
         for (const auto& reference : references) {
             add_string(reference.header_name);
@@ -84,16 +96,23 @@ public:
     void add_module_outputs(const std::vector<Artifact>& outputs) noexcept {
         std::uint64_t count = 0;
         for (const auto& output : outputs) {
-            if (output.kind == ArtifactKind::module_interface) ++count;
+            if (output.kind == ArtifactKind::module_interface) {
+                ++count;
+            }
         }
         add_u64(count);
         for (const auto& output : outputs) {
-            if (output.kind == ArtifactKind::module_interface) add_path(output.path);
+            if (output.kind == ArtifactKind::module_interface) {
+                add_path(output.path);
+            }
         }
     }
 
     [[nodiscard]] SignatureDigest finish() const noexcept {
-        return SignatureDigest{.high = avalanche(primary_), .low = avalanche(secondary_)};
+        return SignatureDigest{
+            .high = avalanche(primary_),
+            .low = avalanche(secondary_),
+        };
     }
 
 private:
@@ -106,6 +125,7 @@ private:
     void add_byte(const std::uint8_t byte) noexcept {
         primary_ ^= byte;
         primary_ *= fnv_prime;
+
         secondary_ ^= static_cast<std::uint64_t>(byte) + secondary_seed
             + (secondary_ << 6u) + (secondary_ >> 2u);
         secondary_ = std::rotl(secondary_, 13);
@@ -132,15 +152,18 @@ BuildSignature BuildSignature::for_compile(
     const CompilerOptions& options) {
     StableHasher hasher;
     hasher.add_string("mqb.compile.signature.v4");
+
     hasher.add_path(unit.source);
     hasher.add_enum(unit.kind);
     hasher.add_module_references(unit.module_references);
     hasher.add_header_unit_references(unit.header_unit_references);
     hasher.add_module_outputs(unit.outputs);
     hasher.add_header_unit_identity(unit.header_unit);
+
     hasher.add_path(toolchain.compiler);
     hasher.add_string(toolchain.version);
     hasher.add_string(toolchain.binary_stamp);
+
     hasher.add_enum(options.configuration);
     hasher.add_enum(options.architecture);
     if (is_c_translation_unit_path(unit.source)) {
@@ -155,6 +178,7 @@ BuildSignature BuildSignature::for_compile(
         hasher.add_string("mqb.runtime-library.v1");
         hasher.add_enum(*options.runtime_library);
     }
+
     return BuildSignature{hasher.finish()};
 }
 
@@ -163,7 +187,12 @@ BuildSignature BuildSignature::for_link(
     const std::filesystem::path& output,
     const LinkerIdentity& linker,
     const LinkOptions& options) {
-    return for_link(objects, std::span<const std::filesystem::path>{}, output, linker, options);
+    return for_link(
+        objects,
+        std::span<const std::filesystem::path>{},
+        output,
+        linker,
+        options);
 }
 
 BuildSignature BuildSignature::for_link(
@@ -187,6 +216,8 @@ BuildSignature BuildSignature::for_link(
     hasher.add_strings(options.libraries);
     hasher.add_strings(options.additional_arguments);
     if (options.target_kind != TargetKind::executable) {
+        // Preserve the exact historical v2 byte stream for executable links.
+        // New executable-style targets append a versioned kind domain only.
         hasher.add_string("mqb.link.target-kind.v1");
         hasher.add_enum(options.target_kind);
     }

--- a/cpp/core/src/BuildTypes.cpp
+++ b/cpp/core/src/BuildTypes.cpp
@@ -4,53 +4,76 @@ namespace mqb {
 
 std::string_view to_string(const BuildConfiguration value) noexcept {
     switch (value) {
-    case BuildConfiguration::debug: return "debug";
-    case BuildConfiguration::release: return "release";
+    case BuildConfiguration::debug:
+        return "debug";
+    case BuildConfiguration::release:
+        return "release";
     }
     return "unknown";
 }
 
 std::string_view to_string(const Architecture value) noexcept {
     switch (value) {
-    case Architecture::x86: return "x86";
-    case Architecture::x64: return "x64";
+    case Architecture::x86:
+        return "x86";
+    case Architecture::x64:
+        return "x64";
     }
     return "unknown";
 }
 
 std::string_view to_string(const CppStandard value) noexcept {
     switch (value) {
-    case CppStandard::cpp14: return "c++14";
-    case CppStandard::cpp17: return "c++17";
-    case CppStandard::cpp20: return "c++20";
-    case CppStandard::cpp23: return "c++23";
-    case CppStandard::latest: return "latest";
+    case CppStandard::cpp14:
+        return "c++14";
+    case CppStandard::cpp17:
+        return "c++17";
+    case CppStandard::cpp20:
+        return "c++20";
+    case CppStandard::cpp23:
+        return "c++23";
+    case CppStandard::latest:
+        return "latest";
     }
     return "unknown";
 }
 
 std::string_view to_string(const TargetKind value) noexcept {
     switch (value) {
-    case TargetKind::executable: return "exe";
-    case TargetKind::dynamic_library: return "dll";
-    case TargetKind::static_library: return "static";
+    case TargetKind::executable:
+        return "exe";
+    case TargetKind::dynamic_library:
+        return "dll";
+    case TargetKind::static_library:
+        return "static";
     }
     return "unknown";
 }
 
 std::string_view to_string(const BuildReason value) noexcept {
     switch (value) {
-    case BuildReason::missing_cache_entry: return "missing cache entry";
-    case BuildReason::missing_output: return "missing output";
-    case BuildReason::source_changed: return "source changed";
-    case BuildReason::dependency_changed: return "dependency changed";
-    case BuildReason::toolchain_changed: return "toolchain changed";
-    case BuildReason::compiler_options_changed: return "compiler options changed";
-    case BuildReason::link_inputs_changed: return "link inputs changed";
-    case BuildReason::linker_options_changed: return "linker options changed";
-    case BuildReason::archive_inputs_changed: return "archive inputs changed";
-    case BuildReason::archive_recipe_changed: return "archive recipe changed";
-    case BuildReason::explicit_rebuild: return "explicit rebuild";
+    case BuildReason::missing_cache_entry:
+        return "missing cache entry";
+    case BuildReason::missing_output:
+        return "missing output";
+    case BuildReason::source_changed:
+        return "source changed";
+    case BuildReason::dependency_changed:
+        return "dependency changed";
+    case BuildReason::toolchain_changed:
+        return "toolchain changed";
+    case BuildReason::compiler_options_changed:
+        return "compiler options changed";
+    case BuildReason::link_inputs_changed:
+        return "link inputs changed";
+    case BuildReason::linker_options_changed:
+        return "linker options changed";
+    case BuildReason::archive_inputs_changed:
+        return "archive inputs changed";
+    case BuildReason::archive_recipe_changed:
+        return "archive recipe changed";
+    case BuildReason::explicit_rebuild:
+        return "explicit rebuild";
     }
     return "unknown";
 }

--- a/cpp/core/src/BuildTypes.cpp
+++ b/cpp/core/src/BuildTypes.cpp
@@ -4,72 +4,53 @@ namespace mqb {
 
 std::string_view to_string(const BuildConfiguration value) noexcept {
     switch (value) {
-    case BuildConfiguration::debug:
-        return "debug";
-    case BuildConfiguration::release:
-        return "release";
+    case BuildConfiguration::debug: return "debug";
+    case BuildConfiguration::release: return "release";
     }
     return "unknown";
 }
 
 std::string_view to_string(const Architecture value) noexcept {
     switch (value) {
-    case Architecture::x86:
-        return "x86";
-    case Architecture::x64:
-        return "x64";
+    case Architecture::x86: return "x86";
+    case Architecture::x64: return "x64";
     }
     return "unknown";
 }
 
 std::string_view to_string(const CppStandard value) noexcept {
     switch (value) {
-    case CppStandard::cpp14:
-        return "c++14";
-    case CppStandard::cpp17:
-        return "c++17";
-    case CppStandard::cpp20:
-        return "c++20";
-    case CppStandard::cpp23:
-        return "c++23";
-    case CppStandard::latest:
-        return "latest";
+    case CppStandard::cpp14: return "c++14";
+    case CppStandard::cpp17: return "c++17";
+    case CppStandard::cpp20: return "c++20";
+    case CppStandard::cpp23: return "c++23";
+    case CppStandard::latest: return "latest";
     }
     return "unknown";
 }
 
 std::string_view to_string(const TargetKind value) noexcept {
     switch (value) {
-    case TargetKind::executable:
-        return "exe";
-    case TargetKind::dynamic_library:
-        return "dll";
-    case TargetKind::static_library:
-        return "static";
+    case TargetKind::executable: return "exe";
+    case TargetKind::dynamic_library: return "dll";
+    case TargetKind::static_library: return "static";
     }
     return "unknown";
 }
 
 std::string_view to_string(const BuildReason value) noexcept {
     switch (value) {
-    case BuildReason::missing_cache_entry:
-        return "missing cache entry";
-    case BuildReason::missing_output:
-        return "missing output";
-    case BuildReason::source_changed:
-        return "source changed";
-    case BuildReason::dependency_changed:
-        return "dependency changed";
-    case BuildReason::toolchain_changed:
-        return "toolchain changed";
-    case BuildReason::compiler_options_changed:
-        return "compiler options changed";
-    case BuildReason::link_inputs_changed:
-        return "link inputs changed";
-    case BuildReason::linker_options_changed:
-        return "linker options changed";
-    case BuildReason::explicit_rebuild:
-        return "explicit rebuild";
+    case BuildReason::missing_cache_entry: return "missing cache entry";
+    case BuildReason::missing_output: return "missing output";
+    case BuildReason::source_changed: return "source changed";
+    case BuildReason::dependency_changed: return "dependency changed";
+    case BuildReason::toolchain_changed: return "toolchain changed";
+    case BuildReason::compiler_options_changed: return "compiler options changed";
+    case BuildReason::link_inputs_changed: return "link inputs changed";
+    case BuildReason::linker_options_changed: return "linker options changed";
+    case BuildReason::archive_inputs_changed: return "archive inputs changed";
+    case BuildReason::archive_recipe_changed: return "archive recipe changed";
+    case BuildReason::explicit_rebuild: return "explicit rebuild";
     }
     return "unknown";
 }

--- a/cpp/core/src/ProjectArtifactLayout.cpp
+++ b/cpp/core/src/ProjectArtifactLayout.cpp
@@ -1,12 +1,13 @@
 #include "mqb/core/ProjectArtifactLayout.hpp"
 
-#include <array>
+#include <algorithm>
 #include <cctype>
-#include <cstddef>
+#include <cstdint>
 #include <filesystem>
+#include <iomanip>
+#include <sstream>
 #include <string>
 #include <string_view>
-#include <system_error>
 #include <utility>
 
 namespace mqb {
@@ -25,37 +26,33 @@ namespace fs = std::filesystem;
     };
 }
 
-[[nodiscard]] char ascii_lower(const char value) noexcept {
-    const unsigned char byte = static_cast<unsigned char>(value);
-    return static_cast<char>(std::tolower(byte));
-}
-
-[[nodiscard]] std::string lower_ascii(std::string value) {
-    for (char& ch : value) {
-        ch = ascii_lower(ch);
-    }
-    return value;
-}
-
-[[nodiscard]] std::string path_text(const fs::path& path) {
-    const auto bytes = path.lexically_normal().generic_u8string();
-    return std::string{
-        reinterpret_cast<const char*>(bytes.data()),
-        bytes.size()};
-}
-
-[[nodiscard]] fs::path normalize_existing_identity(fs::path path) {
+[[nodiscard]] fs::path normalize_existing_identity(const fs::path& path) {
+    fs::path normalized = path.lexically_normal();
     std::error_code error_code;
-    fs::path absolute = fs::absolute(path, error_code);
-    if (!error_code) {
-        path = std::move(absolute);
+    if (!fs::exists(normalized, error_code) || error_code) {
+        return normalized;
     }
+
     error_code.clear();
-    fs::path canonical = fs::weakly_canonical(path, error_code);
-    if (!error_code) {
-        return canonical.lexically_normal();
+    fs::path canonical = fs::weakly_canonical(normalized, error_code);
+    if (error_code || canonical.empty()) {
+        return normalized;
     }
-    return path.lexically_normal();
+    return canonical.lexically_normal();
+}
+
+[[nodiscard]] fs::path windows_identity_casefold(fs::path path) {
+#ifdef _WIN32
+    std::string value = path.generic_string();
+    std::transform(
+        value.begin(),
+        value.end(),
+        value.begin(),
+        [](const unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+    return fs::path{value};
+#else
+    return path;
+#endif
 }
 
 [[nodiscard]] bool safe_relative(const fs::path& relative) {
@@ -70,42 +67,65 @@ namespace fs = std::filesystem;
     return true;
 }
 
-[[nodiscard]] std::uint64_t fnv1a64(std::string_view value) noexcept {
-    std::uint64_t hash = 14695981039346656037ull;
-    for (const unsigned char byte : value) {
-        hash ^= byte;
-        hash *= 1099511628211ull;
+[[nodiscard]] std::optional<fs::path> physical_relative(
+    const fs::path& project_root,
+    const fs::path& source) {
+    std::error_code error_code;
+    if (!fs::exists(project_root, error_code) || error_code) return std::nullopt;
+    error_code.clear();
+    if (!fs::exists(source, error_code) || error_code) return std::nullopt;
+
+    fs::path current = source.parent_path();
+    fs::path relative = source.filename();
+    while (!current.empty()) {
+        error_code.clear();
+        if (fs::equivalent(current, project_root, error_code) && !error_code) {
+            return windows_identity_casefold(relative.lexically_normal());
+        }
+        const fs::path parent = current.parent_path();
+        if (parent.empty() || parent == current) break;
+        relative = current.filename() / relative;
+        current = parent;
     }
-    return hash;
+    return std::nullopt;
 }
 
-[[nodiscard]] std::string hex64(const std::uint64_t value) {
-    static constexpr std::array<char, 16> digits{
-        '0', '1', '2', '3', '4', '5', '6', '7',
-        '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
-    std::string result(16, '0');
-    std::uint64_t remaining = value;
-    for (std::size_t index = result.size(); index > 0; --index) {
-        result[index - 1] = digits[remaining & 0x0fu];
-        remaining >>= 4u;
+[[nodiscard]] std::string stable_path_hash(const fs::path& path) {
+    constexpr std::uint64_t offset = 14695981039346656037ull;
+    constexpr std::uint64_t prime = 1099511628211ull;
+    std::uint64_t hash = offset;
+    const auto bytes = windows_identity_casefold(path.lexically_normal()).generic_u8string();
+    for (const char8_t byte : bytes) {
+        hash ^= static_cast<std::uint8_t>(byte);
+        hash *= prime;
     }
-    return result;
+
+    std::ostringstream stream;
+    stream << std::hex << std::setfill('0') << std::setw(16) << hash;
+    return stream.str();
 }
 
 [[nodiscard]] fs::path source_key(
     const fs::path& project_root,
     const fs::path& source) {
     const fs::path normalized_source = normalize_existing_identity(source);
-    const fs::path normalized_root = normalize_existing_identity(project_root);
-    const fs::path relative = normalized_source.lexically_relative(normalized_root);
+
+    if (auto relative = physical_relative(project_root, normalized_source)) {
+        return *relative;
+    }
+
+    fs::path relative = normalized_source.lexically_relative(project_root);
+#ifdef _WIN32
+    relative = windows_identity_casefold(std::move(relative));
+#endif
     if (safe_relative(relative)) {
         return relative;
     }
 
-    const std::string normalized = lower_ascii(path_text(normalized_source));
-    const std::string filename = normalized_source.filename().string();
-    return fs::path{"external"}
-        / (hex64(fnv1a64(normalized)) + "_" + filename);
+    const fs::path identity = windows_identity_casefold(normalized_source);
+    return fs::path{".external"}
+        / stable_path_hash(identity)
+        / identity.filename();
 }
 
 [[nodiscard]] bool valid_target_name(const std::string_view target_name) {
@@ -193,18 +213,18 @@ ProjectArtifactLayout::for_target(
     fs::path executable = artifact_root_ / "bin" / std::string{target_name};
     executable += target_suffix(target_kind);
 
-    fs::path cache;
+    fs::path target_cache;
     if (target_kind == TargetKind::static_library) {
-        cache = artifact_root_ / "cache" / "archive" / std::string{target_name};
-        cache += ".archivecache";
+        target_cache = artifact_root_ / "cache" / "archive" / std::string{target_name};
+        target_cache += ".archivecache";
     } else {
-        cache = artifact_root_ / "cache" / "link" / std::string{target_name};
-        cache += ".linkcache";
+        target_cache = artifact_root_ / "cache" / "link" / std::string{target_name};
+        target_cache += ".linkcache";
     }
 
     return TargetArtifacts{
         .executable = std::move(executable),
-        .link_cache = std::move(cache),
+        .link_cache = std::move(target_cache),
     };
 }
 

--- a/cpp/core/src/ProjectArtifactLayout.cpp
+++ b/cpp/core/src/ProjectArtifactLayout.cpp
@@ -1,13 +1,12 @@
 #include "mqb/core/ProjectArtifactLayout.hpp"
 
-#include <algorithm>
+#include <array>
 #include <cctype>
-#include <cstdint>
+#include <cstddef>
 #include <filesystem>
-#include <iomanip>
-#include <sstream>
 #include <string>
 #include <string_view>
+#include <system_error>
 #include <utility>
 
 namespace mqb {
@@ -26,33 +25,37 @@ namespace fs = std::filesystem;
     };
 }
 
-[[nodiscard]] fs::path normalize_existing_identity(const fs::path& path) {
-    fs::path normalized = path.lexically_normal();
-    std::error_code error_code;
-    if (!fs::exists(normalized, error_code) || error_code) {
-        return normalized;
-    }
-
-    error_code.clear();
-    fs::path canonical = fs::weakly_canonical(normalized, error_code);
-    if (error_code || canonical.empty()) {
-        return normalized;
-    }
-    return canonical.lexically_normal();
+[[nodiscard]] char ascii_lower(const char value) noexcept {
+    const unsigned char byte = static_cast<unsigned char>(value);
+    return static_cast<char>(std::tolower(byte));
 }
 
-[[nodiscard]] fs::path windows_identity_casefold(fs::path path) {
-#ifdef _WIN32
-    std::string value = path.generic_string();
-    std::transform(
-        value.begin(),
-        value.end(),
-        value.begin(),
-        [](const unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
-    return fs::path{value};
-#else
-    return path;
-#endif
+[[nodiscard]] std::string lower_ascii(std::string value) {
+    for (char& ch : value) {
+        ch = ascii_lower(ch);
+    }
+    return value;
+}
+
+[[nodiscard]] std::string path_text(const fs::path& path) {
+    const auto bytes = path.lexically_normal().generic_u8string();
+    return std::string{
+        reinterpret_cast<const char*>(bytes.data()),
+        bytes.size()};
+}
+
+[[nodiscard]] fs::path normalize_existing_identity(fs::path path) {
+    std::error_code error_code;
+    fs::path absolute = fs::absolute(path, error_code);
+    if (!error_code) {
+        path = std::move(absolute);
+    }
+    error_code.clear();
+    fs::path canonical = fs::weakly_canonical(path, error_code);
+    if (!error_code) {
+        return canonical.lexically_normal();
+    }
+    return path.lexically_normal();
 }
 
 [[nodiscard]] bool safe_relative(const fs::path& relative) {
@@ -67,65 +70,42 @@ namespace fs = std::filesystem;
     return true;
 }
 
-[[nodiscard]] std::optional<fs::path> physical_relative(
-    const fs::path& project_root,
-    const fs::path& source) {
-    std::error_code error_code;
-    if (!fs::exists(project_root, error_code) || error_code) return std::nullopt;
-    error_code.clear();
-    if (!fs::exists(source, error_code) || error_code) return std::nullopt;
-
-    fs::path current = source.parent_path();
-    fs::path relative = source.filename();
-    while (!current.empty()) {
-        error_code.clear();
-        if (fs::equivalent(current, project_root, error_code) && !error_code) {
-            return windows_identity_casefold(relative.lexically_normal());
-        }
-        const fs::path parent = current.parent_path();
-        if (parent.empty() || parent == current) break;
-        relative = current.filename() / relative;
-        current = parent;
+[[nodiscard]] std::uint64_t fnv1a64(std::string_view value) noexcept {
+    std::uint64_t hash = 14695981039346656037ull;
+    for (const unsigned char byte : value) {
+        hash ^= byte;
+        hash *= 1099511628211ull;
     }
-    return std::nullopt;
+    return hash;
 }
 
-[[nodiscard]] std::string stable_path_hash(const fs::path& path) {
-    constexpr std::uint64_t offset = 14695981039346656037ull;
-    constexpr std::uint64_t prime = 1099511628211ull;
-    std::uint64_t hash = offset;
-    const auto bytes = windows_identity_casefold(path.lexically_normal()).generic_u8string();
-    for (const char8_t byte : bytes) {
-        hash ^= static_cast<std::uint8_t>(byte);
-        hash *= prime;
+[[nodiscard]] std::string hex64(const std::uint64_t value) {
+    static constexpr std::array<char, 16> digits{
+        '0', '1', '2', '3', '4', '5', '6', '7',
+        '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+    std::string result(16, '0');
+    std::uint64_t remaining = value;
+    for (std::size_t index = result.size(); index > 0; --index) {
+        result[index - 1] = digits[remaining & 0x0fu];
+        remaining >>= 4u;
     }
-
-    std::ostringstream stream;
-    stream << std::hex << std::setfill('0') << std::setw(16) << hash;
-    return stream.str();
+    return result;
 }
 
 [[nodiscard]] fs::path source_key(
     const fs::path& project_root,
     const fs::path& source) {
     const fs::path normalized_source = normalize_existing_identity(source);
-
-    if (auto relative = physical_relative(project_root, normalized_source)) {
-        return *relative;
-    }
-
-    fs::path relative = normalized_source.lexically_relative(project_root);
-#ifdef _WIN32
-    relative = windows_identity_casefold(std::move(relative));
-#endif
+    const fs::path normalized_root = normalize_existing_identity(project_root);
+    const fs::path relative = normalized_source.lexically_relative(normalized_root);
     if (safe_relative(relative)) {
         return relative;
     }
 
-    const fs::path identity = windows_identity_casefold(normalized_source);
-    return fs::path{".external"}
-        / stable_path_hash(identity)
-        / identity.filename();
+    const std::string normalized = lower_ascii(path_text(normalized_source));
+    const std::string filename = normalized_source.filename().string();
+    return fs::path{"external"}
+        / (hex64(fnv1a64(normalized)) + "_" + filename);
 }
 
 [[nodiscard]] bool valid_target_name(const std::string_view target_name) {
@@ -212,11 +192,19 @@ ProjectArtifactLayout::for_target(
 
     fs::path executable = artifact_root_ / "bin" / std::string{target_name};
     executable += target_suffix(target_kind);
-    fs::path link_cache = artifact_root_ / "cache" / "link" / std::string{target_name};
-    link_cache += ".linkcache";
+
+    fs::path cache;
+    if (target_kind == TargetKind::static_library) {
+        cache = artifact_root_ / "cache" / "archive" / std::string{target_name};
+        cache += ".archivecache";
+    } else {
+        cache = artifact_root_ / "cache" / "link" / std::string{target_name};
+        cache += ".linkcache";
+    }
+
     return TargetArtifacts{
         .executable = std::move(executable),
-        .link_cache = std::move(link_cache),
+        .link_cache = std::move(cache),
     };
 }
 

--- a/cpp/orchestration/CMakeLists.txt
+++ b/cpp/orchestration/CMakeLists.txt
@@ -1,7 +1,9 @@
 add_library(mqb_orchestration STATIC
     src/BoundedWorkScheduler.cpp
+    src/MsvcIncrementalArchiveCoordinator.cpp
     src/MsvcIncrementalCompileCoordinator.cpp
     src/MsvcIncrementalLinkCoordinator.cpp
+    src/MsvcIncrementalStaticTargetCoordinator.cpp
     src/MsvcIncrementalTargetCoordinator.cpp
     src/MsvcModuleCompileCoordinator.cpp
     src/MsvcModuleTargetCoordinator.cpp

--- a/cpp/orchestration/include/mqb/orchestration/MsvcIncrementalArchiveCoordinator.hpp
+++ b/cpp/orchestration/include/mqb/orchestration/MsvcIncrementalArchiveCoordinator.hpp
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <expected>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "mqb/core/ArchiveCache.hpp"
+#include "mqb/core/BuildPlan.hpp"
+#include "mqb/msvc/MsvcLibrarian.hpp"
+#include "mqb/msvc/MsvcToolchainLocator.hpp"
+#include "mqb/process/Process.hpp"
+
+namespace mqb::orchestration {
+
+struct IncrementalArchiveRequest {
+    std::vector<std::filesystem::path> objects;
+    std::filesystem::path output;
+    std::filesystem::path cache_file;
+    std::filesystem::path working_directory;
+    bool force_archive{false};
+};
+
+enum class IncrementalArchiveWarningCode {
+    cache_load_failed,
+    cache_save_failed,
+    file_snapshot_failed,
+};
+
+struct IncrementalArchiveWarning {
+    IncrementalArchiveWarningCode code{IncrementalArchiveWarningCode::file_snapshot_failed};
+    std::filesystem::path path;
+    std::string message;
+};
+
+enum class IncrementalArchiveErrorCode {
+    librarian_identity_failed,
+    planning_failed,
+    archive_failed,
+};
+
+struct IncrementalArchiveError {
+    IncrementalArchiveErrorCode code{IncrementalArchiveErrorCode::planning_failed};
+    std::string message;
+    std::optional<msvc::LibrarianError> librarian_error;
+};
+
+struct IncrementalArchiveResult {
+    ArchiveCacheValidation validation;
+    BuildPlan plan;
+    bool archived{false};
+    std::optional<process::ProcessResult> process;
+    std::vector<IncrementalArchiveWarning> warnings;
+};
+
+class MsvcIncrementalArchiveCoordinator {
+public:
+    MsvcIncrementalArchiveCoordinator(
+        const msvc::MsvcToolchain& toolchain,
+        msvc::MsvcLibrarian& librarian)
+        : toolchain_(toolchain), librarian_(librarian) {}
+
+    [[nodiscard]] std::expected<IncrementalArchiveResult, IncrementalArchiveError>
+    run(const IncrementalArchiveRequest& request) const;
+
+private:
+    const msvc::MsvcToolchain& toolchain_;
+    msvc::MsvcLibrarian& librarian_;
+};
+
+} // namespace mqb::orchestration

--- a/cpp/orchestration/include/mqb/orchestration/MsvcIncrementalStaticTargetCoordinator.hpp
+++ b/cpp/orchestration/include/mqb/orchestration/MsvcIncrementalStaticTargetCoordinator.hpp
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <cstddef>
+#include <expected>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "mqb/core/CompilerOptions.hpp"
+#include "mqb/core/ProjectArtifactLayout.hpp"
+#include "mqb/orchestration/MsvcIncrementalArchiveCoordinator.hpp"
+#include "mqb/orchestration/MsvcIncrementalCompileCoordinator.hpp"
+#include "mqb/orchestration/MsvcIncrementalTargetCoordinator.hpp"
+
+namespace mqb::orchestration {
+
+struct IncrementalStaticTargetRequest {
+    std::vector<TargetSourceRequest> sources;
+    TargetArtifacts target;
+    CompilerOptions compiler_options;
+    std::filesystem::path working_directory;
+    std::size_t max_parallel_compiles{1};
+};
+
+enum class IncrementalStaticTargetErrorCode {
+    no_sources,
+    invalid_parallelism,
+    duplicate_source,
+    duplicate_object,
+    duplicate_dependencies,
+    duplicate_compile_cache,
+    scheduling_failed,
+    compile_failed,
+    archive_failed,
+};
+
+struct IncrementalStaticTargetError {
+    IncrementalStaticTargetErrorCode code{IncrementalStaticTargetErrorCode::no_sources};
+    std::string message;
+    std::filesystem::path source;
+    std::optional<IncrementalCompileError> compile_error;
+    std::optional<IncrementalArchiveError> archive_error;
+};
+
+struct IncrementalStaticTargetResult {
+    std::vector<TargetCompileResult> compiles;
+    IncrementalArchiveResult archive;
+    bool any_compiled{false};
+};
+
+class MsvcIncrementalStaticTargetCoordinator {
+public:
+    MsvcIncrementalStaticTargetCoordinator(
+        MsvcIncrementalCompileCoordinator& compile_coordinator,
+        MsvcIncrementalArchiveCoordinator& archive_coordinator)
+        : compile_coordinator_(compile_coordinator), archive_coordinator_(archive_coordinator) {}
+
+    [[nodiscard]] std::expected<IncrementalStaticTargetResult, IncrementalStaticTargetError>
+    run(const IncrementalStaticTargetRequest& request) const;
+
+private:
+    MsvcIncrementalCompileCoordinator& compile_coordinator_;
+    MsvcIncrementalArchiveCoordinator& archive_coordinator_;
+};
+
+} // namespace mqb::orchestration

--- a/cpp/orchestration/src/MsvcIncrementalArchiveCoordinator.cpp
+++ b/cpp/orchestration/src/MsvcIncrementalArchiveCoordinator.cpp
@@ -1,0 +1,162 @@
+#include "mqb/orchestration/MsvcIncrementalArchiveCoordinator.hpp"
+
+#include <expected>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <system_error>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "mqb/core/ArchiveCacheFile.hpp"
+#include "mqb/core/BuildAction.hpp"
+#include "mqb/core/BuildPlanner.hpp"
+#include "mqb/core/BuildSignature.hpp"
+#include "mqb/core/FileSnapshot.hpp"
+
+namespace mqb::orchestration {
+namespace {
+
+namespace fs = std::filesystem;
+
+[[nodiscard]] std::expected<FileSnapshot, std::string> snapshot_file(const fs::path& path) {
+    std::error_code ec;
+    const bool exists = fs::exists(path, ec);
+    if (ec) return std::unexpected("failed to query file existence: " + ec.message());
+    if (!exists) return FileSnapshot{.path = path, .exists = false};
+    const auto modified = fs::last_write_time(path, ec);
+    if (ec) return std::unexpected("failed to query file timestamp: " + ec.message());
+    return FileSnapshot{.path = path, .exists = true, .modified = modified};
+}
+
+void snapshot_inputs(
+    const std::vector<fs::path>& paths,
+    std::vector<FileSnapshot>& snapshots,
+    std::vector<IncrementalArchiveWarning>& warnings) {
+    snapshots.reserve(paths.size());
+    for (const auto& path : paths) {
+        if (auto snapshot = snapshot_file(path)) {
+            snapshots.push_back(std::move(*snapshot));
+        } else {
+            warnings.push_back(IncrementalArchiveWarning{
+                .code = IncrementalArchiveWarningCode::file_snapshot_failed,
+                .path = path,
+                .message = snapshot.error(),
+            });
+            snapshots.push_back(FileSnapshot{.path = path, .exists = false});
+        }
+    }
+}
+
+} // namespace
+
+std::expected<IncrementalArchiveResult, IncrementalArchiveError>
+MsvcIncrementalArchiveCoordinator::run(const IncrementalArchiveRequest& request) const {
+    IncrementalArchiveResult result;
+
+    auto librarian_identity = msvc::MsvcLibrarian::identity(toolchain_);
+    if (!librarian_identity) {
+        return std::unexpected(IncrementalArchiveError{
+            .code = IncrementalArchiveErrorCode::librarian_identity_failed,
+            .message = "failed to identify MSVC librarian",
+            .librarian_error = librarian_identity.error(),
+        });
+    }
+
+    std::optional<ArchiveCacheEntry> cached_entry;
+    auto loaded = ArchiveCacheFile::load(request.cache_file);
+    if (loaded) {
+        cached_entry = std::move(*loaded);
+    } else {
+        result.warnings.push_back(IncrementalArchiveWarning{
+            .code = IncrementalArchiveWarningCode::cache_load_failed,
+            .path = request.cache_file,
+            .message = loaded.error().message,
+        });
+    }
+
+    FileSnapshot output_snapshot{.path = request.output, .exists = false};
+    if (auto snapshot = snapshot_file(request.output)) {
+        output_snapshot = std::move(*snapshot);
+    } else {
+        result.warnings.push_back(IncrementalArchiveWarning{
+            .code = IncrementalArchiveWarningCode::file_snapshot_failed,
+            .path = request.output,
+            .message = snapshot.error(),
+        });
+    }
+
+    std::vector<FileSnapshot> object_snapshots;
+    snapshot_inputs(request.objects, object_snapshots, result.warnings);
+
+    result.validation = ArchiveCacheValidator::validate(
+        request.objects,
+        request.output,
+        *librarian_identity,
+        cached_entry,
+        output_snapshot,
+        object_snapshots,
+        request.force_archive);
+
+    auto plan = BuildPlanner::plan_archive(ArchivePlanItem{
+        .objects = request.objects,
+        .output = request.output,
+        .cache_validation = result.validation,
+    });
+    if (!plan) {
+        return std::unexpected(IncrementalArchiveError{
+            .code = IncrementalArchiveErrorCode::planning_failed,
+            .message = "failed to create static archive build plan",
+        });
+    }
+    result.plan = std::move(*plan);
+    if (result.plan.empty()) return result;
+    if (result.plan.actions.size() != 1) {
+        return std::unexpected(IncrementalArchiveError{
+            .code = IncrementalArchiveErrorCode::planning_failed,
+            .message = "single-target archive coordinator expected exactly one build action",
+        });
+    }
+
+    const auto* action = std::get_if<ArchiveAction>(&result.plan.actions.front());
+    if (action == nullptr) {
+        return std::unexpected(IncrementalArchiveError{
+            .code = IncrementalArchiveErrorCode::planning_failed,
+            .message = "archive coordinator received a non-archive build action",
+        });
+    }
+
+    auto archived = librarian_.archive(msvc::ArchiveInvocation{
+        .objects = action->objects,
+        .output = action->output,
+        .working_directory = request.working_directory,
+    });
+    if (!archived) {
+        return std::unexpected(IncrementalArchiveError{
+            .code = IncrementalArchiveErrorCode::archive_failed,
+            .message = "MSVC archive action failed",
+            .librarian_error = archived.error(),
+        });
+    }
+    result.archived = true;
+    result.process = std::move(*archived);
+
+    const ArchiveCacheEntry entry{
+        .librarian = *librarian_identity,
+        .signature = BuildSignature::for_archive(action->objects, action->output, *librarian_identity),
+        .objects = action->objects,
+        .output = action->output,
+    };
+    auto saved = ArchiveCacheFile::save(request.cache_file, entry);
+    if (!saved) {
+        result.warnings.push_back(IncrementalArchiveWarning{
+            .code = IncrementalArchiveWarningCode::cache_save_failed,
+            .path = request.cache_file,
+            .message = saved.error().message,
+        });
+    }
+    return result;
+}
+
+} // namespace mqb::orchestration

--- a/cpp/orchestration/src/MsvcIncrementalStaticTargetCoordinator.cpp
+++ b/cpp/orchestration/src/MsvcIncrementalStaticTargetCoordinator.cpp
@@ -1,0 +1,172 @@
+#include "mqb/orchestration/MsvcIncrementalStaticTargetCoordinator.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <expected>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "mqb/core/Artifact.hpp"
+#include "mqb/core/TranslationUnit.hpp"
+#include "mqb/orchestration/BoundedWorkScheduler.hpp"
+
+namespace mqb::orchestration {
+namespace {
+
+namespace fs = std::filesystem;
+
+[[nodiscard]] std::string windows_path_key(const fs::path& path) {
+    std::string value = path.lexically_normal().generic_string();
+    std::transform(value.begin(), value.end(), value.begin(),
+        [](const unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+    return value;
+}
+
+[[nodiscard]] IncrementalStaticTargetError failure(
+    const IncrementalStaticTargetErrorCode code,
+    std::string message,
+    fs::path source = {}) {
+    return IncrementalStaticTargetError{
+        .code = code,
+        .message = std::move(message),
+        .source = std::move(source),
+    };
+}
+
+[[nodiscard]] bool insert_unique(std::vector<std::string>& seen, const fs::path& path) {
+    const std::string key = windows_path_key(path);
+    if (std::find(seen.begin(), seen.end(), key) != seen.end()) return false;
+    seen.push_back(key);
+    return true;
+}
+
+[[nodiscard]] IncrementalCompileRequest compile_request_for(
+    const TargetSourceRequest& source,
+    const CompilerOptions& options) {
+    TranslationUnit unit;
+    unit.source = source.source;
+    unit.kind = TranslationUnitKind::source;
+    unit.outputs.push_back(Artifact{.path = source.artifacts.object, .kind = ArtifactKind::object});
+    return IncrementalCompileRequest{
+        .unit = std::move(unit),
+        .options = options,
+        .cache_file = source.artifacts.compile_cache,
+        .source_dependencies_file = source.artifacts.dependencies,
+        .working_directory = source.source.parent_path(),
+    };
+}
+
+} // namespace
+
+std::expected<IncrementalStaticTargetResult, IncrementalStaticTargetError>
+MsvcIncrementalStaticTargetCoordinator::run(const IncrementalStaticTargetRequest& request) const {
+    if (request.sources.empty()) {
+        return std::unexpected(failure(
+            IncrementalStaticTargetErrorCode::no_sources,
+            "static target build requires at least one source file"));
+    }
+    if (request.max_parallel_compiles == 0) {
+        return std::unexpected(failure(
+            IncrementalStaticTargetErrorCode::invalid_parallelism,
+            "static target compile parallelism must be at least one"));
+    }
+
+    std::vector<std::string> seen_sources;
+    std::vector<std::string> seen_objects;
+    std::vector<std::string> seen_dependencies;
+    std::vector<std::string> seen_caches;
+    for (const auto& source : request.sources) {
+        if (!insert_unique(seen_sources, source.source)) {
+            return std::unexpected(failure(
+                IncrementalStaticTargetErrorCode::duplicate_source,
+                "static target contains the same source more than once",
+                source.source));
+        }
+        if (!insert_unique(seen_objects, source.artifacts.object)) {
+            return std::unexpected(failure(
+                IncrementalStaticTargetErrorCode::duplicate_object,
+                "two static target translation units map to the same object",
+                source.source));
+        }
+        if (!insert_unique(seen_dependencies, source.artifacts.dependencies)) {
+            return std::unexpected(failure(
+                IncrementalStaticTargetErrorCode::duplicate_dependencies,
+                "two static target translation units map to the same dependency metadata",
+                source.source));
+        }
+        if (!insert_unique(seen_caches, source.artifacts.compile_cache)) {
+            return std::unexpected(failure(
+                IncrementalStaticTargetErrorCode::duplicate_compile_cache,
+                "two static target translation units map to the same compile cache",
+                source.source));
+        }
+    }
+
+    using CompileAttempt = std::expected<IncrementalCompileResult, IncrementalCompileError>;
+    std::vector<std::optional<CompileAttempt>> attempts(request.sources.size());
+    const auto scheduled = BoundedWorkScheduler::run(
+        request.sources.size(), request.max_parallel_compiles,
+        [&](const std::size_t index) {
+            auto compile_request = compile_request_for(request.sources[index], request.compiler_options);
+            attempts[index].emplace(compile_coordinator_.run(compile_request));
+            return attempts[index]->has_value();
+        });
+    if (!scheduled) {
+        return std::unexpected(failure(
+            IncrementalStaticTargetErrorCode::scheduling_failed,
+            "static target compile scheduler failed: " + scheduled.error().message));
+    }
+
+    for (std::size_t index = 0; index < attempts.size(); ++index) {
+        if (attempts[index] && !attempts[index]->has_value()) {
+            auto error = failure(
+                IncrementalStaticTargetErrorCode::compile_failed,
+                "static target translation unit compilation failed",
+                request.sources[index].source);
+            error.compile_error = attempts[index]->error();
+            return std::unexpected(std::move(error));
+        }
+    }
+
+    IncrementalStaticTargetResult result;
+    result.compiles.reserve(request.sources.size());
+    std::vector<fs::path> objects;
+    objects.reserve(request.sources.size());
+    for (std::size_t index = 0; index < request.sources.size(); ++index) {
+        if (!attempts[index]) {
+            return std::unexpected(failure(
+                IncrementalStaticTargetErrorCode::scheduling_failed,
+                "static target compile scheduler stopped without a recorded failure",
+                request.sources[index].source));
+        }
+        auto compiled = std::move(attempts[index]->value());
+        result.any_compiled = result.any_compiled || compiled.compiled;
+        result.compiles.push_back(TargetCompileResult{
+            .source = request.sources[index].source,
+            .result = std::move(compiled),
+        });
+        objects.push_back(request.sources[index].artifacts.object);
+    }
+
+    auto archived = archive_coordinator_.run(IncrementalArchiveRequest{
+        .objects = std::move(objects),
+        .output = request.target.executable,
+        .cache_file = request.target.link_cache,
+        .working_directory = request.working_directory,
+        .force_archive = result.any_compiled,
+    });
+    if (!archived) {
+        auto error = failure(
+            IncrementalStaticTargetErrorCode::archive_failed,
+            "static target archive failed");
+        error.archive_error = archived.error();
+        return std::unexpected(std::move(error));
+    }
+    result.archive = std::move(*archived);
+    return result;
+}
+
+} // namespace mqb::orchestration

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -99,6 +99,10 @@ if(WIN32)
     target_link_libraries(mqb_msvc_linker_arguments_tests PRIVATE mqb_msvc)
     target_compile_features(mqb_msvc_linker_arguments_tests PRIVATE cxx_std_23)
 
+    add_executable(mqb_msvc_librarian_arguments_tests msvc_librarian_arguments_tests.cpp)
+    target_link_libraries(mqb_msvc_librarian_arguments_tests PRIVATE mqb_msvc)
+    target_compile_features(mqb_msvc_librarian_arguments_tests PRIVATE cxx_std_23)
+
     add_executable(mqb_msvc_library_resolver_tests msvc_library_resolver_tests.cpp)
     target_link_libraries(mqb_msvc_library_resolver_tests PRIVATE mqb_msvc)
     target_compile_features(mqb_msvc_library_resolver_tests PRIVATE cxx_std_23)
@@ -127,6 +131,7 @@ if(WIN32)
         mqb_msvc_compiler_arguments_tests
         mqb_c_source_recipe_tests
         mqb_msvc_linker_arguments_tests
+        mqb_msvc_librarian_arguments_tests
         mqb_msvc_library_resolver_tests
         mqb_msvc_compile_executor_tests
         mqb_msvc_source_dependencies_tests
@@ -183,6 +188,10 @@ if(WIN32)
         target_link_libraries(mqb_dll_target_e2e_tests PRIVATE mqb_platform_windows)
         target_compile_features(mqb_dll_target_e2e_tests PRIVATE cxx_std_23)
 
+        add_executable(mqb_static_library_e2e_tests mqb_static_library_e2e_tests.cpp)
+        target_link_libraries(mqb_static_library_e2e_tests PRIVATE mqb_platform_windows)
+        target_compile_features(mqb_static_library_e2e_tests PRIVATE cxx_std_23)
+
         list(APPEND MQB_TEST_TARGETS
             mqb_msvc_visual_studio_tests
             mqb_msvc_compile_integration_tests
@@ -196,6 +205,7 @@ if(WIN32)
             mqb_c_source_e2e_tests
             mqb_runtime_subsystem_config_e2e_tests
             mqb_dll_target_e2e_tests
+            mqb_static_library_e2e_tests
         )
     endif()
 endif()
@@ -233,6 +243,7 @@ if(WIN32)
     add_test(NAME mqb.msvc.compiler_arguments COMMAND mqb_msvc_compiler_arguments_tests)
     add_test(NAME mqb.msvc.c_source_recipe COMMAND mqb_c_source_recipe_tests)
     add_test(NAME mqb.msvc.linker_arguments COMMAND mqb_msvc_linker_arguments_tests)
+    add_test(NAME mqb.msvc.librarian_arguments COMMAND mqb_msvc_librarian_arguments_tests)
     add_test(NAME mqb.msvc.library_resolver COMMAND mqb_msvc_library_resolver_tests)
     add_test(NAME mqb.msvc.compile_executor COMMAND mqb_msvc_compile_executor_tests)
     add_test(NAME mqb.msvc.source_dependencies COMMAND mqb_msvc_source_dependencies_tests)
@@ -244,37 +255,14 @@ if(WIN32)
         add_test(NAME mqb.msvc.compile_integration COMMAND mqb_msvc_compile_integration_tests)
         add_test(NAME mqb.msvc.link_integration COMMAND mqb_msvc_link_integration_tests)
         add_test(NAME mqb.msvc.incremental_loop COMMAND mqb_msvc_incremental_loop_tests)
-        add_test(
-            NAME mqb.cli.target_e2e
-            COMMAND mqb_cli_e2e_tests $<TARGET_FILE:mqb>
-        )
-        add_test(
-            NAME mqb.cli.project_config_e2e
-            COMMAND mqb_project_config_e2e_tests $<TARGET_FILE:mqb>
-        )
-        add_test(
-            NAME mqb.cli.parallel_e2e
-            COMMAND mqb_parallel_cli_e2e_tests $<TARGET_FILE:mqb>
-        )
-        add_test(
-            NAME mqb.cli.module_e2e
-            COMMAND mqb_module_cli_e2e_tests $<TARGET_FILE:mqb>
-        )
-        add_test(
-            NAME mqb.cli.build_policy_e2e
-            COMMAND mqb_build_policy_e2e_tests $<TARGET_FILE:mqb>
-        )
-        add_test(
-            NAME mqb.cli.c_source_e2e
-            COMMAND mqb_c_source_e2e_tests $<TARGET_FILE:mqb>
-        )
-        add_test(
-            NAME mqb.cli.runtime_subsystem_config_e2e
-            COMMAND mqb_runtime_subsystem_config_e2e_tests $<TARGET_FILE:mqb>
-        )
-        add_test(
-            NAME mqb.cli.dll_target_e2e
-            COMMAND mqb_dll_target_e2e_tests $<TARGET_FILE:mqb>
-        )
+        add_test(NAME mqb.cli.target_e2e COMMAND mqb_cli_e2e_tests $<TARGET_FILE:mqb>)
+        add_test(NAME mqb.cli.project_config_e2e COMMAND mqb_project_config_e2e_tests $<TARGET_FILE:mqb>)
+        add_test(NAME mqb.cli.parallel_e2e COMMAND mqb_parallel_cli_e2e_tests $<TARGET_FILE:mqb>)
+        add_test(NAME mqb.cli.module_e2e COMMAND mqb_module_cli_e2e_tests $<TARGET_FILE:mqb>)
+        add_test(NAME mqb.cli.build_policy_e2e COMMAND mqb_build_policy_e2e_tests $<TARGET_FILE:mqb>)
+        add_test(NAME mqb.cli.c_source_e2e COMMAND mqb_c_source_e2e_tests $<TARGET_FILE:mqb>)
+        add_test(NAME mqb.cli.runtime_subsystem_config_e2e COMMAND mqb_runtime_subsystem_config_e2e_tests $<TARGET_FILE:mqb>)
+        add_test(NAME mqb.cli.dll_target_e2e COMMAND mqb_dll_target_e2e_tests $<TARGET_FILE:mqb>)
+        add_test(NAME mqb.cli.static_library_e2e COMMAND mqb_static_library_e2e_tests $<TARGET_FILE:mqb>)
     endif()
 endif()

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -255,14 +255,41 @@ if(WIN32)
         add_test(NAME mqb.msvc.compile_integration COMMAND mqb_msvc_compile_integration_tests)
         add_test(NAME mqb.msvc.link_integration COMMAND mqb_msvc_link_integration_tests)
         add_test(NAME mqb.msvc.incremental_loop COMMAND mqb_msvc_incremental_loop_tests)
-        add_test(NAME mqb.cli.target_e2e COMMAND mqb_cli_e2e_tests $<TARGET_FILE:mqb>)
-        add_test(NAME mqb.cli.project_config_e2e COMMAND mqb_project_config_e2e_tests $<TARGET_FILE:mqb>)
-        add_test(NAME mqb.cli.parallel_e2e COMMAND mqb_parallel_cli_e2e_tests $<TARGET_FILE:mqb>)
-        add_test(NAME mqb.cli.module_e2e COMMAND mqb_module_cli_e2e_tests $<TARGET_FILE:mqb>)
-        add_test(NAME mqb.cli.build_policy_e2e COMMAND mqb_build_policy_e2e_tests $<TARGET_FILE:mqb>)
-        add_test(NAME mqb.cli.c_source_e2e COMMAND mqb_c_source_e2e_tests $<TARGET_FILE:mqb>)
-        add_test(NAME mqb.cli.runtime_subsystem_config_e2e COMMAND mqb_runtime_subsystem_config_e2e_tests $<TARGET_FILE:mqb>)
-        add_test(NAME mqb.cli.dll_target_e2e COMMAND mqb_dll_target_e2e_tests $<TARGET_FILE:mqb>)
-        add_test(NAME mqb.cli.static_library_e2e COMMAND mqb_static_library_e2e_tests $<TARGET_FILE:mqb>)
+        add_test(
+            NAME mqb.cli.target_e2e
+            COMMAND mqb_cli_e2e_tests $<TARGET_FILE:mqb>
+        )
+        add_test(
+            NAME mqb.cli.project_config_e2e
+            COMMAND mqb_project_config_e2e_tests $<TARGET_FILE:mqb>
+        )
+        add_test(
+            NAME mqb.cli.parallel_e2e
+            COMMAND mqb_parallel_cli_e2e_tests $<TARGET_FILE:mqb>
+        )
+        add_test(
+            NAME mqb.cli.module_e2e
+            COMMAND mqb_module_cli_e2e_tests $<TARGET_FILE:mqb>
+        )
+        add_test(
+            NAME mqb.cli.build_policy_e2e
+            COMMAND mqb_build_policy_e2e_tests $<TARGET_FILE:mqb>
+        )
+        add_test(
+            NAME mqb.cli.c_source_e2e
+            COMMAND mqb_c_source_e2e_tests $<TARGET_FILE:mqb>
+        )
+        add_test(
+            NAME mqb.cli.runtime_subsystem_config_e2e
+            COMMAND mqb_runtime_subsystem_config_e2e_tests $<TARGET_FILE:mqb>
+        )
+        add_test(
+            NAME mqb.cli.dll_target_e2e
+            COMMAND mqb_dll_target_e2e_tests $<TARGET_FILE:mqb>
+        )
+        add_test(
+            NAME mqb.cli.static_library_e2e
+            COMMAND mqb_static_library_e2e_tests $<TARGET_FILE:mqb>
+        )
     endif()
 endif()

--- a/cpp/tests/build_policy_cli_tests.cpp
+++ b/cpp/tests/build_policy_cli_tests.cpp
@@ -89,7 +89,15 @@ int main() {
     {
         const std::vector arguments{"main.cpp"sv, "--type"sv, "static"sv};
         auto parsed = mqb::cli::parse_arguments(arguments);
-        expect(!parsed, "static-library target should remain fail-closed before librarian support");
+        expect(parsed.has_value() && parsed->target_kind_override == mqb::TargetKind::static_library,
+               "--type static should select the librarian-backed target kind");
+    }
+
+    {
+        const std::vector arguments{"main.cpp"sv, "-type"sv, "lib"sv};
+        auto parsed = mqb::cli::parse_arguments(arguments);
+        expect(parsed.has_value() && parsed->target_kind_override == mqb::TargetKind::static_library,
+               "legacy -type lib should map to static-library target kind");
     }
 
     {

--- a/cpp/tests/mqb_static_library_e2e_tests.cpp
+++ b/cpp/tests/mqb_static_library_e2e_tests.cpp
@@ -1,0 +1,206 @@
+#include <chrono>
+#include <expected>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+#include "mqb/platform/windows/WindowsProcessRunner.hpp"
+#include "mqb/process/Process.hpp"
+
+namespace {
+namespace fs = std::filesystem;
+int failures = 0;
+
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+void write_text(const fs::path& path, const std::string_view text) {
+    fs::create_directories(path.parent_path());
+    std::ofstream stream{path, std::ios::binary | std::ios::trunc};
+    stream << text;
+}
+
+void dump_failure(const mqb::process::ProcessResult& result) {
+    std::cerr << "exit: " << result.exit_code << '\n'
+              << "stdout:\n" << result.stdout_text << '\n'
+              << "stderr:\n" << result.stderr_text << '\n';
+}
+
+[[nodiscard]] bool contains_line(std::string_view output, std::string_view expected) {
+    std::size_t begin = 0;
+    while (begin <= output.size()) {
+        const std::size_t newline = output.find('\n', begin);
+        const std::size_t end = newline == std::string_view::npos ? output.size() : newline;
+        std::string_view line = output.substr(begin, end - begin);
+        if (!line.empty() && line.back() == '\r') line.remove_suffix(1);
+        if (line == expected) return true;
+        if (newline == std::string_view::npos) break;
+        begin = newline + 1;
+    }
+    return false;
+}
+
+struct TempTree {
+    fs::path root;
+    ~TempTree() {
+        std::error_code ignored;
+        fs::remove_all(root, ignored);
+    }
+};
+
+[[nodiscard]] std::expected<mqb::process::ProcessResult, std::string> run_process(
+    mqb::platform::windows::WindowsProcessRunner& runner,
+    const fs::path& executable,
+    const fs::path& root,
+    std::vector<std::string> arguments = {}) {
+    mqb::process::ProcessSpec spec;
+    spec.executable = executable;
+    spec.arguments = std::move(arguments);
+    spec.working_directory = root;
+    spec.capture_stdout = true;
+    spec.capture_stderr = true;
+    auto result = runner.run(spec);
+    if (!result) return std::unexpected("failed to launch process: " + result.error().message);
+    return std::move(*result);
+}
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    if (argc != 2) {
+        std::cerr << "usage: mqb_static_library_e2e_tests <mqb-executable>\n";
+        return 2;
+    }
+
+    const fs::path mqb_executable{argv[1]};
+    const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
+    TempTree tree{.root = fs::temp_directory_path() / ("mqb_static_library_e2e_" + std::to_string(unique))};
+    fs::create_directories(tree.root);
+    mqb::platform::windows::WindowsProcessRunner runner;
+
+    write_text(tree.root / "math.cpp", R"cpp(extern "C" int mqb_answer() {
+    return 42;
+}
+)cpp");
+    write_text(tree.root / "consumer.cpp", R"cpp(extern "C" int mqb_answer();
+int main() {
+    return mqb_answer();
+}
+)cpp");
+
+    const fs::path library = tree.root / ".mqb" / "bin" / "math.lib";
+    const fs::path consumer = tree.root / ".mqb" / "bin" / "consumer.exe";
+
+    auto cold = run_process(
+        runner, mqb_executable, tree.root,
+        {"math.cpp", "--no-discover", "--env", "vs", "--type", "static", "-o", "math"});
+    expect(cold.has_value(), "cold static-library invocation should launch");
+    if (cold) {
+        if (cold->exit_code != 0) dump_failure(*cold);
+        expect(cold->exit_code == 0, "cold static-library target should succeed");
+        expect(cold->stdout_text.find("[compile] math.cpp") != std::string::npos,
+               "cold static target should compile source");
+        expect(cold->stdout_text.find("[archive] math.lib") != std::string::npos,
+               "cold static target should archive with lib.exe");
+    }
+    expect(fs::is_regular_file(library), "static target should produce .mqb/bin/math.lib");
+
+    auto consumer_build = run_process(
+        runner, mqb_executable, tree.root,
+        {"consumer.cpp", "--no-discover", "--env", "vs", "-L", ".mqb/bin", "-l", "math", "-o", "consumer"});
+    expect(consumer_build.has_value(), "consumer build should launch");
+    if (consumer_build) {
+        if (consumer_build->exit_code != 0) dump_failure(*consumer_build);
+        expect(consumer_build->exit_code == 0, "consumer should link against generated static library");
+    }
+    expect(fs::is_regular_file(consumer), "consumer executable should exist");
+    auto consumer_run = run_process(runner, consumer, tree.root);
+    expect(consumer_run.has_value() && consumer_run->exit_code == 42,
+           "consumer should execute symbol from generated static library");
+
+    auto warm = run_process(
+        runner, mqb_executable, tree.root,
+        {"math.cpp", "--no-discover", "--env", "vs", "-type", "static", "-o", "math"});
+    expect(warm.has_value(), "warm static-library invocation should launch");
+    if (warm) {
+        if (warm->exit_code != 0) dump_failure(*warm);
+        expect(warm->exit_code == 0, "warm static target should succeed");
+        expect(contains_line(warm->stdout_text, "[up-to-date] math.cpp"),
+               "warm static target should reuse compile cache");
+        expect(contains_line(warm->stdout_text, "[up-to-date] math.lib"),
+               "warm static target should reuse archive cache");
+    }
+
+    std::error_code ec;
+    fs::remove(library, ec);
+    expect(!ec && !fs::exists(library), "test should remove static archive");
+    auto repair = run_process(
+        runner, mqb_executable, tree.root,
+        {"math.cpp", "--no-discover", "--env", "vs", "--type=static", "-o", "math"});
+    expect(repair.has_value(), "missing-archive repair invocation should launch");
+    if (repair) {
+        if (repair->exit_code != 0) dump_failure(*repair);
+        expect(repair->exit_code == 0, "missing static archive should repair");
+        expect(contains_line(repair->stdout_text, "[up-to-date] math.cpp"),
+               "missing archive should not recompile fresh source");
+        expect(repair->stdout_text.find("[archive] math.lib") != std::string::npos
+                   && repair->stdout_text.find("missing output") != std::string::npos,
+               "missing archive should invalidate archive freshness");
+    }
+    expect(fs::is_regular_file(library), "repair should recreate static archive");
+
+    write_text(tree.root / "math.cpp", R"cpp(extern "C" int mqb_answer() {
+    return 43;
+}
+)cpp");
+    auto mutated = run_process(
+        runner, mqb_executable, tree.root,
+        {"math.cpp", "--no-discover", "--env", "vs", "--type", "static", "-o", "math"});
+    expect(mutated.has_value(), "mutated static-library invocation should launch");
+    if (mutated) {
+        if (mutated->exit_code != 0) dump_failure(*mutated);
+        expect(mutated->exit_code == 0, "mutated static library should rebuild");
+        expect(mutated->stdout_text.find("[compile] math.cpp") != std::string::npos,
+               "mutated source should recompile");
+        expect(mutated->stdout_text.find("[archive] math.lib") != std::string::npos,
+               "fresh object should rearchive static target");
+    }
+
+    auto consumer_relink = run_process(
+        runner, mqb_executable, tree.root,
+        {"consumer.cpp", "--no-discover", "--env", "vs", "-L", ".mqb/bin", "-l", "math", "-o", "consumer"});
+    expect(consumer_relink.has_value(), "consumer relink should launch");
+    if (consumer_relink) {
+        if (consumer_relink->exit_code != 0) dump_failure(*consumer_relink);
+        expect(consumer_relink->exit_code == 0, "consumer should relink after static library mutation");
+        expect(contains_line(consumer_relink->stdout_text, "[up-to-date] consumer.cpp"),
+               "library mutation should not recompile fresh consumer source");
+        expect(consumer_relink->stdout_text.find("[link] consumer.exe") != std::string::npos,
+               "newer static library should invalidate consumer link freshness");
+    }
+    auto consumer_run_after_mutation = run_process(runner, consumer, tree.root);
+    expect(consumer_run_after_mutation.has_value() && consumer_run_after_mutation->exit_code == 43,
+           "consumer should observe mutated static-library behavior");
+
+    auto invalid_policy = run_process(
+        runner, mqb_executable, tree.root,
+        {"math.cpp", "--type", "static", "--subsystem", "console"});
+    expect(invalid_policy.has_value() && invalid_policy->exit_code == 2,
+           "static target should reject explicit linker-only policy");
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+    std::cout << "mqb_static_library_e2e_tests passed\n";
+    return 0;
+}

--- a/cpp/tests/mqb_static_library_e2e_tests.cpp
+++ b/cpp/tests/mqb_static_library_e2e_tests.cpp
@@ -91,24 +91,35 @@ int main(int argc, char* argv[]) {
     return 42;
 }
 )cpp");
+    write_text(tree.root / "obsolete.cpp", R"cpp(extern "C" int mqb_obsolete() {
+    return 7;
+}
+)cpp");
     write_text(tree.root / "consumer.cpp", R"cpp(extern "C" int mqb_answer();
 int main() {
     return mqb_answer();
 }
 )cpp");
+    write_text(tree.root / "obsolete_consumer.cpp", R"cpp(extern "C" int mqb_obsolete();
+int main() {
+    return mqb_obsolete();
+}
+)cpp");
 
     const fs::path library = tree.root / ".mqb" / "bin" / "math.lib";
     const fs::path consumer = tree.root / ".mqb" / "bin" / "consumer.exe";
+    const fs::path obsolete_consumer = tree.root / ".mqb" / "bin" / "obsolete_consumer.exe";
 
     auto cold = run_process(
         runner, mqb_executable, tree.root,
-        {"math.cpp", "--no-discover", "--env", "vs", "--type", "static", "-o", "math"});
+        {"math.cpp", "obsolete.cpp", "--env", "vs", "--type", "static", "-o", "math"});
     expect(cold.has_value(), "cold static-library invocation should launch");
     if (cold) {
         if (cold->exit_code != 0) dump_failure(*cold);
         expect(cold->exit_code == 0, "cold static-library target should succeed");
-        expect(cold->stdout_text.find("[compile] math.cpp") != std::string::npos,
-               "cold static target should compile source");
+        expect(cold->stdout_text.find("[compile] math.cpp") != std::string::npos
+                   && cold->stdout_text.find("[compile] obsolete.cpp") != std::string::npos,
+               "cold static target should compile its object set");
         expect(cold->stdout_text.find("[archive] math.lib") != std::string::npos,
                "cold static target should archive with lib.exe");
     }
@@ -127,14 +138,28 @@ int main() {
     expect(consumer_run.has_value() && consumer_run->exit_code == 42,
            "consumer should execute symbol from generated static library");
 
+    auto obsolete_consumer_build = run_process(
+        runner, mqb_executable, tree.root,
+        {"obsolete_consumer.cpp", "--no-discover", "--env", "vs", "-L", ".mqb/bin", "-l", "math", "-o", "obsolete_consumer"});
+    expect(obsolete_consumer_build.has_value(), "obsolete-symbol consumer build should launch");
+    if (obsolete_consumer_build) {
+        if (obsolete_consumer_build->exit_code != 0) dump_failure(*obsolete_consumer_build);
+        expect(obsolete_consumer_build->exit_code == 0,
+               "initial archive should expose the second object member");
+    }
+    auto obsolete_consumer_run = run_process(runner, obsolete_consumer, tree.root);
+    expect(obsolete_consumer_run.has_value() && obsolete_consumer_run->exit_code == 7,
+           "initial archive should execute symbol from its second object member");
+
     auto warm = run_process(
         runner, mqb_executable, tree.root,
-        {"math.cpp", "--no-discover", "--env", "vs", "-type", "static", "-o", "math"});
+        {"math.cpp", "obsolete.cpp", "--env", "vs", "-type", "static", "-o", "math"});
     expect(warm.has_value(), "warm static-library invocation should launch");
     if (warm) {
         if (warm->exit_code != 0) dump_failure(*warm);
         expect(warm->exit_code == 0, "warm static target should succeed");
-        expect(contains_line(warm->stdout_text, "[up-to-date] math.cpp"),
+        expect(contains_line(warm->stdout_text, "[up-to-date] math.cpp")
+                   && contains_line(warm->stdout_text, "[up-to-date] obsolete.cpp"),
                "warm static target should reuse compile cache");
         expect(contains_line(warm->stdout_text, "[up-to-date] math.lib"),
                "warm static target should reuse archive cache");
@@ -145,13 +170,14 @@ int main() {
     expect(!ec && !fs::exists(library), "test should remove static archive");
     auto repair = run_process(
         runner, mqb_executable, tree.root,
-        {"math.cpp", "--no-discover", "--env", "vs", "--type=static", "-o", "math"});
+        {"math.cpp", "obsolete.cpp", "--env", "vs", "--type=static", "-o", "math"});
     expect(repair.has_value(), "missing-archive repair invocation should launch");
     if (repair) {
         if (repair->exit_code != 0) dump_failure(*repair);
         expect(repair->exit_code == 0, "missing static archive should repair");
-        expect(contains_line(repair->stdout_text, "[up-to-date] math.cpp"),
-               "missing archive should not recompile fresh source");
+        expect(contains_line(repair->stdout_text, "[up-to-date] math.cpp")
+                   && contains_line(repair->stdout_text, "[up-to-date] obsolete.cpp"),
+               "missing archive should not recompile fresh sources");
         expect(repair->stdout_text.find("[archive] math.lib") != std::string::npos
                    && repair->stdout_text.find("missing output") != std::string::npos,
                "missing archive should invalidate archive freshness");
@@ -164,7 +190,7 @@ int main() {
 )cpp");
     auto mutated = run_process(
         runner, mqb_executable, tree.root,
-        {"math.cpp", "--no-discover", "--env", "vs", "--type", "static", "-o", "math"});
+        {"math.cpp", "obsolete.cpp", "--env", "vs", "--type", "static", "-o", "math"});
     expect(mutated.has_value(), "mutated static-library invocation should launch");
     if (mutated) {
         if (mutated->exit_code != 0) dump_failure(*mutated);
@@ -190,6 +216,34 @@ int main() {
     auto consumer_run_after_mutation = run_process(runner, consumer, tree.root);
     expect(consumer_run_after_mutation.has_value() && consumer_run_after_mutation->exit_code == 43,
            "consumer should observe mutated static-library behavior");
+
+    auto shrunk = run_process(
+        runner, mqb_executable, tree.root,
+        {"math.cpp", "--no-discover", "--env", "vs", "--type", "static", "-o", "math"});
+    expect(shrunk.has_value(), "source-set shrink invocation should launch");
+    if (shrunk) {
+        if (shrunk->exit_code != 0) dump_failure(*shrunk);
+        expect(shrunk->exit_code == 0, "source-set shrink should rebuild archive successfully");
+        expect(contains_line(shrunk->stdout_text, "[up-to-date] math.cpp"),
+               "source-set shrink should reuse the remaining fresh object");
+        expect(shrunk->stdout_text.find("[archive] math.lib") != std::string::npos
+                   && shrunk->stdout_text.find("archive inputs changed") != std::string::npos,
+               "source-set shrink should invalidate archive input identity");
+    }
+
+    ec.clear();
+    fs::remove(obsolete_consumer, ec);
+    expect(!ec && !fs::exists(obsolete_consumer),
+           "test should remove old obsolete-symbol consumer output");
+    auto stale_member_probe = run_process(
+        runner, mqb_executable, tree.root,
+        {"obsolete_consumer.cpp", "--no-discover", "--env", "vs", "-L", ".mqb/bin", "-l", "math", "-o", "obsolete_consumer"});
+    expect(stale_member_probe.has_value(), "stale-member probe should launch");
+    if (stale_member_probe) {
+        expect(stale_member_probe->exit_code == 5,
+               "shrunk archive must not retain an object member removed from the current source set");
+        if (stale_member_probe->exit_code == 0) dump_failure(*stale_member_probe);
+    }
 
     auto invalid_policy = run_process(
         runner, mqb_executable, tree.root,

--- a/cpp/tests/msvc_librarian_arguments_tests.cpp
+++ b/cpp/tests/msvc_librarian_arguments_tests.cpp
@@ -1,0 +1,51 @@
+#include <algorithm>
+#include <iostream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "mqb/msvc/MsvcLibrarian.hpp"
+
+namespace {
+int failures = 0;
+void expect(bool condition, std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+[[nodiscard]] bool contains(const std::vector<std::string>& values, std::string_view expected) {
+    return std::find(values.begin(), values.end(), expected) != values.end();
+}
+} // namespace
+
+int main() {
+    mqb::msvc::ArchiveInvocation invocation;
+    invocation.objects = {"obj/math one.obj", "obj/math-two.obj"};
+    invocation.output = "bin/math.lib";
+    const auto arguments = mqb::msvc::MsvcLibrarian::build_arguments(invocation);
+    expect(arguments.has_value(), "valid archive invocation should build argv");
+    if (arguments) {
+        expect(contains(*arguments, "/NOLOGO"), "librarian should suppress banner");
+        expect(contains(*arguments, "/OUT:bin/math.lib"), "librarian should own archive output");
+        expect(contains(*arguments, "obj/math one.obj"), "object path with spaces should stay one argv element");
+        expect(contains(*arguments, "obj/math-two.obj"), "all object inputs should be emitted");
+    }
+
+    auto empty = invocation;
+    empty.objects.clear();
+    expect(!mqb::msvc::MsvcLibrarian::build_arguments(empty),
+           "archive invocation without objects should fail closed");
+
+    auto missing_output = invocation;
+    missing_output.output.clear();
+    expect(!mqb::msvc::MsvcLibrarian::build_arguments(missing_output),
+           "archive invocation without output should fail closed");
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+    std::cout << "mqb_msvc_librarian_arguments_tests passed\n";
+    return 0;
+}

--- a/cpp/tests/project_artifact_layout_tests.cpp
+++ b/cpp/tests/project_artifact_layout_tests.cpp
@@ -8,14 +8,17 @@
 #include "mqb/core/ProjectArtifactLayout.hpp"
 
 namespace {
+
 namespace fs = std::filesystem;
 int failures = 0;
+
 void expect(const bool condition, const std::string_view message) {
     if (!condition) {
         ++failures;
         std::cerr << "FAIL: " << message << '\n';
     }
 }
+
 } // namespace
 
 int main() {
@@ -91,6 +94,9 @@ int main() {
     }
 
 #ifdef _WIN32
+    // Existing physical paths are normalized before deriving source identity.
+    // This prevents scanner/user aliases (case differences, 8.3/long-path or
+    // other canonical spellings) from splitting one source into two caches.
     const auto tick = std::chrono::steady_clock::now().time_since_epoch().count();
     const fs::path physical_root = fs::temp_directory_path()
         / ("MqB_Artifact_Alias_" + std::to_string(tick));

--- a/cpp/tests/project_artifact_layout_tests.cpp
+++ b/cpp/tests/project_artifact_layout_tests.cpp
@@ -8,17 +8,14 @@
 #include "mqb/core/ProjectArtifactLayout.hpp"
 
 namespace {
-
 namespace fs = std::filesystem;
 int failures = 0;
-
 void expect(const bool condition, const std::string_view message) {
     if (!condition) {
         ++failures;
         std::cerr << "FAIL: " << message << '\n';
     }
 }
-
 } // namespace
 
 int main() {
@@ -73,19 +70,27 @@ int main() {
                "external IFCs should share the stable external-source namespace");
     }
 
-    auto target = layout->for_target("demo");
-    expect(target.has_value(), "simple target name should map to target artifacts");
-    if (target) {
-        expect(target->executable == root / ".mqb" / "bin" / "demo.exe",
-               "target executable should live in project-level bin directory");
-        expect(target->link_cache == root / ".mqb" / "cache" / "link" / "demo.linkcache",
-               "link cache should be isolated from compile cache metadata");
+    auto executable = layout->for_target("demo", mqb::TargetKind::executable);
+    auto dll = layout->for_target("demo", mqb::TargetKind::dynamic_library);
+    auto static_library = layout->for_target("demo", mqb::TargetKind::static_library);
+    expect(executable.has_value() && dll.has_value() && static_library.has_value(),
+           "all typed target kinds should map to deterministic artifacts");
+    if (executable && dll && static_library) {
+        expect(executable->executable == root / ".mqb" / "bin" / "demo.exe",
+               "executable target should retain historical output path");
+        expect(dll->executable == root / ".mqb" / "bin" / "demo.dll",
+               "DLL target should map to .dll output");
+        expect(static_library->executable == root / ".mqb" / "bin" / "demo.lib",
+               "static target should map to .lib output");
+        expect(executable->link_cache == root / ".mqb" / "cache" / "link" / "demo.linkcache"
+                   && dll->link_cache == executable->link_cache,
+               "exe/DLL should preserve the established link-cache path");
+        expect(static_library->link_cache
+                   == root / ".mqb" / "cache" / "archive" / "demo.archivecache",
+               "static target should use its own archive-cache namespace");
     }
 
 #ifdef _WIN32
-    // Existing physical paths are normalized before deriving source identity.
-    // This prevents scanner/user aliases (case differences, 8.3/long-path or
-    // other canonical spellings) from splitting one source into two caches.
     const auto tick = std::chrono::steady_clock::now().time_since_epoch().count();
     const fs::path physical_root = fs::temp_directory_path()
         / ("MqB_Artifact_Alias_" + std::to_string(tick));

--- a/docs/V5_PARITY.md
+++ b/docs/V5_PARITY.md
@@ -33,7 +33,7 @@ Status meanings:
 | `-o`, `-output` | `-o`, `--output`; legacy `-output` accepted | **compat** |
 | `-run` | `--run`; legacy `-run` accepted for executable targets | **compat** |
 | `-std` | `--std`; legacy `-std` accepts 14/17/20/23/latest | **compat** |
-| `-type exe/dll` | `--type exe/dll`; legacy `-type` accepted | **compat** for executable/DLL; static remains pending librarian support |
+| `-type exe/dll/static` | `--type exe/dll/static`; legacy `-type` accepted | **compat** for CLI target-kind spelling; static config parity follows separately |
 | `-x86` | `--x86`; legacy spelling accepted | **compat** |
 | default x64 | `--x64` / x64 default; legacy `-x64` accepted | **compat** |
 | `-I`, `-include` | `-I`; legacy `-include` accepted | **compat** |
@@ -55,13 +55,14 @@ Status meanings:
 | --- | --- | --- |
 | executable target | ready | **ready** |
 | DLL target (`-type dll`) | typed Core/CLI/config target kind, `.dll` layout, `/DLL` + deterministic `/IMPLIB`, cache-correct side-output repair, real DLL load/call E2E | **ready/compat** |
-| static library target (`-type static`) | internal enum reserved; public CLI/config fail closed | **implement** with an explicit `lib.exe`/librarian owner |
-| automatic `.exe/.dll` suffix by target kind | ready | **ready** |
-| automatic `.lib` suffix for static target | layout support is reserved but public static pipeline is not exposed | **implement** with librarian work |
+| static library target (`-type static`) | dedicated `lib.exe` backend, archive identity/cache/coordinator, `.lib` output, CLI/legacy alias, and real consumer-link E2E for ordinary C/C++ | **ready/compat** for CLI ordinary targets; static+Modules remains fail-closed |
+| automatic `.exe/.dll/.lib` suffix by target kind | typed layout is ready | **ready** |
 | console subsystem | typed CLI/config policy; default console | **ready/compat** |
 | windows subsystem | typed CLI/config policy with link-only cache invalidation E2E | **ready/compat** |
 
 DLL link identity is typed and separate from executable identity while preserving the historical executable link-signature byte stream. For exporting DLLs, MQB owns a deterministic `.mqb/bin/<target>.lib` import-library path. Linker side outputs that were observed after a successful link are persisted in link-cache v3; v2 executable caches remain readable. Removing a recorded import library/export file invalidates only the link and repairs it without recompiling fresh translation units.
+
+Static libraries have a separate build owner rather than being modeled as `link.exe` targets. `MsvcLibrarian` invokes `lib.exe` over the compiled object set, archive identity hashes object order/output/librarian identity, and static metadata lives under `.mqb/cache/archive/<target>.archivecache` so it cannot collide with established executable/DLL link caches. Missing archives repair without recompiling fresh TUs; changed library sources recompile only affected TUs and re-archive. Linker-only policy is rejected for static targets instead of being silently ignored. Static targets that require the named-module/header-unit pipeline remain fail-closed until archive topology is explicitly validated.
 
 ## Compiler and linker policy
 
@@ -91,10 +92,10 @@ The native backend has typed `CompilerOptions` / `LinkOptions` plus ordered addi
 | Legacy behavior | Native C++ status | Stable-v5 decision |
 | --- | --- | --- |
 | `msvc_list.json`, upward search up to five levels | native uses nearest upward `mqb.json` | **migrate** to `mqb.json`; provide upgrade guidance/tooling rather than keeping two authoritative schemas forever |
-| CLI overrides scalar config | ready, including type/runtime/subsystem | **ready** |
+| CLI overrides scalar config | ready, including type/runtime/subsystem for currently accepted config target kinds | **ready** |
 | additive list precedence | config lists first, CLI lists append | **ready** |
 | 14/17/20/23/latest standard config | ready | **ready** |
-| target-kind config | strict `build.type` supports `exe`/`dll`; static remains fail-closed | **ready** for exe/DLL |
+| target-kind config | strict `build.type` supports `exe`/`dll`; static schema parity is the immediate follow-up after the librarian slice | **implement** static config value before stable cutover |
 | runtime/subsystem config | typed strict-schema fields with real cache-invalidation E2E | **ready** |
 | include/lib/define/library config | ready in `mqb.json` | **ready** |
 | `compiler_args` / `linker_args` | ready in strict `mqb.json` v1 schema | **ready** |
@@ -116,15 +117,15 @@ The native backend has typed `CompilerOptions` / `LinkOptions` plus ordered addi
 
 Stable v5 does not require byte-for-byte artifact layout parity with PowerShell. It requires equivalent observable correctness: cold build succeeds, warm no-op avoids unnecessary work, source/header/library/config/toolchain/build-policy changes invalidate the right work, missing required artifacts repair correctly, and outputs are collision-free.
 
-Typed runtime changes are compile-recipe identity and therefore force affected compile + downstream link. Typed target-kind/subsystem changes are link-recipe identity and relink without recompiling otherwise-fresh TUs. The same semantics hold whether policy comes from CLI or `mqb.json`.
+Typed runtime changes are compile-recipe identity and therefore force affected compile + downstream target work. Typed target-kind/subsystem changes are target recipe identity; subsystem changes relink without recompiling otherwise-fresh TUs. Static archives have their own archive identity/cache and do not reuse `LinkCache`.
 
-Raw compiler argument changes are compile-recipe identity and therefore force affected compile + downstream link. Raw linker argument changes are link-recipe identity and therefore relink without recompiling otherwise-fresh TUs.
+Raw compiler argument changes are compile-recipe identity and therefore force affected compile + downstream target work. Raw linker argument changes are link-recipe identity and therefore relink without recompiling otherwise-fresh TUs. Linker-only options are invalid for static targets in the current public contract.
 
 The native `.mqb/obj`, `.mqb/deps`, `.mqb/scan`, `.mqb/ifc`, `.mqb/cache`, and `.mqb/bin` layout is the stable direction rather than the old PowerShell temporary layout.
 
 ## C++ Modules boundary (#16)
 
-Project-local named modules and project-local header units are in the RC/stable-capable surface, but they require C++20 or newer. C++14/17 are ordinary-target compatibility modes only; attempting to scan or compile a module/header-unit contract below C++20 fails before MSVC is launched. External/prebuilt named-module providers and `import std` remain tracked in #16. Stable v5 may ship with those cases still fail-closed if release notes keep that boundary explicit; they must not be accidentally accepted through compatibility parsing.
+Project-local named modules and project-local header units are in the RC/stable-capable executable/DLL surface, but they require C++20 or newer. C++14/17 are ordinary-target compatibility modes only; attempting to scan or compile a module/header-unit contract below C++20 fails before MSVC is launched. Static targets currently support ordinary C/C++ TUs only and fail closed if discovery or explicit sources require the module/header-unit pipeline. External/prebuilt named-module providers and `import std` remain tracked in #16. Stable v5 may ship with those cases still fail-closed if release notes keep that boundary explicit; they must not be accidentally accepted through compatibility parsing.
 
 ## Parity campaign order
 
@@ -135,8 +136,8 @@ Project-local named modules and project-local header units are in the RC/stable-
 5. Typed runtime/subsystem CLI policy and cache semantics. **Done in #31.**
 6. Isolate C smart discovery from C++ module lexical syntax. **Done in #32.**
 7. Typed `mqb.json` runtime/subsystem policy with CLI precedence and real invalidation E2E. **Done in #33.**
-8. Native DLL target kind with typed linker routing, deterministic import library, and side-output repair. **Done in #35 once merged.**
-9. Static-library target with an explicit `lib.exe`/librarian backend and archive cache owner.
+8. Native DLL target kind with typed linker routing, deterministic import library, and side-output repair. **Done in #35.**
+9. Static-library target with an explicit `lib.exe`/librarian backend and archive cache owner. **CLI/engine slice done in #36 once merged; strict `mqb.json build.type=static` follows immediately.**
 10. Close the remaining high-value coupled MSVC policy gap (notably LTCG and any charset requirement proven by parity fixtures).
 11. Shared PowerShell-vs-C++ fixtures for ordinary targets, config precedence, incremental rebuilds, libraries, run argv, x86/x64, Debug/Release, and failure behavior.
 12. Installer/profile/`build` command cutover and clean-machine upgrade/rollback validation.


### PR DESCRIPTION
Implements the librarian-backed static-library engine/CLI slice after DLL support.

## Architecture

- keep executable/DLL `link.exe` path and historical link-cache identity unchanged
- add distinct `LibrarianIdentity`, archive signature/cache, and `ArchiveAction`
- add `MsvcLibrarian` as the sole `lib.exe` backend owner
- add cache-aware `MsvcIncrementalArchiveCoordinator`
- add a dedicated static-target coordinator that reuses incremental compile then archives objects
- isolate static metadata under `.mqb/cache/archive/<target>.archivecache`
- preserve the existing source artifact identity and `.external` namespace
- build each archive into a clean temporary `.lib` and install it only after `lib.exe` succeeds, so shrinking the current object set cannot retain stale archive members

## Public scope

- native `--type static` plus legacy-compatible `-type static` (`lib` alias also accepted)
- ordinary C/C++ static targets produce `.mqb/bin/<target>.lib`
- compile policy still applies; linker-only policy is rejected rather than silently ignored
- `--run` remains executable-only
- static targets requiring named Modules/Header Units fail closed until archive topology is explicitly validated
- strict `mqb.json build.type=static` is intentionally the immediate follow-up schema-parity PR; this PR does not claim that config value yet

## Final validation

Exact head: `ced520b941516072c2dd7b7f14bca0b869abec9c`.

- C++ V2 workflow #309: **success** — full Debug build and **67/67 CTest**
- C++ Release Candidate workflow #82: **success** — full Release build and tests, embedded rc.2 version gate, package/checksum staging, and artifact upload; prerelease publish skipped by design on PR
- `mqb.msvc.librarian_arguments` passes
- real VS2026 `mqb.cli.static_library_e2e` passes and proves:
  - cold archive build through `lib.exe`
  - a real consumer links the generated `.lib` with MQB and executes successfully
  - warm compile/archive cache reuse
  - deleting the archive triggers archive-only missing-output repair
  - mutating a library TU recompiles/re-archives; the consumer relinks without recompiling its fresh TU and observes the new behavior
  - shrinking the static source/object set rebuilds from a clean archive snapshot; a consumer of a removed object member then fails to link, proving stale members are not retained
  - explicit linker-only policy on static targets fails closed

The earlier artifact-layout regression encountered during development was repaired before this exact head; the final 67/67 run includes the restored `.external` source-identity regression.