### PR TITLE
feat: add typed LTCG build policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 >
 > - `cpp/` 中的 **C++23 重构版 (`mqb.exe`)** 已具备普通 C/C++、project-local named modules 与 project-local header units 的端到端构建链，并由 Visual Studio 2026 真实工具链 E2E 持续验证。
 > - `v5.0.0-rc.2` 是 C++ 重构版的第二个可分发 Release Candidate；它新增原生 `.c`、typed runtime/subsystem CLI 与 `mqb.json` policy，**尚不代表 PowerShell → C++ 的最终 cutover**。
+> - **当前 `main` 已领先于 rc.2**：普通 C/C++ 目标已具备 typed `exe` / `dll` / `static` 输出，以及耦合的 typed LTCG（compile `/GL` + downstream `/LTCG`）；CLI 与 strict `mqb.json` 都可表达这些 policy。这些能力尚未作为新的 prerelease 发布。
 > - `build.ps1` 仍保留为 **PowerShell Golden Reference / 过渡期稳定入口**；现有 `install.bat` 和 PowerShell profile 不会被 RC 静默替换。
 > - MQB 不宣称与 MSBuild “1:1 等价”。当前原则是：显式建模已支持的常用 MSVC 语义，并用真实编译器回归测试证明行为。
 
@@ -37,23 +38,28 @@ MQB 5.0.0-rc.2 - MSVC Quick Build (C++ refactor)
 
 发布二进制使用静态 MSVC runtime，避免要求用户额外安装 Visual C++ Redistributable。Release Candidate 的完整边界见 [`release/v5.0.0-rc.2.md`](release/v5.0.0-rc.2.md)。
 
+> 本节描述**已发布的 rc.2 包**。下面“现在能做什么”描述的是**当前仓库 mainline**，因此会包含 rc.2 之后已经合入但尚未重新发布的能力。
+
 ---
 
 ## C++ 重构版现在能做什么
 
-- **结构化 MSVC 调用**：直接执行 `cl.exe` / `link.exe`，不通过 shell 拼接命令字符串。
+- **结构化 MSVC 调用**：直接执行 `cl.exe` / `link.exe` / `lib.exe`，不通过 shell 拼接命令字符串。
 - **C 与 C++ translation units**：原生支持 `.c`、`.cpp`、`.cc`、`.cxx`；C discovery 不会把合法的 `module/import/export` 标识符误识别成 C++ Modules 语法。
 - **工具链发现**：支持 Visual Studio 与 portable MSVC 路径，工具链身份进入缓存判断。
 - **单入口智能发现**：`mqb main.cpp` / `mqb main.c` 会从项目内 include / named-import 连接关系选择相关 translation units。
 - **Project-local named modules**：支持 `.ixx` / `.cppm` / `.mpp` interface providers、partitions 与 implementation units，使用 `/scanDependencies` + P1689 建立真实拓扑。
 - **Project-local header units**：`import "header.hpp";` / `import <header>;` 会进入 P1689 模块管线；header 本身不会被伪装成普通 TU，IFC 由 target 动态分配、增量生成与修复。
 - **增量编译**：使用 `/sourceDependencies` 跟踪实际头文件 freshness；编译参数、工具链、模块引用和计划输出参与 compile identity。
+- **Typed target kinds**：`--type exe|dll|static`（以及兼容 `-type`）统一进入 typed target policy。exe/DLL 由 linker pipeline 负责，普通 C/C++ static target 由独立 `MsvcLibrarian` / `lib.exe` pipeline 负责。
 - **Typed MSVC runtime**：`--runtime MD|MDd|MT|MTd`（以及兼容 `-runtime`）由 backend 统一映射，参与 compile identity，并保持 typed policy 对冲突 raw flag 的最终权威。
+- **Typed LTCG**：`--ltcg` / `--no-ltcg`（兼容 legacy `-ltcg`）是一条耦合 policy：compile 侧统一加入 `/GL`，exe/DLL 由 `link.exe /LTCG` 收口，ordinary static 由 `lib.exe /LTCG` 收口；compile/link/archive identity 都区分 LTCG 状态，且 typed flag 在 raw escape hatch 之后保持最终权威。
 - **Typed subsystem**：`--subsystem console|windows`（以及兼容 `-subsystem`）进入 link identity；仅 subsystem 改变时不会误重编 fresh TUs。
 - **IFC 增量正确性**：provider IFC 缺失、provider/header-unit 重编或引用变化会可靠传导到 consumer。
-- **增量链接**：对象、显式库、linker identity 与 link options 共同决定是否重新链接。
+- **增量 downstream target**：exe/DLL 使用 link identity/cache；static archive 使用独立 archive identity/cache。目标输出缺失会触发修复，fresh translation units 不会被无关重编。
+- **Static archive correctness**：static archive 从干净临时库重建后替换目标，source/object set 缩小时不会残留已移除的旧 object member。
 - **有界并行**：`-j/--jobs` 控制 TU scan/compile 并发；job count 是 execution policy，不污染 build cache identity。
-- **`mqb.json`**：严格、带版本的项目配置，遵循 `explicit CLI > mqb.json > built-in defaults`，并支持 `build.runtime` / `build.subsystem`。
+- **`mqb.json`**：严格、带版本的项目配置，遵循 `explicit CLI > mqb.json > built-in defaults`，并支持 `build.type` / `build.runtime` / `build.ltcg` / `build.subsystem`。
 - **结构化运行参数**：`--run -- arg1 "arg 2"` 保持 argv 边界。
 - **隔离构建产物**：全部 C++ 中间产物放在项目 `.mqb/` 下，不在源码目录通配删除 `.obj/.ifc`。
 
@@ -63,8 +69,8 @@ MQB 5.0.0-rc.2 - MSVC Quick Build (C++ refactor)
 
 - external / prebuilt named-module providers；
 - `import std;`；
-- DLL target 与 static-library target（正在 stable-v5 parity 主线中分别接入 linker / librarian pipeline）；
-- 将 C++ RC 宣称为 PowerShell 版本的完整行为替代品。
+- 需要 named-module / header-unit pipeline 的 static-library target（普通 C/C++ static target 已支持）；
+- 将当前 C++ mainline 宣称为 PowerShell 版本的完整行为替代品。
 
 Modules 剩余扩展策略跟踪在 Issue #16；最终 stable v5 还需要 PowerShell ↔ C++ parity / installer / default-entry cutover 的独立验收。
 
@@ -120,11 +126,32 @@ mqb main.cpp src/math.cpp src/io.cpp --release -j 8 -o app
 
 多个 positional sources 表示**精确 source set**，不再自动扩大集合。
 
-### Runtime / subsystem
+### Target kind：exe / DLL / static
+
+```powershell
+# 默认 executable
+mqb main.cpp -o app
+
+# DLL；导出符号时 import library 会放在 .mqb/bin/ 下
+mqb api.cpp --type dll -o codec
+
+# 普通 C/C++ static library；由 lib.exe pipeline 生成 .lib
+mqb math.cpp vector.cpp --type static -o math
+```
+
+`--type` 也接受 `executable` / `dynamic` / `lib` alias。static target 不接受 subsystem、library search path、linked libraries 或 raw linker args；这些 linker-only policy 会 fail closed，而不是被静默忽略。需要 named modules/header units 的 static target 目前也会 fail closed。
+
+### Runtime / LTCG / subsystem
 
 ```powershell
 # 静态 CRT Release 风格 runtime policy
 mqb main.cpp --runtime MT
+
+# 耦合 LTCG：compile /GL + executable/DLL link /LTCG
+mqb main.cpp --ltcg
+
+# ordinary static 同样支持：compile /GL + lib.exe /LTCG
+mqb math.cpp vector.cpp --type static --ltcg -o math
 
 # Windows GUI subsystem；只改变 link policy，不应让 fresh TU 重编
 mqb winmain.cpp --subsystem windows
@@ -137,12 +164,13 @@ mqb winmain.cpp --subsystem windows
   "version": 1,
   "build": {
     "runtime": "MT",
+    "ltcg": true,
     "subsystem": "console"
   }
 }
 ```
 
-显式 CLI scalar 始终覆盖 config scalar。
+显式 CLI scalar 始终覆盖 config scalar，例如 `--no-ltcg` 会覆盖 `build.ltcg: true`。
 
 ### 运行时参数
 
