### PR TITLE
test: validate msvc_list to mqb config migration parity

### DIFF
--- a/.github/workflows/cpp-parity.yml
+++ b/.github/workflows/cpp-parity.yml
@@ -50,3 +50,11 @@ jobs:
           & (Join-Path $PWD 'cpp/tests/parity/shared_library_arch_failure.ps1') `
             -MqbPath $mqb `
             -RepoRoot $PWD
+
+      - name: Run shared project-config migration parity
+        shell: pwsh
+        run: |
+          $mqb = Join-Path $PWD "cpp/build-parity/apps/mqb/${{ matrix.configuration }}/mqb.exe"
+          & (Join-Path $PWD 'cpp/tests/parity/shared_config_migration.ps1') `
+            -MqbPath $mqb `
+            -RepoRoot $PWD

--- a/cpp/tests/parity/fixtures/config_migration/cli_override/include/parity_config.hpp
+++ b/cpp/tests/parity/fixtures/config_migration/cli_override/include/parity_config.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+inline constexpr int parity_header_value = 31;

--- a/cpp/tests/parity/fixtures/config_migration/cli_override/mqb.json
+++ b/cpp/tests/parity/fixtures/config_migration/cli_override/mqb.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "build": {
+    "configuration": "release",
+    "standard": "17",
+    "type": "static",
+    "output": "should_not_win",
+    "defines": ["PARITY_CONFIG=41"],
+    "include_dirs": ["include"]
+  }
+}

--- a/cpp/tests/parity/fixtures/config_migration/cli_override/msvc_list.json
+++ b/cpp/tests/parity/fixtures/config_migration/cli_override/msvc_list.json
@@ -1,0 +1,8 @@
+{
+  "config": "release",
+  "std": "17",
+  "type": "static",
+  "output": "should_not_win",
+  "defines": ["PARITY_CONFIG=41"],
+  "include": ["include"]
+}

--- a/cpp/tests/parity/fixtures/config_migration/cli_override/src/main.cpp
+++ b/cpp/tests/parity/fixtures/config_migration/cli_override/src/main.cpp
@@ -1,0 +1,31 @@
+#include "parity_config.hpp"
+
+#include <iostream>
+
+#ifndef PARITY_CONFIG
+#error PARITY_CONFIG must remain additive from project config
+#endif
+
+#ifndef CLI_OVERRIDE
+#error CLI_OVERRIDE must come from the command line
+#endif
+
+#if !defined(_MSVC_LANG) || _MSVC_LANG != 201703L
+#error project config standard must survive scalar CLI overrides
+#endif
+
+#ifndef _DEBUG
+#error CLI must override project Release with Debug
+#endif
+
+#ifdef NDEBUG
+#error CLI Debug override must remove Release NDEBUG behavior
+#endif
+
+int main() {
+    std::cout << "config=debug;config_define=" << PARITY_CONFIG
+              << ";cli_define=" << CLI_OVERRIDE
+              << ";include=" << parity_header_value
+              << ";std=17\n";
+    return 0;
+}

--- a/cpp/tests/parity/fixtures/config_migration/config_only/include/parity_config.hpp
+++ b/cpp/tests/parity/fixtures/config_migration/config_only/include/parity_config.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+inline constexpr int parity_header_value = 31;

--- a/cpp/tests/parity/fixtures/config_migration/config_only/mqb.json
+++ b/cpp/tests/parity/fixtures/config_migration/config_only/mqb.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "build": {
+    "configuration": "release",
+    "standard": "17",
+    "type": "exe",
+    "output": "config_file",
+    "defines": ["PARITY_CONFIG=41"],
+    "include_dirs": ["include"]
+  }
+}

--- a/cpp/tests/parity/fixtures/config_migration/config_only/msvc_list.json
+++ b/cpp/tests/parity/fixtures/config_migration/config_only/msvc_list.json
@@ -1,0 +1,8 @@
+{
+  "config": "release",
+  "std": "17",
+  "type": "exe",
+  "output": "config_file",
+  "defines": ["PARITY_CONFIG=41"],
+  "include": ["include"]
+}

