### PR TITLE
test: extend shared parity to incremental and run argv

### DIFF
--- a/.github/workflows/cpp-parity.yml
+++ b/.github/workflows/cpp-parity.yml
@@ -1,0 +1,44 @@
+name: Shared PowerShell C++ Parity
+
+on:
+  pull_request:
+    paths:
+      - 'build.ps1'
+      - 'cpp/**'
+      - '.github/workflows/cpp-parity.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'build.ps1'
+      - 'cpp/**'
+      - '.github/workflows/cpp-parity.yml'
+
+jobs:
+  shared-parity:
+    name: ${{ matrix.configuration }} shared parity
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        configuration:
+          - Debug
+          - Release
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Configure
+        run: cmake -S cpp -B cpp/build-parity -G "Visual Studio 18 2026" -A x64
+
+      - name: Build mqb
+        run: cmake --build cpp/build-parity --config ${{ matrix.configuration }} --target mqb --parallel
+
+      - name: Run shared incremental and argv parity
+        shell: pwsh
+        run: |
+          $mqb = Join-Path $PWD "cpp/build-parity/apps/mqb/${{ matrix.configuration }}/mqb.exe"
+          & (Join-Path $PWD 'cpp/tests/parity/shared_incremental_run.ps1') `
+            -MqbPath $mqb `
+            -RepoRoot $PWD

--- a/cpp/tests/parity/INCREMENTAL_RUN.md
+++ b/cpp/tests/parity/INCREMENTAL_RUN.md
@@ -1,0 +1,45 @@
+# Incremental + run-argv shared parity
+
+This slice extends the stable-v5 PowerShell ↔ C++ migration campaign with observable behavior that should remain meaningful across the two different build implementations.
+
+## Incremental contract
+
+The parity driver copies the same `fixtures/incremental` source into isolated PowerShell and native C++ sandboxes.
+
+For each implementation it then:
+
+1. performs a cold build and runs the result;
+2. records the target executable timestamp;
+3. rebuilds without changing inputs and requires the target timestamp to remain unchanged;
+4. applies the same source mutation to both sandboxes;
+5. rebuilds and requires both programs to expose the same new behavior.
+
+The test intentionally does **not** compare PowerShell cache files with `.mqb/`, object names, or implementation-specific "up-to-date" log strings. The stable contract is that a warm no-op does not rewrite the final target and that a real source change reaches the rebuilt program.
+
+## Run-argv contract
+
+The shared `fixtures/run_argv` program prints its received argv tokens.
+
+The Golden Reference is exercised through its public legacy surface:
+
+```powershell
+build.ps1 main.cpp -run -a "alpha beta 42"
+```
+
+Native MQB is exercised through structured argv:
+
+```powershell
+mqb main.cpp --run -- alpha beta 42
+```
+
+Both must expose the shared simple-token result:
+
+```text
+argv=alpha|beta|42
+```
+
+This does not claim that every historical quoting/escaping quirk of the legacy single-string `-a` tokenizer is part of the native contract. Those edge cases remain an explicit migration decision; native `--` preserves structured argv boundaries by design.
+
+## CI
+
+`.github/workflows/cpp-parity.yml` builds native `mqb.exe` in both Debug and Release configurations and runs the same PowerShell Golden Reference parity driver against each binary. The ordinary CTest suites remain responsible for lower-level and baseline shared-parity coverage; this workflow is the growing cross-implementation migration matrix.

--- a/cpp/tests/parity/fixtures/incremental/main.cpp
+++ b/cpp/tests/parity/fixtures/incremental/main.cpp
@@ -1,0 +1,6 @@
+#include <iostream>
+
+int main() {
+    std::cout << "incremental=1\n";
+    return 0;
+}

--- a/cpp/tests/parity/fixtures/run_argv/main.cpp
+++ b/cpp/tests/parity/fixtures/run_argv/main.cpp
@@ -1,0 +1,11 @@
+#include <iostream>
+
+int main(int argc, char* argv[]) {
+    std::cout << "argv=";
+    for (int index = 1; index < argc; ++index) {
+        if (index != 1) std::cout << '|';
+        std::cout << argv[index];
+    }
+    std::cout << '\n';
+    return 0;
+}

