### PR TITLE
test: add shared PowerShell C++ parity harness

### DIFF
--- a/.github/workflows/cpp-release.yml
+++ b/.github/workflows/cpp-release.yml
@@ -93,3 +93,48 @@ jobs:
             dist/${{ env.MQB_PACKAGE_NAME }}.zip
             dist/${{ env.MQB_PACKAGE_NAME }}.zip.sha256
           if-no-files-found: error
+          retention-days: 30
+
+  publish-prerelease:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build-test-package
+    runs-on: windows-latest
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      MQB_RELEASE_VERSION: 5.0.0-rc.2
+      MQB_PACKAGE_NAME: vscode-msvc-quick-build-v5.0.0-rc.2-windows-x64
+
+    steps:
+      - name: Checkout release notes
+        uses: actions/checkout@v7
+
+      - name: Download validated package
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ env.MQB_PACKAGE_NAME }}
+          path: dist-publish
+
+      - name: Publish GitHub prerelease
+        shell: pwsh
+        run: |
+          $tag = "v$env:MQB_RELEASE_VERSION"
+          gh release view $tag --repo $env:GITHUB_REPOSITORY *> $null
+          if ($LASTEXITCODE -eq 0) {
+            Write-Host "Release $tag already exists; leaving it unchanged."
+            exit 0
+          }
+
+          $zip = Join-Path $PWD "dist-publish/$($env:MQB_PACKAGE_NAME).zip"
+          $sha = $zip + '.sha256'
+          if (-not (Test-Path -LiteralPath $zip -PathType Leaf)) { throw "Missing release package: $zip" }
+          if (-not (Test-Path -LiteralPath $sha -PathType Leaf)) { throw "Missing checksum: $sha" }
+
+          gh release create $tag $zip $sha `
+            --repo $env:GITHUB_REPOSITORY `
+            --target $env:GITHUB_SHA `
+            --title "$tag — C++ Refactor Release Candidate" `
+            --notes-file 'release/v5.0.0-rc.2.md' `
+            --prerelease
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/.github/workflows/cpp-release.yml
+++ b/.github/workflows/cpp-release.yml
@@ -3,6 +3,7 @@ name: C++ Release Candidate
 on:
   pull_request:
     paths:
+      - 'build.ps1'
       - 'cpp/**'
       - 'README.md'
       - 'docs/**'
@@ -92,48 +93,3 @@ jobs:
             dist/${{ env.MQB_PACKAGE_NAME }}.zip
             dist/${{ env.MQB_PACKAGE_NAME }}.zip.sha256
           if-no-files-found: error
-          retention-days: 30
-
-  publish-prerelease:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: build-test-package
-    runs-on: windows-latest
-    permissions:
-      contents: write
-    env:
-      GH_TOKEN: ${{ github.token }}
-      MQB_RELEASE_VERSION: 5.0.0-rc.2
-      MQB_PACKAGE_NAME: vscode-msvc-quick-build-v5.0.0-rc.2-windows-x64
-
-    steps:
-      - name: Checkout release notes
-        uses: actions/checkout@v7
-
-      - name: Download validated package
-        uses: actions/download-artifact@v8
-        with:
-          name: ${{ env.MQB_PACKAGE_NAME }}
-          path: dist-publish
-
-      - name: Publish GitHub prerelease
-        shell: pwsh
-        run: |
-          $tag = "v$env:MQB_RELEASE_VERSION"
-          gh release view $tag --repo $env:GITHUB_REPOSITORY *> $null
-          if ($LASTEXITCODE -eq 0) {
-            Write-Host "Release $tag already exists; leaving it unchanged."
-            exit 0
-          }
-
-          $zip = Join-Path $PWD "dist-publish/$($env:MQB_PACKAGE_NAME).zip"
-          $sha = $zip + '.sha256'
-          if (-not (Test-Path -LiteralPath $zip -PathType Leaf)) { throw "Missing release package: $zip" }
-          if (-not (Test-Path -LiteralPath $sha -PathType Leaf)) { throw "Missing checksum: $sha" }
-
-          gh release create $tag $zip $sha `
-            --repo $env:GITHUB_REPOSITORY `
-            --target $env:GITHUB_SHA `
-            --title "$tag — C++ Refactor Release Candidate" `
-            --notes-file 'release/v5.0.0-rc.2.md' `
-            --prerelease
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/.github/workflows/cpp-v2.yml
+++ b/.github/workflows/cpp-v2.yml
@@ -7,6 +7,7 @@ on:
       - refactor/cpp-v2
   pull_request:
     paths:
+      - 'build.ps1'
       - 'cpp/**'
       - 'README.md'
       - 'docs/CPP_V2_ARCHITECTURE.md'

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -192,6 +192,10 @@ if(WIN32)
         target_link_libraries(mqb_static_library_e2e_tests PRIVATE mqb_platform_windows)
         target_compile_features(mqb_static_library_e2e_tests PRIVATE cxx_std_23)
 
+        add_executable(mqb_parity_e2e_tests parity_e2e_tests.cpp)
+        target_link_libraries(mqb_parity_e2e_tests PRIVATE mqb_platform_windows)
+        target_compile_features(mqb_parity_e2e_tests PRIVATE cxx_std_23)
+
         list(APPEND MQB_TEST_TARGETS
             mqb_msvc_visual_studio_tests
             mqb_msvc_compile_integration_tests
@@ -206,6 +210,7 @@ if(WIN32)
             mqb_runtime_subsystem_config_e2e_tests
             mqb_dll_target_e2e_tests
             mqb_static_library_e2e_tests
+            mqb_parity_e2e_tests
         )
     endif()
 endif()
@@ -290,6 +295,13 @@ if(WIN32)
         add_test(
             NAME mqb.cli.static_library_e2e
             COMMAND mqb_static_library_e2e_tests $<TARGET_FILE:mqb>
+        )
+        add_test(
+            NAME mqb.parity.shared_e2e
+            COMMAND mqb_parity_e2e_tests
+                $<TARGET_FILE:mqb>
+                "${CMAKE_CURRENT_SOURCE_DIR}/../../build.ps1"
+                "${CMAKE_CURRENT_SOURCE_DIR}/parity/fixtures"
         )
     endif()
 endif()

--- a/cpp/tests/parity/README.md
+++ b/cpp/tests/parity/README.md
@@ -1,0 +1,32 @@
+# Shared PowerShell ↔ C++ parity fixtures
+
+This directory backs the stable-v5 migration parity campaign.
+
+The goal is **observable behavioral parity**, not identical implementation details. The PowerShell Golden Reference and native C++ `mqb.exe` intentionally use different internal artifact layouts, cache formats, and orchestration code.
+
+## Harness model
+
+`mqb_parity_e2e_tests` copies each committed fixture into two isolated temporary sandboxes:
+
+1. the PowerShell sandbox is built by the repository-root `build.ps1` Golden Reference;
+2. the C++ sandbox is built by the test build's `mqb.exe`;
+3. each produced executable is launched independently;
+4. process success and normalized program output are checked against the fixture contract and against each other.
+
+Build-log wording, `.cache/` vs `.mqb/`, object names, and other implementation-private details are not parity assertions unless a later migration requirement explicitly makes them observable API.
+
+## Initial scenarios
+
+- `fixtures/single`: one translation unit.
+- `fixtures/multi`: explicit multi-source target.
+- `fixtures/configuration`: explicit Debug and Release configuration behavior through `_DEBUG` / `NDEBUG`.
+
+Follow-up slices should extend the same harness for project/config precedence, incremental rebuild behavior, libraries, run argv, x86/x64, and failure behavior.
+
+## Important legacy semantic difference
+
+Do **not** translate native `mqb --env vs` into `build.ps1 -env vs` inside a build scenario.
+
+The legacy PowerShell `-env` spelling is a persistent preference command: it writes/removes `$HOME\bin\.msvc_build_env` and exits immediately. Native `--env` is invocation-scoped toolchain selection. On installed-MSVC CI, the Golden Reference is therefore allowed to auto-detect Visual Studio while native MQB explicitly selects `--env vs`.
+
+This is representative of the parity campaign rule: similarly named CLI spellings are not assumed to have identical semantics; the shared fixtures verify the user-visible contract.