--- a/cpp/tests/parity/fixtures/config_migration/config_only/src/main.cpp
+++ b/cpp/tests/parity/fixtures/config_migration/config_only/src/main.cpp
@@ -1,0 +1,26 @@
+#include "parity_config.hpp"
+
+#include <iostream>
+
+#ifndef PARITY_CONFIG
+#error PARITY_CONFIG must come from the project config
+#endif
+
+#if !defined(_MSVC_LANG) || _MSVC_LANG != 201703L
+#error project config must select C++17
+#endif
+
+#ifndef NDEBUG
+#error project config must select Release
+#endif
+
+#ifdef _DEBUG
+#error Release config must not define _DEBUG
+#endif
+
+int main() {
+    std::cout << "config=release;define=" << PARITY_CONFIG
+              << ";include=" << parity_header_value
+              << ";std=17\n";
+    return 0;
+}

--- a/cpp/tests/parity/shared_config_migration.ps1
+++ b/cpp/tests/parity/shared_config_migration.ps1
@@ -1,0 +1,232 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$MqbPath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$RepoRoot
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$mqb = [System.IO.Path]::GetFullPath($MqbPath)
+$repo = [System.IO.Path]::GetFullPath($RepoRoot)
+$buildPs1 = Join-Path $repo 'build.ps1'
+$fixturesRoot = Join-Path $repo 'cpp/tests/parity/fixtures/config_migration'
+
+if (-not (Test-Path -LiteralPath $mqb -PathType Leaf)) {
+    throw "mqb executable does not exist: $mqb"
+}
+if (-not (Test-Path -LiteralPath $buildPs1 -PathType Leaf)) {
+    throw "PowerShell Golden Reference does not exist: $buildPs1"
+}
+if (-not (Test-Path -LiteralPath $fixturesRoot -PathType Container)) {
+    throw "config-migration fixture root does not exist: $fixturesRoot"
+}
+
+function Invoke-Captured {
+    param(
+        [Parameter(Mandatory = $true)][string]$FilePath,
+        [Parameter(Mandatory = $true)][AllowEmptyCollection()][string[]]$Arguments,
+        [Parameter(Mandatory = $true)][string]$WorkingDirectory
+    )
+
+    Push-Location $WorkingDirectory
+    try {
+        $lines = @(& $FilePath @Arguments 2>&1 | ForEach-Object { $_.ToString() })
+        $exitCode = $LASTEXITCODE
+    }
+    finally {
+        Pop-Location
+    }
+
+    return [pscustomobject]@{
+        ExitCode = $exitCode
+        Lines = $lines
+    }
+}
+
+function Assert-Success {
+    param(
+        [Parameter(Mandatory = $true)]$Result,
+        [Parameter(Mandatory = $true)][string]$Label
+    )
+
+    if ($Result.ExitCode -ne 0) {
+        Write-Host "--- $Label output ---"
+        $Result.Lines | ForEach-Object { Write-Host $_ }
+        throw "$Label failed with exit code $($Result.ExitCode)"
+    }
+}
+
+function Assert-ContainsLine {
+    param(
+        [Parameter(Mandatory = $true)]$Result,
+        [Parameter(Mandatory = $true)][string]$Expected,
+        [Parameter(Mandatory = $true)][string]$Label
+    )
+
+    if (-not ($Result.Lines -contains $Expected)) {
+        Write-Host "--- $Label output ---"
+        $Result.Lines | ForEach-Object { Write-Host $_ }
+        throw "$Label did not contain expected line '$Expected'"
+    }
+}
+
+function Assert-NotFile {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][string]$Label
+    )
+
+    if (Test-Path -LiteralPath $Path -PathType Leaf) {
+        throw "$Label unexpectedly exists: $Path"
+    }
+}
+
+function Copy-ProjectFixture {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][string]$Destination
+    )
+
+    $source = Join-Path $fixturesRoot $Name
+    if (-not (Test-Path -LiteralPath $source -PathType Container)) {
+        throw "missing config-migration fixture: $source"
+    }
+    New-Item -ItemType Directory -Force -Path $Destination | Out-Null
+    Copy-Item -Path (Join-Path $source '*') -Destination $Destination -Recurse -Force
+    New-Item -ItemType Directory -Force -Path (Join-Path $Destination 'nested/work') | Out-Null
+}
+
+function Invoke-GoldenBuild {
+    param(
+        [Parameter(Mandatory = $true)][string]$WorkingDirectory,
+        [Parameter(Mandatory = $true)][string[]]$Arguments
+    )
+
+    $pwsh = (Get-Process -Id $PID).Path
+    $allArguments = @(
+        '-NoLogo',
+        '-NoProfile',
+        '-File',
+        $buildPs1
+    ) + $Arguments
+    return Invoke-Captured -FilePath $pwsh -WorkingDirectory $WorkingDirectory -Arguments $allArguments
+}
+
+function Invoke-NativeBuild {
+    param(
+        [Parameter(Mandatory = $true)][string]$WorkingDirectory,
+        [Parameter(Mandatory = $true)][string[]]$Arguments
+    )
+
+    return Invoke-Captured -FilePath $mqb -WorkingDirectory $WorkingDirectory -Arguments $Arguments
+}
+
+function Invoke-Program {
+    param(
+        [Parameter(Mandatory = $true)][string]$Executable,
+        [Parameter(Mandatory = $true)][string]$WorkingDirectory
+    )
+
+    return Invoke-Captured -FilePath $Executable -WorkingDirectory $WorkingDirectory -Arguments @()
+}
+
+$runRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("mqb-config-migration-parity-" + [Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Force -Path $runRoot | Out-Null
+
+try {
+    # Config-only parity. Both entry points start two levels below the project
+    # config, so success proves upward discovery plus config-relative include paths.
+    $configOnlyRoot = Join-Path $runRoot 'config-only'
+    $configOnlyPs = Join-Path $configOnlyRoot 'powershell'
+    $configOnlyCpp = Join-Path $configOnlyRoot 'cpp'
+    Copy-ProjectFixture -Name 'config_only' -Destination $configOnlyPs
+    Copy-ProjectFixture -Name 'config_only' -Destination $configOnlyCpp
+
+    $configOnlyPsWork = Join-Path $configOnlyPs 'nested/work'
+    $configOnlyCppWork = Join-Path $configOnlyCpp 'nested/work'
+    $relativeSource = '..\..\src\main.cpp'
+
+    $psConfigOnly = Invoke-GoldenBuild -WorkingDirectory $configOnlyPsWork -Arguments @($relativeSource)
+    $cppConfigOnly = Invoke-NativeBuild -WorkingDirectory $configOnlyCppWork -Arguments @(
+        $relativeSource, '--env', 'vs'
+    )
+    Assert-Success $psConfigOnly 'PowerShell config-only migration build'
+    Assert-Success $cppConfigOnly 'C++ config-only migration build'
+
+    $psConfigOnlyExe = Join-Path $configOnlyPsWork 'config_file.exe'
+    $cppConfigOnlyExe = Join-Path $configOnlyCpp '.mqb/bin/config_file.exe'
+    if (-not (Test-Path -LiteralPath $psConfigOnlyExe -PathType Leaf)) {
+        throw "PowerShell config output does not exist: $psConfigOnlyExe"
+    }
+    if (-not (Test-Path -LiteralPath $cppConfigOnlyExe -PathType Leaf)) {
+        throw "C++ config output does not exist: $cppConfigOnlyExe"
+    }
+
+    $psConfigOnlyRun = Invoke-Program -Executable $psConfigOnlyExe -WorkingDirectory $configOnlyPsWork
+    $cppConfigOnlyRun = Invoke-Program -Executable $cppConfigOnlyExe -WorkingDirectory $configOnlyCppWork
+    Assert-Success $psConfigOnlyRun 'PowerShell config-only migration program'
+    Assert-Success $cppConfigOnlyRun 'C++ config-only migration program'
+    $configOnlyExpected = 'config=release;define=41;include=31;std=17'
+    Assert-ContainsLine $psConfigOnlyRun $configOnlyExpected 'PowerShell config-only migration program'
+    Assert-ContainsLine $cppConfigOnlyRun $configOnlyExpected 'C++ config-only migration program'
+
+    # Scalar CLI precedence parity. The files deliberately request Release,
+    # static output, and a losing target name. CLI must override those scalars
+    # while config define/include/standard remain active and CLI define is additive.
+    $overrideRoot = Join-Path $runRoot 'cli-override'
+    $overridePs = Join-Path $overrideRoot 'powershell'
+    $overrideCpp = Join-Path $overrideRoot 'cpp'
+    Copy-ProjectFixture -Name 'cli_override' -Destination $overridePs
+    Copy-ProjectFixture -Name 'cli_override' -Destination $overrideCpp
+
+    $overridePsWork = Join-Path $overridePs 'nested/work'
+    $overrideCppWork = Join-Path $overrideCpp 'nested/work'
+
+    $psOverride = Invoke-GoldenBuild -WorkingDirectory $overridePsWork -Arguments @(
+        $relativeSource,
+        '-config', 'debug',
+        '-type', 'exe',
+        '-o', 'config_cli',
+        '-D', 'CLI_OVERRIDE=59'
+    )
+    $cppOverride = Invoke-NativeBuild -WorkingDirectory $overrideCppWork -Arguments @(
+        $relativeSource,
+        '--env', 'vs',
+        '--config', 'debug',
+        '--type', 'exe',
+        '-o', 'config_cli',
+        '-D', 'CLI_OVERRIDE=59'
+    )
+    Assert-Success $psOverride 'PowerShell config CLI-override build'
+    Assert-Success $cppOverride 'C++ config CLI-override build'
+
+    $psOverrideExe = Join-Path $overridePsWork 'config_cli.exe'
+    $cppOverrideExe = Join-Path $overrideCpp '.mqb/bin/config_cli.exe'
+    if (-not (Test-Path -LiteralPath $psOverrideExe -PathType Leaf)) {
+        throw "PowerShell CLI-override output does not exist: $psOverrideExe"
+    }
+    if (-not (Test-Path -LiteralPath $cppOverrideExe -PathType Leaf)) {
+        throw "C++ CLI-override output does not exist: $cppOverrideExe"
+    }
+
+    Assert-NotFile (Join-Path $overridePsWork 'should_not_win.lib') 'PowerShell losing config target'
+    Assert-NotFile (Join-Path $overrideCpp '.mqb/bin/should_not_win.lib') 'C++ losing config target'
+
+    $psOverrideRun = Invoke-Program -Executable $psOverrideExe -WorkingDirectory $overridePsWork
+    $cppOverrideRun = Invoke-Program -Executable $cppOverrideExe -WorkingDirectory $overrideCppWork
+    Assert-Success $psOverrideRun 'PowerShell config CLI-override program'
+    Assert-Success $cppOverrideRun 'C++ config CLI-override program'
+    $overrideExpected = 'config=debug;config_define=41;cli_define=59;include=31;std=17'
+    Assert-ContainsLine $psOverrideRun $overrideExpected 'PowerShell config CLI-override program'
+    Assert-ContainsLine $cppOverrideRun $overrideExpected 'C++ config CLI-override program'
+
+    Write-Host 'shared project-config migration parity passed'
+}
+finally {
+    Remove-Item -LiteralPath $runRoot -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+exit 0

--- a/docs/V5_CONFIG_MIGRATION.md
+++ b/docs/V5_CONFIG_MIGRATION.md
@@ -1,0 +1,117 @@
+# Stable v5 project-config migration: `msvc_list.json` -> `mqb.json`
+
+Stable v5 does not treat `mqb.json` as a renamed `msvc_list.json`. The native schema is strict, typed, and intentionally different. This document records the supported semantic mapping and the boundaries that require user review.
+
+## Direct semantic mapping
+
+| Legacy `msvc_list.json` | Native `mqb.json` | Migration status |
+| --- | --- | --- |
+| `config` | `build.configuration` | direct: `debug` / `release` |
+| `std` | `build.standard` | direct: `14` / `17` / `20` / `23` / `latest` |
+| `output` | `build.output` | direct target-name mapping; artifact directory changes |
+| `type` | `build.type` | direct for `exe` / `dll` / `static` |
+| `runtime` | `build.runtime` | direct for `MD` / `MDd` / `MT` / `MTd` |
+| `ltcg` | `build.ltcg` | direct boolean coupled LTCG policy |
+| `subsystem` | `build.subsystem` | direct for executable/DLL targets |
+| `defines` | `build.defines` | direct values; ordering caveat below |
+| `include` | `build.include_dirs` | direct paths; config-relative paths remain config-root-relative |
+| `libpath` | `build.library_dirs` | direct paths; config-relative paths remain config-root-relative |
+| `libs` | `build.libraries` | direct library names; ordering caveat below |
+| `flags` | `build.compiler_args` | direct raw argv values after reviewing tokenization |
+| `link_flags` | `build.linker_args` | direct raw argv values after reviewing tokenization |
+
+A minimal migrated file therefore looks like:
+
+```json
+{
+  "version": 1,
+  "build": {
+    "configuration": "release",
+    "standard": "17",
+    "type": "exe",
+    "output": "game",
+    "defines": ["GAME_BUILD=1"],
+    "include_dirs": ["include"]
+  }
+}
+```
+
+## Precedence contract
+
+Both implementations share the important scalar rule:
+
+```text
+explicit CLI scalar > project config scalar > built-in/preset default
+```
+
+The shared parity fixture validates this rather than only checking parser fields. A project file deliberately requests `release + static + output=should_not_win`; explicit CLI selects `debug + exe + output=config_cli`, and the resulting executable must run with Debug behavior while config-provided standard/define/include settings remain active.
+
+For native MQB, list-like values have one consistent rule:
+
+```text
+mqb.json entries first, then CLI entries
+```
+
+The legacy script is not uniform: `defines`, `flags`, and `link_flags` are config-first, while include paths, library paths, and libraries are assembled CLI-first before config entries. Migrating projects that rely on conflicting/order-sensitive list entries therefore requires manual review; stable v5 does not emulate inconsistent historical ordering.
+
+## Upward lookup and relative paths
+
+Legacy `build.ps1` searches for `msvc_list.json` starting at the invocation directory and walking upward for at most five levels. Native MQB searches upward for the nearest `mqb.json` until the filesystem root.
+
+Both treat relative paths stored in the discovered project file as relative to that file's directory. The shared fixture launches both tools from `nested/work`, two levels below the project file, and requires a header reachable only through the project-config include directory. This proves the common migration contract without pretending the search-depth limits are identical.
+
+## Intentional non-equivalences
+
+### Discovery excludes
+
+Legacy `exclude` is a filename-glob filter in the PowerShell smart-discovery path. Native `discovery.exclude_dirs`, `discovery.extra_sources`, and `discovery.exclude_sources` are strict path-oriented corrections. Do not mechanically rename `exclude`; translate the intended source topology explicitly.
+
+### Long-tail compiler/linker policy
+
+The following legacy fields do not have a one-for-one typed `mqb.json` v1 field:
+
+- `optimize`
+- `warnings`
+- `WX`
+- `debug_info`
+- `exceptions`
+- `rtc1`
+- `jmc`
+- `sdl`
+- `permissive`
+- `fp`
+- `charset`
+- `incremental`
+
+Some are already represented by native Debug/Release defaults; others can be expressed through `build.compiler_args` or `build.linker_args`. They should be migrated intentionally rather than silently copied. Typed runtime, LTCG, subsystem, target kind, and architecture should use their native typed fields where available.
+
+### Architecture
+
+Legacy project config has no equivalent typed architecture field in the established schema: the script defaults to x64 and exposes `-x86` as a command switch. Native `mqb.json` supports `build.architecture: "x64" | "x86"`. Choose the native field explicitly if architecture belongs to project policy.
+
+### Output layout
+
+Legacy project output is placed in the invocation working directory. Native project output belongs to the project-root `.mqb/bin/` layout. Stable-v5 parity requires the same target behavior, not byte-for-byte artifact paths.
+
+### Environment preference
+
+Legacy `-env` / `.msvc_build_env` is a persistent preference mechanism and is not a project-config field equivalent to native invocation-scoped `--env`. The stable migration keeps that distinction explicit.
+
+## Shared parity fixture
+
+`cpp/tests/parity/shared_config_migration.ps1` owns two paired scenarios, each containing both schemas while each implementation reads only its own file:
+
+1. **config-only** — upward lookup plus config-relative include path; configuration selects Release, C++17, executable target, output name, define, and include directory.
+2. **CLI override** — project files request Release/static/a losing output name; CLI overrides those scalars to Debug/executable/a new output while config standard/define/include and an additive CLI define remain observable in the running program.
+
+The fixture deliberately does not compare artifact directories, log wording, cache formats, legacy list-order quirks, or discovery-exclude syntax.
+
+## Migration checklist
+
+1. Create `mqb.json` with `"version": 1`.
+2. Move direct scalar/list mappings using the table above.
+3. Convert discovery intent to native path-oriented fields instead of renaming `exclude`.
+4. Review order-sensitive include/library/flag lists.
+5. Review long-tail legacy policy and keep only policy still required, using typed native fields first and raw argv only where necessary.
+6. Validate from the same subdirectory users normally invoke the build from.
+7. Confirm the resulting target behavior and the new `.mqb/bin` artifact location before removing `msvc_list.json`.

--- a/docs/V5_PARITY.md
+++ b/docs/V5_PARITY.md
@@ -35,7 +35,7 @@ Status meanings:
 | `-std` | `--std`; legacy `-std` accepts 14/17/20/23/latest | **compat** |
 | `-type exe/dll/static` | `--type exe/dll/static`; legacy `-type` accepted; same typed target kind is available in `mqb.json` | **compat** |
 | `-x86` | `--x86`; legacy spelling accepted | **compat** |
-| default x64 | `--x64` / x64 default; legacy `-x64` accepted | **compat** |
+| default x64 | PowerShell has no `-x64` switch: x64 is implicit. Native is also x64 by default and supports explicit `--x64` (plus parser-compatible `-x64`) | **ready**; real shared architecture parity is covered in #42 |
 | `-I`, `-include` | `-I`; legacy `-include` accepted | **compat** |
 | `-L`, `-libpath` | `-L`, `--lib-path`; legacy `-libpath` accepted | **compat** |
 | `-libs` | `-l`, `--lib`; legacy `-libs <value>` accepted and repeatable | **compat** for scalar/repeated values; shell-array tokenization is not emulated |
@@ -94,17 +94,19 @@ Typed LTCG is a single coupled policy, not two user-maintained raw lists. Enabli
 
 | Legacy behavior | Native C++ status | Stable-v5 decision |
 | --- | --- | --- |
-| `msvc_list.json`, upward search up to five levels | native uses nearest upward `mqb.json` | **migrate** to `mqb.json`; provide upgrade guidance/tooling rather than keeping two authoritative schemas forever |
-| CLI overrides scalar config | ready, including type/runtime/LTCG/subsystem | **ready** |
-| additive list precedence | config lists first, CLI lists append | **ready** |
-| 14/17/20/23/latest standard config | ready | **ready** |
-| target-kind config | strict `build.type` supports `exe`/`dll`/`static` (`lib` alias accepted); real static config routing and CLI target-kind precedence are covered | **ready** |
+| `msvc_list.json`, upward search up to five levels | nearest-upward strict `mqb.json`; paired config-only + CLI-override shared fixtures validate semantic migration | **migrate** to `mqb.json` using `V5_CONFIG_MIGRATION.md`; do not keep two authoritative schemas |
+| CLI overrides scalar config | paired Golden/native fixture validates Release/static/losing-output config overridden by Debug/exe/new-output CLI while untouched config values remain active | **ready** |
+| additive list precedence | native consistently applies config entries before CLI entries; legacy ordering differs by field (notably include/libpath/libs are CLI-first) | **migrate ordering semantics**; review order-sensitive lists rather than emulating the inconsistency |
+| 14/17/20/23/latest standard config | ready; paired migration fixture validates C++17 through `_MSVC_LANG` | **ready** |
+| target-kind config | strict `build.type` supports `exe`/`dll`/`static` (`lib` alias accepted); real static config routing and paired CLI target-kind precedence are covered | **ready** |
 | runtime/subsystem config | typed strict-schema fields with real cache-invalidation E2E | **ready** |
 | LTCG config | strict boolean `build.ltcg`; CLI `--ltcg`/`--no-ltcg` precedence and real executable/static E2E | **ready** |
-| include/lib/define/library config | ready in `mqb.json` | **ready** |
-| `compiler_args` / `linker_args` | ready in strict `mqb.json` v1 schema | **ready** |
-| source discovery excludes | ready with the native discovery schema | **ready** |
+| include/lib/define/library config | native fields are ready; paired migration fixture validates config-relative include + config define and additive CLI define | **ready**, subject to list-order migration above |
+| `compiler_args` / `linker_args` | ready in strict `mqb.json` v1 schema | **ready** after argv/tokenization review during migration |
+| legacy `exclude` discovery glob | native has strict path-oriented `exclude_dirs` / `extra_sources` / `exclude_sources`; semantics are intentionally different | **migrate** discovery intent explicitly; do not mechanically rename the field |
 | legacy config keys for remaining coupled policies | no remaining high-value coupled policy is accepted by default solely through raw-list synchronization | **implement** only when parity fixtures prove another typed policy is required |
+
+The authoritative field mapping, search-depth difference, list-order caveat, discovery conversion, long-tail policy review, architecture difference, and output-layout change are documented in `docs/V5_CONFIG_MIGRATION.md`. The paired fixture starts both implementations from `nested/work`, so config discovery and config-root-relative include resolution are exercised rather than inferred from parser unit tests.
 
 ## Toolchain/environment behavior
 
@@ -145,6 +147,6 @@ Project-local named modules and project-local header units are in the RC/stable-
 8. Native DLL target kind with typed linker routing, deterministic import library, and side-output repair. **Done in #35.**
 9. Static-library target with an explicit `lib.exe`/librarian backend, archive cache owner, strict `mqb.json` target kind, and real CLI/config consumer coverage. **Done in #36 + #37.**
 10. Close the high-value coupled MSVC LTCG gap with typed `/GL` + downstream `/LTCG`, config/CLI precedence, cache identities, and real executable/static E2E. **Done in #39.** Charset remains evidence-driven rather than an automatic typed-surface requirement.
-11. Shared PowerShell-vs-C++ fixtures for ordinary targets, config precedence, incremental rebuilds, libraries, run argv, x86/x64, Debug/Release, and failure behavior. **Harness foundation in #40:** same committed fixtures run through isolated PowerShell/C++ sandboxes with observable-result comparison; initial single-TU, explicit multi-TU, Debug, and Release scenarios are covered. Config/incremental/libraries/run argv/x86/x64/failure scenarios remain follow-up slices.
+11. Shared PowerShell-vs-C++ observable parity. **Completed through #40 + #41 + #42 + #43:** #40 established same-fixture isolated sandboxes and single/multi-TU + Debug/Release; #41 added warm no-op/source-mutation incremental behavior and shared simple-token run argv; #42 added static-library producer/consumer, default-x64/x86, and compile-failure behavior; #43 adds paired `msvc_list.json` -> `mqb.json` project-config discovery/mapping and scalar CLI precedence. Additional parity work should now be evidence-driven by cutover findings rather than expanding the matrix speculatively.
 12. Installer/profile/`build` command cutover and clean-machine upgrade/rollback validation.
 13. Generalize the release workflow and publish stable v5 only from the exact validated artifact.


### PR DESCRIPTION
## Stable-v5 config migration parity

This PR validates semantic migration from legacy `msvc_list.json` to strict native `mqb.json` without pretending the schemas are source-compatible.

### Paired fixture model

Each sandbox contains both project files. The PowerShell Golden Reference reads only `msvc_list.json`; native MQB reads only `mqb.json`. Both builds are launched from `nested/work`, two levels below the project root.

This directly validates upward project-config discovery, config-relative include paths, Release/Debug configuration, C++ standard, target kind, output name, config defines, additive CLI defines, and scalar CLI precedence over project config.

### Scenario 1: config-only

Both schemas select Release + C++17 + executable target + `config_file` output + a config define + a config-relative include directory. The source checks `_MSVC_LANG`, `NDEBUG`, the config macro, and a header that is only reachable through the project config.

Both programs expose:

`config=release;define=41;include=31;std=17`

Artifact directories intentionally differ: legacy output stays in the invocation working directory, while native output stays under project-root `.mqb/bin`.

### Scenario 2: CLI scalar override

Both project files deliberately request Release + static + `output=should_not_win`. CLI overrides those scalars to Debug + executable + `output=config_cli`, while project standard/define/include remain active and an additional CLI define is visible.

Both programs expose:

`config=debug;config_define=41;cli_define=59;include=31;std=17`

The losing config `.lib` target is not produced.

### Explicit migration boundaries

`docs/V5_CONFIG_MIGRATION.md` records the direct field mapping and intentionally non-equivalent behavior:

- legacy upward search is capped at five levels; native searches to filesystem root;
- native list precedence is uniformly config entries then CLI entries, while legacy ordering differs by field;
- legacy `exclude` filename glob is not source-compatible with native path-oriented discovery corrections;
- long-tail legacy policy such as optimize/warnings/debug-info/charset/incremental requires manual typed/raw-policy review;
- architecture and environment-preference semantics are intentionally different;
- output layout is behaviorally equivalent, not path-identical.

`docs/V5_PARITY.md` is synchronized with the cumulative #40/#41/#42/#43 campaign, corrects the old implication that PowerShell had a `-x64` switch (it only defaults to x64), and records the config list-order migration boundary.

### CI

The `Shared PowerShell C++ Parity` Debug/Release matrix now runs cumulatively:

1. incremental + run argv (#41);
2. library + architecture + failure (#42);
3. project-config migration parity (#43).

C++ V2 and Release Candidate remain independent baseline gates.

### Validation

Exact final head: `d4f1bc6de61b9348d0d7d53c0bc59c603530d6db`.

- **Shared PowerShell C++ Parity #9:** Debug success + Release success; all three cumulative parity slices passed on both configurations.
- **C++ V2 #339:** success on the exact head.
- **C++ Release Candidate #105:** success on the exact head, including Release tests, embedded `5.0.0-rc.2` verification, package staging, checksum, and artifact upload; PR publish remained skipped as designed.
- No unresolved review threads.

The functional-only predecessor head `131da48b...` had already passed Shared Parity #8; the final head reran all authoritative gates after central documentation synchronization.

### Resulting stable-v5 boundary

The planned ordinary-target PowerShell↔C++ shared parity campaign is now covered through single/multi-TU, Debug/Release, incremental no-op/source mutation, simple-token run argv, static-library producer/consumer, x64/x86, compile failure, and paired project-config migration. Further parity additions should be evidence-driven by installer/cutover findings rather than speculative matrix growth.