@@ -218,7 +246,9 @@ C++ 重构版使用根目录 `mqb.json`，不是 PowerShell 版本的 `msvc_list
     "configuration": "release",
     "architecture": "x64",
     "standard": "latest",
+    "type": "exe",
     "runtime": "MT",
+    "ltcg": true,
     "subsystem": "console",
     "output": "game",
     "defines": ["GAME_BUILD=1"],
@@ -235,7 +265,7 @@ C++ 重构版使用根目录 `mqb.json`，不是 PowerShell 版本的 `msvc_list
 }
 ```
 
-MQB 从 invocation directory 向上查找最近的 `mqb.json`；配置文件所在目录成为 project root 和 `.mqb/` 根。完整 schema、路径基准、precedence 与 cache 行为见 [`docs/MQB_CONFIG.md`](docs/MQB_CONFIG.md)。
+MQB 从 invocation directory 向上查找最近的 `mqb.json`；配置文件所在目录成为 project root 和 `.mqb/` 根。`build.type` 支持 `exe` / `dll` / `static`（以及 `executable` / `dynamic` / `lib` aliases）；`build.ltcg` 是 strict boolean typed policy。完整 schema、路径基准、precedence 与 cache 行为见 [`docs/MQB_CONFIG.md`](docs/MQB_CONFIG.md)。
 
 ---
 
@@ -250,12 +280,14 @@ mqb <source.c|source.cpp|module.ixx|module.cppm|module.mpp> <more-sources...> [o
 |---|---|
 | `--debug` / `--release` | 选择构建配置 |
 | `--std <14|17|20|23|latest>` | 选择 C++ 标准（C TU 不发 C++ `/std`） |
+| `--type <exe|dll|static>` | 选择 executable / DLL / static-library target kind |
 | `--x86` / `--x64` | 选择目标架构 |
 | `--runtime <MD|MDd|MT|MTd>` | 选择 MSVC runtime library |
-| `--subsystem <console|windows>` | 选择 executable subsystem |
+| `--ltcg` / `--no-ltcg` | 开启/关闭耦合 LTCG：compile `/GL` + downstream `/LTCG`；legacy `-ltcg` 可开启 |
+| `--subsystem <console|windows>` | 选择 executable/DLL subsystem；static target 不适用 |
 | `-j, --jobs <N>` | 最大并发 scan/compile 数量 |
 | `-o, --output <name>` | `.mqb/bin/` 下的目标名 |
-| `--run` | 构建成功后运行 |
+| `--run` | 构建成功后运行 executable target |
 | `--discover` / `--no-discover` | 显式打开/关闭单入口 smart discovery |
 | `-I <dir>` | include directory |
 | `-D <value>` | preprocessor definition |
@@ -266,7 +298,7 @@ mqb <source.c|source.cpp|module.ixx|module.cppm|module.mpp> <more-sources...> [o
 | `--env <auto|vs|portable>` | 工具链选择 |
 | `--portable-root <dir>` | 增加 portable toolchain root 候选 |
 | `-v, --verbose` | 输出 project/config/toolchain/artifact/pipeline 信息 |
-| `--` | 后续参数原样作为 program argv |
+| `--` | 后续参数原样作为 executable program argv |
 
 `mqb --help` 是 CLI 的权威即时说明，并显示当前二进制内嵌版本。
 
@@ -280,8 +312,8 @@ mqb <source.c|source.cpp|module.ixx|module.cppm|module.mpp> <more-sources...> [o
 ├── deps/    # /sourceDependencies metadata
 ├── scan/    # /scanDependencies / P1689 metadata
 ├── ifc/     # named-module / header-unit IFC artifacts
-├── cache/   # compile/link cache metadata
-└── bin/     # current target output
+├── cache/   # compile/link/archive cache metadata
+└── bin/     # executable / DLL / static-library target artifacts
 ```
 
 Windows 上同一物理源文件即使被用户或 MSVC scanner 以不同大小写/路径别名表示，也会归一到稳定 artifact identity，避免一份 source 分裂出两套 cache/IFC。
@@ -303,9 +335,9 @@ Build plan
       ↓
 Bounded compile waves
       ↓
-Incremental link
+Incremental link / archive
       ↓