--- a/cpp/tests/parity/fixtures/configuration/main.cpp
+++ b/cpp/tests/parity/fixtures/configuration/main.cpp
@@ -1,0 +1,12 @@
+#include <iostream>
+
+int main() {
+#if defined(_DEBUG)
+    std::cout << "config=debug\n";
+#elif defined(NDEBUG)
+    std::cout << "config=release\n";
+#else
+    std::cout << "config=unknown\n";
+#endif
+    return 0;
+}

--- a/cpp/tests/parity/fixtures/multi/main.cpp
+++ b/cpp/tests/parity/fixtures/multi/main.cpp
@@ -1,0 +1,8 @@
+#include <iostream>
+
+int parity_value();
+
+int main() {
+    std::cout << "multi=" << parity_value() << '\n';
+    return 0;
+}

--- a/cpp/tests/parity/fixtures/multi/value.cpp
+++ b/cpp/tests/parity/fixtures/multi/value.cpp
@@ -1,0 +1,3 @@
+int parity_value() {
+    return 42;
+}

--- a/cpp/tests/parity/fixtures/single/main.cpp
+++ b/cpp/tests/parity/fixtures/single/main.cpp
@@ -1,0 +1,6 @@
+#include <iostream>
+
+int main() {
+    std::cout << "single=17\n";
+    return 0;
+}

