### PR TITLE
test: extend shared parity to libraries architecture and failures

### DIFF
--- a/.github/workflows/cpp-parity.yml
+++ b/.github/workflows/cpp-parity.yml
@@ -1,0 +1,52 @@
+name: Shared PowerShell C++ Parity
+
+on:
+  pull_request:
+    paths:
+      - 'build.ps1'
+      - 'cpp/**'
+      - '.github/workflows/cpp-parity.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'build.ps1'
+      - 'cpp/**'
+      - '.github/workflows/cpp-parity.yml'
+
+jobs:
+  shared-parity:
+    name: ${{ matrix.configuration }} shared parity
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        configuration:
+          - Debug
+          - Release
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Configure
+        run: cmake -S cpp -B cpp/build-parity -G "Visual Studio 18 2026" -A x64
+
+      - name: Build mqb
+        run: cmake --build cpp/build-parity --config ${{ matrix.configuration }} --target mqb --parallel
+
+      - name: Run shared incremental and argv parity
+        shell: pwsh
+        run: |
+          $mqb = Join-Path $PWD "cpp/build-parity/apps/mqb/${{ matrix.configuration }}/mqb.exe"
+          & (Join-Path $PWD 'cpp/tests/parity/shared_incremental_run.ps1') `
+            -MqbPath $mqb `
+            -RepoRoot $PWD
+
+      - name: Run shared library architecture and failure parity
+        shell: pwsh
+        run: |
+          $mqb = Join-Path $PWD "cpp/build-parity/apps/mqb/${{ matrix.configuration }}/mqb.exe"
+          & (Join-Path $PWD 'cpp/tests/parity/shared_library_arch_failure.ps1') `
+            -MqbPath $mqb `
+            -RepoRoot $PWD

--- a/cpp/tests/parity/LIBRARY_ARCH_FAILURE.md
+++ b/cpp/tests/parity/LIBRARY_ARCH_FAILURE.md
@@ -1,0 +1,37 @@
+# Library, architecture, and failure shared parity
+
+This slice extends the stable-v5 PowerShell Golden Reference ↔ native C++ migration matrix without comparing implementation-private cache or artifact metadata.
+
+## Library consumer contract
+
+The same fixture contains a static-library provider and a consumer. Each implementation first builds the provider through its public static-library target surface, then builds the consumer through its public library search/name surface, and finally runs the executable.
+
+The observable contract is:
+
+```text
+library=73
+```
+
+PowerShell and native MQB intentionally use their own artifact locations (`parity_support.lib` beside the legacy build versus `.mqb/bin/parity_support.lib` for native MQB). Location parity is not required; successful production, resolution, linking, and execution are.
+
+## Architecture contract
+
+The same source is built twice by each implementation:
+
+- x64 must run and report `arch=x64` through `_M_X64`;
+- x86 must run and report `arch=x86` through `_M_IX86`.
+
+This validates the user-visible target architecture rather than only checking that the CLI accepted an architecture switch.
+
+## Failure contract
+
+The same syntax-invalid translation unit is built in isolated sandboxes. Both implementations must:
+
+- return a non-zero build status;
+- leave no final target executable behind.
+
+The exact numeric exit code and diagnostic wording are implementation details and are not required to match. Stable parity requires a clear failed build with no stale success artifact.
+
+## CI
+
+The existing `Shared PowerShell C++ Parity` workflow runs this driver against both Debug- and Release-built native `mqb.exe` binaries, alongside the earlier incremental/run-argv parity driver. Future config-migration scenarios should extend the same workflow.

--- a/cpp/tests/parity/fixtures/architecture/main.cpp
+++ b/cpp/tests/parity/fixtures/architecture/main.cpp
@@ -1,0 +1,12 @@
+#include <iostream>
+
+int main() {
+#if defined(_M_X64)
+    std::cout << "arch=x64\n";
+#elif defined(_M_IX86)
+    std::cout << "arch=x86\n";
+#else
+    std::cout << "arch=unknown\n";
+#endif
+    return 0;
+}

--- a/cpp/tests/parity/fixtures/failure_compile/broken.cpp
+++ b/cpp/tests/parity/fixtures/failure_compile/broken.cpp
@@ -1,0 +1,4 @@
+int main() {
+    this is intentionally not valid C++
+    return 0;
+}

--- a/cpp/tests/parity/fixtures/library/consumer.cpp
+++ b/cpp/tests/parity/fixtures/library/consumer.cpp
@@ -1,0 +1,8 @@
+#include <iostream>
+
+extern "C" int parity_library_value();
+
+int main() {
+    std::cout << "library=" << parity_library_value() << '\n';
+    return 0;
+}