-Optional run
+Optional executable run
 ```
 
 关键边界：Source discovery 只选候选；`/scanDependencies` 管模块拓扑，`/sourceDependencies` 管实际 header freshness；Planner 与 Executor 分离；shell text 不是构建模型；缓存命中必须由 identity + outputs + dependencies 一起证明；并行度只是 execution policy；未定义 artifact/freshness policy 的能力必须 fail closed。
@@ -326,11 +358,12 @@ Optional run
 
 ## 当前路线
 
-- `v5.0.0-rc.2`：交付新增 C translation units 与 typed runtime/subsystem policy 的 C++ standalone candidate；
-- stable-v5 parity：继续 DLL target、static librarian pipeline、必要 coupled policy 与 shared PowerShell↔C++ fixtures；
-- Issue #16：继续 external/prebuilt named-module providers 与 `import std`；
-- installer/profile/default-entry cutover；
-- 满足上述 stable gate 后发布正式 v5，并逐步删除不再需要的 PowerShell Golden Reference。
+- **已发布 `v5.0.0-rc.2`**：交付原生 C translation units 与 typed runtime/subsystem policy 的 C++ standalone candidate；
+- **当前 mainline**：普通 C/C++ `exe` / `dll` / `static` typed target-kind parity 与 typed LTCG 已完成，CLI + strict `mqb.json` + compile/link/archive identity + 真实 MSVC executable/static consumer E2E 已合入，但尚未重新发布；
+- **下一主线**：shared PowerShell ↔ C++ parity fixtures/harness，用同一批 observable fixtures 对照普通目标、config precedence、incremental rebuild、libraries、run argv、x86/x64、Debug/Release 与失败行为；
+- **随后**：installer/profile/default-entry cutover → stable release workflow generalization；
+- **Issue #16**：独立继续 external/prebuilt named-module providers 与 `import std`；
+- 满足 stable gate 后，从**同一份已验证 artifact** 发布正式 `v5.0.0`，再逐步收缩 PowerShell Golden Reference。
 
 ## License
 

--- a/cpp/apps/mqb/Cli.cpp
+++ b/cpp/apps/mqb/Cli.cpp
@@ -173,6 +173,14 @@ parse_arguments(const std::span<const std::string_view> arguments) {
             options.build.run_after_build = true;
             continue;
         }
+        if (argument == "--ltcg" || argument == "-ltcg") {
+            options.ltcg_override = true;
+            continue;
+        }
+        if (argument == "--no-ltcg") {
+            options.ltcg_override = false;
+            continue;
+        }
         if (argument == "-j" || argument == "--jobs") {
             auto value = require_value(arguments, index, argument);
             if (!value) return std::unexpected(value.error());
@@ -452,6 +460,7 @@ Options:
   --type <exe|dll|static>  Select executable, DLL, or static-library output (legacy -type accepted)
   --runtime <MD|MDd|MT|MTd>
                            Explicitly select MSVC CRT runtime (legacy -runtime accepted)
+  --ltcg | --no-ltcg      Enable/disable coupled /GL + downstream /LTCG (legacy -ltcg enables)
   --subsystem <console|windows>
                            Explicitly select PE subsystem for executable/DLL targets (legacy -subsystem accepted)
   --x86 | --x64            Explicitly select target architecture (legacy -x86/-x64 accepted)
@@ -474,12 +483,14 @@ Options:
 
 Static libraries are produced by MSVC lib.exe from the compiled object set. Linker-only policy
 (libraries, library search paths, subsystem, and raw linker arguments) does not apply to a static
-archive and is rejected when explicitly supplied for a static target.
+archive and is rejected when explicitly supplied for a static target. Typed LTCG remains valid
+for static targets and couples /GL compilation with lib.exe /LTCG archive policy.
 
 Raw compiler/linker arguments are one argv element per option occurrence; MQB does not split a
 quoted string into multiple switches. Project config entries are applied first and CLI raw args
-append afterward. Structured artifact routing such as /Fo, /scanDependencies, /DLL, /IMPLIB,
-/MACHINE and /OUT is emitted after raw arguments so the BuildPlan remains authoritative.
+append afterward. Typed runtime/LTCG and structured artifact routing such as /Fo,
+/scanDependencies, /DLL, /IMPLIB, /MACHINE and /OUT are emitted after raw arguments so the
+BuildPlan remains authoritative.
 
 Legacy compatibility aliases intentionally cover spelling only. Legacy-only semantics such as
 -a string splitting remain tracked by the stable-v5 parity inventory and are not silently accepted here.

--- a/cpp/apps/mqb/Cli.hpp
+++ b/cpp/apps/mqb/Cli.hpp
@@ -23,6 +23,7 @@ struct Options {
     std::optional<CppStandard> standard_override;
     std::optional<TargetKind> target_kind_override;
     std::optional<RuntimeLibrary> runtime_override;
+    std::optional<bool> ltcg_override;
     std::optional<LinkSubsystem> subsystem_override;
     std::vector<std::string> defines;
     std::vector<std::filesystem::path> include_directories;

--- a/cpp/apps/mqb/main.cpp
+++ b/cpp/apps/mqb/main.cpp
@@ -340,6 +340,7 @@ int main(const int argc, char* argv[]) {
     cli_overrides.build.standard = options.standard_override;
     cli_overrides.build.target_kind = options.target_kind_override;
     cli_overrides.build.runtime_library = options.runtime_override;
+    cli_overrides.build.link_time_code_generation = options.ltcg_override;
     cli_overrides.build.subsystem = options.subsystem_override;
     cli_overrides.build.output_name = options.build.output_name;
     cli_overrides.build.defines = options.defines;
@@ -358,6 +359,7 @@ int main(const int argc, char* argv[]) {
     options.build.standard = effective.standard;
     options.build.target_kind = effective.target_kind;
     options.runtime_override = effective.runtime_library;
+    options.ltcg_override = effective.link_time_code_generation;
     options.subsystem_override = effective.subsystem;
     options.build.output_name = effective.output_name;
     options.discover_sources = effective.discovery_enabled;
@@ -488,6 +490,7 @@ int main(const int argc, char* argv[]) {
     compiler_options.architecture = options.build.architecture;
     compiler_options.standard = options.build.standard;
     compiler_options.runtime_library = options.runtime_override;
+    compiler_options.link_time_code_generation = effective.link_time_code_generation;
     compiler_options.defines = std::move(options.defines);
     compiler_options.include_directories = std::move(options.include_directories);
     compiler_options.additional_arguments = std::move(options.compiler_arguments);
@@ -531,6 +534,7 @@ int main(const int argc, char* argv[]) {
     link_options.architecture = options.build.architecture;
     link_options.target_kind = options.build.target_kind;
     link_options.subsystem = options.subsystem_override.value_or(mqb::LinkSubsystem::console);
+    link_options.link_time_code_generation = effective.link_time_code_generation;
     link_options.library_directories = std::move(options.library_directories);
     link_options.libraries = std::move(options.libraries);
     link_options.additional_arguments = std::move(options.linker_arguments);
@@ -565,6 +569,7 @@ int main(const int argc, char* argv[]) {
             std::cout << "  config:  " << path_text(project_config->file) << '\n';
         }
         std::cout << "  type:    " << mqb::to_string(options.build.target_kind) << '\n'
+                  << "  ltcg:    " << (effective.link_time_code_generation ? "on" : "off") << '\n'
                   << "  jobs:    " << compile_jobs
                   << (options.jobs ? "" : " (auto)") << '\n'
                   << "  cl:      " << path_text(toolchain->identity.compiler) << '\n'

--- a/cpp/backends/msvc/include/mqb/msvc/MsvcLibrarian.hpp
+++ b/cpp/backends/msvc/include/mqb/msvc/MsvcLibrarian.hpp
@@ -16,6 +16,7 @@ struct ArchiveInvocation {
     std::vector<std::filesystem::path> objects;
     std::filesystem::path output;
     std::filesystem::path working_directory;
+    bool link_time_code_generation{false};
 };
 
 enum class LibrarianErrorCode {

--- a/cpp/backends/msvc/src/MsvcCompiler.cpp
+++ b/cpp/backends/msvc/src/MsvcCompiler.cpp
@@ -132,6 +132,11 @@ void append_configuration_arguments(
         // leaving the historical default preset byte-for-byte unchanged.
         arguments.push_back(runtime_argument(*options.runtime_library));
     }
+    if (options.link_time_code_generation) {
+        // LTCG is coupled typed policy. Emit /GL after raw compiler arguments so
+        // a raw escape-hatch flag cannot silently disable the compile half.
+        arguments.emplace_back("/GL");
+    }
 
     return {};
 }
@@ -291,7 +296,7 @@ MsvcCompiler::build_arguments(const CompileInvocation& invocation) {
     const bool c_translation_unit = is_c_translation_unit_path(invocation.source);
     std::vector<std::string> arguments;
     arguments.reserve(
-        22
+        23
         + invocation.options.defines.size()
         + invocation.options.include_directories.size()
         + invocation.options.additional_arguments.size()
@@ -363,7 +368,7 @@ MsvcCompiler::build_header_unit_arguments(const HeaderUnitCompileInvocation& inv
 
     std::vector<std::string> arguments;
     arguments.reserve(
-        23
+        24
         + invocation.options.defines.size()
         + invocation.options.include_directories.size()
         + invocation.options.additional_arguments.size());

--- a/cpp/backends/msvc/src/MsvcLibrarian.cpp
+++ b/cpp/backends/msvc/src/MsvcLibrarian.cpp
@@ -74,8 +74,11 @@ MsvcLibrarian::build_arguments(const ArchiveInvocation& invocation) {
             LibrarianErrorCode::invalid_request, "archive output path is empty"));
     }
     std::vector<std::string> arguments;
-    arguments.reserve(invocation.objects.size() + 2);
+    arguments.reserve(invocation.objects.size() + 3);
     arguments.emplace_back("/NOLOGO");
+    if (invocation.link_time_code_generation) {
+        arguments.emplace_back("/LTCG");
+    }
     arguments.push_back("/OUT:" + path_to_utf8(invocation.output));
     for (const auto& object : invocation.objects) {
         if (object.empty()) {

--- a/cpp/backends/msvc/src/MsvcLinker.cpp
+++ b/cpp/backends/msvc/src/MsvcLinker.cpp
@@ -146,7 +146,7 @@ MsvcLinker::build_arguments(const LinkInvocation& invocation) {
 
     std::vector<std::string> arguments;
     arguments.reserve(
-        14
+        15
         + invocation.objects.size()
         + invocation.options.library_directories.size()
         + invocation.libraries.size()
@@ -155,7 +155,10 @@ MsvcLinker::build_arguments(const LinkInvocation& invocation) {
     arguments.emplace_back("/NOLOGO");
     if (invocation.options.configuration == BuildConfiguration::debug) {
         arguments.emplace_back("/DEBUG");
-        arguments.emplace_back("/INCREMENTAL");
+        arguments.emplace_back(
+            invocation.options.link_time_code_generation
+                ? "/INCREMENTAL:NO"
+                : "/INCREMENTAL");
     } else {
         arguments.emplace_back("/INCREMENTAL:NO");
         arguments.emplace_back("/OPT:REF");
@@ -180,6 +183,12 @@ MsvcLinker::build_arguments(const LinkInvocation& invocation) {
                 "additional linker argument must not be empty"));
         }
         arguments.push_back(argument);
+    }
+
+    // Typed LTCG is downstream structured policy and therefore follows raw
+    // linker arguments. This keeps the coupled /GL + /LTCG contract authoritative.
+    if (invocation.options.link_time_code_generation) {
+        arguments.emplace_back("/LTCG");
     }
 
     // Structured routing is emitted after raw flags so the BuildPlan owns the

--- a/cpp/config/include/mqb/config/ProjectConfig.hpp
+++ b/cpp/config/include/mqb/config/ProjectConfig.hpp
@@ -16,6 +16,7 @@ struct BuildOverrides {
     std::optional<Architecture> architecture;
     std::optional<CppStandard> standard;
     std::optional<RuntimeLibrary> runtime_library;
+    std::optional<bool> link_time_code_generation;
     std::optional<LinkSubsystem> subsystem;
     std::optional<TargetKind> target_kind;
     std::optional<std::string> output_name;

--- a/cpp/config/include/mqb/config/ProjectOptions.hpp
+++ b/cpp/config/include/mqb/config/ProjectOptions.hpp
@@ -19,6 +19,7 @@ struct EffectiveProjectOptions {
     Architecture architecture{Architecture::x64};
     CppStandard standard{CppStandard::cpp23};
     std::optional<RuntimeLibrary> runtime_library;
+    bool link_time_code_generation{false};
     LinkSubsystem subsystem{LinkSubsystem::console};
     TargetKind target_kind{TargetKind::executable};
     std::optional<std::string> output_name;

--- a/cpp/config/src/ProjectConfig.cpp
+++ b/cpp/config/src/ProjectConfig.cpp
@@ -428,7 +428,7 @@ decode_build(const fs::path& file, const fs::path& root, const JsonValue& value,
     auto object = require_object(file, value, "build");
     if (!object) return std::unexpected(object.error());
     auto known = reject_unknown(file, **object,
-        {"configuration", "architecture", "standard", "runtime", "subsystem", "type", "output", "defines", "include_dirs",
+        {"configuration", "architecture", "standard", "runtime", "ltcg", "subsystem", "type", "output", "defines", "include_dirs",
          "library_dirs", "libraries", "compiler_args", "linker_args"},
         "build");
     if (!known) return std::unexpected(known.error());
@@ -460,6 +460,11 @@ decode_build(const fs::path& file, const fs::path& root, const JsonValue& value,
         auto parsed = runtime_library(*text);
         if (!parsed) return std::unexpected(schema_error(file, it->second, "build.runtime must be 'MD', 'MDd', 'MT', or 'MTd'"));
         out.runtime_library = *parsed;
+    }
+    if (auto it = (**object).find("ltcg"); it != (**object).end()) {
+        auto enabled = require_bool(file, it->second, "build.ltcg");
+        if (!enabled) return std::unexpected(enabled.error());
+        out.link_time_code_generation = *enabled;
     }
     if (auto it = (**object).find("subsystem"); it != (**object).end()) {
         auto text = require_string(file, it->second, "build.subsystem");

--- a/cpp/config/src/ProjectOptions.cpp
+++ b/cpp/config/src/ProjectOptions.cpp
@@ -17,6 +17,9 @@ void apply_build(
     if (overrides.architecture) effective.architecture = *overrides.architecture;
     if (overrides.standard) effective.standard = *overrides.standard;
     if (overrides.runtime_library) effective.runtime_library = overrides.runtime_library;
+    if (overrides.link_time_code_generation) {
+        effective.link_time_code_generation = *overrides.link_time_code_generation;
+    }
     if (overrides.subsystem) effective.subsystem = *overrides.subsystem;
     if (overrides.target_kind) effective.target_kind = *overrides.target_kind;
     if (overrides.output_name) effective.output_name = overrides.output_name;

--- a/cpp/config/tests/build_policy_config_tests.cpp
+++ b/cpp/config/tests/build_policy_config_tests.cpp
@@ -45,6 +45,7 @@ int main() {
     "standard": "17",
     "type": "dll",
     "runtime": "MT",
+    "ltcg": true,
     "subsystem": "windows",
     "compiler_args": ["/W4", "/DCONFIG_POLICY=1"],
     "linker_args": ["/OPT:NOREF"]
@@ -60,6 +61,8 @@ int main() {
                "mqb.json should decode typed DLL output");
         expect(loaded->build.runtime_library == mqb::RuntimeLibrary::mt,
                "mqb.json should decode typed MT runtime");
+        expect(loaded->build.link_time_code_generation == true,
+               "mqb.json should decode typed LTCG enablement");
         expect(loaded->build.subsystem == mqb::LinkSubsystem::windows,
                "mqb.json should decode typed Windows subsystem");
         expect(loaded->build.compiler_arguments.size() == 2
@@ -74,6 +77,7 @@ int main() {
         cli.build.standard = mqb::CppStandard::cpp14;
         cli.build.target_kind = mqb::TargetKind::executable;
         cli.build.runtime_library = mqb::RuntimeLibrary::mdd;
+        cli.build.link_time_code_generation = false;
         cli.build.subsystem = mqb::LinkSubsystem::console;
         cli.build.compiler_arguments = {"/WX"};
         cli.build.linker_arguments = {"/MAP:cli.map"};
@@ -84,6 +88,8 @@ int main() {
                "CLI scalar target kind should override DLL project config");
         expect(effective.runtime_library == mqb::RuntimeLibrary::mdd,
                "CLI scalar runtime should override project config");
+        expect(!effective.link_time_code_generation,
+               "CLI scalar --no-ltcg should override project config");
         expect(effective.subsystem == mqb::LinkSubsystem::console,
                "CLI scalar subsystem should override project config");
         expect(effective.compiler_arguments.size() == 3
@@ -108,6 +114,11 @@ int main() {
                && static_target->build.target_kind == mqb::TargetKind::static_library,
            "mqb.json should accept static target kind after librarian support");
 
+    write_text(file, R"json({"version":1,"build":{"ltcg":false}})json");
+    auto ltcg_false = mqb::config::ProjectConfigLoader::load(file);
+    expect(ltcg_false.has_value() && ltcg_false->build.link_time_code_generation == false,
+           "mqb.json should accept explicit LTCG disablement");
+
     write_text(file, R"json({"version":1,"build":{"runtime":"dynamic"}})json");
     auto bad_runtime = mqb::config::ProjectConfigLoader::load(file);
     expect(!bad_runtime && bad_runtime.error().code == mqb::config::ErrorCode::schema_error,
@@ -122,6 +133,11 @@ int main() {
     auto runtime_type = mqb::config::ProjectConfigLoader::load(file);
     expect(!runtime_type && runtime_type.error().code == mqb::config::ErrorCode::schema_error,
            "runtime must be a JSON string");
+
+    write_text(file, R"json({"version":1,"build":{"ltcg":"true"}})json");
+    auto ltcg_type = mqb::config::ProjectConfigLoader::load(file);
+    expect(!ltcg_type && ltcg_type.error().code == mqb::config::ErrorCode::schema_error,
+           "ltcg must be a JSON boolean");
 
     write_text(file, R"json({"version":1,"build":{"compiler_args":[""]}})json");
     auto empty = mqb::config::ProjectConfigLoader::load(file);

--- a/cpp/core/include/mqb/core/ArchiveCache.hpp
+++ b/cpp/core/include/mqb/core/ArchiveCache.hpp
@@ -34,7 +34,8 @@ public:
         const std::optional<ArchiveCacheEntry>& cached_entry,
         const FileSnapshot& output_snapshot,
         std::span<const FileSnapshot> object_snapshots,
-        bool force_archive = false);
+        bool force_archive = false,
+        bool link_time_code_generation = false);
 };
 
 } // namespace mqb

--- a/cpp/core/include/mqb/core/BuildSignature.hpp
+++ b/cpp/core/include/mqb/core/BuildSignature.hpp
@@ -45,7 +45,8 @@ public:
     [[nodiscard]] static BuildSignature for_archive(
         std::span<const std::filesystem::path> objects,
         const std::filesystem::path& output,
-        const LibrarianIdentity& librarian);
+        const LibrarianIdentity& librarian,
+        bool link_time_code_generation = false);
 
     [[nodiscard]] static BuildSignature from_digest(const SignatureDigest digest) noexcept {
         return BuildSignature{digest};

--- a/cpp/core/include/mqb/core/CompilerOptions.hpp
+++ b/cpp/core/include/mqb/core/CompilerOptions.hpp
@@ -24,6 +24,10 @@ struct CompilerOptions {
     // Release -> /MD. An explicit value is emitted later in argv and is
     // additional compile identity without perturbing old default signatures.
     std::optional<RuntimeLibrary> runtime_library;
+    // Typed LTCG is coupled with downstream /LTCG policy. False preserves the
+    // historical compiler recipe/signature byte stream; true appends /GL as
+    // authoritative structured policy after raw compiler arguments.
+    bool link_time_code_generation{false};
     std::vector<std::string> defines;
     std::vector<std::filesystem::path> include_directories;
     std::vector<std::string> additional_arguments;

--- a/cpp/core/include/mqb/core/LinkOptions.hpp
+++ b/cpp/core/include/mqb/core/LinkOptions.hpp
@@ -18,6 +18,9 @@ struct LinkOptions {
     Architecture architecture{Architecture::x64};
     TargetKind target_kind{TargetKind::executable};
     LinkSubsystem subsystem{LinkSubsystem::console};
+    // Coupled with CompilerOptions::link_time_code_generation. False preserves
+    // the historical link signature/recipe; true makes /LTCG structured policy.
+    bool link_time_code_generation{false};
     std::vector<std::filesystem::path> library_directories;
     std::vector<std::string> libraries;
     std::vector<std::string> additional_arguments;

--- a/cpp/core/src/ArchiveCache.cpp
+++ b/cpp/core/src/ArchiveCache.cpp
@@ -55,7 +55,8 @@ ArchiveCacheValidation ArchiveCacheValidator::validate(
     const std::optional<ArchiveCacheEntry>& cached_entry,
     const FileSnapshot& output_snapshot,
     const std::span<const FileSnapshot> object_snapshots,
-    const bool force_archive) {
+    const bool force_archive,
+    const bool link_time_code_generation) {
     ArchiveCacheValidation result;
 
     if (force_archive) add_reason(result.reasons, BuildReason::explicit_rebuild);
@@ -74,7 +75,10 @@ ArchiveCacheValidation ArchiveCacheValidator::validate(
     if (!inputs_match) add_reason(result.reasons, BuildReason::archive_inputs_changed);
 
     const auto signature = BuildSignature::for_archive(
-        current_objects, current_output, current_librarian);
+        current_objects,
+        current_output,
+        current_librarian,
+        link_time_code_generation);
     if (cached.signature != signature && librarian_matches && inputs_match) {
         add_reason(result.reasons, BuildReason::archive_recipe_changed);
     }

--- a/cpp/core/src/BuildSignature.cpp
+++ b/cpp/core/src/BuildSignature.cpp
@@ -178,6 +178,10 @@ BuildSignature BuildSignature::for_compile(
         hasher.add_string("mqb.runtime-library.v1");
         hasher.add_enum(*options.runtime_library);
     }
+    if (options.link_time_code_generation) {
+        // Preserve the historical signature byte stream when typed LTCG is off.
+        hasher.add_string("mqb.ltcg.compile.v1");
+    }
 
     return BuildSignature{hasher.finish()};
 }
@@ -221,13 +225,18 @@ BuildSignature BuildSignature::for_link(
         hasher.add_string("mqb.link.target-kind.v1");
         hasher.add_enum(options.target_kind);
     }
+    if (options.link_time_code_generation) {
+        // Preserve historical executable/DLL link identities when LTCG is off.
+        hasher.add_string("mqb.ltcg.link.v1");
+    }
     return BuildSignature{hasher.finish()};
 }
 
 BuildSignature BuildSignature::for_archive(
     const std::span<const std::filesystem::path> objects,
     const std::filesystem::path& output,
-    const LibrarianIdentity& librarian) {
+    const LibrarianIdentity& librarian,
+    const bool link_time_code_generation) {
     StableHasher hasher;
     hasher.add_string("mqb.archive.signature.v1");
     hasher.add_paths(objects);
@@ -235,6 +244,10 @@ BuildSignature BuildSignature::for_archive(
     hasher.add_path(librarian.librarian);
     hasher.add_string(librarian.version);
     hasher.add_string(librarian.binary_stamp);
+    if (link_time_code_generation) {
+        // Preserve historical archive identities when LTCG is off.
+        hasher.add_string("mqb.ltcg.archive.v1");
+    }
     return BuildSignature{hasher.finish()};
 }
 

--- a/cpp/orchestration/include/mqb/orchestration/MsvcIncrementalArchiveCoordinator.hpp
+++ b/cpp/orchestration/include/mqb/orchestration/MsvcIncrementalArchiveCoordinator.hpp
@@ -19,6 +19,7 @@ struct IncrementalArchiveRequest {
     std::filesystem::path output;
     std::filesystem::path cache_file;
     std::filesystem::path working_directory;
+    bool link_time_code_generation{false};
     bool force_archive{false};
 };
 

--- a/cpp/orchestration/src/MsvcIncrementalArchiveCoordinator.cpp
+++ b/cpp/orchestration/src/MsvcIncrementalArchiveCoordinator.cpp
@@ -97,7 +97,8 @@ MsvcIncrementalArchiveCoordinator::run(const IncrementalArchiveRequest& request)
         cached_entry,
         output_snapshot,
         object_snapshots,
-        request.force_archive);
+        request.force_archive,
+        request.link_time_code_generation);
 
     auto plan = BuildPlanner::plan_archive(ArchivePlanItem{
         .objects = request.objects,
@@ -131,6 +132,7 @@ MsvcIncrementalArchiveCoordinator::run(const IncrementalArchiveRequest& request)
         .objects = action->objects,
         .output = action->output,
         .working_directory = request.working_directory,
+        .link_time_code_generation = request.link_time_code_generation,
     });
     if (!archived) {
         return std::unexpected(IncrementalArchiveError{
@@ -144,7 +146,11 @@ MsvcIncrementalArchiveCoordinator::run(const IncrementalArchiveRequest& request)
 
     const ArchiveCacheEntry entry{
         .librarian = *librarian_identity,
-        .signature = BuildSignature::for_archive(action->objects, action->output, *librarian_identity),
+        .signature = BuildSignature::for_archive(
+            action->objects,
+            action->output,
+            *librarian_identity,
+            request.link_time_code_generation),
         .objects = action->objects,
         .output = action->output,
     };

--- a/cpp/orchestration/src/MsvcIncrementalStaticTargetCoordinator.cpp
+++ b/cpp/orchestration/src/MsvcIncrementalStaticTargetCoordinator.cpp
@@ -156,6 +156,7 @@ MsvcIncrementalStaticTargetCoordinator::run(const IncrementalStaticTargetRequest
         .output = request.target.executable,
         .cache_file = request.target.link_cache,
         .working_directory = request.working_directory,
+        .link_time_code_generation = request.compiler_options.link_time_code_generation,
         .force_archive = result.any_compiled,
     });
     if (!archived) {

--- a/cpp/tests/build_policy_cli_tests.cpp
+++ b/cpp/tests/build_policy_cli_tests.cpp
@@ -44,10 +44,11 @@ int main() {
             "main.cpp"sv,
             "--type"sv, "dll"sv,
             "--runtime"sv, "MT"sv,
+            "--ltcg"sv,
             "--subsystem=windows"sv,
         };
         auto parsed = mqb::cli::parse_arguments(arguments);
-        expect(parsed.has_value(), "typed native target/runtime/subsystem options should parse");
+        expect(parsed.has_value(), "typed native target/runtime/LTCG/subsystem options should parse");
         if (parsed) {
             expect(parsed->target_kind_override == mqb::TargetKind::dynamic_library,
                    "--type dll should select typed DLL output");
@@ -55,6 +56,8 @@ int main() {
                    "typed DLL selection should also update BuildRequest");
             expect(parsed->runtime_override == mqb::RuntimeLibrary::mt,
                    "--runtime MT should select static release CRT");
+            expect(parsed->ltcg_override == true,
+                   "--ltcg should enable the coupled LTCG policy");
             expect(parsed->subsystem_override == mqb::LinkSubsystem::windows,
                    "--subsystem=windows should select Windows subsystem");
         }
@@ -65,18 +68,28 @@ int main() {
             "main.cpp"sv,
             "-type"sv, "dll"sv,
             "-runtime"sv, "MDd"sv,
+            "-ltcg"sv,
             "-subsystem"sv, "console"sv,
         };
         auto parsed = mqb::cli::parse_arguments(arguments);
-        expect(parsed.has_value(), "legacy type/runtime/subsystem aliases should parse");
+        expect(parsed.has_value(), "legacy type/runtime/LTCG/subsystem aliases should parse");
         if (parsed) {
             expect(parsed->target_kind_override == mqb::TargetKind::dynamic_library,
                    "legacy -type dll should map to typed DLL output");
             expect(parsed->runtime_override == mqb::RuntimeLibrary::mdd,
                    "legacy -runtime MDd should map to typed runtime");
+            expect(parsed->ltcg_override == true,
+                   "legacy -ltcg should map to typed LTCG enablement");
             expect(parsed->subsystem_override == mqb::LinkSubsystem::console,
                    "legacy -subsystem console should map to typed subsystem");
         }
+    }
+
+    {
+        const std::vector arguments{"main.cpp"sv, "--ltcg"sv, "--no-ltcg"sv};
+        auto parsed = mqb::cli::parse_arguments(arguments);
+        expect(parsed.has_value() && parsed->ltcg_override == false,
+               "later --no-ltcg should override earlier CLI enablement");
     }
 
     {

--- a/cpp/tests/build_signature_tests.cpp
+++ b/cpp/tests/build_signature_tests.cpp
@@ -2,10 +2,14 @@
 #include <iostream>
 #include <string_view>
 #include <utility>
+#include <vector>
 
 #include "mqb/core/Artifact.hpp"
 #include "mqb/core/BuildSignature.hpp"
 #include "mqb/core/CompilerOptions.hpp"
+#include "mqb/core/LibrarianIdentity.hpp"
+#include "mqb/core/LinkOptions.hpp"
+#include "mqb/core/LinkerIdentity.hpp"
 #include "mqb/core/ToolchainIdentity.hpp"
 #include "mqb/core/TranslationUnit.hpp"
 
@@ -80,6 +84,11 @@ int main() {
     x86_options.architecture = mqb::Architecture::x86;
     expect(mqb::BuildSignature::for_compile(unit, toolchain, x86_options) != baseline,
            "changing target architecture should invalidate the compile signature");
+
+    auto ltcg_options = options;
+    ltcg_options.link_time_code_generation = true;
+    expect(mqb::BuildSignature::for_compile(unit, toolchain, ltcg_options) != baseline,
+           "enabling typed LTCG should invalidate the compile signature");
 
     auto define_options = options;
     define_options.defines.emplace_back("FEATURE_X=1");
@@ -188,6 +197,34 @@ int main() {
     output_only_change.outputs.front().path = std::filesystem::path{"another-cache/main.obj"};
     expect(mqb::BuildSignature::for_compile(output_only_change, toolchain, options) == baseline,
            "ordinary object placement should not change compiler recipe identity");
+
+    const std::vector<std::filesystem::path> objects{"build/main.obj"};
+    const mqb::LinkerIdentity linker{
+        .linker = "toolchain/link.exe",
+        .version = "14.50.12345",
+        .binary_stamp = "link-stamp",
+    };
+    mqb::LinkOptions link_options;
+    link_options.configuration = mqb::BuildConfiguration::debug;
+    link_options.architecture = mqb::Architecture::x64;
+    const auto link_baseline = mqb::BuildSignature::for_link(
+        objects, "bin/app.exe", linker, link_options);
+    auto ltcg_link_options = link_options;
+    ltcg_link_options.link_time_code_generation = true;
+    expect(mqb::BuildSignature::for_link(objects, "bin/app.exe", linker, ltcg_link_options)
+               != link_baseline,
+           "enabling typed LTCG should invalidate downstream link identity");
+
+    const mqb::LibrarianIdentity librarian{
+        .librarian = "toolchain/lib.exe",
+        .version = "14.50.12345",
+        .binary_stamp = "lib-stamp",
+    };
+    const auto archive_baseline = mqb::BuildSignature::for_archive(
+        objects, "bin/math.lib", librarian);
+    expect(mqb::BuildSignature::for_archive(objects, "bin/math.lib", librarian, true)
+               != archive_baseline,
+           "enabling typed LTCG should invalidate downstream archive identity");
 
     if (failures != 0) {
         std::cerr << failures << " test(s) failed\n";

--- a/cpp/tests/mqb_build_policy_e2e_tests.cpp
+++ b/cpp/tests/mqb_build_policy_e2e_tests.cpp
@@ -258,11 +258,37 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
                "unchanged subsystem should keep link cache warm");
     }
 
+    auto ltcg_policy = windows_policy;
+    ltcg_policy.emplace_back("--ltcg");
+    auto ltcg_changed = run_mqb(runner, mqb_executable, tree.root, ltcg_policy);
+    expect(ltcg_changed.has_value(), "typed-LTCG invocation should launch");
+    if (ltcg_changed) {
+        if (ltcg_changed->exit_code != 0) dump_failure(*ltcg_changed);
+        expect(ltcg_changed->exit_code == 0, "typed LTCG executable build should succeed");
+        expect(ltcg_changed->stdout_text.find("[compile] main.cpp") != std::string::npos
+                   && ltcg_changed->stdout_text.find("compiler options changed") != std::string::npos,
+               "enabling typed LTCG should invalidate compile identity for /GL");
+        expect(ltcg_changed->stdout_text.find("[link] policy.exe") != std::string::npos,
+               "enabling typed LTCG should relink with /LTCG");
+    }
+
+    auto ltcg_warm = run_mqb(runner, mqb_executable, tree.root, ltcg_policy);
+    expect(ltcg_warm.has_value(), "warm typed-LTCG invocation should launch");
+    if (ltcg_warm) {
+        if (ltcg_warm->exit_code != 0) dump_failure(*ltcg_warm);
+        expect(ltcg_warm->exit_code == 0, "warm typed LTCG executable build should succeed");
+        expect(contains_line(ltcg_warm->stdout_text, "[up-to-date] main.cpp"),
+               "unchanged typed LTCG should reuse /GL compile cache");
+        expect(contains_line(ltcg_warm->stdout_text, "[up-to-date] policy.exe"),
+               "unchanged typed LTCG should reuse /LTCG link cache");
+    }
+
     const fs::path config_map = tree.root / "config-policy.map";
     const std::string config = std::string{R"json({
   "version": 1,
   "build": {
     "standard": "17",
+    "ltcg": true,
     "output": "config_policy",
     "compiler_args": ["/DPOLICY_VALUE=3"],
     "linker_args": ["/MAP:)json"}
@@ -278,9 +304,9 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
         if (config_cold->exit_code != 0) dump_failure(*config_cold);
         expect(config_cold->exit_code == 0, "C++17 config build-policy target should succeed");
         expect(config_cold->stdout_text.find("[compile] main.cpp") != std::string::npos,
-               "config standard/compiler policy should produce a fresh compile");
+               "config standard/compiler/LTCG policy should produce a fresh compile");
         expect(config_cold->stdout_text.find("[link] config_policy.exe") != std::string::npos,
-               "config linker policy should produce the configured target");
+               "config linker/LTCG policy should produce the configured target");
     }
     expect(fs::is_regular_file(config_map), "mqb.json linker_args should reach link.exe");
 
@@ -299,9 +325,26 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int) {
         if (config_warm->exit_code != 0) dump_failure(*config_warm);
         expect(config_warm->exit_code == 0, "warm config build-policy target should succeed");
         expect(contains_line(config_warm->stdout_text, "[up-to-date] main.cpp"),
-               "unchanged config compiler policy should be reusable");
+               "unchanged config compiler/LTCG policy should be reusable");
         expect(contains_line(config_warm->stdout_text, "[up-to-date] config_policy.exe"),
-               "unchanged config linker policy should be reusable");
+               "unchanged config linker/LTCG policy should be reusable");
+    }
+
+    auto config_cli_disable = run_mqb(
+        runner,
+        mqb_executable,
+        tree.root,
+        {"--no-ltcg"});
+    expect(config_cli_disable.has_value(), "CLI LTCG-disable override invocation should launch");
+    if (config_cli_disable) {
+        if (config_cli_disable->exit_code != 0) dump_failure(*config_cli_disable);
+        expect(config_cli_disable->exit_code == 0,
+               "--no-ltcg should override build.ltcg=true and remain buildable");
+        expect(config_cli_disable->stdout_text.find("[compile] main.cpp") != std::string::npos
+                   && config_cli_disable->stdout_text.find("compiler options changed") != std::string::npos,
+               "CLI disablement should invalidate the config-driven /GL compile identity");
+        expect(config_cli_disable->stdout_text.find("[link] config_policy.exe") != std::string::npos,
+               "CLI disablement should relink without typed /LTCG");
     }
 
     if (failures != 0) {

--- a/cpp/tests/mqb_static_library_e2e_tests.cpp
+++ b/cpp/tests/mqb_static_library_e2e_tests.cpp
@@ -245,10 +245,53 @@ int main() {
         if (stale_member_probe->exit_code == 0) dump_failure(*stale_member_probe);
     }
 
+    auto ltcg_static = run_process(
+        runner, mqb_executable, tree.root,
+        {"math.cpp", "--no-discover", "--env", "vs", "--type", "static", "--ltcg", "-o", "math"});
+    expect(ltcg_static.has_value(), "typed-LTCG static invocation should launch");
+    if (ltcg_static) {
+        if (ltcg_static->exit_code != 0) dump_failure(*ltcg_static);
+        expect(ltcg_static->exit_code == 0, "typed LTCG static target should succeed");
+        expect(ltcg_static->stdout_text.find("[compile] math.cpp") != std::string::npos
+                   && ltcg_static->stdout_text.find("compiler options changed") != std::string::npos,
+               "enabling typed LTCG should rebuild the static input with /GL");
+        expect(ltcg_static->stdout_text.find("[archive] math.lib") != std::string::npos,
+               "typed LTCG should rebuild the archive through lib.exe /LTCG");
+    }
+
+    auto ltcg_static_warm = run_process(
+        runner, mqb_executable, tree.root,
+        {"math.cpp", "--no-discover", "--env", "vs", "--type", "static", "--ltcg", "-o", "math"});
+    expect(ltcg_static_warm.has_value(), "warm typed-LTCG static invocation should launch");
+    if (ltcg_static_warm) {
+        if (ltcg_static_warm->exit_code != 0) dump_failure(*ltcg_static_warm);
+        expect(ltcg_static_warm->exit_code == 0, "warm typed LTCG static target should succeed");
+        expect(contains_line(ltcg_static_warm->stdout_text, "[up-to-date] math.cpp"),
+               "unchanged typed LTCG should reuse /GL compile cache");
+        expect(contains_line(ltcg_static_warm->stdout_text, "[up-to-date] math.lib"),
+               "unchanged typed LTCG should reuse archive cache");
+    }
+
+    const fs::path ltcg_consumer = tree.root / ".mqb" / "bin" / "ltcg_consumer.exe";
+    auto ltcg_consumer_build = run_process(
+        runner, mqb_executable, tree.root,
+        {"consumer.cpp", "--no-discover", "--env", "vs", "--ltcg",
+         "-L", ".mqb/bin", "-l", "math", "-o", "ltcg_consumer"});
+    expect(ltcg_consumer_build.has_value(), "LTCG static-library consumer build should launch");
+    if (ltcg_consumer_build) {
+        if (ltcg_consumer_build->exit_code != 0) dump_failure(*ltcg_consumer_build);
+        expect(ltcg_consumer_build->exit_code == 0,
+               "an LTCG executable should link against the generated LTCG static library");
+    }
+    auto ltcg_consumer_run = run_process(runner, ltcg_consumer, tree.root);
+    expect(ltcg_consumer_run.has_value() && ltcg_consumer_run->exit_code == 43,
+           "LTCG consumer should execute the symbol from the LTCG static library");
+
     write_text(tree.root / "mqb.json", R"json({
   "version": 1,
   "build": {
     "type": "static",
+    "ltcg": true,
     "output": "config_math"
   },
   "discovery": {
@@ -262,9 +305,9 @@ int main() {
     if (config_static) {
         if (config_static->exit_code != 0) dump_failure(*config_static);
         expect(config_static->exit_code == 0,
-               "mqb.json build.type=static should build without a CLI target-kind flag");
+               "mqb.json build.type=static/build.ltcg=true should build without CLI target policy");
         expect(config_static->stdout_text.find("[archive] config_math.lib") != std::string::npos,
-               "config target kind and output should route to the librarian pipeline");
+               "config target kind, LTCG, and output should route to the librarian pipeline");
     }
     expect(fs::is_regular_file(tree.root / ".mqb" / "bin" / "config_math.lib"),
            "config-only static target should produce the configured .lib output");
@@ -277,7 +320,7 @@ int main() {
     if (cli_type_override) {
         if (cli_type_override->exit_code != 0) dump_failure(*cli_type_override);
         expect(cli_type_override->exit_code == 0,
-               "CLI --type exe should override mqb.json build.type=static");
+               "CLI --type exe should override mqb.json build.type=static while retaining config LTCG");
         expect(cli_type_override->stdout_text.find("[link] config_override.exe") != std::string::npos,
                "CLI target-kind override should route back to the linker pipeline");
     }
@@ -286,7 +329,7 @@ int main() {
         tree.root / ".mqb" / "bin" / "config_override.exe",
         tree.root);
     expect(override_run.has_value() && override_run->exit_code == 43,
-           "CLI-overridden executable should consume the existing static library");
+           "CLI-overridden LTCG executable should consume the existing static library");
 
     auto invalid_policy = run_process(
         runner, mqb_executable, tree.root,

--- a/cpp/tests/msvc_compiler_arguments_tests.cpp
+++ b/cpp/tests/msvc_compiler_arguments_tests.cpp
@@ -65,6 +65,7 @@ int main() {
         expect(contains(*result, "/Iinclude"), "include path should become one /I argv element");
         expect(contains(*result, "/Ivendor include"), "include path with spaces should remain one argv element");
         expect(contains(*result, "/sourceDependencies"), "dependency output should enable /sourceDependencies");
+        expect(!contains(*result, "/GL"), "default compiler recipe should preserve non-LTCG behavior");
         expect(!contains(*result, "/interface") && !contains(*result, "/ifcOutput"),
                "ordinary source compilation should not emit module-interface switches");
 
@@ -80,6 +81,19 @@ int main() {
         const auto structured_fo = std::find(result->begin(), result->end(), "/Fobuild/my file.obj");
         expect(raw_fo != result->end() && structured_fo != result->end() && raw_fo < structured_fo,
                "structured object routing should win by appearing after a raw /Fo");
+    }
+
+    auto ltcg = invocation;
+    ltcg.options.link_time_code_generation = true;
+    ltcg.options.additional_arguments = {"/GL-"};
+    const auto ltcg_result = mqb::msvc::MsvcCompiler::build_arguments(ltcg);
+    expect(ltcg_result.has_value(), "typed LTCG compile invocation should produce argv");
+    if (ltcg_result) {
+        expect(contains(*ltcg_result, "/GL"), "typed LTCG should emit /GL");
+        const auto raw_gl = std::find(ltcg_result->begin(), ltcg_result->end(), "/GL-");
+        const auto typed_gl = std::find(ltcg_result->begin(), ltcg_result->end(), "/GL");
+        expect(raw_gl != ltcg_result->end() && typed_gl != ltcg_result->end() && raw_gl < typed_gl,
+               "typed /GL must follow raw compiler arguments and remain authoritative");
     }
 
     auto cpp14 = invocation;

--- a/cpp/tests/msvc_librarian_arguments_tests.cpp
+++ b/cpp/tests/msvc_librarian_arguments_tests.cpp
@@ -27,9 +27,19 @@ int main() {
     expect(arguments.has_value(), "valid archive invocation should build argv");
     if (arguments) {
         expect(contains(*arguments, "/NOLOGO"), "librarian should suppress banner");
+        expect(!contains(*arguments, "/LTCG"), "default archive recipe should preserve non-LTCG behavior");
         expect(contains(*arguments, "/OUT:bin/math.lib"), "librarian should own archive output");
         expect(contains(*arguments, "obj/math one.obj"), "object path with spaces should stay one argv element");
         expect(contains(*arguments, "obj/math-two.obj"), "all object inputs should be emitted");
+    }
+
+    auto ltcg = invocation;
+    ltcg.link_time_code_generation = true;
+    const auto ltcg_arguments = mqb::msvc::MsvcLibrarian::build_arguments(ltcg);
+    expect(ltcg_arguments.has_value(), "LTCG archive invocation should build argv");
+    if (ltcg_arguments) {
+        expect(contains(*ltcg_arguments, "/LTCG"),
+               "typed static LTCG should emit lib.exe /LTCG");
     }
 
     auto empty = invocation;

--- a/cpp/tests/msvc_linker_arguments_tests.cpp
+++ b/cpp/tests/msvc_linker_arguments_tests.cpp
@@ -45,6 +45,7 @@ int main() {
         expect(contains(*result, "/NOLOGO"), "link should suppress banner");
         expect(contains(*result, "/DEBUG"), "debug link should emit /DEBUG");
         expect(contains(*result, "/INCREMENTAL"), "debug link should be incremental");
+        expect(!contains(*result, "/LTCG"), "default link recipe should preserve non-LTCG behavior");
         expect(contains(*result, "/LIBPATH:vendor libs"), "library path should stay one argv element");
         expect(contains(*result, "C:/sdk libs/user32.lib"),
                "linker should consume exact resolved library path");
@@ -58,6 +59,24 @@ int main() {
         const auto planned_out = std::find(result->begin(), result->end(), "/OUT:bin/my app.exe");
         expect(raw_out != result->end() && planned_out != result->end() && raw_out < planned_out,
                "planned output must override a conflicting raw /OUT");
+    }
+
+    auto ltcg = invocation;
+    ltcg.options.link_time_code_generation = true;
+    ltcg.options.additional_arguments = {"/LTCG:OFF"};
+    const auto ltcg_result = mqb::msvc::MsvcLinker::build_arguments(ltcg);
+    expect(ltcg_result.has_value(), "typed LTCG link invocation should produce argv");
+    if (ltcg_result) {
+        expect(contains(*ltcg_result, "/LTCG"), "typed LTCG should emit /LTCG");
+        expect(contains(*ltcg_result, "/INCREMENTAL:NO"),
+               "debug LTCG should disable incremental linking");
+        expect(!contains(*ltcg_result, "/INCREMENTAL"),
+               "debug LTCG must not retain the incompatible /INCREMENTAL recipe");
+        const auto raw_ltcg = std::find(ltcg_result->begin(), ltcg_result->end(), "/LTCG:OFF");
+        const auto typed_ltcg = std::find(ltcg_result->begin(), ltcg_result->end(), "/LTCG");
+        expect(raw_ltcg != ltcg_result->end() && typed_ltcg != ltcg_result->end()
+                   && raw_ltcg < typed_ltcg,
+               "typed /LTCG must follow raw linker arguments and remain authoritative");
     }
 
     auto dll = invocation;

--- a/docs/MQB_CONFIG.md
+++ b/docs/MQB_CONFIG.md
@@ -25,6 +25,7 @@ MQB searches upward from the directory where it is invoked and uses the nearest 
     "standard": "17",
     "type": "exe",
     "runtime": "MT",
+    "ltcg": true,
     "subsystem": "console",
     "output": "game",
     "defines": [
@@ -73,6 +74,7 @@ MQB searches upward from the directory where it is invoked and uses the nearest 
 | `standard` | string | `14`, `17`, `20`, `23`, or `latest` (`c++14`, `c++17`, `c++20`, `c++23`, `c++latest` are also accepted) |
 | `type` | string | `exe`, `dll`, or `static` (`executable`, `dynamic`, and `lib` aliases are also accepted) |
 | `runtime` | string | MSVC CRT runtime: `MD`, `MDd`, `MT`, or `MTd` |
+| `ltcg` | boolean | enable/disable coupled MSVC link-time code generation; `true` emits compile `/GL` plus downstream `/LTCG` |
 | `subsystem` | string | PE subsystem: `console` or `windows`; not valid for a static target |
 | `output` | string | target name under `.mqb/bin/`; MQB supplies the `.exe`, `.dll`, or `.lib` suffix from `type` |
 | `defines` | string array | preprocessor definitions, without `/D` |
@@ -84,11 +86,13 @@ MQB searches upward from the directory where it is invoked and uses the nearest 
 
 All path-valued config entries are resolved relative to the directory containing `mqb.json`, not the shell's current working directory.
 
-`type`, `runtime`, and `subsystem` are typed policy, not shorthand for raw flags. The MSVC backend remains the sole owner of their command-line spelling. An explicit typed runtime is emitted after raw compiler arguments; typed DLL/output/subsystem routing is emitted after raw linker arguments, so conflicting raw `/MD*`, `/DLL`, `/IMPLIB`, `/SUBSYSTEM:*`, or `/OUT:*` switches cannot silently override the typed project policy.
+`type`, `runtime`, `ltcg`, and `subsystem` are typed policy, not shorthand for raw flags. The MSVC backend remains the sole owner of their command-line spelling. Explicit typed runtime and LTCG compile policy are emitted after raw compiler arguments; typed LTCG downstream policy and DLL/output/subsystem routing are emitted after raw linker arguments. Therefore conflicting raw `/MD*`, `/GL-`, `/LTCG:*`, `/DLL`, `/IMPLIB`, `/SUBSYSTEM:*`, or `/OUT:*` switches cannot silently override the corresponding typed project policy.
+
+Typed LTCG is intentionally coupled. `build.ltcg: true` means `/GL` is part of every affected compilation and `/LTCG` is part of the downstream target recipe. Executable/DLL targets pass `/LTCG` to `link.exe`; static targets pass `/LTCG` to `lib.exe`. Debug executable/DLL LTCG disables MSVC incremental linking (`/INCREMENTAL:NO`) because the typed LTCG contract must not produce an internally incompatible linker recipe.
 
 For a DLL target that exports symbols, MQB supplies a deterministic import-library location beside the DLL (`.mqb/bin/<target>.lib`). Linker side outputs that were actually produced are recorded in the link cache; deleting a recorded import library or export file invalidates link freshness and causes a repair relink without recompiling otherwise-fresh translation units.
 
-For a static target, MQB routes the compiled ordinary C/C++ object set to the dedicated `lib.exe` librarian pipeline. Static archive metadata lives under `.mqb/cache/archive/<target>.archivecache`, separate from executable/DLL link cache metadata. Linker-only policy (`subsystem`, `library_dirs`, `libraries`, or `linker_args`) is rejected for static targets rather than silently ignored. Static targets that require the named-module/header-unit pipeline remain fail-closed until archive topology is explicitly validated.
+For a static target, MQB routes the compiled ordinary C/C++ object set to the dedicated `lib.exe` librarian pipeline. Static archive metadata lives under `.mqb/cache/archive/<target>.archivecache`, separate from executable/DLL link cache metadata. Linker-only policy (`subsystem`, `library_dirs`, `libraries`, or `linker_args`) is rejected for static targets rather than silently ignored. `ltcg` is not linker-only policy: it remains valid for static targets because it couples `/GL` compilation with the librarian `/LTCG` archive recipe. Static targets that require the named-module/header-unit pipeline remain fail-closed until archive topology is explicitly validated.
 
 Raw compiler/linker arguments are literal argv elements. MQB does not split one JSON string containing spaces into several switches. For example:
 
@@ -98,7 +102,7 @@ Raw compiler/linker arguments are literal argv elements. MQB does not split one 
 
 represents two compiler arguments, while `"/W4 /WX"` is one argument and is not rewritten by MQB.
 
-Backend-owned structured routing remains authoritative. Raw arguments are emitted before MQB's planned output/topology switches such as `/Fo`, `/ifcOutput`, `/scanDependencies`, `/DLL`, `/IMPLIB`, `/MACHINE`, `/SUBSYSTEM`, and `/OUT`.
+Backend-owned typed policy and structured routing remain authoritative. Raw arguments are emitted before typed `/GL`/`/LTCG` and planned output/topology switches such as `/Fo`, `/ifcOutput`, `/scanDependencies`, `/DLL`, `/IMPLIB`, `/MACHINE`, `/SUBSYSTEM`, and `/OUT`.
 
 ## Discovery fields
 
@@ -152,7 +156,7 @@ For scalar options:
 explicit CLI option > mqb.json > built-in default
 ```
 