--- a/cpp/tests/parity_e2e_tests.cpp
+++ b/cpp/tests/parity_e2e_tests.cpp
@@ -1,0 +1,336 @@
+#include <chrono>
+#include <cstdlib>
+#include <expected>
+#include <filesystem>
+#include <iostream>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+#include "mqb/platform/windows/WindowsProcessRunner.hpp"
+#include "mqb/process/Process.hpp"
+
+namespace {
+
+namespace fs = std::filesystem;
+
+int failures = 0;
+
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+[[nodiscard]] std::string path_text(const fs::path& path) {
+    const auto bytes = path.generic_u8string();
+    return std::string{reinterpret_cast<const char*>(bytes.data()), bytes.size()};
+}
+
+[[nodiscard]] std::string normalize_newlines(std::string text) {
+    std::string normalized;
+    normalized.reserve(text.size());
+    for (const char ch : text) {
+        if (ch != '\r') normalized.push_back(ch);
+    }
+    return normalized;
+}
+
+void dump_process(const std::string_view label, const mqb::process::ProcessResult& result) {
+    std::cerr << label << " exit: " << result.exit_code << '\n'
+              << label << " stdout:\n" << result.stdout_text << '\n'
+              << label << " stderr:\n" << result.stderr_text << '\n';
+}
+
+[[nodiscard]] std::expected<void, std::string> copy_fixture(
+    const fs::path& source,
+    const fs::path& destination) {
+    std::error_code ec;
+    if (!fs::is_directory(source, ec) || ec) {
+        return std::unexpected("fixture directory does not exist: " + path_text(source));
+    }
+    fs::create_directories(destination, ec);
+    if (ec) {
+        return std::unexpected("failed to create parity sandbox: " + ec.message());
+    }
+
+    for (fs::recursive_directory_iterator it{source, ec}, end; it != end; it.increment(ec)) {
+        if (ec) {
+            return std::unexpected("failed while enumerating parity fixture: " + ec.message());
+        }
+        const fs::path relative = it->path().lexically_relative(source);
+        const fs::path target = destination / relative;
+        if (it->is_directory(ec)) {
+            if (ec) return std::unexpected("failed to inspect fixture directory: " + ec.message());
+            fs::create_directories(target, ec);
+            if (ec) return std::unexpected("failed to copy fixture directory: " + ec.message());
+        } else if (it->is_regular_file(ec)) {
+            if (ec) return std::unexpected("failed to inspect fixture file: " + ec.message());
+            fs::create_directories(target.parent_path(), ec);
+            if (ec) return std::unexpected("failed to prepare fixture target directory: " + ec.message());
+            fs::copy_file(it->path(), target, fs::copy_options::overwrite_existing, ec);
+            if (ec) return std::unexpected("failed to copy parity fixture file: " + ec.message());
+        }
+    }
+    return {};
+}
+
+[[nodiscard]] fs::path powershell_executable() {
+    if (const char* system_root = std::getenv("SystemRoot"); system_root != nullptr) {
+        const fs::path candidate = fs::path{system_root}
+            / "System32" / "WindowsPowerShell" / "v1.0" / "powershell.exe";
+        std::error_code ec;
+        if (fs::is_regular_file(candidate, ec) && !ec) return candidate;
+    }
+    return fs::path{"powershell.exe"};
+}
+
+[[nodiscard]] std::expected<mqb::process::ProcessResult, std::string> run_process(
+    mqb::platform::windows::WindowsProcessRunner& runner,
+    const fs::path& executable,
+    const fs::path& working_directory,
+    std::vector<std::string> arguments = {}) {
+    mqb::process::ProcessSpec spec;
+    spec.executable = executable;
+    spec.arguments = std::move(arguments);
+    spec.working_directory = working_directory;
+    spec.capture_stdout = true;
+    spec.capture_stderr = true;
+    auto result = runner.run(spec);
+    if (!result) {
+        return std::unexpected(
+            "failed to launch '" + path_text(executable) + "': " + result.error().message);
+    }
+    return std::move(*result);
+}
+
+struct Scenario {
+    std::string name;
+    fs::path fixture;
+    std::vector<std::string> sources;
+    std::string output_name;
+    std::vector<std::string> powershell_options;
+    std::vector<std::string> cpp_options;
+    std::string expected_stdout;
+};
+
+[[nodiscard]] std::vector<std::string> powershell_build_arguments(
+    const fs::path& build_script,
+    const Scenario& scenario) {
+    std::vector<std::string> arguments{
+        "-NoLogo",
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        path_text(build_script),
+    };
+    arguments.insert(arguments.end(), scenario.sources.begin(), scenario.sources.end());
+    arguments.emplace_back("-env");
+    arguments.emplace_back("vs");
+    arguments.emplace_back("-o");
+    arguments.push_back(scenario.output_name);
+    arguments.insert(
+        arguments.end(), scenario.powershell_options.begin(), scenario.powershell_options.end());
+    return arguments;
+}
+
+[[nodiscard]] std::vector<std::string> cpp_build_arguments(const Scenario& scenario) {
+    std::vector<std::string> arguments = scenario.sources;
+    arguments.emplace_back("--env");
+    arguments.emplace_back("vs");
+    arguments.emplace_back("-o");
+    arguments.push_back(scenario.output_name);
+    arguments.insert(arguments.end(), scenario.cpp_options.begin(), scenario.cpp_options.end());
+    return arguments;
+}
+
+void run_scenario(
+    mqb::platform::windows::WindowsProcessRunner& runner,
+    const fs::path& mqb_executable,
+    const fs::path& build_script,
+    const fs::path& fixtures_root,
+    const fs::path& temp_root,
+    const Scenario& scenario) {
+    const fs::path fixture = fixtures_root / scenario.fixture;
+    const fs::path scenario_root = temp_root / scenario.name;
+    const fs::path powershell_root = scenario_root / "powershell";
+    const fs::path cpp_root = scenario_root / "cpp";
+
+    auto copied_ps = copy_fixture(fixture, powershell_root);
+    expect(copied_ps.has_value(), scenario.name + ": PowerShell fixture copy should succeed");
+    if (!copied_ps) {
+        std::cerr << copied_ps.error() << '\n';
+        return;
+    }
+    auto copied_cpp = copy_fixture(fixture, cpp_root);
+    expect(copied_cpp.has_value(), scenario.name + ": C++ fixture copy should succeed");
+    if (!copied_cpp) {
+        std::cerr << copied_cpp.error() << '\n';
+        return;
+    }
+
+    auto powershell_build = run_process(
+        runner,
+        powershell_executable(),
+        powershell_root,
+        powershell_build_arguments(build_script, scenario));
+    expect(powershell_build.has_value(), scenario.name + ": PowerShell build should launch");
+    if (!powershell_build) {
+        std::cerr << powershell_build.error() << '\n';
+        return;
+    }
+    if (powershell_build->exit_code != 0) dump_process("PowerShell build", *powershell_build);
+    expect(powershell_build->exit_code == 0, scenario.name + ": PowerShell build should succeed");
+
+    auto cpp_build = run_process(
+        runner,
+        mqb_executable,
+        cpp_root,
+        cpp_build_arguments(scenario));
+    expect(cpp_build.has_value(), scenario.name + ": C++ build should launch");
+    if (!cpp_build) {
+        std::cerr << cpp_build.error() << '\n';
+        return;
+    }
+    if (cpp_build->exit_code != 0) dump_process("C++ build", *cpp_build);
+    expect(cpp_build->exit_code == 0, scenario.name + ": C++ build should succeed");
+
+    if (powershell_build->exit_code != 0 || cpp_build->exit_code != 0) return;
+
+    const fs::path powershell_output = powershell_root / (scenario.output_name + ".exe");
+    const fs::path cpp_output = cpp_root / ".mqb" / "bin" / (scenario.output_name + ".exe");
+    std::error_code ec;
+    expect(fs::is_regular_file(powershell_output, ec) && !ec,
+           scenario.name + ": PowerShell executable should exist");
+    ec.clear();
+    expect(fs::is_regular_file(cpp_output, ec) && !ec,
+           scenario.name + ": C++ executable should exist");
+    if (!fs::is_regular_file(powershell_output) || !fs::is_regular_file(cpp_output)) return;
+
+    auto powershell_run = run_process(runner, powershell_output, powershell_root);
+    expect(powershell_run.has_value(), scenario.name + ": PowerShell-built executable should launch");
+    if (!powershell_run) {
+        std::cerr << powershell_run.error() << '\n';
+        return;
+    }
+    auto cpp_run = run_process(runner, cpp_output, cpp_root);
+    expect(cpp_run.has_value(), scenario.name + ": C++-built executable should launch");
+    if (!cpp_run) {
+        std::cerr << cpp_run.error() << '\n';
+        return;
+    }
+
+    if (powershell_run->exit_code != 0) dump_process("PowerShell program", *powershell_run);
+    if (cpp_run->exit_code != 0) dump_process("C++ program", *cpp_run);
+    expect(powershell_run->exit_code == 0, scenario.name + ": PowerShell-built program should succeed");
+    expect(cpp_run->exit_code == 0, scenario.name + ": C++-built program should succeed");
+
+    const std::string powershell_stdout = normalize_newlines(powershell_run->stdout_text);
+    const std::string cpp_stdout = normalize_newlines(cpp_run->stdout_text);
+    expect(powershell_stdout == scenario.expected_stdout,
+           scenario.name + ": PowerShell program should satisfy fixture contract");
+    expect(cpp_stdout == scenario.expected_stdout,
+           scenario.name + ": C++ program should satisfy fixture contract");
+    expect(powershell_stdout == cpp_stdout,
+           scenario.name + ": PowerShell and C++ observable stdout should match");
+}
+
+struct TempTree {
+    fs::path root;
+    ~TempTree() {
+        std::error_code ignored;
+        fs::remove_all(root, ignored);
+    }
+};
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    if (argc != 4) {
+        std::cerr << "usage: mqb_parity_e2e_tests <mqb-executable> <build.ps1> <fixtures-root>\n";
+        return 2;
+    }
+
+    const fs::path mqb_executable = fs::absolute(fs::path{argv[1]}).lexically_normal();
+    const fs::path build_script = fs::absolute(fs::path{argv[2]}).lexically_normal();
+    const fs::path fixtures_root = fs::absolute(fs::path{argv[3]}).lexically_normal();
+
+    std::error_code ec;
+    if (!fs::is_regular_file(mqb_executable, ec) || ec) {
+        std::cerr << "mqb executable does not exist: " << path_text(mqb_executable) << '\n';
+        return 2;
+    }
+    ec.clear();
+    if (!fs::is_regular_file(build_script, ec) || ec) {
+        std::cerr << "PowerShell Golden Reference does not exist: " << path_text(build_script) << '\n';
+        return 2;
+    }
+    ec.clear();
+    if (!fs::is_directory(fixtures_root, ec) || ec) {
+        std::cerr << "parity fixture root does not exist: " << path_text(fixtures_root) << '\n';
+        return 2;
+    }
+
+    const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
+    TempTree tree{
+        .root = fs::temp_directory_path() / ("mqb_shared_parity_" + std::to_string(unique)),
+    };
+    fs::create_directories(tree.root);
+
+    mqb::platform::windows::WindowsProcessRunner runner;
+    const std::vector<Scenario> scenarios{
+        Scenario{
+            .name = "single",
+            .fixture = "single",
+            .sources = {"main.cpp"},
+            .output_name = "parity_single",
+            .expected_stdout = "single=17\n",
+        },
+        Scenario{
+            .name = "multi",
+            .fixture = "multi",
+            .sources = {"main.cpp", "value.cpp"},
+            .output_name = "parity_multi",
+            .expected_stdout = "multi=42\n",
+        },
+        Scenario{
+            .name = "configuration_debug",
+            .fixture = "configuration",
+            .sources = {"main.cpp"},
+            .output_name = "parity_debug",
+            .powershell_options = {"-config", "debug"},
+            .cpp_options = {"--config", "debug"},
+            .expected_stdout = "config=debug\n",
+        },
+        Scenario{
+            .name = "configuration_release",
+            .fixture = "configuration",
+            .sources = {"main.cpp"},
+            .output_name = "parity_release",
+            .powershell_options = {"-config", "release"},
+            .cpp_options = {"--config", "release"},
+            .expected_stdout = "config=release\n",
+        },
+    };
+
+    for (const auto& scenario : scenarios) {
+        run_scenario(
+            runner,
+            mqb_executable,
+            build_script,
+            fixtures_root,
+            tree.root,
+            scenario);
+    }
+
+    if (failures != 0) {
+        std::cerr << failures << " parity assertion(s) failed\n";
+        return 1;
+    }
+    std::cout << "mqb_parity_e2e_tests passed (" << scenarios.size() << " shared scenarios)\n";
+    return 0;
+}