--- a/cpp/tests/parity/fixtures/library/support.cpp
+++ b/cpp/tests/parity/fixtures/library/support.cpp
@@ -1,0 +1,3 @@
+extern "C" int parity_library_value() {
+    return 73;
+}

--- a/cpp/tests/parity/shared_library_arch_failure.ps1
+++ b/cpp/tests/parity/shared_library_arch_failure.ps1
@@ -1,0 +1,247 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$MqbPath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$RepoRoot
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$mqb = [System.IO.Path]::GetFullPath($MqbPath)
+$repo = [System.IO.Path]::GetFullPath($RepoRoot)
+$buildPs1 = Join-Path $repo 'build.ps1'
+$fixturesRoot = Join-Path $repo 'cpp/tests/parity/fixtures'
+
+if (-not (Test-Path -LiteralPath $mqb -PathType Leaf)) {
+    throw "mqb executable does not exist: $mqb"
+}
+if (-not (Test-Path -LiteralPath $buildPs1 -PathType Leaf)) {
+    throw "PowerShell Golden Reference does not exist: $buildPs1"
+}
+if (-not (Test-Path -LiteralPath $fixturesRoot -PathType Container)) {
+    throw "parity fixture root does not exist: $fixturesRoot"
+}
+
+function Invoke-Captured {
+    param(
+        [Parameter(Mandatory = $true)][string]$FilePath,
+        [Parameter(Mandatory = $true)][string[]]$Arguments,
+        [Parameter(Mandatory = $true)][string]$WorkingDirectory
+    )
+
+    Push-Location $WorkingDirectory
+    try {
+        $lines = @(& $FilePath @Arguments 2>&1 | ForEach-Object { $_.ToString() })
+        $exitCode = $LASTEXITCODE
+    }
+    finally {
+        Pop-Location
+    }
+
+    return [pscustomobject]@{
+        ExitCode = $exitCode
+        Lines = $lines
+    }
+}
+
+function Assert-Success {
+    param(
+        [Parameter(Mandatory = $true)]$Result,
+        [Parameter(Mandatory = $true)][string]$Label
+    )
+
+    if ($Result.ExitCode -ne 0) {
+        Write-Host "--- $Label output ---"
+        $Result.Lines | ForEach-Object { Write-Host $_ }
+        throw "$Label failed with exit code $($Result.ExitCode)"
+    }
+}
+
+function Assert-Failure {
+    param(
+        [Parameter(Mandatory = $true)]$Result,
+        [Parameter(Mandatory = $true)][string]$Label
+    )
+
+    if ($Result.ExitCode -eq 0) {
+        Write-Host "--- $Label output ---"
+        $Result.Lines | ForEach-Object { Write-Host $_ }
+        throw "$Label unexpectedly succeeded"
+    }
+}
+
+function Assert-ContainsLine {
+    param(
+        [Parameter(Mandatory = $true)]$Result,
+        [Parameter(Mandatory = $true)][string]$Expected,
+        [Parameter(Mandatory = $true)][string]$Label
+    )
+
+    if (-not ($Result.Lines -contains $Expected)) {
+        Write-Host "--- $Label output ---"
+        $Result.Lines | ForEach-Object { Write-Host $_ }
+        throw "$Label did not contain expected line '$Expected'"
+    }
+}
+
+function Copy-Fixture {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][string]$Destination
+    )
+
+    $source = Join-Path $fixturesRoot $Name
+    if (-not (Test-Path -LiteralPath $source -PathType Container)) {
+        throw "missing parity fixture: $source"
+    }
+    New-Item -ItemType Directory -Force -Path $Destination | Out-Null
+    Copy-Item -Path (Join-Path $source '*') -Destination $Destination -Recurse -Force
+}
+
+function Invoke-GoldenBuild {
+    param(
+        [Parameter(Mandatory = $true)][string]$WorkingDirectory,
+        [Parameter(Mandatory = $true)][string[]]$Arguments
+    )
+
+    $pwsh = (Get-Process -Id $PID).Path
+    $allArguments = @(
+        '-NoLogo',
+        '-NoProfile',
+        '-File',
+        $buildPs1
+    ) + $Arguments
+    return Invoke-Captured -FilePath $pwsh -WorkingDirectory $WorkingDirectory -Arguments $allArguments
+}
+
+function Invoke-NativeBuild {
+    param(
+        [Parameter(Mandatory = $true)][string]$WorkingDirectory,
+        [Parameter(Mandatory = $true)][string[]]$Arguments
+    )
+
+    return Invoke-Captured -FilePath $mqb -WorkingDirectory $WorkingDirectory -Arguments $Arguments
+}
+
+function Invoke-Program {
+    param(
+        [Parameter(Mandatory = $true)][string]$Executable,
+        [Parameter(Mandatory = $true)][string]$WorkingDirectory
+    )
+
+    return Invoke-Captured -FilePath $Executable -WorkingDirectory $WorkingDirectory -Arguments @()
+}
+
+$runRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("mqb-shared-parity-" + [Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Force -Path $runRoot | Out-Null
+
+try {
+    # Library parity: each implementation builds the same static-library source,
+    # then the same consumer resolves and links that library through its public CLI.
+    $libraryRoot = Join-Path $runRoot 'library'
+    $libraryPsRoot = Join-Path $libraryRoot 'powershell'
+    $libraryCppRoot = Join-Path $libraryRoot 'cpp'
+    Copy-Fixture -Name 'library' -Destination $libraryPsRoot
+    Copy-Fixture -Name 'library' -Destination $libraryCppRoot
+
+    $psLibrary = Invoke-GoldenBuild -WorkingDirectory $libraryPsRoot -Arguments @(
+        'support.cpp', '-type', 'static', '-o', 'parity_support'
+    )
+    $cppLibrary = Invoke-NativeBuild -WorkingDirectory $libraryCppRoot -Arguments @(
+        'support.cpp', '--env', 'vs', '--type', 'static', '-o', 'parity_support'
+    )
+    Assert-Success $psLibrary 'PowerShell static-library build'
+    Assert-Success $cppLibrary 'C++ static-library build'
+
+    $psLibraryPath = Join-Path $libraryPsRoot 'parity_support.lib'
+    $cppLibraryPath = Join-Path $libraryCppRoot '.mqb/bin/parity_support.lib'
+    if (-not (Test-Path -LiteralPath $psLibraryPath -PathType Leaf)) {
+        throw "PowerShell static library does not exist: $psLibraryPath"
+    }
+    if (-not (Test-Path -LiteralPath $cppLibraryPath -PathType Leaf)) {
+        throw "C++ static library does not exist: $cppLibraryPath"
+    }
+
+    $psConsumer = Invoke-GoldenBuild -WorkingDirectory $libraryPsRoot -Arguments @(
+        'consumer.cpp', '-libpath', '.', '-libs', 'parity_support', '-o', 'parity_library_app'
+    )
+    $cppConsumer = Invoke-NativeBuild -WorkingDirectory $libraryCppRoot -Arguments @(
+        'consumer.cpp', '--env', 'vs', '--lib-path', '.mqb/bin', '--lib', 'parity_support', '-o', 'parity_library_app'
+    )
+    Assert-Success $psConsumer 'PowerShell library consumer build'
+    Assert-Success $cppConsumer 'C++ library consumer build'
+
+    $psLibraryExe = Join-Path $libraryPsRoot 'parity_library_app.exe'
+    $cppLibraryExe = Join-Path $libraryCppRoot '.mqb/bin/parity_library_app.exe'
+    $psLibraryRun = Invoke-Program -Executable $psLibraryExe -WorkingDirectory $libraryPsRoot
+    $cppLibraryRun = Invoke-Program -Executable $cppLibraryExe -WorkingDirectory $libraryCppRoot
+    Assert-Success $psLibraryRun 'PowerShell library consumer program'
+    Assert-Success $cppLibraryRun 'C++ library consumer program'
+    Assert-ContainsLine $psLibraryRun 'library=73' 'PowerShell library consumer program'
+    Assert-ContainsLine $cppLibraryRun 'library=73' 'C++ library consumer program'
+
+    # Architecture parity: both public CLIs must produce runnable x64 and x86 targets
+    # exposing the architecture selected through MSVC predefined macros.
+    $architectures = @(
+        [pscustomobject]@{ Name = 'x64'; GoldenFlag = '-x64'; NativeFlag = '--x64'; Expected = 'arch=x64' },
+        [pscustomobject]@{ Name = 'x86'; GoldenFlag = '-x86'; NativeFlag = '--x86'; Expected = 'arch=x86' }
+    )
+    foreach ($architecture in $architectures) {
+        $archRoot = Join-Path $runRoot ("architecture-" + $architecture.Name)
+        $archPsRoot = Join-Path $archRoot 'powershell'
+        $archCppRoot = Join-Path $archRoot 'cpp'
+        Copy-Fixture -Name 'architecture' -Destination $archPsRoot
+        Copy-Fixture -Name 'architecture' -Destination $archCppRoot
+
+        $outputName = "parity_arch_$($architecture.Name)"
+        $psArch = Invoke-GoldenBuild -WorkingDirectory $archPsRoot -Arguments @(
+            'main.cpp', $architecture.GoldenFlag, '-o', $outputName
+        )
+        $cppArch = Invoke-NativeBuild -WorkingDirectory $archCppRoot -Arguments @(
+            'main.cpp', '--env', 'vs', $architecture.NativeFlag, '-o', $outputName
+        )
+        Assert-Success $psArch "PowerShell $($architecture.Name) build"
+        Assert-Success $cppArch "C++ $($architecture.Name) build"
+
+        $psArchExe = Join-Path $archPsRoot ($outputName + '.exe')
+        $cppArchExe = Join-Path $archCppRoot ('.mqb/bin/' + $outputName + '.exe')
+        $psArchRun = Invoke-Program -Executable $psArchExe -WorkingDirectory $archPsRoot
+        $cppArchRun = Invoke-Program -Executable $cppArchExe -WorkingDirectory $archCppRoot
+        Assert-Success $psArchRun "PowerShell $($architecture.Name) program"
+        Assert-Success $cppArchRun "C++ $($architecture.Name) program"
+        Assert-ContainsLine $psArchRun $architecture.Expected "PowerShell $($architecture.Name) program"
+        Assert-ContainsLine $cppArchRun $architecture.Expected "C++ $($architecture.Name) program"
+    }
+
+    # Failure parity: syntax-invalid source must fail the build and leave no target.
+    $failureRoot = Join-Path $runRoot 'failure-compile'
+    $failurePsRoot = Join-Path $failureRoot 'powershell'
+    $failureCppRoot = Join-Path $failureRoot 'cpp'
+    Copy-Fixture -Name 'failure_compile' -Destination $failurePsRoot
+    Copy-Fixture -Name 'failure_compile' -Destination $failureCppRoot
+
+    $psFailure = Invoke-GoldenBuild -WorkingDirectory $failurePsRoot -Arguments @(
+        'broken.cpp', '-o', 'parity_failure'
+    )
+    $cppFailure = Invoke-NativeBuild -WorkingDirectory $failureCppRoot -Arguments @(
+        'broken.cpp', '--env', 'vs', '-o', 'parity_failure'
+    )
+    Assert-Failure $psFailure 'PowerShell compile-failure build'
+    Assert-Failure $cppFailure 'C++ compile-failure build'
+
+    $psFailureExe = Join-Path $failurePsRoot 'parity_failure.exe'
+    $cppFailureExe = Join-Path $failureCppRoot '.mqb/bin/parity_failure.exe'
+    if (Test-Path -LiteralPath $psFailureExe -PathType Leaf) {
+        throw "PowerShell compile failure left a target executable: $psFailureExe"
+    }
+    if (Test-Path -LiteralPath $cppFailureExe -PathType Leaf) {
+        throw "C++ compile failure left a target executable: $cppFailureExe"
+    }
+
+    Write-Host 'shared library/architecture/failure parity passed'
+}
+finally {
+    Remove-Item -LiteralPath $runRoot -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/cpp/tests/parity/shared_library_arch_failure.ps1
+++ b/cpp/tests/parity/shared_library_arch_failure.ps1
@@ -27,7 +27,7 @@ if (-not (Test-Path -LiteralPath $fixturesRoot -PathType Container)) {
 function Invoke-Captured {
     param(
         [Parameter(Mandatory = $true)][string]$FilePath,
-        [Parameter(Mandatory = $true)][string[]]$Arguments,
+        [Parameter(Mandatory = $true)][AllowEmptyCollection()][string[]]$Arguments,
         [Parameter(Mandatory = $true)][string]$WorkingDirectory
     )
 
@@ -182,10 +182,10 @@ try {
     Assert-ContainsLine $psLibraryRun 'library=73' 'PowerShell library consumer program'
     Assert-ContainsLine $cppLibraryRun 'library=73' 'C++ library consumer program'
 
-    # Architecture parity: both public CLIs must produce runnable x64 and x86 targets
-    # exposing the architecture selected through MSVC predefined macros.
+    # Architecture parity: legacy default is x64; both public CLIs must also
+    # produce a runnable x86 target exposing the selected MSVC architecture macro.
     $architectures = @(
-        [pscustomobject]@{ Name = 'x64'; GoldenFlag = '-x64'; NativeFlag = '--x64'; Expected = 'arch=x64' },
+        [pscustomobject]@{ Name = 'x64'; GoldenFlag = $null; NativeFlag = '--x64'; Expected = 'arch=x64' },
         [pscustomobject]@{ Name = 'x86'; GoldenFlag = '-x86'; NativeFlag = '--x86'; Expected = 'arch=x86' }
     )
     foreach ($architecture in $architectures) {
@@ -196,9 +196,12 @@ try {
         Copy-Fixture -Name 'architecture' -Destination $archCppRoot
 
         $outputName = "parity_arch_$($architecture.Name)"
-        $psArch = Invoke-GoldenBuild -WorkingDirectory $archPsRoot -Arguments @(
-            'main.cpp', $architecture.GoldenFlag, '-o', $outputName
-        )
+        $psArchArguments = @('main.cpp')
+        if ($architecture.GoldenFlag) {
+            $psArchArguments += $architecture.GoldenFlag
+        }
+        $psArchArguments += @('-o', $outputName)
+        $psArch = Invoke-GoldenBuild -WorkingDirectory $archPsRoot -Arguments $psArchArguments
         $cppArch = Invoke-NativeBuild -WorkingDirectory $archCppRoot -Arguments @(
             'main.cpp', '--env', 'vs', $architecture.NativeFlag, '-o', $outputName
         )

--- a/cpp/tests/parity/shared_library_arch_failure.ps1
+++ b/cpp/tests/parity/shared_library_arch_failure.ps1
@@ -248,3 +248,8 @@ try {
 finally {
     Remove-Item -LiteralPath $runRoot -Recurse -Force -ErrorAction SilentlyContinue
 }
+
+# The final parity scenario intentionally invokes failing compiler processes.
+# Normalize the script result only after every assertion above has completed;
+# any thrown assertion skips this line and still fails the workflow step.
+exit 0


### PR DESCRIPTION
## Shared-parity slice: libraries + target architecture + compile failure

This PR extends the stable-v5 PowerShell Golden Reference ↔ native C++ matrix using the dedicated `Shared PowerShell C++ Parity` workflow introduced by #41.

### Library producer/consumer parity

The same fixture contains a static-library provider and a consumer. Each implementation builds the provider through its public static-library target surface, resolves the produced library through its public library-search/library-name CLI, links the same consumer source, and runs it with observable output `library=73`.

Artifact locations intentionally differ (`parity_support.lib` for the legacy build versus `.mqb/bin/parity_support.lib` for native MQB); successful production, resolution, link, and execution are the shared contract.

### x64 / x86 parity

The same source reports the MSVC target macro it was compiled for.

- legacy **default x64** is compared with native explicit `--x64`, both requiring `arch=x64`;
- legacy `-x86` is compared with native `--x86`, both requiring a runnable `arch=x86` program.

This verifies the actual target architecture rather than only accepting a switch.

### Compile-failure parity

The same syntax-invalid source must make both build entry points return non-zero and leave no final target executable behind. Exact exit-code numbers and diagnostic wording are intentionally not compared.

### CI

The existing Debug/Release shared-parity matrix now runs both the #41 incremental/run-argv slice and this library/architecture/failure slice. C++ V2 and Release Candidate suites continue to run independently as baseline implementation gates.

### Validation

Exact final head: `ca69b89845c16a551eadaf58c0b7bf18b37630e7`.

- **Shared PowerShell C++ Parity #6:** Debug success + Release success. Both jobs first passed #41 incremental/run-argv parity, then passed library producer/consumer, default-x64/explicit-x64, x86, and compile-failure parity.
- **C++ V2 #336:** success on the exact head.
- **C++ Release Candidate #103:** success on the exact head, including Release tests, embedded `5.0.0-rc.2` verification, package staging/checksum/artifact upload; PR publish remained skipped as designed.

The first dedicated #42 run already passed every behavioral assertion but ended the PowerShell step with stale `$LASTEXITCODE=1` from the intentionally failing compiler scenario. The final driver explicitly normalizes success only after all assertions and cleanup complete; assertion exceptions still fail the step.

### Remaining matrix

After this slice, the major shared-parity item still requiring a dedicated migration mapping is paired **`msvc_list.json` ↔ `mqb.json` project/config precedence**. It remains separate because the schemas are intentionally different and should be mapped explicitly rather than made to look source-compatible.