-This includes `configuration`, `architecture`, `standard`, `type`, `runtime`, `subsystem`, and `output`.
+This includes `configuration`, `architecture`, `standard`, `type`, `runtime`, `ltcg`, `subsystem`, and `output`.
 
 Examples:
 
@@ -165,6 +169,12 @@ mqb main.cpp --type exe
 
 # mqb.json says MT; this invocation uses the dynamic CRT.
 mqb main.cpp --runtime MD
+
+# mqb.json enables LTCG; this invocation explicitly disables it.
+mqb main.cpp --no-ltcg
+
+# mqb.json disables LTCG; this invocation enables the coupled /GL + /LTCG policy.
+mqb main.cpp --ltcg
 
 # mqb.json says windows; this invocation uses the console subsystem.
 mqb main.cpp --subsystem console
@@ -219,13 +229,15 @@ The config file timestamp itself is not a special global rebuild trigger. Instea
 
 Changing `runtime` changes compiler recipe identity, recompiles affected TUs, and therefore rebuilds the downstream target. Leaving `runtime` unset preserves the historical Debug `/MDd` and Release `/MD` recipes and their existing signature identity.
 
+Changing `ltcg` changes both halves of the coupled policy. Enabling it changes compile identity because `/GL` becomes part of the typed compiler recipe, then changes executable/DLL link identity or static archive identity because downstream `/LTCG` becomes part of that target recipe. Repeating the same LTCG policy is cache-reusable. Leaving `ltcg` unset (or setting it to `false`) preserves the historical non-LTCG recipe/signature byte stream.
+
 Changing `type` changes target output/recipe ownership. The historical executable signature byte stream is retained for executable targets; DLL targets add typed link target-kind identity. Static targets use a separate archive identity/cache and the `lib.exe` pipeline. Switching among executable/DLL/static does not recompile otherwise-fresh translation units when the compile recipe is unchanged, but it does build the appropriate downstream target artifact.
 
 Changing only `subsystem` changes link recipe identity and relinks without recompiling otherwise-fresh TUs. `subsystem` is not valid when the effective target kind is static.
 
 Changing a compiler argument changes compiler recipe identity and recompiles affected TUs even if no source timestamp changed. The resulting fresh objects force the downstream target action. Changing only a linker argument changes link recipe identity and relinks without recompiling otherwise-fresh TUs; linker arguments are invalid for static targets.
 