--- a/cpp/tests/parity_e2e_tests.cpp
+++ b/cpp/tests/parity_e2e_tests.cpp
@@ -129,8 +129,9 @@ struct Scenario {
         path_text(build_script),
     };
     arguments.insert(arguments.end(), scenario.sources.begin(), scenario.sources.end());
-    arguments.emplace_back("-env");
-    arguments.emplace_back("vs");
+    // Legacy -env is a persistent preference command that exits immediately;
+    // it is not equivalent to native --env. A clean installed-MSVC CI runner
+    // therefore lets the Golden Reference auto-detect Visual Studio.
     arguments.emplace_back("-o");
     arguments.push_back(scenario.output_name);
     arguments.insert(

--- a/cpp/tests/parity_e2e_tests.cpp
+++ b/cpp/tests/parity_e2e_tests.cpp
@@ -79,6 +79,13 @@ void dump_process(const std::string_view label, const mqb::process::ProcessResul
 }
 
 [[nodiscard]] fs::path powershell_executable() {
+    // Mirror the installed profile contract: prefer PowerShell 7 when present,
+    // then fall back to the legacy Windows PowerShell host.
+    if (const char* program_files = std::getenv("ProgramFiles"); program_files != nullptr) {
+        const fs::path candidate = fs::path{program_files} / "PowerShell" / "7" / "pwsh.exe";
+        std::error_code ec;
+        if (fs::is_regular_file(candidate, ec) && !ec) return candidate;
+    }
     if (const char* system_root = std::getenv("SystemRoot"); system_root != nullptr) {
         const fs::path candidate = fs::path{system_root}
             / "System32" / "WindowsPowerShell" / "v1.0" / "powershell.exe";

--- a/docs/V5_PARITY.md
+++ b/docs/V5_PARITY.md
@@ -44,7 +44,7 @@ Status meanings:
 | `-runtime MD/MDd/MT/MTd` | `--runtime`; legacy `-runtime` accepted | **compat** |
 | `-ltcg` | `--ltcg` / `--no-ltcg`; legacy `-ltcg` enables the same coupled typed policy | **compat** |
 | `-subsystem console/windows` | `--subsystem`; legacy `-subsystem` accepted | **compat** |
-| `-env vs/portable/port/p/auto` | `--env auto/vs/portable`; legacy spelling and portable aliases accepted | **compat** |
+| PowerShell `-env vs/portable/port/p/auto` | native `--env auto/vs/portable` (and parser-compatible `-env`) is invocation-scoped, while PowerShell `-env` writes/removes a persistent preference file and exits | **migrate** semantics; keep native invocation-scoped selection and document the legacy preference-file transition |
 | `-help`, `-?` | `--help`, `-h`; legacy help aliases accepted | **compat** |
 | `-flags` | `--compiler-arg <one argv>`; legacy `-flags <one argv>` accepted and repeatable | **compat** with explicit one-argv-per-occurrence semantics |
 | `-link_flags` | `--linker-arg <one argv>`; legacy alias accepted and repeatable | **compat** with explicit one-argv-per-occurrence semantics |
@@ -113,9 +113,11 @@ Typed LTCG is a single coupled policy, not two user-maintained raw lists. Enabli
 | Visual Studio discovery | ready | **ready** |
 | portable MSVC discovery | ready | **ready** |
 | automatic preference | ready | **ready** |
-| environment aliases `portable/port/p` | parser compatibility added | **compat** |
+| environment aliases `portable/port/p` | native parser accepts the legacy spellings for invocation-scoped selection | **compat spelling only**; PowerShell `-env` command semantics still migrate |
 | legacy `.msvc_build_env` preference file | native does not use it | **migrate** to explicit CLI/config/environment contract; document upgrade |
 | cached vcvars environment text file | native locator owns process environment differently | **migrate** implementation detail; no parity requirement |
+
+The installed PowerShell profile prefers `pwsh.exe -NoProfile -File build.ps1` and falls back to the current host only when PowerShell 7 is unavailable. Shared parity tests mirror that host-selection behavior. They intentionally do not invoke `build.ps1 -env vs` as part of a build, because that legacy command persists the preference and exits instead of selecting Visual Studio for only that invocation.
 
 ## Incremental/artifact behavior
 
@@ -143,6 +145,6 @@ Project-local named modules and project-local header units are in the RC/stable-
 8. Native DLL target kind with typed linker routing, deterministic import library, and side-output repair. **Done in #35.**
 9. Static-library target with an explicit `lib.exe`/librarian backend, archive cache owner, strict `mqb.json` target kind, and real CLI/config consumer coverage. **Done in #36 + #37.**
 10. Close the high-value coupled MSVC LTCG gap with typed `/GL` + downstream `/LTCG`, config/CLI precedence, cache identities, and real executable/static E2E. **Done in #39.** Charset remains evidence-driven rather than an automatic typed-surface requirement.
-11. Shared PowerShell-vs-C++ fixtures for ordinary targets, config precedence, incremental rebuilds, libraries, run argv, x86/x64, Debug/Release, and failure behavior.
+11. Shared PowerShell-vs-C++ fixtures for ordinary targets, config precedence, incremental rebuilds, libraries, run argv, x86/x64, Debug/Release, and failure behavior. **Harness foundation in #40:** same committed fixtures run through isolated PowerShell/C++ sandboxes with observable-result comparison; initial single-TU, explicit multi-TU, Debug, and Release scenarios are covered. Config/incremental/libraries/run argv/x86/x64/failure scenarios remain follow-up slices.
 12. Installer/profile/`build` command cutover and clean-machine upgrade/rollback validation.
 13. Generalize the release workflow and publish stable v5 only from the exact validated artifact.


### PR DESCRIPTION
## Shared-parity foundation

This PR establishes the stable-v5 PowerShell ↔ C++ parity harness rather than adding another implementation-specific E2E suite.

### Harness contract

- the same committed fixture source tree is copied into two isolated sandboxes
- one sandbox is built by the repository-root PowerShell Golden Reference (`build.ps1`)
- the other is built by the native C++ `mqb.exe`
- implementation-specific artifact paths, cache formats, and build-log wording are intentionally not compared
- both produced executables are launched independently and compared against the same observable contract (process success + normalized stdout)

### Initial shared scenarios

1. single-TU executable
2. explicit multi-TU executable
3. explicit Debug configuration (`_DEBUG` observable)
4. explicit Release configuration (`NDEBUG` observable)

### Legacy environment semantic discovered by the harness

The first real CI run exposed an important migration boundary: PowerShell `build.ps1 -env vs` is **not** an invocation-scoped toolchain selector. It writes the legacy `$HOME\bin\.msvc_build_env` preference and exits. Native `mqb --env vs` is invocation-scoped.

The harness therefore follows the installed profile contract instead of mechanically translating similarly named switches:
- prefer PowerShell 7 (`pwsh.exe`) for the Golden Reference, matching `Microsoft.PowerShell_profile.ps1`
- fall back to Windows PowerShell only when PowerShell 7 is unavailable
- let the Golden Reference auto-detect its configured/installed toolchain during a build
- explicitly select `--env vs` only on the native C++ side

`docs/V5_PARITY.md` now classifies this as a semantic migration rather than pretending it is byte-for-byte CLI compatibility.

### CI ownership

Because the parity suite directly consumes `build.ps1`, changes to the PowerShell Golden Reference now trigger both C++ V2 and Release Candidate PR workflows. This prevents the reference implementation from drifting without running the native parity gate.

### Scope boundary

This is deliberately the harness foundation, not the entire parity matrix. Follow-up scenarios still need to cover config precedence, incremental rebuild behavior, libraries, run argv, x86/x64, and failure behavior using the same runner/fixture model.

### Validation

Exact head: `34474daafa5fb4d8e8fd6d66b3cc3bedf2567d67`.

- **C++ V2 #327:** success; full **68-test** installed-MSVC suite passed, including `mqb.parity.shared_e2e`.
- **C++ Release Candidate #96:** success; full **68-test** Release suite passed.
- Release embedded-version verification remained exactly `MQB 5.0.0-rc.2 - MSVC Quick Build (C++ refactor)`.
- Release package staging, checksum generation, and artifact upload all passed.

The first failing parity attempt was also useful evidence: forcing Windows PowerShell 5.1 caused the no-BOM UTF-8 Golden Reference to fail parsing before any build. The final harness instead mirrors the repository's installed profile and prefers PowerShell 7, so the passing final gates exercise the real legacy entry contract rather than an artificial host choice.