--- a/cpp/tests/parity/shared_incremental_run.ps1
+++ b/cpp/tests/parity/shared_incremental_run.ps1
@@ -27,7 +27,7 @@ if (-not (Test-Path -LiteralPath $fixturesRoot -PathType Container)) {
 function Invoke-Captured {
     param(
         [Parameter(Mandatory = $true)][string]$FilePath,
-        [Parameter(Mandatory = $true)][string[]]$Arguments,
+        [Parameter(Mandatory = $true)][AllowEmptyCollection()][string[]]$Arguments,
         [Parameter(Mandatory = $true)][string]$WorkingDirectory
     )
 
@@ -175,7 +175,6 @@ int main() {
     return 0;
 }
 '@
-    $mutatedSource = $mutatedSource.Replace('\"', '"')
     $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
     [System.IO.File]::WriteAllText((Join-Path $psRoot 'main.cpp'), $mutatedSource, $utf8NoBom)
     [System.IO.File]::WriteAllText((Join-Path $cppRoot 'main.cpp'), $mutatedSource, $utf8NoBom)

--- a/cpp/tests/parity/shared_incremental_run.ps1
+++ b/cpp/tests/parity/shared_incremental_run.ps1
@@ -1,0 +1,220 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$MqbPath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$RepoRoot
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$mqb = [System.IO.Path]::GetFullPath($MqbPath)
+$repo = [System.IO.Path]::GetFullPath($RepoRoot)
+$buildPs1 = Join-Path $repo 'build.ps1'
+$fixturesRoot = Join-Path $repo 'cpp/tests/parity/fixtures'
+
+if (-not (Test-Path -LiteralPath $mqb -PathType Leaf)) {
+    throw "mqb executable does not exist: $mqb"
+}
+if (-not (Test-Path -LiteralPath $buildPs1 -PathType Leaf)) {
+    throw "PowerShell Golden Reference does not exist: $buildPs1"
+}
+if (-not (Test-Path -LiteralPath $fixturesRoot -PathType Container)) {
+    throw "parity fixture root does not exist: $fixturesRoot"
+}
+
+function Invoke-Captured {
+    param(
+        [Parameter(Mandatory = $true)][string]$FilePath,
+        [Parameter(Mandatory = $true)][string[]]$Arguments,
+        [Parameter(Mandatory = $true)][string]$WorkingDirectory
+    )
+
+    Push-Location $WorkingDirectory
+    try {
+        $lines = @(& $FilePath @Arguments 2>&1 | ForEach-Object { $_.ToString() })
+        $exitCode = $LASTEXITCODE
+    }
+    finally {
+        Pop-Location
+    }
+
+    return [pscustomobject]@{
+        ExitCode = $exitCode
+        Lines = $lines
+    }
+}
+
+function Assert-Success {
+    param(
+        [Parameter(Mandatory = $true)]$Result,
+        [Parameter(Mandatory = $true)][string]$Label
+    )
+
+    if ($Result.ExitCode -ne 0) {
+        Write-Host "--- $Label output ---"
+        $Result.Lines | ForEach-Object { Write-Host $_ }
+        throw "$Label failed with exit code $($Result.ExitCode)"
+    }
+}
+
+function Assert-ContainsLine {
+    param(
+        [Parameter(Mandatory = $true)]$Result,
+        [Parameter(Mandatory = $true)][string]$Expected,
+        [Parameter(Mandatory = $true)][string]$Label
+    )
+
+    if (-not ($Result.Lines -contains $Expected)) {
+        Write-Host "--- $Label output ---"
+        $Result.Lines | ForEach-Object { Write-Host $_ }
+        throw "$Label did not contain expected line '$Expected'"
+    }
+}
+
+function Copy-Fixture {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][string]$Destination
+    )
+
+    $source = Join-Path $fixturesRoot $Name
+    if (-not (Test-Path -LiteralPath $source -PathType Container)) {
+        throw "missing parity fixture: $source"
+    }
+    New-Item -ItemType Directory -Force -Path $Destination | Out-Null
+    Copy-Item -Path (Join-Path $source '*') -Destination $Destination -Recurse -Force
+}
+
+function Invoke-GoldenBuild {
+    param(
+        [Parameter(Mandatory = $true)][string]$WorkingDirectory,
+        [Parameter(Mandatory = $true)][string[]]$Arguments
+    )
+
+    $pwsh = (Get-Process -Id $PID).Path
+    return Invoke-Captured -FilePath $pwsh -WorkingDirectory $WorkingDirectory -Arguments @(
+        '-NoLogo',
+        '-NoProfile',
+        '-File',
+        $buildPs1
+    ) + $Arguments
+}
+
+function Invoke-NativeBuild {
+    param(
+        [Parameter(Mandatory = $true)][string]$WorkingDirectory,
+        [Parameter(Mandatory = $true)][string[]]$Arguments
+    )
+
+    return Invoke-Captured -FilePath $mqb -WorkingDirectory $WorkingDirectory -Arguments $Arguments
+}
+
+function Invoke-Program {
+    param(
+        [Parameter(Mandatory = $true)][string]$Executable,
+        [Parameter(Mandatory = $true)][string]$WorkingDirectory
+    )
+
+    return Invoke-Captured -FilePath $Executable -WorkingDirectory $WorkingDirectory -Arguments @()
+}
+
+$runRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("mqb-shared-parity-" + [Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Force -Path $runRoot | Out-Null
+
+try {
+    # Incremental observable parity: unchanged builds must not rewrite the target;
+    # a source mutation must reach the rebuilt program on both implementations.
+    $incrementalRoot = Join-Path $runRoot 'incremental'
+    $psRoot = Join-Path $incrementalRoot 'powershell'
+    $cppRoot = Join-Path $incrementalRoot 'cpp'
+    Copy-Fixture -Name 'incremental' -Destination $psRoot
+    Copy-Fixture -Name 'incremental' -Destination $cppRoot
+
+    $psCold = Invoke-GoldenBuild -WorkingDirectory $psRoot -Arguments @('main.cpp', '-o', 'parity_incremental')
+    $cppCold = Invoke-NativeBuild -WorkingDirectory $cppRoot -Arguments @('main.cpp', '--env', 'vs', '-o', 'parity_incremental')
+    Assert-Success $psCold 'PowerShell incremental cold build'
+    Assert-Success $cppCold 'C++ incremental cold build'
+
+    $psExe = Join-Path $psRoot 'parity_incremental.exe'
+    $cppExe = Join-Path $cppRoot '.mqb/bin/parity_incremental.exe'
+    if (-not (Test-Path -LiteralPath $psExe -PathType Leaf)) { throw "missing PowerShell parity output: $psExe" }
+    if (-not (Test-Path -LiteralPath $cppExe -PathType Leaf)) { throw "missing C++ parity output: $cppExe" }
+
+    $psColdRun = Invoke-Program -Executable $psExe -WorkingDirectory $psRoot
+    $cppColdRun = Invoke-Program -Executable $cppExe -WorkingDirectory $cppRoot
+    Assert-Success $psColdRun 'PowerShell incremental cold program'
+    Assert-Success $cppColdRun 'C++ incremental cold program'
+    Assert-ContainsLine $psColdRun 'incremental=1' 'PowerShell incremental cold program'
+    Assert-ContainsLine $cppColdRun 'incremental=1' 'C++ incremental cold program'
+
+    $psColdStamp = (Get-Item -LiteralPath $psExe).LastWriteTimeUtc.Ticks
+    $cppColdStamp = (Get-Item -LiteralPath $cppExe).LastWriteTimeUtc.Ticks
+
+    $psWarm = Invoke-GoldenBuild -WorkingDirectory $psRoot -Arguments @('main.cpp', '-o', 'parity_incremental')
+    $cppWarm = Invoke-NativeBuild -WorkingDirectory $cppRoot -Arguments @('main.cpp', '--env', 'vs', '-o', 'parity_incremental')
+    Assert-Success $psWarm 'PowerShell incremental warm build'
+    Assert-Success $cppWarm 'C++ incremental warm build'
+
+    $psWarmStamp = (Get-Item -LiteralPath $psExe).LastWriteTimeUtc.Ticks
+    $cppWarmStamp = (Get-Item -LiteralPath $cppExe).LastWriteTimeUtc.Ticks
+    if ($psWarmStamp -ne $psColdStamp) {
+        throw 'PowerShell warm no-op rewrote the target executable'
+    }
+    if ($cppWarmStamp -ne $cppColdStamp) {
+        throw 'C++ warm no-op rewrote the target executable'
+    }
+
+    $mutatedSource = @'
+#include <iostream>
+
+int main() {
+    std::cout << "incremental=2\n";
+    return 0;
+}
+'@
+    $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+    [System.IO.File]::WriteAllText((Join-Path $psRoot 'main.cpp'), $mutatedSource, $utf8NoBom)
+    [System.IO.File]::WriteAllText((Join-Path $cppRoot 'main.cpp'), $mutatedSource, $utf8NoBom)
+    $future = [DateTime]::UtcNow.AddSeconds(2)
+    (Get-Item -LiteralPath (Join-Path $psRoot 'main.cpp')).LastWriteTimeUtc = $future
+    (Get-Item -LiteralPath (Join-Path $cppRoot 'main.cpp')).LastWriteTimeUtc = $future
+
+    $psChanged = Invoke-GoldenBuild -WorkingDirectory $psRoot -Arguments @('main.cpp', '-o', 'parity_incremental')
+    $cppChanged = Invoke-NativeBuild -WorkingDirectory $cppRoot -Arguments @('main.cpp', '--env', 'vs', '-o', 'parity_incremental')
+    Assert-Success $psChanged 'PowerShell incremental changed-source build'
+    Assert-Success $cppChanged 'C++ incremental changed-source build'
+
+    $psChangedRun = Invoke-Program -Executable $psExe -WorkingDirectory $psRoot
+    $cppChangedRun = Invoke-Program -Executable $cppExe -WorkingDirectory $cppRoot
+    Assert-Success $psChangedRun 'PowerShell incremental changed program'
+    Assert-Success $cppChangedRun 'C++ incremental changed program'
+    Assert-ContainsLine $psChangedRun 'incremental=2' 'PowerShell incremental changed program'
+    Assert-ContainsLine $cppChangedRun 'incremental=2' 'C++ incremental changed program'
+
+    # Run-argv parity: compare the logical token sequence shared by legacy -a
+    # and native structured -- argv. Quoted/escaped legacy tokenizer behavior
+    # remains an explicit migration boundary rather than being silently copied.
+    $argvRoot = Join-Path $runRoot 'run-argv'
+    $argvPsRoot = Join-Path $argvRoot 'powershell'
+    $argvCppRoot = Join-Path $argvRoot 'cpp'
+    Copy-Fixture -Name 'run_argv' -Destination $argvPsRoot
+    Copy-Fixture -Name 'run_argv' -Destination $argvCppRoot
+
+    $psArgv = Invoke-GoldenBuild -WorkingDirectory $argvPsRoot -Arguments @(
+        'main.cpp', '-o', 'parity_run_argv', '-run', '-a', 'alpha beta 42'
+    )
+    $cppArgv = Invoke-NativeBuild -WorkingDirectory $argvCppRoot -Arguments @(
+        'main.cpp', '--env', 'vs', '-o', 'parity_run_argv', '--run', '--', 'alpha', 'beta', '42'
+    )
+    Assert-Success $psArgv 'PowerShell run-argv build/run'
+    Assert-Success $cppArgv 'C++ run-argv build/run'
+    Assert-ContainsLine $psArgv 'argv=alpha|beta|42' 'PowerShell run-argv build/run'
+    Assert-ContainsLine $cppArgv 'argv=alpha|beta|42' 'C++ run-argv build/run'
+
+    Write-Host 'shared incremental/run-argv parity passed'
+}
+finally {
+    Remove-Item -LiteralPath $runRoot -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/cpp/tests/parity/shared_incremental_run.ps1
+++ b/cpp/tests/parity/shared_incremental_run.ps1
@@ -94,12 +94,13 @@ function Invoke-GoldenBuild {
     )
 
     $pwsh = (Get-Process -Id $PID).Path
-    return Invoke-Captured -FilePath $pwsh -WorkingDirectory $WorkingDirectory -Arguments @(
+    $allArgs = @(
         '-NoLogo',
         '-NoProfile',
         '-File',
         $buildPs1
     ) + $Arguments
+    return Invoke-Captured -FilePath $pwsh -WorkingDirectory $WorkingDirectory -Arguments $allArgs
 }
 
 function Invoke-NativeBuild {
@@ -174,6 +175,7 @@ int main() {
     return 0;
 }
 '@
+    $mutatedSource = $mutatedSource.Replace('\"', '"')
     $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
     [System.IO.File]::WriteAllText((Join-Path $psRoot 'main.cpp'), $mutatedSource, $utf8NoBom)
     [System.IO.File]::WriteAllText((Join-Path $cppRoot 'main.cpp'), $mutatedSource, $utf8NoBom)


### PR DESCRIPTION
## Shared-parity slice: incremental behavior + run argv

This PR extends the PowerShell Golden Reference ↔ native C++ migration harness with two user-visible contracts while keeping implementation-private cache/layout details out of the comparison.

### Incremental observable parity

The same committed fixture is copied into isolated PowerShell/C++ sandboxes. Each side then performs:

1. cold build + program execution (`incremental=1`);
2. unchanged warm build, requiring the final executable timestamp to remain unchanged;
3. the same source mutation in both sandboxes;
4. rebuild + program execution, requiring both to expose `incremental=2`.

This intentionally does not compare cache files, object names, or implementation-specific "up-to-date" log wording. The observable contract is that a no-op build does not rewrite the target and a real source change reaches the rebuilt program.

### Run-argv parity

The shared fixture prints argv token boundaries.

- Golden Reference: `-run -a "alpha beta 42"`
- native MQB: `--run -- alpha beta 42`

Both expose `argv=alpha|beta|42`.

This covers the shared simple-token behavior only. Legacy quoted/escaped single-string tokenizer quirks remain an explicit migration boundary; native structured `--` argv semantics are not weakened to imitate ambiguous historical parsing.

### Dedicated migration gate

Adds `.github/workflows/cpp-parity.yml` (`Shared PowerShell C++ Parity`). It builds `mqb.exe` in both **Debug** and **Release** configurations and runs the same Golden Reference parity driver against each binary.

The existing C++ V2 / Release Candidate suites remain the baseline implementation gates. The new workflow is the growing cross-implementation stable-v5 migration matrix that later config/libraries/x86/failure scenarios can extend directly.

### Validation

Exact final head: `bc7ca459604addfeb47c5ba1ca1639c9a0bac1df`.

- **Shared PowerShell C++ Parity #3:** Debug success + Release success; cold/warm/source-mutation/run-argv checks all passed.
- **C++ V2 #332:** success on the exact head.
- **C++ Release Candidate #100:** success on the exact head, including Release tests, embedded `5.0.0-rc.2` verification, package staging, checksum, and artifact upload; publish remains skipped for PRs as designed.

Two earlier parity attempts failed only in the new PowerShell test driver before meaningful parity assertions (argv-array expression binding, then empty-argv parameter binding). Those harness defects were fixed without weakening any behavioral assertion.

### Scope after this slice

Still outstanding in the shared matrix: paired project/config precedence, libraries, x86/x64, and failure behavior. Those remain follow-up slices rather than being claimed complete here.