-Likewise, library names/search paths affect link recipe identity, while exact resolved `.lib` files are separately tracked as link freshness inputs. Recorded DLL linker side outputs are separately checked for existence and repaired by relinking if missing. Static archive freshness separately checks its current object inputs, archive output, and librarian identity.
+Likewise, library names/search paths affect link recipe identity, while exact resolved `.lib` files are separately tracked as link freshness inputs. Recorded DLL linker side outputs are separately checked for existence and repaired by relinking if missing. Static archive freshness separately checks its current object inputs, archive output, librarian identity, and typed LTCG archive recipe.
 
 For named modules and header units, compile identity also includes typed provider/reference and interface-output identity. Imported IFC files participate in consumer freshness validation, and a missing provider IFC invalidates the provider's cached outputs.
 
@@ -242,6 +254,7 @@ Changing the job count does not alter compile, link, or archive signatures and t
 ## Current boundaries
 
 - v1 `build.type` supports `exe`, `dll`, and `static`; `lib` is accepted as a static-library alias.
+- v1 `build.ltcg` is a boolean coupled policy: `/GL` at compile time plus `/LTCG` at executable/DLL link or static archive time.
 - Static targets currently support ordinary C/C++ translation units; static targets requiring named Modules/Header Units fail closed until archive topology is explicitly validated.
 - `--run` is executable-only; DLL/static targets are built artifacts and are not launched as programs.
 - v1 config has no external/prebuilt module-provider or `import std` policy.

