### PR TITLE
feat: add static target kind to mqb.json

### DIFF
--- a/cpp/config/src/ProjectConfig.cpp
+++ b/cpp/config/src/ProjectConfig.cpp
@@ -199,7 +199,7 @@ private:
     }
     static void append_utf8(std::string& out, std::uint32_t cp) {
         if (cp <= 0x7fu) out.push_back(static_cast<char>(cp));
-        else if (cp <= 0x7ffu) {
+        else if (cp <= 0x7fffu) {
             out.push_back(static_cast<char>(0xc0u | (cp >> 6u)));
             out.push_back(static_cast<char>(0x80u | (cp & 0x3fu)));
         } else if (cp <= 0xffffu) {
@@ -419,6 +419,7 @@ require_paths(const fs::path& file, const fs::path& root, const JsonValue& value
 [[nodiscard]] std::optional<TargetKind> target_kind(std::string_view value) {
     if (value == "exe" || value == "executable") return TargetKind::executable;
     if (value == "dll" || value == "dynamic") return TargetKind::dynamic_library;
+    if (value == "static" || value == "lib") return TargetKind::static_library;
     return std::nullopt;
 }
 
@@ -473,7 +474,7 @@ decode_build(const fs::path& file, const fs::path& root, const JsonValue& value,
         auto parsed = target_kind(*text);
         if (!parsed) return std::unexpected(schema_error(
             file, it->second,
-            "build.type must be 'exe' or 'dll'; static libraries require the librarian milestone"));
+            "build.type must be 'exe', 'dll', or 'static'"));
         out.target_kind = *parsed;
     }
     if (auto it = (**object).find("output"); it != (**object).end()) {

--- a/cpp/config/src/ProjectConfig.cpp
+++ b/cpp/config/src/ProjectConfig.cpp
@@ -199,7 +199,7 @@ private:
     }
     static void append_utf8(std::string& out, std::uint32_t cp) {
         if (cp <= 0x7fu) out.push_back(static_cast<char>(cp));
-        else if (cp <= 0x7fffu) {
+        else if (cp <= 0x7ffu) {
             out.push_back(static_cast<char>(0xc0u | (cp >> 6u)));
             out.push_back(static_cast<char>(0x80u | (cp & 0x3fu)));
         } else if (cp <= 0xffffu) {

--- a/cpp/config/tests/build_policy_config_tests.cpp
+++ b/cpp/config/tests/build_policy_config_tests.cpp
@@ -104,8 +104,9 @@ int main() {
 
     write_text(file, R"json({"version":1,"build":{"type":"static"}})json");
     auto static_target = mqb::config::ProjectConfigLoader::load(file);
-    expect(!static_target && static_target.error().code == mqb::config::ErrorCode::schema_error,
-           "static target must remain fail-closed before librarian support");
+    expect(static_target.has_value()
+               && static_target->build.target_kind == mqb::TargetKind::static_library,
+           "mqb.json should accept static target kind after librarian support");
 
     write_text(file, R"json({"version":1,"build":{"runtime":"dynamic"}})json");
     auto bad_runtime = mqb::config::ProjectConfigLoader::load(file);

--- a/cpp/config/tests/project_config_tests.cpp
+++ b/cpp/config/tests/project_config_tests.cpp
@@ -51,6 +51,7 @@ int main() {
     "configuration": "release",
     "architecture": "x86",
     "standard": "latest",
+    "type": "static",
     "output": "demo",
     "defines": ["ONE=1", "TEXT=\u6d4b\u8bd5"],
     "include_dirs": ["include", "unicode/\u6d4b\u8bd5"],
@@ -85,6 +86,8 @@ int main() {
                "x86 override should decode");
         expect(loaded->build.standard == mqb::CppStandard::latest,
                "latest standard override should decode");
+        expect(loaded->build.target_kind == mqb::TargetKind::static_library,
+               "static target kind should decode");
         expect(loaded->build.output_name && *loaded->build.output_name == "demo",
                "output override should decode");
         expect(loaded->build.defines.size() == 2,
@@ -129,12 +132,19 @@ int main() {
                "excluded source should resolve from config directory");
     }
 
+    write_text(config_file, R"json({"version":1,"build":{"type":"lib"}})json");
+    auto static_alias = mqb::config::ProjectConfigLoader::load(config_file);
+    expect(static_alias.has_value()
+               && static_alias->build.target_kind == mqb::TargetKind::static_library,
+           "lib alias should decode to static target kind");
+
     write_text(config_file, R"json({"version":1})json");
     auto minimal = mqb::config::ProjectConfigLoader::load(config_file);
     expect(minimal.has_value(), "minimal version-only config should load");
     if (minimal) {
         expect(!minimal->build.configuration && !minimal->build.architecture
-                   && !minimal->build.standard && !minimal->build.output_name,
+                   && !minimal->build.standard && !minimal->build.target_kind
+                   && !minimal->build.output_name,
                "missing build scalar fields must remain unset rather than receiving defaults");
         expect(minimal->build.defines.empty() && minimal->build.include_directories.empty()
                    && minimal->build.library_directories.empty() && minimal->build.libraries.empty(),

--- a/cpp/config/tests/project_options_tests.cpp
+++ b/cpp/config/tests/project_options_tests.cpp
@@ -26,6 +26,8 @@ int main() {
                "built-in architecture default should be x64");
         expect(effective.standard == mqb::CppStandard::cpp23,
                "built-in language default should be C++23");
+        expect(effective.target_kind == mqb::TargetKind::executable,
+               "built-in target kind should be executable");
         expect(effective.discovery_enabled,
                "smart discovery should be enabled by default");
         expect(!effective.output_name,
@@ -36,6 +38,7 @@ int main() {
     project.build.configuration = mqb::BuildConfiguration::release;
     project.build.architecture = mqb::Architecture::x86;
     project.build.standard = mqb::CppStandard::latest;
+    project.build.target_kind = mqb::TargetKind::static_library;
     project.build.output_name = "from-config";
     project.build.defines = {"CONFIG_A=1", "SHARED=config"};
     project.build.include_directories = {fs::path{"config/include"}};
@@ -55,6 +58,8 @@ int main() {
                "project config should override built-in architecture");
         expect(effective.standard == mqb::CppStandard::latest,
                "project config should override built-in standard");
+        expect(effective.target_kind == mqb::TargetKind::static_library,
+               "project config should override built-in target kind");
         expect(effective.output_name && *effective.output_name == "from-config",
                "project output should override built-in unset output");
         expect(!effective.discovery_enabled,
@@ -68,6 +73,7 @@ int main() {
         cli.build.configuration = mqb::BuildConfiguration::debug;
         cli.build.architecture = mqb::Architecture::x64;
         cli.build.standard = mqb::CppStandard::cpp20;
+        cli.build.target_kind = mqb::TargetKind::dynamic_library;
         cli.build.output_name = "from-cli";
         cli.build.defines = {"CLI_B=2", "SHARED=cli"};
         cli.build.include_directories = {fs::path{"cli/include"}};
@@ -85,6 +91,8 @@ int main() {
                "CLI architecture should override project config");
         expect(effective.standard == mqb::CppStandard::cpp20,
                "CLI standard should override project config");
+        expect(effective.target_kind == mqb::TargetKind::dynamic_library,
+               "CLI target kind should override static project config");
         expect(effective.output_name && *effective.output_name == "from-cli",
                "CLI output should override project config");
         expect(effective.discovery_enabled,

--- a/cpp/tests/mqb_static_library_e2e_tests.cpp
+++ b/cpp/tests/mqb_static_library_e2e_tests.cpp
@@ -245,6 +245,49 @@ int main() {
         if (stale_member_probe->exit_code == 0) dump_failure(*stale_member_probe);
     }
 
+    write_text(tree.root / "mqb.json", R"json({
+  "version": 1,
+  "build": {
+    "type": "static",
+    "output": "config_math"
+  },
+  "discovery": {
+    "enabled": false
+  }
+})json");
+    auto config_static = run_process(
+        runner, mqb_executable, tree.root,
+        {"math.cpp", "--no-discover", "--env", "vs"});
+    expect(config_static.has_value(), "config-only static target invocation should launch");
+    if (config_static) {
+        if (config_static->exit_code != 0) dump_failure(*config_static);
+        expect(config_static->exit_code == 0,
+               "mqb.json build.type=static should build without a CLI target-kind flag");
+        expect(config_static->stdout_text.find("[archive] config_math.lib") != std::string::npos,
+               "config target kind and output should route to the librarian pipeline");
+    }
+    expect(fs::is_regular_file(tree.root / ".mqb" / "bin" / "config_math.lib"),
+           "config-only static target should produce the configured .lib output");
+
+    auto cli_type_override = run_process(
+        runner, mqb_executable, tree.root,
+        {"consumer.cpp", "--no-discover", "--env", "vs", "--type", "exe",
+         "-L", ".mqb/bin", "-l", "math", "-o", "config_override"});
+    expect(cli_type_override.has_value(), "CLI target-kind override invocation should launch");
+    if (cli_type_override) {
+        if (cli_type_override->exit_code != 0) dump_failure(*cli_type_override);
+        expect(cli_type_override->exit_code == 0,
+               "CLI --type exe should override mqb.json build.type=static");
+        expect(cli_type_override->stdout_text.find("[link] config_override.exe") != std::string::npos,
+               "CLI target-kind override should route back to the linker pipeline");
+    }
+    auto override_run = run_process(
+        runner,
+        tree.root / ".mqb" / "bin" / "config_override.exe",
+        tree.root);
+    expect(override_run.has_value() && override_run->exit_code == 43,
+           "CLI-overridden executable should consume the existing static library");
+
     auto invalid_policy = run_process(
         runner, mqb_executable, tree.root,
         {"math.cpp", "--type", "static", "--subsystem", "console"});

--- a/docs/MQB_CONFIG.md
+++ b/docs/MQB_CONFIG.md
@@ -71,22 +71,24 @@ MQB searches upward from the directory where it is invoked and uses the nearest 
 | `configuration` | string | `debug` or `release` |
 | `architecture` | string | `x86` or `x64` |
 | `standard` | string | `14`, `17`, `20`, `23`, or `latest` (`c++14`, `c++17`, `c++20`, `c++23`, `c++latest` are also accepted) |
-| `type` | string | `exe` or `dll`; static libraries remain fail-closed until the dedicated librarian pipeline lands |
+| `type` | string | `exe`, `dll`, or `static` (`executable`, `dynamic`, and `lib` aliases are also accepted) |
 | `runtime` | string | MSVC CRT runtime: `MD`, `MDd`, `MT`, or `MTd` |
-| `subsystem` | string | PE subsystem: `console` or `windows` |
-| `output` | string | target name under `.mqb/bin/`; MQB supplies the `.exe` or `.dll` suffix from `type` |
+| `subsystem` | string | PE subsystem: `console` or `windows`; not valid for a static target |
+| `output` | string | target name under `.mqb/bin/`; MQB supplies the `.exe`, `.dll`, or `.lib` suffix from `type` |
 | `defines` | string array | preprocessor definitions, without `/D` |
 | `include_dirs` | string array | include search directories |
-| `library_dirs` | string array | library search directories |
-| `libraries` | string array | requested libraries; `.lib` is optional for ordinary names |
+| `library_dirs` | string array | library search directories; linker-only and therefore invalid for a static target |
+| `libraries` | string array | requested libraries; `.lib` is optional for ordinary names; linker-only and invalid for a static target |
 | `compiler_args` | string array | ordered raw `cl.exe` argv elements |
-| `linker_args` | string array | ordered raw `link.exe` argv elements |
+| `linker_args` | string array | ordered raw `link.exe` argv elements; invalid for a static target |
 
 All path-valued config entries are resolved relative to the directory containing `mqb.json`, not the shell's current working directory.
 
 `type`, `runtime`, and `subsystem` are typed policy, not shorthand for raw flags. The MSVC backend remains the sole owner of their command-line spelling. An explicit typed runtime is emitted after raw compiler arguments; typed DLL/output/subsystem routing is emitted after raw linker arguments, so conflicting raw `/MD*`, `/DLL`, `/IMPLIB`, `/SUBSYSTEM:*`, or `/OUT:*` switches cannot silently override the typed project policy.
 
 For a DLL target that exports symbols, MQB supplies a deterministic import-library location beside the DLL (`.mqb/bin/<target>.lib`). Linker side outputs that were actually produced are recorded in the link cache; deleting a recorded import library or export file invalidates link freshness and causes a repair relink without recompiling otherwise-fresh translation units.
+
+For a static target, MQB routes the compiled ordinary C/C++ object set to the dedicated `lib.exe` librarian pipeline. Static archive metadata lives under `.mqb/cache/archive/<target>.archivecache`, separate from executable/DLL link cache metadata. Linker-only policy (`subsystem`, `library_dirs`, `libraries`, or `linker_args`) is rejected for static targets rather than silently ignored. Static targets that require the named-module/header-unit pipeline remain fail-closed until archive topology is explicitly validated.
 
 Raw compiler/linker arguments are literal argv elements. MQB does not split one JSON string containing spaces into several switches. For example:
 
@@ -158,7 +160,7 @@ Examples:
 # mqb.json says release; this build is debug.
 mqb main.cpp --debug
 
-# mqb.json says DLL; this invocation explicitly builds an executable.
+# mqb.json says DLL or static; this invocation explicitly builds an executable.
 mqb main.cpp --type exe
 
 # mqb.json says MT; this invocation uses the dynamic CRT.
@@ -182,7 +184,7 @@ List-like options are additive rather than replacing the config list. The effect
 mqb.json entries, then CLI entries
 ```
 
-This applies to defines, include directories, library directories, libraries, `compiler_args`, and `linker_args`. For example, a CLI `--compiler-arg /WX` is appended after project `compiler_args` entries.
+This applies to defines, include directories, library directories, libraries, `compiler_args`, and `linker_args`. For example, a CLI `--compiler-arg /WX` is appended after project `compiler_args` entries. If the effective target kind is `static`, any effective linker-only list remains invalid and fails closed.
 
 ## Path bases
 
@@ -213,17 +215,17 @@ still loads `project/mqb.json`, places artifacts under `project/.mqb/`, and inte
 
 ## Cache behavior
 
-The config file timestamp itself is not a special global rebuild trigger. Instead, the effective typed build options produced from the file participate in the existing compile/link signatures.
+The config file timestamp itself is not a special global rebuild trigger. Instead, the effective typed build options produced from the file participate in the existing compile/link/archive identities.
 
-Changing `runtime` changes compiler recipe identity, recompiles affected TUs, and therefore relinks the target. Leaving `runtime` unset preserves the historical Debug `/MDd` and Release `/MD` recipes and their existing signature identity.
+Changing `runtime` changes compiler recipe identity, recompiles affected TUs, and therefore rebuilds the downstream target. Leaving `runtime` unset preserves the historical Debug `/MDd` and Release `/MD` recipes and their existing signature identity.
 
-Changing `type` changes link recipe/output identity. The historical executable signature byte stream is retained for executable targets; DLL targets add their typed target-kind identity. Changing executable↔DLL relinks without recompiling otherwise-fresh translation units when the compile recipe is unchanged.
+Changing `type` changes target output/recipe ownership. The historical executable signature byte stream is retained for executable targets; DLL targets add typed link target-kind identity. Static targets use a separate archive identity/cache and the `lib.exe` pipeline. Switching among executable/DLL/static does not recompile otherwise-fresh translation units when the compile recipe is unchanged, but it does build the appropriate downstream target artifact.
 
-Changing only `subsystem` changes link recipe identity and relinks without recompiling otherwise-fresh TUs.
+Changing only `subsystem` changes link recipe identity and relinks without recompiling otherwise-fresh TUs. `subsystem` is not valid when the effective target kind is static.
 
-Changing a compiler argument changes compiler recipe identity and recompiles affected TUs even if no source timestamp changed. The resulting fresh objects force the downstream link. Changing only a linker argument changes link recipe identity and relinks without recompiling otherwise-fresh TUs.
+Changing a compiler argument changes compiler recipe identity and recompiles affected TUs even if no source timestamp changed. The resulting fresh objects force the downstream target action. Changing only a linker argument changes link recipe identity and relinks without recompiling otherwise-fresh TUs; linker arguments are invalid for static targets.
 
-Likewise, library names/search paths affect link recipe identity, while exact resolved `.lib` files are separately tracked as link freshness inputs. Recorded DLL linker side outputs are separately checked for existence and repaired by relinking if missing.
+Likewise, library names/search paths affect link recipe identity, while exact resolved `.lib` files are separately tracked as link freshness inputs. Recorded DLL linker side outputs are separately checked for existence and repaired by relinking if missing. Static archive freshness separately checks its current object inputs, archive output, and librarian identity.
 
 For named modules and header units, compile identity also includes typed provider/reference and interface-output identity. Imported IFC files participate in consumer freshness validation, and a missing provider IFC invalidates the provider's cached outputs.
 
@@ -235,12 +237,13 @@ For named modules and header units, compile identity also includes typed provide
 mqb main.cpp -j 8
 ```
 
-Changing the job count does not alter compile or link signatures and therefore must not invalidate an otherwise reusable build cache.
+Changing the job count does not alter compile, link, or archive signatures and therefore must not invalidate an otherwise reusable build cache.
 
 ## Current boundaries
 
-- v1 `build.type` supports `exe` and `dll`; static libraries remain fail-closed until the dedicated `lib.exe`/librarian pipeline lands.
-- `--run` is executable-only; DLL targets are built artifacts and are not launched as programs.
+- v1 `build.type` supports `exe`, `dll`, and `static`; `lib` is accepted as a static-library alias.
+- Static targets currently support ordinary C/C++ translation units; static targets requiring named Modules/Header Units fail closed until archive topology is explicitly validated.
+- `--run` is executable-only; DLL/static targets are built artifacts and are not launched as programs.
 - v1 config has no external/prebuilt module-provider or `import std` policy.
 - v1 config does not store parallel job count.
 - `exclude_dirs`, `extra_sources`, and `exclude_sources` are exact paths, not globs.

--- a/docs/V5_PARITY.md
+++ b/docs/V5_PARITY.md
@@ -33,7 +33,7 @@ Status meanings:
 | `-o`, `-output` | `-o`, `--output`; legacy `-output` accepted | **compat** |
 | `-run` | `--run`; legacy `-run` accepted for executable targets | **compat** |
 | `-std` | `--std`; legacy `-std` accepts 14/17/20/23/latest | **compat** |
-| `-type exe/dll/static` | `--type exe/dll/static`; legacy `-type` accepted | **compat** for CLI target-kind spelling; static config parity follows separately |
+| `-type exe/dll/static` | `--type exe/dll/static`; legacy `-type` accepted; same typed target kind is available in `mqb.json` | **compat** |
 | `-x86` | `--x86`; legacy spelling accepted | **compat** |
 | default x64 | `--x64` / x64 default; legacy `-x64` accepted | **compat** |
 | `-I`, `-include` | `-I`; legacy `-include` accepted | **compat** |
@@ -55,14 +55,14 @@ Status meanings:
 | --- | --- | --- |
 | executable target | ready | **ready** |
 | DLL target (`-type dll`) | typed Core/CLI/config target kind, `.dll` layout, `/DLL` + deterministic `/IMPLIB`, cache-correct side-output repair, real DLL load/call E2E | **ready/compat** |
-| static library target (`-type static`) | dedicated `lib.exe` backend, archive identity/cache/coordinator, `.lib` output, CLI/legacy alias, and real consumer-link E2E for ordinary C/C++ | **ready/compat** for CLI ordinary targets; static+Modules remains fail-closed |
+| static library target (`-type static`) | dedicated `lib.exe` backend, archive identity/cache/coordinator, `.lib` output, CLI/config/legacy spelling, real consumer-link E2E, and config-only routing/CLI precedence E2E for ordinary C/C++ | **ready/compat** for ordinary targets; static+Modules remains fail-closed |
 | automatic `.exe/.dll/.lib` suffix by target kind | typed layout is ready | **ready** |
 | console subsystem | typed CLI/config policy; default console | **ready/compat** |
 | windows subsystem | typed CLI/config policy with link-only cache invalidation E2E | **ready/compat** |
 
 DLL link identity is typed and separate from executable identity while preserving the historical executable link-signature byte stream. For exporting DLLs, MQB owns a deterministic `.mqb/bin/<target>.lib` import-library path. Linker side outputs that were observed after a successful link are persisted in link-cache v3; v2 executable caches remain readable. Removing a recorded import library/export file invalidates only the link and repairs it without recompiling fresh translation units.
 
-Static libraries have a separate build owner rather than being modeled as `link.exe` targets. `MsvcLibrarian` invokes `lib.exe` over the compiled object set, archive identity hashes object order/output/librarian identity, and static metadata lives under `.mqb/cache/archive/<target>.archivecache` so it cannot collide with established executable/DLL link caches. Missing archives repair without recompiling fresh TUs; changed library sources recompile only affected TUs and re-archive. Linker-only policy is rejected for static targets instead of being silently ignored. Static targets that require the named-module/header-unit pipeline remain fail-closed until archive topology is explicitly validated.
+Static libraries have a separate build owner rather than being modeled as `link.exe` targets. `MsvcLibrarian` invokes `lib.exe` over the compiled object set, archive identity hashes object order/output/librarian identity, and static metadata lives under `.mqb/cache/archive/<target>.archivecache` so it cannot collide with established executable/DLL link caches. Missing archives repair without recompiling fresh TUs; changed library sources recompile only affected TUs and re-archive. Each rebuild is created from a clean temporary archive before installation, so shrinking the source/object set cannot retain stale members. Linker-only policy is rejected for static targets instead of being silently ignored. Static targets that require the named-module/header-unit pipeline remain fail-closed until archive topology is explicitly validated.
 
 ## Compiler and linker policy
 
@@ -92,10 +92,10 @@ The native backend has typed `CompilerOptions` / `LinkOptions` plus ordered addi
 | Legacy behavior | Native C++ status | Stable-v5 decision |
 | --- | --- | --- |
 | `msvc_list.json`, upward search up to five levels | native uses nearest upward `mqb.json` | **migrate** to `mqb.json`; provide upgrade guidance/tooling rather than keeping two authoritative schemas forever |
-| CLI overrides scalar config | ready, including type/runtime/subsystem for currently accepted config target kinds | **ready** |
+| CLI overrides scalar config | ready, including type/runtime/subsystem | **ready** |
 | additive list precedence | config lists first, CLI lists append | **ready** |
 | 14/17/20/23/latest standard config | ready | **ready** |
-| target-kind config | strict `build.type` supports `exe`/`dll`; static schema parity is the immediate follow-up after the librarian slice | **implement** static config value before stable cutover |
+| target-kind config | strict `build.type` supports `exe`/`dll`/`static` (`lib` alias accepted); real static config routing and CLI target-kind precedence are covered | **ready** |
 | runtime/subsystem config | typed strict-schema fields with real cache-invalidation E2E | **ready** |
 | include/lib/define/library config | ready in `mqb.json` | **ready** |
 | `compiler_args` / `linker_args` | ready in strict `mqb.json` v1 schema | **ready** |
@@ -137,7 +137,7 @@ Project-local named modules and project-local header units are in the RC/stable-
 6. Isolate C smart discovery from C++ module lexical syntax. **Done in #32.**
 7. Typed `mqb.json` runtime/subsystem policy with CLI precedence and real invalidation E2E. **Done in #33.**
 8. Native DLL target kind with typed linker routing, deterministic import library, and side-output repair. **Done in #35.**
-9. Static-library target with an explicit `lib.exe`/librarian backend and archive cache owner. **CLI/engine slice done in #36 once merged; strict `mqb.json build.type=static` follows immediately.**
+9. Static-library target with an explicit `lib.exe`/librarian backend, archive cache owner, strict `mqb.json` target kind, and real CLI/config consumer coverage. **Done in #36 + #37 once #37 merges.**
 10. Close the remaining high-value coupled MSVC policy gap (notably LTCG and any charset requirement proven by parity fixtures).
 11. Shared PowerShell-vs-C++ fixtures for ordinary targets, config precedence, incremental rebuilds, libraries, run argv, x86/x64, Debug/Release, and failure behavior.
 12. Installer/profile/`build` command cutover and clean-machine upgrade/rollback validation.


### PR DESCRIPTION
Closes the strict-schema parity gap left intentionally after #36.

## Scope

- accept `build.type: "static"` in strict `mqb.json` v1 (`"lib"` alias also maps to static)
- preserve `explicit CLI > mqb.json > built-in default` target-kind precedence
- keep static linker-only policy fail-closed after config resolution
- prove config-only static routing through the real `lib.exe` pipeline
- prove CLI `--type exe` overrides static config and returns to the linker pipeline
- update config/parity documentation so target-kind parity is complete for ordinary C/C++ targets

## Diff discipline

`ProjectConfig.cpp` was reconstructed from the exact main text because the connector replaces whole files. The semantic parser change is only the static/lib target-kind branch plus the updated schema diagnostic; unrelated parser behavior was preserved. A transient manual-transcription typo was caught and fixed before the final exact head.

## Final validation

Exact head: `2040ef979edfa61d689cec70b0ef7b25268c59c8`.

- C++ V2 workflow #312: **success** — full Debug build and **67/67 CTest**
- C++ Release Candidate workflow #84: **success** — full Release build/tests, embedded rc.2 version gate, package/checksum staging, and artifact upload; prerelease publish skipped by design on PR
- focused/config evidence:
  - strict parser accepts `static` and `lib`
  - config resolver applies static target kind and preserves CLI scalar override precedence
  - the formerly stale pre-librarian `mqb.config.build_policy` assertion is updated and passes
  - real VS2026 `mqb.cli.static_library_e2e` passes with config-only static routing and CLI `--type exe` override
  - the same E2E still covers clean-snapshot archive rebuilds, missing-output repair, consumer relink, and source-set shrink without stale archive members

With #36 + #37, executable/DLL/static target-kind parity is complete for ordinary C/C++ across CLI and strict `mqb.json`. Static targets requiring Modules/Header Units remain intentionally fail-closed pending explicit archive-topology work.