--- a/docs/V5_PARITY.md
+++ b/docs/V5_PARITY.md
@@ -42,6 +42,7 @@ Status meanings:
 | `-D`, `-defines` | `-D`; legacy `-defines` accepted | **compat** |
 | `-config debug/release` | `--debug`, `--release`, `--config`; legacy `-config` accepted | **compat** |
 | `-runtime MD/MDd/MT/MTd` | `--runtime`; legacy `-runtime` accepted | **compat** |
+| `-ltcg` | `--ltcg` / `--no-ltcg`; legacy `-ltcg` enables the same coupled typed policy | **compat** |
 | `-subsystem console/windows` | `--subsystem`; legacy `-subsystem` accepted | **compat** |
 | `-env vs/portable/port/p/auto` | `--env auto/vs/portable`; legacy spelling and portable aliases accepted | **compat** |
 | `-help`, `-?` | `--help`, `-h`; legacy help aliases accepted | **compat** |
@@ -62,11 +63,13 @@ Status meanings:
 
 DLL link identity is typed and separate from executable identity while preserving the historical executable link-signature byte stream. For exporting DLLs, MQB owns a deterministic `.mqb/bin/<target>.lib` import-library path. Linker side outputs that were observed after a successful link are persisted in link-cache v3; v2 executable caches remain readable. Removing a recorded import library/export file invalidates only the link and repairs it without recompiling fresh translation units.
 
-Static libraries have a separate build owner rather than being modeled as `link.exe` targets. `MsvcLibrarian` invokes `lib.exe` over the compiled object set, archive identity hashes object order/output/librarian identity, and static metadata lives under `.mqb/cache/archive/<target>.archivecache` so it cannot collide with established executable/DLL link caches. Missing archives repair without recompiling fresh TUs; changed library sources recompile only affected TUs and re-archive. Each rebuild is created from a clean temporary archive before installation, so shrinking the source/object set cannot retain stale members. Linker-only policy is rejected for static targets instead of being silently ignored. Static targets that require the named-module/header-unit pipeline remain fail-closed until archive topology is explicitly validated.
+Static libraries have a separate build owner rather than being modeled as `link.exe` targets. `MsvcLibrarian` invokes `lib.exe` over the compiled object set, archive identity hashes object order/output/librarian identity and typed archive policy, and static metadata lives under `.mqb/cache/archive/<target>.archivecache` so it cannot collide with established executable/DLL link caches. Missing archives repair without recompiling fresh TUs; changed library sources recompile only affected TUs and re-archive. Each rebuild is created from a clean temporary archive before installation, so shrinking the source/object set cannot retain stale members. Linker-only policy is rejected for static targets instead of being silently ignored. Static targets that require the named-module/header-unit pipeline remain fail-closed until archive topology is explicitly validated.
 
 ## Compiler and linker policy
 
-The native backend has typed `CompilerOptions` / `LinkOptions` plus ordered additional argument vectors. CLI and `mqb.json` expose those vectors, and compile/link signatures hash them in order. Config arguments are applied first and CLI arguments append afterward. High-value typed policy remains authoritative over conflicting raw flags: typed runtime is emitted after raw compiler arguments, while structured target-kind/subsystem/output routing is emitted after raw linker arguments.
+The native backend has typed `CompilerOptions` / `LinkOptions` plus ordered additional argument vectors. CLI and `mqb.json` expose those vectors, and compile/link/archive signatures hash the relevant typed and raw policy. Config arguments are applied first and CLI arguments append afterward. High-value typed policy remains authoritative over conflicting raw flags: typed runtime and LTCG compile policy are emitted after raw compiler arguments, while typed LTCG downstream policy and structured target-kind/subsystem/output routing are emitted after raw linker arguments.
+
+Typed LTCG is a single coupled policy, not two user-maintained raw lists. Enabling it adds `/GL` to affected compilation and `/LTCG` to the downstream target recipe. Executable/DLL targets use `link.exe /LTCG`; ordinary static-library targets use `lib.exe /LTCG`. Debug executable/DLL LTCG forces `/INCREMENTAL:NO` rather than generating an incompatible `/INCREMENTAL` + `/LTCG` recipe. Compile, link, and archive identities all distinguish LTCG-on from LTCG-off, while the historical non-LTCG signature byte streams remain unchanged. Real installed-MSVC E2E covers cold/warm executable LTCG, `mqb.json`/CLI precedence, static LTCG archive creation, and an LTCG executable consuming the generated static library.
 
 | Legacy option | Native C++ status | Stable-v5 decision |
 | --- | --- | --- |
@@ -82,7 +85,7 @@ The native backend has typed `CompilerOptions` / `LinkOptions` plus ordered addi
 | `-permissive` | native baseline is `/permissive-`; raw args can add a later MSVC conformance switch where supported | **migrate** strict conformance remains default |
 | `-fp precise/strict/fast` | raw compiler args exist | **migrate** to raw build policy |
 | `-charset unicode/mbcs` | UTF-8 source/execution is native baseline; Windows macro charset is not typed | **implement** only if parity fixtures show `_UNICODE/UNICODE` vs `_MBCS` is a required stable contract |
-| `-ltcg` | requires coupled compile `/GL` + link `/LTCG` policy | **implement** typed/coupled policy; do not rely on users manually keeping two raw lists coherent |
+| `-ltcg` | typed CLI/config coupled `/GL` + downstream `/LTCG`, cache identities, legacy spelling, and real MSVC E2E are covered | **ready/compat** |
 | `-incremental` linker switch | native build engine is incrementally cached; linker `/INCREMENTAL` can be passed raw | **migrate** terminology; expose raw linker switch if specifically desired |
 | `-flags` / arbitrary compiler switches | ordered CLI/config pass-through is wired and cache-safe | **ready/compat** |
 | `-link_flags` / arbitrary linker switches | ordered CLI/config pass-through is wired and cache-safe | **ready/compat** |
@@ -92,15 +95,16 @@ The native backend has typed `CompilerOptions` / `LinkOptions` plus ordered addi
 | Legacy behavior | Native C++ status | Stable-v5 decision |
 | --- | --- | --- |
 | `msvc_list.json`, upward search up to five levels | native uses nearest upward `mqb.json` | **migrate** to `mqb.json`; provide upgrade guidance/tooling rather than keeping two authoritative schemas forever |
-| CLI overrides scalar config | ready, including type/runtime/subsystem | **ready** |
+| CLI overrides scalar config | ready, including type/runtime/LTCG/subsystem | **ready** |
 | additive list precedence | config lists first, CLI lists append | **ready** |
 | 14/17/20/23/latest standard config | ready | **ready** |
 | target-kind config | strict `build.type` supports `exe`/`dll`/`static` (`lib` alias accepted); real static config routing and CLI target-kind precedence are covered | **ready** |
 | runtime/subsystem config | typed strict-schema fields with real cache-invalidation E2E | **ready** |
+| LTCG config | strict boolean `build.ltcg`; CLI `--ltcg`/`--no-ltcg` precedence and real executable/static E2E | **ready** |
 | include/lib/define/library config | ready in `mqb.json` | **ready** |
 | `compiler_args` / `linker_args` | ready in strict `mqb.json` v1 schema | **ready** |
 | source discovery excludes | ready with the native discovery schema | **ready** |
-| legacy config keys for remaining coupled policies | not all represented | **implement** only for capabilities accepted into the stable parity surface |
+| legacy config keys for remaining coupled policies | no remaining high-value coupled policy is accepted by default solely through raw-list synchronization | **implement** only when parity fixtures prove another typed policy is required |
 
 ## Toolchain/environment behavior
 
@@ -117,9 +121,9 @@ The native backend has typed `CompilerOptions` / `LinkOptions` plus ordered addi
 
 Stable v5 does not require byte-for-byte artifact layout parity with PowerShell. It requires equivalent observable correctness: cold build succeeds, warm no-op avoids unnecessary work, source/header/library/config/toolchain/build-policy changes invalidate the right work, missing required artifacts repair correctly, and outputs are collision-free.
 
-Typed runtime changes are compile-recipe identity and therefore force affected compile + downstream target work. Typed target-kind/subsystem changes are target recipe identity; subsystem changes relink without recompiling otherwise-fresh TUs. Static archives have their own archive identity/cache and do not reuse `LinkCache`.
+Typed runtime changes are compile-recipe identity and therefore force affected compile + downstream target work. Typed target-kind/subsystem changes are target recipe identity; subsystem changes relink without recompiling otherwise-fresh TUs. Typed LTCG changes compile identity and the corresponding downstream link/archive identity as one coupled policy. Static archives have their own archive identity/cache and do not reuse `LinkCache`.
 
-Raw compiler argument changes are compile-recipe identity and therefore force affected compile + downstream target work. Raw linker argument changes are link-recipe identity and therefore relink without recompiling otherwise-fresh TUs. Linker-only options are invalid for static targets in the current public contract.
+Raw compiler argument changes are compile-recipe identity and therefore force affected compile + downstream target work. Raw linker argument changes are link-recipe identity and therefore relink without recompiling otherwise-fresh TUs. Linker-only options are invalid for static targets in the current public contract; typed LTCG is valid because it owns both compile and archive halves.
 
 The native `.mqb/obj`, `.mqb/deps`, `.mqb/scan`, `.mqb/ifc`, `.mqb/cache`, and `.mqb/bin` layout is the stable direction rather than the old PowerShell temporary layout.
 
@@ -137,8 +141,8 @@ Project-local named modules and project-local header units are in the RC/stable-
 6. Isolate C smart discovery from C++ module lexical syntax. **Done in #32.**
 7. Typed `mqb.json` runtime/subsystem policy with CLI precedence and real invalidation E2E. **Done in #33.**
 8. Native DLL target kind with typed linker routing, deterministic import library, and side-output repair. **Done in #35.**
-9. Static-library target with an explicit `lib.exe`/librarian backend, archive cache owner, strict `mqb.json` target kind, and real CLI/config consumer coverage. **Done in #36 + #37 once #37 merges.**
-10. Close the remaining high-value coupled MSVC policy gap (notably LTCG and any charset requirement proven by parity fixtures).
+9. Static-library target with an explicit `lib.exe`/librarian backend, archive cache owner, strict `mqb.json` target kind, and real CLI/config consumer coverage. **Done in #36 + #37.**
+10. Close the high-value coupled MSVC LTCG gap with typed `/GL` + downstream `/LTCG`, config/CLI precedence, cache identities, and real executable/static E2E. **Done in #39.** Charset remains evidence-driven rather than an automatic typed-surface requirement.
 11. Shared PowerShell-vs-C++ fixtures for ordinary targets, config precedence, incremental rebuilds, libraries, run argv, x86/x64, Debug/Release, and failure behavior.
 12. Installer/profile/`build` command cutover and clean-machine upgrade/rollback validation.
 13. Generalize the release workflow and publish stable v5 only from the exact validated artifact.


### PR DESCRIPTION
## What changed

- add typed `--ltcg` / `--no-ltcg` policy plus legacy `-ltcg` enablement
- add strict `mqb.json` `build.ltcg: boolean` with `explicit CLI > mqb.json > built-in default` precedence
- couple the policy across the whole target lifecycle:
  - compile: authoritative `/GL`
  - executable/DLL: `link.exe /LTCG`
  - ordinary static library: `lib.exe /LTCG`
- make Debug executable/DLL LTCG use `/INCREMENTAL:NO` instead of producing an incompatible incremental-link recipe
- emit typed `/GL` / `/LTCG` after raw compiler/linker escape-hatch arguments so structured policy remains authoritative
- include LTCG in compile, link, and archive identities only when enabled, preserving the historical non-LTCG signature byte streams
- make static archive cache validation LTCG-aware
- document the CLI/config/cache contract in README, `docs/MQB_CONFIG.md`, and `docs/V5_PARITY.md`

## Real MSVC coverage

- executable LTCG cold build recompiles for `/GL`, relinks with `/LTCG`, then hits warm compile/link cache
- `mqb.json` `ltcg: true` is exercised end-to-end, including CLI `--no-ltcg` precedence
- static LTCG cold build recompiles with `/GL`, archives through `lib.exe /LTCG`, then hits warm compile/archive cache
- an LTCG executable links against the generated LTCG static library and executes the archived symbol successfully
- existing static missing-output repair, source mutation, source-set shrink, and stale-member regression coverage remains intact

## Validation

Exact head: `f6d10f54eac6f6229d333addd63934c61a9bd3e6`

- **C++ V2 #321**: success, **67/67** tests passed
- **C++ Release Candidate #91**: success, **67/67** tests passed
- Release workflow embedded-version verification passed exactly as `MQB 5.0.0-rc.2 - MSVC Quick Build (C++ refactor)`
- package staging, checksum generation, and artifact upload all passed

The Release Candidate workflow remains a regression/package gate only. This PR is post-`v5.0.0-rc.2` mainline work and does **not** claim that typed LTCG is already included in the published rc.2 release.

## Next

With exe/DLL/static target kinds and typed LTCG closed, the next stable-v5 mainline slice is the shared PowerShell ↔ C++ parity fixture/harness campaign before installer/profile/default-entry cutover.