### PR TITLE
feat: cut over installer and build entry to native mqb

### DIFF
--- a/.github/workflows/cpp-v2.yml
+++ b/.github/workflows/cpp-v2.yml
@@ -12,9 +12,16 @@ on:
       - 'README.md'
       - 'docs/CPP_V2_ARCHITECTURE.md'
       - 'docs/MQB_CONFIG.md'
+      - 'docs/V5_INSTALL_CUTOVER.md'
+      - 'install.bat'
+      - 'install.ps1'
+      - 'uninstall.ps1'
+      - 'Microsoft.PowerShell_profile.ps1'
+      - 'tests/installer/**'
       - 'release/**'
       - '.github/workflows/cpp-v2.yml'
       - '.github/workflows/cpp-release.yml'
+      - '.github/workflows/install-cutover.yml'
 
 jobs:
   build-and-test:

--- a/.github/workflows/install-cutover.yml
+++ b/.github/workflows/install-cutover.yml
@@ -1,0 +1,53 @@
+name: Installer Cutover
+
+on:
+  pull_request:
+    paths:
+      - 'install.bat'
+      - 'install.ps1'
+      - 'uninstall.ps1'
+      - 'Microsoft.PowerShell_profile.ps1'
+      - 'build.ps1'
+      - 'tests/installer/**'
+      - 'docs/V5_INSTALL_CUTOVER.md'
+      - 'README.md'
+      - '.github/workflows/install-cutover.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'install.bat'
+      - 'install.ps1'
+      - 'uninstall.ps1'
+      - 'Microsoft.PowerShell_profile.ps1'
+      - 'build.ps1'
+      - 'tests/installer/**'
+      - 'docs/V5_INSTALL_CUTOVER.md'
+      - 'README.md'
+      - '.github/workflows/install-cutover.yml'
+
+jobs:
+  clean-upgrade-rollback:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Configure Release mqb
+        shell: pwsh
+        run: |
+          cmake -S cpp -B cpp/build-installer `
+            -G "Visual Studio 18 2026" -A x64 `
+            -DMQB_ENABLE_INSTALLED_MSVC_TESTS=OFF
+
+      - name: Build Release mqb
+        run: cmake --build cpp/build-installer --config Release --target mqb --parallel
+
+      - name: Validate clean install upgrade rollback
+        shell: pwsh
+        run: |
+          $mqb = Join-Path $PWD 'cpp/build-installer/apps/mqb/Release/mqb.exe'
+          & (Join-Path $PWD 'tests/installer/installer_cutover.ps1') `
+            -MqbPath $mqb `
+            -RepoRoot $PWD

--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -1,8 +1,5 @@
-$OutputEncoding = [console]::InputEncoding = [console]::OutputEncoding = New-Object System.Text.UTF8Encoding
+# MQB stable-v5 compatibility fragment for manual profile setup.
+# The installer no longer overwrites user profiles; it merges an equivalent managed block only when needed.
 function build {
-    if (Get-Command pwsh.exe -ErrorAction SilentlyContinue) {
-        & pwsh.exe -NoProfile -File "$HOME\bin\build.ps1" @args
-    } else {
-        & "$HOME\bin\build.ps1" @args
-    }
+    & "$HOME\bin\mqb.exe" @args
 }

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 > **当前迁移状态**
 >
 > - `cpp/` 中的 **C++23 重构版 (`mqb.exe`)** 已具备普通 C/C++、project-local named modules 与 project-local header units 的端到端构建链，并由 Visual Studio 2026 真实工具链 E2E 持续验证。
-> - `v5.0.0-rc.2` 是 C++ 重构版的第二个可分发 Release Candidate；它新增原生 `.c`、typed runtime/subsystem CLI 与 `mqb.json` policy，**尚不代表 PowerShell → C++ 的最终 cutover**。
-> - **当前 `main` 已领先于 rc.2**：普通 C/C++ 目标已具备 typed `exe` / `dll` / `static` 输出，以及耦合的 typed LTCG（compile `/GL` + downstream `/LTCG`）；CLI 与 strict `mqb.json` 都可表达这些 policy。这些能力尚未作为新的 prerelease 发布。
-> - `build.ps1` 仍保留为 **PowerShell Golden Reference / 过渡期稳定入口**；现有 `install.bat` 和 PowerShell profile 不会被 RC 静默替换。
+> - `v5.0.0-rc.2` 是 C++ 重构版的第二个已发布 Release Candidate；它**不包含**后续 mainline 的最终 installer/default-entry cutover。
+> - **当前 `main` 已领先于 rc.2**：普通 C/C++ 目标已具备 typed `exe` / `dll` / `static`、typed LTCG，以及完成的 PowerShell ↔ C++ shared parity campaign；stable-v5 安装入口也已切换为 native `mqb.exe`，同时保留 `build` compatibility shim 与明确 rollback 路径。这些 post-rc.2 能力尚未作为正式 stable 包发布。
+> - `build.ps1` 继续保留为 **PowerShell Golden Reference / rollback implementation**，但不再是新的 stable-v5 安装默认入口。
 > - MQB 不宣称与 MSBuild “1:1 等价”。当前原则是：显式建模已支持的常用 MSVC 语义，并用真实编译器回归测试证明行为。
 
 ## v5.0.0-rc.2 C++ Release Candidate
@@ -38,7 +38,7 @@ MQB 5.0.0-rc.2 - MSVC Quick Build (C++ refactor)
 
 发布二进制使用静态 MSVC runtime，避免要求用户额外安装 Visual C++ Redistributable。Release Candidate 的完整边界见 [`release/v5.0.0-rc.2.md`](release/v5.0.0-rc.2.md)。
 
-> 本节描述**已发布的 rc.2 包**。下面“现在能做什么”描述的是**当前仓库 mainline**，因此会包含 rc.2 之后已经合入但尚未重新发布的能力。
+> 本节描述**已发布的 rc.2 包**。下面“现在能做什么”和 stable-v5 cutover 说明描述的是**当前仓库 mainline**，因此会包含 rc.2 之后已经合入但尚未重新发布的能力。
 
 ---
 
@@ -70,9 +70,9 @@ MQB 5.0.0-rc.2 - MSVC Quick Build (C++ refactor)
 - external / prebuilt named-module providers；
 - `import std;`；
 - 需要 named-module / header-unit pipeline 的 static-library target（普通 C/C++ static target 已支持）；
-- 将当前 C++ mainline 宣称为 PowerShell 版本的完整行为替代品。
+- 将 native v5 宣称为旧 PowerShell / MSBuild 的无差异完整行为复制品；稳定边界以 `docs/V5_PARITY.md` 中已测试的 compat/migration 分类为准。
 
-Modules 剩余扩展策略跟踪在 Issue #16；最终 stable v5 还需要 PowerShell ↔ C++ parity / installer / default-entry cutover 的独立验收。
+Modules 剩余扩展策略跟踪在 Issue #16；stable-v5 的普通目标 parity 与 installer/default-entry cutover 已完成，剩余发布门主要是 stable release workflow generalization 与 exact-artifact publication。
 
 ---
 
@@ -86,7 +86,7 @@ cmake --build cpp/build --config Release --target mqb
 .\cpp\build\apps\mqb\Release\mqb.exe --help
 ```
 
-默认开发构建版本为 `5.0.0-dev`。发布流水线会显式传入 `-DMQB_VERSION=5.0.0-rc.2`，因此开发二进制不会冒充已发布版本。
+默认开发构建版本为 `5.0.0-dev`。当前 RC 发布流水线仍显式传入 `-DMQB_VERSION=5.0.0-rc.2`，因此开发二进制不会冒充已发布版本；stable workflow generalization 会在正式 `v5.0.0` 发布前独立收口。
 
 ### 运行完整测试
 
@@ -265,7 +265,7 @@ C++ 重构版使用根目录 `mqb.json`，不是 PowerShell 版本的 `msvc_list
 }
 ```
 
-MQB 从 invocation directory 向上查找最近的 `mqb.json`；配置文件所在目录成为 project root 和 `.mqb/` 根。`build.type` 支持 `exe` / `dll` / `static`（以及 `executable` / `dynamic` / `lib` aliases）；`build.ltcg` 是 strict boolean typed policy。完整 schema、路径基准、precedence 与 cache 行为见 [`docs/MQB_CONFIG.md`](docs/MQB_CONFIG.md)。
+MQB 从 invocation directory 向上查找最近的 `mqb.json`；配置文件所在目录成为 project root 和 `.mqb/` 根。`build.type` 支持 `exe` / `dll` / `static`（以及 `executable` / `dynamic` / `lib` aliases）；`build.ltcg` 是 strict boolean typed policy。完整 schema、路径基准、precedence 与 cache 行为见 [`docs/MQB_CONFIG.md`](docs/MQB_CONFIG.md)。PowerShell `msvc_list.json` → native `mqb.json` 的迁移边界与 paired parity 见 [`docs/V5_CONFIG_MIGRATION.md`](docs/V5_CONFIG_MIGRATION.md)。
 
 ---
 
@@ -346,24 +346,53 @@ Optional executable run
 
 ---
 
-## PowerShell Golden Reference（过渡期）
+## Stable-v5 installer / PowerShell Golden Reference
 
-根目录的 `build.ps1`、`install.bat`、`Microsoft.PowerShell_profile.ps1` 仍属于旧 PowerShell 实现。它们继续保持已有用户的稳定入口、作为 C++ 迁移 Golden Reference，并支撑后续 parity campaign。
+当前 mainline 的安装默认入口已经切到 native `mqb.exe`：
 
-**`v5.0.0-rc.2` 不修改这套安装入口。** RC 用户应直接解压 `mqb.exe` 并自行加入 PATH；在 stable v5 的 parity/cutover 通过之前，不应把 `install.bat` 理解为 C++ `mqb.exe` 的安装器。
+```powershell
+.\install.bat
+```
 
-旧 `msvc_list.json` / PowerShell 参数体系也不等于 C++ 的 `mqb.json` schema；不要混用两套配置契约。
+默认安装根仍是 `%USERPROFILE%\bin`。安装后：
+
+- `mqb` 是 canonical 命令；
+- `build` 由 `build.cmd` 作为 compatibility shim 直接转发到 `mqb.exe`；
+- 安装器只在需要迁移已知 legacy profile 时添加带 marker 的受控 block，不再覆盖整个 PowerShell profile；
+- 安装器不会覆盖或删除已有 `%USERPROFILE%\bin\build.ps1`；升级时会保留 `build-legacy.ps1` 供 rollback；
+- user PATH 只在缺失时添加，并记录 ownership；uninstall / rollback 只撤销 v5 自己拥有的状态。
+
+显式卸载：
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass `
+  -File "$HOME\bin\uninstall-mqb.ps1"
+```
+
+回滚到 PowerShell Golden Reference：
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass `
+  -File "$HOME\bin\uninstall-mqb.ps1" `
+  -RestoreLegacy
+```
+
+根目录的 `build.ps1` 继续作为 shared parity 的 PowerShell Golden Reference；它被保留用于迁移验证和 rollback，而不是新的 stable-v5 默认执行路径。
+
+完整安装、profile ownership、PATH ownership、clean install、upgrade 与 rollback 契约见 [`docs/V5_INSTALL_CUTOVER.md`](docs/V5_INSTALL_CUTOVER.md)。
+
+> **发布边界：** 已发布的 `v5.0.0-rc.2` 仍是 standalone C++ candidate，并不包含上述 post-rc.2 installer cutover。正式 stable `v5.0.0` 必须由后续 generalized release workflow 把**同一份已验证 binary + installer files**打包并发布。
 
 ---
 
 ## 当前路线
 
-- **已发布 `v5.0.0-rc.2`**：交付原生 C translation units 与 typed runtime/subsystem policy 的 C++ standalone candidate；
-- **当前 mainline**：普通 C/C++ `exe` / `dll` / `static` typed target-kind parity 与 typed LTCG 已完成，CLI + strict `mqb.json` + compile/link/archive identity + 真实 MSVC executable/static consumer E2E 已合入，但尚未重新发布；
-- **下一主线**：shared PowerShell ↔ C++ parity fixtures/harness，用同一批 observable fixtures 对照普通目标、config precedence、incremental rebuild、libraries、run argv、x86/x64、Debug/Release 与失败行为；
-- **随后**：installer/profile/default-entry cutover → stable release workflow generalization；
+- **已发布 `v5.0.0-rc.2`**：保留为已验证的 standalone C++ Release Candidate，不追写 post-rc.2 installer 能力；
+- **shared parity campaign**：single/multi-TU、Debug/Release、incremental no-op/source mutation、run argv、static library consumer、x64/x86、compile failure、`msvc_list.json` → `mqb.json` config migration 已完成；
+- **installer/profile/default-entry cutover**：当前 mainline 已切换到 native `mqb.exe` + `build.cmd` compatibility shim，并具备 clean install / legacy upgrade / uninstall / rollback Windows gate；
+- **下一主线**：generalize stable release workflow，打包经过同一 gate 验证的 binary + installer/rollback files，补 stable migration/release notes，并从 exact artifact 发布 `v5.0.0`；
 - **Issue #16**：独立继续 external/prebuilt named-module providers 与 `import std`；
-- 满足 stable gate 后，从**同一份已验证 artifact** 发布正式 `v5.0.0`，再逐步收缩 PowerShell Golden Reference。
+- stable 发布后再逐步收缩 PowerShell Golden Reference，同时保留 v4.x → v5 的历史迁移指导。
 
 ## License
 

--- a/docs/V5_INSTALL_CUTOVER.md
+++ b/docs/V5_INSTALL_CUTOVER.md
@@ -1,0 +1,141 @@
+# Stable v5 installer / default-entry cutover
+
+This document defines the Windows install and rollback contract for the stable-v5 C++ cutover.
+
+## Installed command layout
+
+The canonical stable command is:
+
+```text
+mqb
+```
+
+For users upgrading from the PowerShell release line, stable v5 also installs:
+
+```text
+build
+```
+
+`build` is a compatibility shim that forwards argv directly to `mqb.exe`. It is not a second PowerShell execution path. Legacy spellings already classified as compatible in `docs/V5_PARITY.md` continue to be parsed by the C++ CLI; intentionally migrated semantics such as structured program argv remain migrations rather than hidden emulation.
+
+The default per-user install root remains:
+
+```text
+%USERPROFILE%\bin
+```
+
+This preserves the location used by the old installer while allowing both `mqb.exe` and `build.cmd` to work in PowerShell, cmd.exe, and other shells once that directory is on the user PATH.
+
+## What the installer deploys
+
+A stable package installs or maintains these files under the install root:
+
+```text
+mqb.exe
+build.cmd
+build-legacy.ps1
+mqb-install.ps1
+uninstall-mqb.ps1
+mqb-install-state.json
+```
+
+`build.ps1` from an existing PowerShell installation is never overwritten or deleted by the v5 cutover.
+
+When upgrading from the legacy line, the first v5 install copies the existing installed `build.ps1` to `build-legacy.ps1`. On a clean install, the package Golden Reference is copied there instead. This makes rollback available without making PowerShell the default implementation.
+
+## PowerShell profile policy
+
+The old installer copied `Microsoft.PowerShell_profile.ps1` over the user's complete Windows PowerShell and PowerShell 7 profiles.
+
+Stable v5 must not do that.
+
+The new installer:
+
+1. leaves unrelated profile files untouched;
+2. recognizes the known legacy `build` function that invokes `%USERPROFILE%\bin\build.ps1`;
+3. appends a clearly delimited MQB-managed block after that function so `build` resolves to the installed `mqb.exe`;
+4. updates only that managed block on reinstall;
+5. leaves unrelated custom `build` functions alone and emits a warning rather than silently taking ownership.
+
+Clean installations do not need a PowerShell function at all: `mqb.exe` and `build.cmd` are shell-neutral commands through PATH.
+
+Managed blocks are delimited by:
+
+```text
+# >>> MQB v5 C++ default >>>
+# <<< MQB v5 C++ default <<<
+```
+
+Rollback uses a separate explicit legacy block:
+
+```text
+# >>> MQB v5 legacy rollback >>>
+# <<< MQB v5 legacy rollback <<<
+```
+
+## PATH ownership
+
+The installer adds the install root to the **current user's** PATH only when it is not already present.
+
+`mqb-install-state.json` records whether the v5 installer added that PATH entry. Uninstall and rollback remove the entry only when v5 owns it; a pre-existing user PATH entry is not removed.
+
+Reinstall is idempotent and must not duplicate the PATH entry.
+
+## Install
+
+A packaged stable build contains `mqb.exe` next to `install.bat` / `install.ps1`.
+
+```powershell
+.\install.bat
+```
+
+`install.bat` is now a non-interactive wrapper around Windows PowerShell. It does not change the user's execution policy and it no longer prompts for or extracts `portable_msvc.zip`.
+
+The PowerShell implementation is also directly callable:
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\install.ps1 -Action Install
+```
+
+For source-tree validation, `-MqbPath` can select an already-built `mqb.exe`.
+
+## Uninstall
+
+The installed maintenance entry is:
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass `
+  -File "$HOME\bin\uninstall-mqb.ps1"
+```
+
+Uninstall removes the C++ binary, `build.cmd`, MQB-managed profile blocks, and installer-owned PATH state. Pre-existing legacy `build.ps1` and unrelated profile content remain untouched.
+
+## Roll back to the PowerShell Golden Reference
+
+Use:
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass `
+  -File "$HOME\bin\uninstall-mqb.ps1" `
+  -RestoreLegacy
+```
+
+Rollback removes the C++ default entry and its installer-owned PATH entry, preserves `build-legacy.ps1`, and installs an explicit profile fallback when necessary.
+
+For an upgraded machine that still has the original `%USERPROFILE%\bin\build.ps1`, rollback points to that prior installed implementation. For a clean stable-v5 install, rollback points to `build-legacy.ps1` copied from the package Golden Reference.
+
+## CI acceptance
+
+`.github/workflows/install-cutover.yml` builds a Release `mqb.exe` on Windows and exercises all of the following against isolated install/profile directories:
+
+- clean install through `install.bat`;
+- deployed `mqb.exe` and `build.cmd` expose the same `--help` identity;
+- unrelated profiles are not overwritten;
+- user PATH insertion is idempotent and installer-owned;
+- uninstall removes only v5-owned state;
+- upgrade from a seeded PowerShell `build.ps1` + legacy profile preserves the original script and user profile content;
+- the upgraded PowerShell `build` function resolves to `mqb.exe`;
+- rollback removes the C++ default, preserves the old script, and restores a legacy `build` entry;
+- a clean install can also roll back using the packaged Golden Reference.
+
+This is the installer/default-entry gate required by issue #26. Stable release publication remains a separate follow-up and must package these validated installer files with the exact tested stable binary.

--- a/install.bat
+++ b/install.bat
@@ -1,51 +1,24 @@
 @echo off
-echo ========================================
-echo   VS Code MSVC 快速编译工具 - 安装向导
-echo ========================================
-echo.
+setlocal
+set "SCRIPT_DIR=%~dp0"
 
-set "BIN_DIR=%USERPROFILE%\bin"
-set "PS4_DIR=%USERPROFILE%\Documents\WindowsPowerShell"
-set "PS7_DIR=%USERPROFILE%\Documents\PowerShell"
-
-echo [1/3] 创建目录结构...
-if not exist "%BIN_DIR%" mkdir "%BIN_DIR%"
-if not exist "%PS4_DIR%" mkdir "%PS4_DIR%"
-if not exist "%PS7_DIR%" mkdir "%PS7_DIR%"
-
-echo [2/3] 部署脚本文件...
-powershell -NoProfile -Command "Set-ExecutionPolicy RemoteSigned -Scope CurrentUser -Force" >nul 2>&1
-copy /Y "build.ps1" "%BIN_DIR%\build.ps1" >nul
-copy /Y "Microsoft.PowerShell_profile.ps1" "%PS4_DIR%\Microsoft.PowerShell_profile.ps1" >nul
-copy /Y "Microsoft.PowerShell_profile.ps1" "%PS7_DIR%\Microsoft.PowerShell_profile.ps1" >nul
-echo 脚本部署完毕。
-echo.
-
-echo [3/3] 便携版工具链 (可选)
-echo 如果您没有安装 Visual Studio，可以解压自带的编译器。
-echo 如果按 y，请耐心等待解压完成。
-set /p "UNZIP=是否解压 portable_msvc.zip? [y/N]: "
-
-if /I "%UNZIP%"=="y" (
-    if exist "portable_msvc.zip" (
-        echo.
-        echo 正在解压 portable_msvc.zip ...
-        if not exist "%BIN_DIR%\portable_msvc" mkdir "%BIN_DIR%\portable_msvc"
-        tar -xf portable_msvc.zip -C "%BIN_DIR%\portable_msvc"
-        if errorlevel 1 (
-            echo 原生解压失败，用 PowerShell 解压...
-            powershell -NoProfile -Command "Expand-Archive -Force 'portable_msvc.zip' '%BIN_DIR%\portable_msvc'"
-        )
-        echo 解压完成！
-    ) else (
-        echo 未找到 portable_msvc.zip
-    )
-) else (
-    echo 已跳过解压。
+where powershell.exe >nul 2>&1
+if errorlevel 1 (
+    echo [MQB] Windows PowerShell was not found.
+    exit /b 1
 )
 
-echo.
-echo ========================================
-echo 安装完成！请重启终端后输入 build 测试。
-echo ========================================
-pause
+if not exist "%SCRIPT_DIR%install.ps1" (
+    echo [MQB] install.ps1 was not found next to install.bat.
+    exit /b 1
+)
+
+powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File "%SCRIPT_DIR%install.ps1" -Action Install %*
+set "RC=%ERRORLEVEL%"
+if not "%RC%"=="0" (
+    echo [MQB] Installation failed with exit code %RC%.
+    exit /b %RC%
+)
+
+echo [MQB] Installation succeeded.
+exit /b 0

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,471 @@
+[CmdletBinding()]
+param(
+    [ValidateSet('Install', 'Uninstall', 'Rollback')]
+    [string]$Action = 'Install',
+
+    [string]$MqbPath,
+    [string]$LegacyBuildPath,
+    [string]$InstallRoot = (Join-Path $HOME 'bin'),
+    [string[]]$ProfilePaths,
+    [switch]$SkipUserPath
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+$CppMarkerStart = '# >>> MQB v5 C++ default >>>'
+$CppMarkerEnd = '# <<< MQB v5 C++ default <<<'
+$LegacyMarkerStart = '# >>> MQB v5 legacy rollback >>>'
+$LegacyMarkerEnd = '# <<< MQB v5 legacy rollback <<<'
+
+function Get-FullPath {
+    param([Parameter(Mandatory = $true)][string]$Path)
+    return [System.IO.Path]::GetFullPath($Path)
+}
+
+function Get-DefaultProfilePaths {
+    $documents = [Environment]::GetFolderPath('MyDocuments')
+    if ([string]::IsNullOrWhiteSpace($documents)) {
+        $documents = Join-Path $HOME 'Documents'
+    }
+    return @(
+        (Join-Path $documents 'WindowsPowerShell\Microsoft.PowerShell_profile.ps1'),
+        (Join-Path $documents 'PowerShell\Microsoft.PowerShell_profile.ps1')
+    )
+}
+
+function ConvertTo-SingleQuotedLiteral {
+    param([Parameter(Mandatory = $true)][string]$Value)
+    return "'" + $Value.Replace("'", "''") + "'"
+}
+
+function Remove-ManagedBlock {
+    param(
+        [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Content,
+        [Parameter(Mandatory = $true)][string]$StartMarker,
+        [Parameter(Mandatory = $true)][string]$EndMarker
+    )
+    $pattern = '(?ms)^[ \t]*' + [regex]::Escape($StartMarker) + '[ \t]*\r?\n.*?^[ \t]*' +
+        [regex]::Escape($EndMarker) + '[ \t]*(?:\r?\n)?'
+    return [regex]::Replace($Content, $pattern, '')
+}
+
+function Add-ManagedBlock {
+    param(
+        [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Content,
+        [Parameter(Mandatory = $true)][string]$Block
+    )
+    $trimmed = $Content.TrimEnd()
+    if ($trimmed.Length -eq 0) {
+        return $Block.TrimEnd() + [Environment]::NewLine
+    }
+    return $trimmed + [Environment]::NewLine + [Environment]::NewLine + $Block.TrimEnd() + [Environment]::NewLine
+}
+
+function Test-RecognizedLegacyBuildFunction {
+    param([Parameter(Mandatory = $true)][AllowEmptyString()][string]$Content)
+    return (
+        $Content -match '(?is)function\s+(?:global:)?build\s*\{.*?(?:\$HOME|%USERPROFILE%|USERPROFILE).*?bin[\\/]+build\.ps1'
+    )
+}
+
+function Test-AnyBuildFunction {
+    param([Parameter(Mandatory = $true)][AllowEmptyString()][string]$Content)
+    return ($Content -match '(?im)^[ \t]*function\s+(?:global:)?build\b')
+}
+
+function New-CppProfileBlock {
+    param([Parameter(Mandatory = $true)][string]$Executable)
+    $exeLiteral = ConvertTo-SingleQuotedLiteral $Executable
+    return @"
+$CppMarkerStart
+function global:build {
+    & $exeLiteral @args
+}
+$CppMarkerEnd
+"@
+}
+
+function New-LegacyProfileBlock {
+    param([Parameter(Mandatory = $true)][string]$LegacyScript)
+    $legacyLiteral = ConvertTo-SingleQuotedLiteral $LegacyScript
+    return @"
+$LegacyMarkerStart
+function global:build {
+    if (Get-Command pwsh.exe -ErrorAction SilentlyContinue) {
+        & pwsh.exe -NoProfile -File $legacyLiteral @args
+    } else {
+        & $legacyLiteral @args
+    }
+}
+$LegacyMarkerEnd
+"@
+}
+
+function Read-TextFile {
+    param([Parameter(Mandatory = $true)][string]$Path)
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        return ''
+    }
+    return [System.IO.File]::ReadAllText($Path)
+}
+
+function Write-TextFileIfChanged {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][AllowEmptyString()][string]$Content
+    )
+    $existing = Read-TextFile $Path
+    if ($existing -ceq $Content) {
+        return
+    }
+    $parent = Split-Path -Parent $Path
+    if (-not [string]::IsNullOrWhiteSpace($parent)) {
+        New-Item -ItemType Directory -Force -Path $parent | Out-Null
+    }
+    [System.IO.File]::WriteAllText($Path, $Content, (New-Object System.Text.UTF8Encoding($false)))
+}
+
+function Remove-AllMqbProfileBlocks {
+    param([Parameter(Mandatory = $true)][AllowEmptyString()][string]$Content)
+    $result = Remove-ManagedBlock $Content $CppMarkerStart $CppMarkerEnd
+    $result = Remove-ManagedBlock $result $LegacyMarkerStart $LegacyMarkerEnd
+    return $result
+}
+
+function Update-ProfileForInstall {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][string]$Executable
+    )
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        return $false
+    }
+
+    $original = Read-TextFile $Path
+    $hadCppBlock = $original.Contains($CppMarkerStart)
+    $base = Remove-AllMqbProfileBlocks $original
+    $recognizedLegacy = Test-RecognizedLegacyBuildFunction $base
+
+    if (-not $recognizedLegacy -and -not $hadCppBlock) {
+        if (Test-AnyBuildFunction $base) {
+            Write-Warning "Custom PowerShell 'build' function left untouched in $Path. Use 'mqb', or rename that function to use the compatibility build.cmd."
+        }
+        return $false
+    }
+
+    $updated = Add-ManagedBlock $base (New-CppProfileBlock $Executable)
+    Write-TextFileIfChanged $Path $updated
+    return $true
+}
+
+function Update-ProfileForRollback {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][string]$LegacyScript
+    )
+
+    $original = Read-TextFile $Path
+    $base = Remove-AllMqbProfileBlocks $original
+    $recognizedLegacy = Test-RecognizedLegacyBuildFunction $base
+
+    if ((Test-AnyBuildFunction $base) -and -not $recognizedLegacy) {
+        Write-Warning "Custom PowerShell 'build' function left untouched during rollback in $Path."
+        Write-TextFileIfChanged $Path $base
+        return $false
+    }
+
+    $updated = Add-ManagedBlock $base (New-LegacyProfileBlock $LegacyScript)
+    Write-TextFileIfChanged $Path $updated
+    return $true
+}
+
+function Remove-ProfileCutoverBlocks {
+    param([Parameter(Mandatory = $true)][string]$Path)
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        return
+    }
+    $original = Read-TextFile $Path
+    $updated = Remove-AllMqbProfileBlocks $original
+    Write-TextFileIfChanged $Path $updated
+}
+
+function Normalize-PathEntry {
+    param([Parameter(Mandatory = $true)][AllowEmptyString()][string]$Entry)
+    $value = $Entry.Trim().Trim('"')
+    if ([string]::IsNullOrWhiteSpace($value)) {
+        return ''
+    }
+    try {
+        $value = [System.IO.Path]::GetFullPath($value)
+    } catch {
+        # Preserve unusual PATH entries rather than rejecting the user's PATH.
+    }
+    return $value.TrimEnd('\')
+}
+
+function Test-PathContains {
+    param(
+        [AllowEmptyString()][string]$PathValue,
+        [Parameter(Mandatory = $true)][string]$Entry
+    )
+    $needle = Normalize-PathEntry $Entry
+    foreach ($part in @($PathValue -split ';')) {
+        if ([string]::Equals((Normalize-PathEntry $part), $needle, [System.StringComparison]::OrdinalIgnoreCase)) {
+            return $true
+        }
+    }
+    return $false
+}
+
+function Add-UserPathEntry {
+    param([Parameter(Mandatory = $true)][string]$Entry)
+    $current = [Environment]::GetEnvironmentVariable('Path', 'User')
+    if ($null -eq $current) { $current = '' }
+    if (Test-PathContains $current $Entry) {
+        return $false
+    }
+    $parts = @($current -split ';' | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    $newValue = (($parts + $Entry) -join ';')
+    [Environment]::SetEnvironmentVariable('Path', $newValue, 'User')
+    return $true
+}
+
+function Remove-UserPathEntry {
+    param([Parameter(Mandatory = $true)][string]$Entry)
+    $current = [Environment]::GetEnvironmentVariable('Path', 'User')
+    if ($null -eq $current) { return }
+    $needle = Normalize-PathEntry $Entry
+    $parts = @()
+    foreach ($part in @($current -split ';')) {
+        if ([string]::IsNullOrWhiteSpace($part)) { continue }
+        if (-not [string]::Equals((Normalize-PathEntry $part), $needle, [System.StringComparison]::OrdinalIgnoreCase)) {
+            $parts += $part
+        }
+    }
+    [Environment]::SetEnvironmentVariable('Path', ($parts -join ';'), 'User')
+}
+
+function Read-InstallState {
+    param([Parameter(Mandatory = $true)][string]$Path)
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        return $null
+    }
+    try {
+        return (Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json)
+    } catch {
+        Write-Warning "Ignoring unreadable install state: $Path"
+        return $null
+    }
+}
+
+function Write-InstallState {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)]$State
+    )
+    $json = $State | ConvertTo-Json -Depth 5
+    [System.IO.File]::WriteAllText($Path, $json + [Environment]::NewLine, (New-Object System.Text.UTF8Encoding($false)))
+}
+
+function Resolve-LegacySource {
+    if (-not [string]::IsNullOrWhiteSpace($LegacyBuildPath)) {
+        return (Get-FullPath $LegacyBuildPath)
+    }
+
+    $candidates = @(
+        (Join-Path $PSScriptRoot 'legacy\build.ps1'),
+        (Join-Path $PSScriptRoot 'build.ps1')
+    )
+    foreach ($candidate in $candidates) {
+        if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+            return (Get-FullPath $candidate)
+        }
+    }
+    return $null
+}
+
+function Resolve-MqbSource {
+    if (-not [string]::IsNullOrWhiteSpace($MqbPath)) {
+        return (Get-FullPath $MqbPath)
+    }
+    return (Get-FullPath (Join-Path $PSScriptRoot 'mqb.exe'))
+}
+
+function Copy-FileUnlessSame {
+    param(
+        [Parameter(Mandatory = $true)][string]$Source,
+        [Parameter(Mandatory = $true)][string]$Destination
+    )
+    $sourceFull = Get-FullPath $Source
+    $destinationFull = Get-FullPath $Destination
+    if ([string]::Equals($sourceFull, $destinationFull, [System.StringComparison]::OrdinalIgnoreCase)) {
+        return
+    }
+    Copy-Item -LiteralPath $sourceFull -Destination $destinationFull -Force
+}
+
+$InstallRoot = Get-FullPath $InstallRoot
+$statePath = Join-Path $InstallRoot 'mqb-install-state.json'
+$previousState = Read-InstallState $statePath
+
+if (-not $PSBoundParameters.ContainsKey('ProfilePaths') -or $null -eq $ProfilePaths -or $ProfilePaths.Count -eq 0) {
+    if ($null -ne $previousState -and $null -ne $previousState.profile_paths) {
+        $ProfilePaths = @($previousState.profile_paths)
+    } else {
+        $ProfilePaths = Get-DefaultProfilePaths
+    }
+}
+$ProfilePaths = @($ProfilePaths | ForEach-Object { Get-FullPath $_ } | Select-Object -Unique)
+
+if ($Action -eq 'Install') {
+    $mqbSource = Resolve-MqbSource
+    if (-not (Test-Path -LiteralPath $mqbSource -PathType Leaf)) {
+        throw "mqb.exe not found. Expected '$mqbSource'. Use -MqbPath when installing from a source checkout."
+    }
+
+    New-Item -ItemType Directory -Force -Path $InstallRoot | Out-Null
+
+    $destinationMqb = Join-Path $InstallRoot 'mqb.exe'
+    $buildCmd = Join-Path $InstallRoot 'build.cmd'
+    $legacyInstalled = Join-Path $InstallRoot 'build-legacy.ps1'
+    $priorBuildPs1 = Join-Path $InstallRoot 'build.ps1'
+    $maintenanceInstall = Join-Path $InstallRoot 'mqb-install.ps1'
+    $maintenanceUninstall = Join-Path $InstallRoot 'uninstall-mqb.ps1'
+
+    $legacyBackupCreated = $false
+    if ($null -ne $previousState -and $null -ne $previousState.legacy_backup_created) {
+        $legacyBackupCreated = [bool]$previousState.legacy_backup_created
+    }
+
+    if (-not (Test-Path -LiteralPath $legacyInstalled -PathType Leaf)) {
+        if (Test-Path -LiteralPath $priorBuildPs1 -PathType Leaf) {
+            Copy-Item -LiteralPath $priorBuildPs1 -Destination $legacyInstalled -Force
+            $legacyBackupCreated = $true
+        } else {
+            $legacySource = Resolve-LegacySource
+            if ($null -ne $legacySource -and (Test-Path -LiteralPath $legacySource -PathType Leaf)) {
+                Copy-Item -LiteralPath $legacySource -Destination $legacyInstalled -Force
+                $legacyBackupCreated = $true
+            }
+        }
+    }
+
+    Copy-FileUnlessSame $mqbSource $destinationMqb
+
+    $shim = "@echo off`r`n`"%~dp0mqb.exe`" %*`r`nexit /b %errorlevel%`r`n"
+    [System.IO.File]::WriteAllText($buildCmd, $shim, [System.Text.Encoding]::ASCII)
+
+    Copy-FileUnlessSame $PSCommandPath $maintenanceInstall
+    $uninstallSource = Join-Path $PSScriptRoot 'uninstall.ps1'
+    if (Test-Path -LiteralPath $uninstallSource -PathType Leaf) {
+        Copy-FileUnlessSame $uninstallSource $maintenanceUninstall
+    }
+
+    $profileTouched = @()
+    foreach ($profilePath in $ProfilePaths) {
+        if (Update-ProfileForInstall $profilePath $destinationMqb) {
+            $profileTouched += $profilePath
+        }
+    }
+
+    $pathAdded = $false
+    if ($null -ne $previousState -and $null -ne $previousState.path_added) {
+        $pathAdded = [bool]$previousState.path_added
+    }
+    if (-not $SkipUserPath) {
+        if (Add-UserPathEntry $InstallRoot) {
+            $pathAdded = $true
+        }
+    }
+
+    $help = @(& $destinationMqb --help 2>&1 | ForEach-Object { $_.ToString() })
+    $helpExit = $LASTEXITCODE
+    if ($helpExit -ne 0 -or $help.Count -eq 0) {
+        throw "Installed mqb.exe failed verification with exit code $helpExit"
+    }
+
+    $state = [ordered]@{
+        version = 1
+        install_root = $InstallRoot
+        path_added = [bool]$pathAdded
+        profile_paths = @($ProfilePaths)
+        profile_touched = @($profileTouched)
+        legacy_backup_created = [bool]$legacyBackupCreated
+        prior_build_ps1 = [bool](Test-Path -LiteralPath $priorBuildPs1 -PathType Leaf)
+        installed_help_line = $help[0]
+        installed_at_utc = [DateTime]::UtcNow.ToString('o')
+    }
+    Write-InstallState $statePath $state
+
+    Write-Host "Installed MQB C++ default to: $destinationMqb"
+    Write-Host "Canonical command: mqb"
+    Write-Host "Compatibility command: build"
+    Write-Host "Verified: $($help[0])"
+    if (-not $SkipUserPath) {
+        Write-Host "User PATH contains: $InstallRoot"
+    }
+    if (Test-Path -LiteralPath $legacyInstalled -PathType Leaf) {
+        Write-Host "Legacy rollback copy: $legacyInstalled"
+    }
+    Write-Host "Restart open terminals so PATH/profile changes are reloaded."
+    exit 0
+}
+
+$destinationMqb = Join-Path $InstallRoot 'mqb.exe'
+$buildCmd = Join-Path $InstallRoot 'build.cmd'
+$legacyInstalled = Join-Path $InstallRoot 'build-legacy.ps1'
+$priorBuildPs1 = Join-Path $InstallRoot 'build.ps1'
+$maintenanceInstall = Join-Path $InstallRoot 'mqb-install.ps1'
+$maintenanceUninstall = Join-Path $InstallRoot 'uninstall-mqb.ps1'
+
+if ($Action -eq 'Rollback') {
+    $legacyTarget = $null
+    $priorExists = Test-Path -LiteralPath $priorBuildPs1 -PathType Leaf
+    if ($priorExists) {
+        $legacyTarget = $priorBuildPs1
+    } elseif (Test-Path -LiteralPath $legacyInstalled -PathType Leaf) {
+        $legacyTarget = $legacyInstalled
+    }
+
+    if ($null -eq $legacyTarget) {
+        throw "Rollback requested, but no legacy PowerShell build script is available in '$InstallRoot'."
+    }
+
+    foreach ($profilePath in $ProfilePaths) {
+        Update-ProfileForRollback $profilePath $legacyTarget | Out-Null
+    }
+} else {
+    foreach ($profilePath in $ProfilePaths) {
+        Remove-ProfileCutoverBlocks $profilePath
+    }
+}
+
+if (-not $SkipUserPath -and $null -ne $previousState -and $null -ne $previousState.path_added -and [bool]$previousState.path_added) {
+    Remove-UserPathEntry $InstallRoot
+}
+
+Remove-Item -LiteralPath $destinationMqb -Force -ErrorAction SilentlyContinue
+Remove-Item -LiteralPath $buildCmd -Force -ErrorAction SilentlyContinue
+
+if ($Action -eq 'Uninstall') {
+    if ($null -ne $previousState -and $null -ne $previousState.legacy_backup_created -and [bool]$previousState.legacy_backup_created) {
+        Remove-Item -LiteralPath $legacyInstalled -Force -ErrorAction SilentlyContinue
+    }
+    Write-Host "Uninstalled the stable-v5 C++ default entry. Pre-existing legacy files/profile content were left untouched."
+} else {
+    Write-Host "Rolled back the default 'build' entry to the legacy PowerShell implementation."
+    Write-Host "Legacy script: $legacyTarget"
+}
+
+Remove-Item -LiteralPath $statePath -Force -ErrorAction SilentlyContinue
+Remove-Item -LiteralPath $maintenanceUninstall -Force -ErrorAction SilentlyContinue
+if (-not [string]::Equals((Get-FullPath $PSCommandPath), (Get-FullPath $maintenanceInstall), [System.StringComparison]::OrdinalIgnoreCase)) {
+    Remove-Item -LiteralPath $maintenanceInstall -Force -ErrorAction SilentlyContinue
+} else {
+    # The current script can be deleted after it has been parsed; defer until the final operation.
+    Remove-Item -LiteralPath $maintenanceInstall -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host "Restart open terminals so PATH/profile changes are reloaded."
+exit 0

--- a/tests/installer/installer_cutover.ps1
+++ b/tests/installer/installer_cutover.ps1
@@ -1,184 +1,158 @@
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory = $true)]
-    [string]$MqbPath,
-
-    [Parameter(Mandatory = $true)]
-    [string]$RepoRoot
+    [Parameter(Mandatory = $true)][string]$MqbPath,
+    [Parameter(Mandatory = $true)][string]$RepoRoot
 )
 
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version 2.0
 
-$mqb = [System.IO.Path]::GetFullPath($MqbPath)
-$repo = [System.IO.Path]::GetFullPath($RepoRoot)
+$mqb = [IO.Path]::GetFullPath($MqbPath)
+$repo = [IO.Path]::GetFullPath($RepoRoot)
 $installPs1 = Join-Path $repo 'install.ps1'
 $installBat = Join-Path $repo 'install.bat'
 $legacySource = Join-Path $repo 'build.ps1'
 
-foreach ($required in @($mqb, $installPs1, $installBat, $legacySource)) {
-    if (-not (Test-Path -LiteralPath $required -PathType Leaf)) {
-        throw "installer cutover prerequisite missing: $required"
+foreach ($path in @($mqb, $installPs1, $installBat, $legacySource)) {
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+        throw "installer cutover prerequisite missing: $path"
     }
 }
 
 function Assert-True {
-    param(
-        [Parameter(Mandatory = $true)][bool]$Condition,
-        [Parameter(Mandatory = $true)][string]$Message
-    )
-    if (-not $Condition) {
-        throw $Message
-    }
+    param([bool]$Condition, [string]$Message)
+    if (-not $Condition) { throw $Message }
 }
 
-function Quote-PowerShellLiteral {
-    param([Parameter(Mandatory = $true)][string]$Value)
+function Q {
+    param([string]$Value)
     return "'" + $Value.Replace("'", "''") + "'"
 }
 
-function Invoke-WindowsPowerShell {
-    param(
-        [Parameter(Mandatory = $true)][string]$Command,
-        [Parameter(Mandatory = $true)][string]$Label
-    )
+function Invoke-PS5 {
+    param([string]$Command, [string]$Label)
     $lines = @(& powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -Command $Command 2>&1 |
         ForEach-Object { $_.ToString() })
-    $exitCode = $LASTEXITCODE
-    if ($exitCode -ne 0) {
+    $code = $LASTEXITCODE
+    if ($code -ne 0) {
         Write-Host "--- $Label output ---"
         $lines | ForEach-Object { Write-Host $_ }
-        throw "$Label failed with exit code $exitCode"
+        throw "$Label failed with exit code $code"
     }
     return $lines
 }
 
-function Invoke-InstallPowerShell {
-    param(
-        [Parameter(Mandatory = $true)][string]$Root,
-        [Parameter(Mandatory = $true)][string[]]$Profiles
-    )
-    $profileExpr = '@(' + (($Profiles | ForEach-Object { Quote-PowerShellLiteral $_ }) -join ',') + ')'
-    $command = '& ' + (Quote-PowerShellLiteral $installPs1) +
-        ' -Action Install -MqbPath ' + (Quote-PowerShellLiteral $mqb) +
-        ' -LegacyBuildPath ' + (Quote-PowerShellLiteral $legacySource) +
-        ' -InstallRoot ' + (Quote-PowerShellLiteral $Root) +
-        ' -ProfilePaths ' + $profileExpr
-    return Invoke-WindowsPowerShell $command "PowerShell install into $Root"
+function Profiles-Expr {
+    param([string[]]$Profiles)
+    return '@(' + (($Profiles | ForEach-Object { Q $_ }) -join ',') + ')'
 }
 
-function Invoke-Maintenance {
-    param(
-        [Parameter(Mandatory = $true)][string]$Root,
-        [Parameter(Mandatory = $true)][string[]]$Profiles,
-        [switch]$RestoreLegacy
-    )
+function Install-Mqb {
+    param([string]$Root, [string[]]$Profiles)
+    $command = '& ' + (Q $installPs1) +
+        ' -Action Install -MqbPath ' + (Q $mqb) +
+        ' -LegacyBuildPath ' + (Q $legacySource) +
+        ' -InstallRoot ' + (Q $Root) +
+        ' -ProfilePaths ' + (Profiles-Expr $Profiles)
+    Invoke-PS5 $command "install $Root" | Out-Null
+}
+
+function Maintain-Mqb {
+    param([string]$Root, [string[]]$Profiles, [switch]$RestoreLegacy)
     $wrapper = Join-Path $Root 'uninstall-mqb.ps1'
     Assert-True (Test-Path -LiteralPath $wrapper -PathType Leaf) "maintenance wrapper missing: $wrapper"
-    $profileExpr = '@(' + (($Profiles | ForEach-Object { Quote-PowerShellLiteral $_ }) -join ',') + ')'
-    $command = '& ' + (Quote-PowerShellLiteral $wrapper) +
-        ' -InstallRoot ' + (Quote-PowerShellLiteral $Root) +
-        ' -ProfilePaths ' + $profileExpr
-    if ($RestoreLegacy) {
-        $command += ' -RestoreLegacy'
-    }
-    return Invoke-WindowsPowerShell $command "maintenance action for $Root"
+    $command = '& ' + (Q $wrapper) +
+        ' -InstallRoot ' + (Q $Root) +
+        ' -ProfilePaths ' + (Profiles-Expr $Profiles)
+    if ($RestoreLegacy) { $command += ' -RestoreLegacy' }
+    Invoke-PS5 $command "maintenance $Root" | Out-Null
 }
 
 function Normalize-PathEntry {
     param([AllowEmptyString()][string]$Entry)
     if ([string]::IsNullOrWhiteSpace($Entry)) { return '' }
     $value = $Entry.Trim().Trim('"')
-    try { $value = [System.IO.Path]::GetFullPath($value) } catch {}
+    try { $value = [IO.Path]::GetFullPath($value) } catch {}
     return $value.TrimEnd('\')
 }
 
 function Count-UserPathEntry {
-    param([Parameter(Mandatory = $true)][string]$Entry)
-    $current = [Environment]::GetEnvironmentVariable('Path', 'User')
-    if ($null -eq $current) { return 0 }
+    param([string]$Entry)
+    $path = [Environment]::GetEnvironmentVariable('Path', 'User')
+    if ($null -eq $path) { return 0 }
     $needle = Normalize-PathEntry $Entry
     $count = 0
-    foreach ($part in @($current -split ';')) {
-        if ([string]::Equals((Normalize-PathEntry $part), $needle, [System.StringComparison]::OrdinalIgnoreCase)) {
+    foreach ($part in @($path -split ';')) {
+        if ([string]::Equals((Normalize-PathEntry $part), $needle, [StringComparison]::OrdinalIgnoreCase)) {
             ++$count
         }
     }
     return $count
 }
 
-function Get-HelpLine {
-    param([Parameter(Mandatory = $true)][string]$Executable)
-    $lines = @(& $Executable --help 2>&1 | ForEach-Object { $_.ToString() })
-    if ($LASTEXITCODE -ne 0 -or $lines.Count -eq 0) {
-        throw "help invocation failed: $Executable"
-    }
+function Help-Line {
+    param([string]$Command)
+    $lines = @(& $Command --help 2>&1 | ForEach-Object { $_.ToString() })
+    if ($LASTEXITCODE -ne 0 -or $lines.Count -eq 0) { throw "help failed: $Command" }
     return $lines[0]
 }
 
-function Get-BuildShimHelpLine {
-    param([Parameter(Mandatory = $true)][string]$BuildCmd)
-    $lines = @(& $BuildCmd --help 2>&1 | ForEach-Object { $_.ToString() })
-    if ($LASTEXITCODE -ne 0 -or $lines.Count -eq 0) {
-        throw "build.cmd help invocation failed: $BuildCmd"
-    }
-    return $lines[0]
-}
-
-$runRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("mqb-installer-cutover-" + [Guid]::NewGuid().ToString('N'))
+$runRoot = Join-Path ([IO.Path]::GetTempPath()) ("mqb-installer-" + [Guid]::NewGuid().ToString('N'))
 New-Item -ItemType Directory -Force -Path $runRoot | Out-Null
-
 $originalUserPath = [Environment]::GetEnvironmentVariable('Path', 'User')
 
 try {
-    # 1. Clean-machine style install through install.bat.
+    # Clean install through the public batch entry.
     $cleanRoot = Join-Path $runRoot 'clean\bin'
     $cleanProfile = Join-Path $runRoot 'clean\profile.ps1'
     New-Item -ItemType Directory -Force -Path (Split-Path -Parent $cleanProfile) | Out-Null
-    $cleanSentinel = "# clean-profile-sentinel`r`n"
-    [System.IO.File]::WriteAllText($cleanProfile, $cleanSentinel, (New-Object System.Text.UTF8Encoding($false)))
+    $sentinel = "# clean-profile-sentinel`r`n"
+    [IO.File]::WriteAllText($cleanProfile, $sentinel, (New-Object Text.UTF8Encoding($false)))
 
-    $cleanInstallOutput = @(& $installBat `
+    $output = @(& $installBat `
         -MqbPath $mqb `
         -LegacyBuildPath $legacySource `
         -InstallRoot $cleanRoot `
         -ProfilePaths $cleanProfile 2>&1 | ForEach-Object { $_.ToString() })
     if ($LASTEXITCODE -ne 0) {
-        $cleanInstallOutput | ForEach-Object { Write-Host $_ }
-        throw "install.bat clean install failed with exit code $LASTEXITCODE"
+        $output | ForEach-Object { Write-Host $_ }
+        throw "install.bat failed with exit code $LASTEXITCODE"
     }
 
     $cleanMqb = Join-Path $cleanRoot 'mqb.exe'
     $cleanBuild = Join-Path $cleanRoot 'build.cmd'
     $cleanLegacy = Join-Path $cleanRoot 'build-legacy.ps1'
-    Assert-True (Test-Path -LiteralPath $cleanMqb -PathType Leaf) 'clean install did not deploy mqb.exe'
-    Assert-True (Test-Path -LiteralPath $cleanBuild -PathType Leaf) 'clean install did not deploy build.cmd'
-    Assert-True (Test-Path -LiteralPath $cleanLegacy -PathType Leaf) 'clean install did not deploy rollback Golden Reference'
-    Assert-True (Test-Path -LiteralPath (Join-Path $cleanRoot 'mqb-install.ps1') -PathType Leaf) 'clean install did not deploy maintenance installer'
-    Assert-True (Test-Path -LiteralPath (Join-Path $cleanRoot 'uninstall-mqb.ps1') -PathType Leaf) 'clean install did not deploy uninstall wrapper'
-    Assert-True (([System.IO.File]::ReadAllText($cleanProfile)) -ceq $cleanSentinel) 'clean install unexpectedly rewrote an unrelated PowerShell profile'
-    Assert-True ((Get-HelpLine $cleanMqb) -ceq (Get-BuildShimHelpLine $cleanBuild)) 'build compatibility shim does not forward to the installed mqb.exe'
-    Assert-True ((Count-UserPathEntry $cleanRoot) -eq 1) 'clean install did not add exactly one user PATH entry'
+    foreach ($required in @(
+        $cleanMqb,
+        $cleanBuild,
+        $cleanLegacy,
+        (Join-Path $cleanRoot 'mqb-install.ps1'),
+        (Join-Path $cleanRoot 'uninstall-mqb.ps1'),
+        (Join-Path $cleanRoot 'mqb-install-state.json')
+    )) {
+        Assert-True (Test-Path -LiteralPath $required -PathType Leaf) "clean install missing: $required"
+    }
+    Assert-True (([IO.File]::ReadAllText($cleanProfile)) -ceq $sentinel) 'clean install rewrote unrelated profile content'
+    Assert-True ((Help-Line $cleanMqb) -ceq (Help-Line $cleanBuild)) 'build.cmd does not resolve to the installed mqb.exe'
+    Assert-True ((Count-UserPathEntry $cleanRoot) -eq 1) 'clean install did not own exactly one PATH entry'
 
-    # Reinstall must remain idempotent, especially PATH state.
-    Invoke-InstallPowerShell $cleanRoot @($cleanProfile) | Out-Null
-    Assert-True ((Count-UserPathEntry $cleanRoot) -eq 1) 'reinstall duplicated the user PATH entry'
+    Install-Mqb $cleanRoot @($cleanProfile)
+    Assert-True ((Count-UserPathEntry $cleanRoot) -eq 1) 'reinstall duplicated PATH'
+    Maintain-Mqb $cleanRoot @($cleanProfile)
+    Assert-True (-not (Test-Path -LiteralPath $cleanMqb -PathType Leaf)) 'uninstall left mqb.exe'
+    Assert-True (-not (Test-Path -LiteralPath $cleanBuild -PathType Leaf)) 'uninstall left build.cmd'
+    Assert-True (-not (Test-Path -LiteralPath $cleanLegacy -PathType Leaf)) 'uninstall left installer-owned legacy backup'
+    Assert-True ((Count-UserPathEntry $cleanRoot) -eq 0) 'uninstall left installer-owned PATH'
+    Assert-True (([IO.File]::ReadAllText($cleanProfile)) -ceq $sentinel) 'uninstall changed unrelated profile content'
 
-    Invoke-Maintenance $cleanRoot @($cleanProfile) | Out-Null
-    Assert-True (-not (Test-Path -LiteralPath $cleanMqb -PathType Leaf)) 'uninstall left mqb.exe behind'
-    Assert-True (-not (Test-Path -LiteralPath $cleanBuild -PathType Leaf)) 'uninstall left build.cmd behind'
-    Assert-True (-not (Test-Path -LiteralPath $cleanLegacy -PathType Leaf)) 'clean uninstall left an installer-created legacy backup behind'
-    Assert-True ((Count-UserPathEntry $cleanRoot) -eq 0) 'clean uninstall did not remove the installer-owned PATH entry'
-    Assert-True (([System.IO.File]::ReadAllText($cleanProfile)) -ceq $cleanSentinel) 'clean uninstall changed unrelated profile content'
-
-    # 2. Upgrade from the current PowerShell release line.
+    # Upgrade from the existing PowerShell installation shape.
     $upgradeRoot = Join-Path $runRoot 'upgrade\bin'
     New-Item -ItemType Directory -Force -Path $upgradeRoot | Out-Null
     $priorBuild = Join-Path $upgradeRoot 'build.ps1'
     Copy-Item -LiteralPath $legacySource -Destination $priorBuild -Force
-    $priorBuildHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $priorBuild).Hash
+    $priorHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $priorBuild).Hash
 
-    $legacyProfileBody = @'
+    $legacyProfile = @'
 $OutputEncoding = [console]::InputEncoding = [console]::OutputEncoding = New-Object System.Text.UTF8Encoding
 function build {
     if (Get-Command pwsh.exe -ErrorAction SilentlyContinue) {
@@ -188,61 +162,57 @@ function build {
     }
 }
 '@
-    $upgradeProfiles = @(
+    $profiles = @(
         (Join-Path $runRoot 'upgrade\WindowsPowerShell\Microsoft.PowerShell_profile.ps1'),
         (Join-Path $runRoot 'upgrade\PowerShell\Microsoft.PowerShell_profile.ps1')
     )
-    foreach ($profile in $upgradeProfiles) {
+    foreach ($profile in $profiles) {
         New-Item -ItemType Directory -Force -Path (Split-Path -Parent $profile) | Out-Null
-        $body = "# user-before`r`n" + $legacyProfileBody.TrimEnd() + "`r`n# user-after`r`n"
-        [System.IO.File]::WriteAllText($profile, $body, (New-Object System.Text.UTF8Encoding($false)))
+        [IO.File]::WriteAllText(
+            $profile,
+            "# user-before`r`n" + $legacyProfile.TrimEnd() + "`r`n# user-after`r`n",
+            (New-Object Text.UTF8Encoding($false)))
     }
 
-    Invoke-InstallPowerShell $upgradeRoot $upgradeProfiles | Out-Null
-
+    Install-Mqb $upgradeRoot $profiles
     $upgradeMqb = Join-Path $upgradeRoot 'mqb.exe'
     $upgradeLegacy = Join-Path $upgradeRoot 'build-legacy.ps1'
-    Assert-True ((Get-FileHash -Algorithm SHA256 -LiteralPath $priorBuild).Hash -ceq $priorBuildHash) 'upgrade modified the existing build.ps1 Golden Reference'
-    Assert-True ((Get-FileHash -Algorithm SHA256 -LiteralPath $upgradeLegacy).Hash -ceq $priorBuildHash) 'upgrade did not preserve the installed legacy build.ps1 as build-legacy.ps1'
-    Assert-True ((Count-UserPathEntry $upgradeRoot) -eq 1) 'upgrade did not add the C++ install root to user PATH'
+    Assert-True ((Get-FileHash -Algorithm SHA256 -LiteralPath $priorBuild).Hash -ceq $priorHash) 'upgrade modified prior build.ps1'
+    Assert-True ((Get-FileHash -Algorithm SHA256 -LiteralPath $upgradeLegacy).Hash -ceq $priorHash) 'upgrade did not preserve prior build.ps1'
+    Assert-True ((Count-UserPathEntry $upgradeRoot) -eq 1) 'upgrade did not add installer-owned PATH'
+    $expected = Help-Line $upgradeMqb
 
-    $expectedHelp = Get-HelpLine $upgradeMqb
-    foreach ($profile in $upgradeProfiles) {
-        $content = [System.IO.File]::ReadAllText($profile)
-        Assert-True $content.Contains('# user-before') 'upgrade lost user profile prefix content'
-        Assert-True $content.Contains('# user-after') 'upgrade lost user profile suffix content'
-        Assert-True $content.Contains('# >>> MQB v5 C++ default >>>') 'upgrade did not append the managed C++ default profile block'
-
-        $command = '. ' + (Quote-PowerShellLiteral $profile) + '; build --help | Select-Object -First 1'
-        $buildHelp = @(Invoke-WindowsPowerShell $command "profile build shim from $profile")
-        Assert-True ($buildHelp.Count -gt 0 -and $buildHelp[-1] -ceq $expectedHelp) 'PowerShell build function did not resolve to mqb.exe after upgrade'
+    foreach ($profile in $profiles) {
+        $content = [IO.File]::ReadAllText($profile)
+        Assert-True ($content.Contains('# user-before') -and $content.Contains('# user-after')) 'upgrade lost user profile content'
+        Assert-True $content.Contains('# >>> MQB v5 C++ default >>>') 'upgrade did not add C++ profile block'
+        $line = @(Invoke-PS5 ('. ' + (Q $profile) + '; build --help | Select-Object -First 1') "profile shim $profile")
+        Assert-True ($line.Count -gt 0 -and $line[-1] -ceq $expected) 'upgraded build function does not resolve to mqb.exe'
     }
 
-    Invoke-Maintenance $upgradeRoot $upgradeProfiles -RestoreLegacy | Out-Null
-    Assert-True (-not (Test-Path -LiteralPath $upgradeMqb -PathType Leaf)) 'rollback left mqb.exe as the default binary'
-    Assert-True (Test-Path -LiteralPath $upgradeLegacy -PathType Leaf) 'rollback removed the preserved legacy implementation'
-    Assert-True ((Get-FileHash -Algorithm SHA256 -LiteralPath $priorBuild).Hash -ceq $priorBuildHash) 'rollback modified the pre-existing build.ps1'
-    Assert-True ((Count-UserPathEntry $upgradeRoot) -eq 0) 'rollback did not remove the installer-owned PATH entry'
-    foreach ($profile in $upgradeProfiles) {
-        $content = [System.IO.File]::ReadAllText($profile)
-        Assert-True (-not $content.Contains('# >>> MQB v5 C++ default >>>')) 'rollback left the C++ default profile block'
-        Assert-True $content.Contains('# >>> MQB v5 legacy rollback >>>') 'rollback did not install the explicit legacy fallback block'
-        Assert-True $content.Contains('# user-before') 'rollback lost user profile prefix content'
-        Assert-True $content.Contains('# user-after') 'rollback lost user profile suffix content'
+    Maintain-Mqb $upgradeRoot $profiles -RestoreLegacy
+    Assert-True (-not (Test-Path -LiteralPath $upgradeMqb -PathType Leaf)) 'rollback left mqb.exe'
+    Assert-True (Test-Path -LiteralPath $upgradeLegacy -PathType Leaf) 'rollback removed legacy backup'
+    Assert-True ((Get-FileHash -Algorithm SHA256 -LiteralPath $priorBuild).Hash -ceq $priorHash) 'rollback modified prior build.ps1'
+    Assert-True ((Count-UserPathEntry $upgradeRoot) -eq 0) 'rollback left installer-owned PATH'
+    foreach ($profile in $profiles) {
+        $content = [IO.File]::ReadAllText($profile)
+        Assert-True (-not $content.Contains('# >>> MQB v5 C++ default >>>')) 'rollback left C++ profile block'
+        Assert-True $content.Contains('# >>> MQB v5 legacy rollback >>>') 'rollback did not install legacy fallback'
+        Assert-True ($content.Contains('# user-before') -and $content.Contains('# user-after')) 'rollback lost user profile content'
     }
 
-    # 3. Clean install can still roll back because the package ships the Golden Reference.
-    $rollbackRoot = Join-Path $runRoot 'clean-rollback\bin'
-    $rollbackProfile = Join-Path $runRoot 'clean-rollback\PowerShell\Microsoft.PowerShell_profile.ps1'
-    Invoke-InstallPowerShell $rollbackRoot @($rollbackProfile) | Out-Null
-    Invoke-Maintenance $rollbackRoot @($rollbackProfile) -RestoreLegacy | Out-Null
-
-    $rollbackLegacy = Join-Path $rollbackRoot 'build-legacy.ps1'
-    Assert-True (Test-Path -LiteralPath $rollbackLegacy -PathType Leaf) 'clean rollback has no legacy implementation to return to'
-    $rollbackContent = [System.IO.File]::ReadAllText($rollbackProfile)
-    Assert-True $rollbackContent.Contains('# >>> MQB v5 legacy rollback >>>') 'clean rollback did not create a legacy profile entry'
-    Assert-True $rollbackContent.Contains('build-legacy.ps1') 'clean rollback profile does not point at the preserved Golden Reference'
-    Assert-True ((Count-UserPathEntry $rollbackRoot) -eq 0) 'clean rollback left a C++ PATH entry behind'
+    # A clean v5 install also has a package Golden Reference to roll back to.
+    $fallbackRoot = Join-Path $runRoot 'fallback\bin'
+    $fallbackProfile = Join-Path $runRoot 'fallback\PowerShell\Microsoft.PowerShell_profile.ps1'
+    Install-Mqb $fallbackRoot @($fallbackProfile)
+    Maintain-Mqb $fallbackRoot @($fallbackProfile) -RestoreLegacy
+    $fallbackLegacy = Join-Path $fallbackRoot 'build-legacy.ps1'
+    $fallbackContent = [IO.File]::ReadAllText($fallbackProfile)
+    Assert-True (Test-Path -LiteralPath $fallbackLegacy -PathType Leaf) 'clean rollback removed package Golden Reference'
+    Assert-True $fallbackContent.Contains('# >>> MQB v5 legacy rollback >>>') 'clean rollback has no legacy profile entry'
+    Assert-True $fallbackContent.Contains('build-legacy.ps1') 'clean rollback does not target build-legacy.ps1'
+    Assert-True ((Count-UserPathEntry $fallbackRoot) -eq 0) 'clean rollback left installer-owned PATH'
 
     Write-Host 'installer clean-install / upgrade / rollback validation passed'
 }

--- a/tests/installer/installer_cutover.ps1
+++ b/tests/installer/installer_cutover.ps1
@@ -1,0 +1,252 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$MqbPath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$RepoRoot
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+$mqb = [System.IO.Path]::GetFullPath($MqbPath)
+$repo = [System.IO.Path]::GetFullPath($RepoRoot)
+$installPs1 = Join-Path $repo 'install.ps1'
+$installBat = Join-Path $repo 'install.bat'
+$legacySource = Join-Path $repo 'build.ps1'
+
+foreach ($required in @($mqb, $installPs1, $installBat, $legacySource)) {
+    if (-not (Test-Path -LiteralPath $required -PathType Leaf)) {
+        throw "installer cutover prerequisite missing: $required"
+    }
+}
+
+function Assert-True {
+    param(
+        [Parameter(Mandatory = $true)][bool]$Condition,
+        [Parameter(Mandatory = $true)][string]$Message
+    )
+    if (-not $Condition) {
+        throw $Message
+    }
+}
+
+function Quote-PowerShellLiteral {
+    param([Parameter(Mandatory = $true)][string]$Value)
+    return "'" + $Value.Replace("'", "''") + "'"
+}
+
+function Invoke-WindowsPowerShell {
+    param(
+        [Parameter(Mandatory = $true)][string]$Command,
+        [Parameter(Mandatory = $true)][string]$Label
+    )
+    $lines = @(& powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -Command $Command 2>&1 |
+        ForEach-Object { $_.ToString() })
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne 0) {
+        Write-Host "--- $Label output ---"
+        $lines | ForEach-Object { Write-Host $_ }
+        throw "$Label failed with exit code $exitCode"
+    }
+    return $lines
+}
+
+function Invoke-InstallPowerShell {
+    param(
+        [Parameter(Mandatory = $true)][string]$Root,
+        [Parameter(Mandatory = $true)][string[]]$Profiles
+    )
+    $profileExpr = '@(' + (($Profiles | ForEach-Object { Quote-PowerShellLiteral $_ }) -join ',') + ')'
+    $command = '& ' + (Quote-PowerShellLiteral $installPs1) +
+        ' -Action Install -MqbPath ' + (Quote-PowerShellLiteral $mqb) +
+        ' -LegacyBuildPath ' + (Quote-PowerShellLiteral $legacySource) +
+        ' -InstallRoot ' + (Quote-PowerShellLiteral $Root) +
+        ' -ProfilePaths ' + $profileExpr
+    return Invoke-WindowsPowerShell $command "PowerShell install into $Root"
+}
+
+function Invoke-Maintenance {
+    param(
+        [Parameter(Mandatory = $true)][string]$Root,
+        [Parameter(Mandatory = $true)][string[]]$Profiles,
+        [switch]$RestoreLegacy
+    )
+    $wrapper = Join-Path $Root 'uninstall-mqb.ps1'
+    Assert-True (Test-Path -LiteralPath $wrapper -PathType Leaf) "maintenance wrapper missing: $wrapper"
+    $profileExpr = '@(' + (($Profiles | ForEach-Object { Quote-PowerShellLiteral $_ }) -join ',') + ')'
+    $command = '& ' + (Quote-PowerShellLiteral $wrapper) +
+        ' -InstallRoot ' + (Quote-PowerShellLiteral $Root) +
+        ' -ProfilePaths ' + $profileExpr
+    if ($RestoreLegacy) {
+        $command += ' -RestoreLegacy'
+    }
+    return Invoke-WindowsPowerShell $command "maintenance action for $Root"
+}
+
+function Normalize-PathEntry {
+    param([AllowEmptyString()][string]$Entry)
+    if ([string]::IsNullOrWhiteSpace($Entry)) { return '' }
+    $value = $Entry.Trim().Trim('"')
+    try { $value = [System.IO.Path]::GetFullPath($value) } catch {}
+    return $value.TrimEnd('\')
+}
+
+function Count-UserPathEntry {
+    param([Parameter(Mandatory = $true)][string]$Entry)
+    $current = [Environment]::GetEnvironmentVariable('Path', 'User')
+    if ($null -eq $current) { return 0 }
+    $needle = Normalize-PathEntry $Entry
+    $count = 0
+    foreach ($part in @($current -split ';')) {
+        if ([string]::Equals((Normalize-PathEntry $part), $needle, [System.StringComparison]::OrdinalIgnoreCase)) {
+            ++$count
+        }
+    }
+    return $count
+}
+
+function Get-HelpLine {
+    param([Parameter(Mandatory = $true)][string]$Executable)
+    $lines = @(& $Executable --help 2>&1 | ForEach-Object { $_.ToString() })
+    if ($LASTEXITCODE -ne 0 -or $lines.Count -eq 0) {
+        throw "help invocation failed: $Executable"
+    }
+    return $lines[0]
+}
+
+function Get-BuildShimHelpLine {
+    param([Parameter(Mandatory = $true)][string]$BuildCmd)
+    $lines = @(& $BuildCmd --help 2>&1 | ForEach-Object { $_.ToString() })
+    if ($LASTEXITCODE -ne 0 -or $lines.Count -eq 0) {
+        throw "build.cmd help invocation failed: $BuildCmd"
+    }
+    return $lines[0]
+}
+
+$runRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("mqb-installer-cutover-" + [Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Force -Path $runRoot | Out-Null
+
+$originalUserPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+
+try {
+    # 1. Clean-machine style install through install.bat.
+    $cleanRoot = Join-Path $runRoot 'clean\bin'
+    $cleanProfile = Join-Path $runRoot 'clean\profile.ps1'
+    New-Item -ItemType Directory -Force -Path (Split-Path -Parent $cleanProfile) | Out-Null
+    $cleanSentinel = "# clean-profile-sentinel`r`n"
+    [System.IO.File]::WriteAllText($cleanProfile, $cleanSentinel, (New-Object System.Text.UTF8Encoding($false)))
+
+    $cleanInstallOutput = @(& $installBat `
+        -MqbPath $mqb `
+        -LegacyBuildPath $legacySource `
+        -InstallRoot $cleanRoot `
+        -ProfilePaths $cleanProfile 2>&1 | ForEach-Object { $_.ToString() })
+    if ($LASTEXITCODE -ne 0) {
+        $cleanInstallOutput | ForEach-Object { Write-Host $_ }
+        throw "install.bat clean install failed with exit code $LASTEXITCODE"
+    }
+
+    $cleanMqb = Join-Path $cleanRoot 'mqb.exe'
+    $cleanBuild = Join-Path $cleanRoot 'build.cmd'
+    $cleanLegacy = Join-Path $cleanRoot 'build-legacy.ps1'
+    Assert-True (Test-Path -LiteralPath $cleanMqb -PathType Leaf) 'clean install did not deploy mqb.exe'
+    Assert-True (Test-Path -LiteralPath $cleanBuild -PathType Leaf) 'clean install did not deploy build.cmd'
+    Assert-True (Test-Path -LiteralPath $cleanLegacy -PathType Leaf) 'clean install did not deploy rollback Golden Reference'
+    Assert-True (Test-Path -LiteralPath (Join-Path $cleanRoot 'mqb-install.ps1') -PathType Leaf) 'clean install did not deploy maintenance installer'
+    Assert-True (Test-Path -LiteralPath (Join-Path $cleanRoot 'uninstall-mqb.ps1') -PathType Leaf) 'clean install did not deploy uninstall wrapper'
+    Assert-True (([System.IO.File]::ReadAllText($cleanProfile)) -ceq $cleanSentinel) 'clean install unexpectedly rewrote an unrelated PowerShell profile'
+    Assert-True ((Get-HelpLine $cleanMqb) -ceq (Get-BuildShimHelpLine $cleanBuild)) 'build compatibility shim does not forward to the installed mqb.exe'
+    Assert-True ((Count-UserPathEntry $cleanRoot) -eq 1) 'clean install did not add exactly one user PATH entry'
+
+    # Reinstall must remain idempotent, especially PATH state.
+    Invoke-InstallPowerShell $cleanRoot @($cleanProfile) | Out-Null
+    Assert-True ((Count-UserPathEntry $cleanRoot) -eq 1) 'reinstall duplicated the user PATH entry'
+
+    Invoke-Maintenance $cleanRoot @($cleanProfile) | Out-Null
+    Assert-True (-not (Test-Path -LiteralPath $cleanMqb -PathType Leaf)) 'uninstall left mqb.exe behind'
+    Assert-True (-not (Test-Path -LiteralPath $cleanBuild -PathType Leaf)) 'uninstall left build.cmd behind'
+    Assert-True (-not (Test-Path -LiteralPath $cleanLegacy -PathType Leaf)) 'clean uninstall left an installer-created legacy backup behind'
+    Assert-True ((Count-UserPathEntry $cleanRoot) -eq 0) 'clean uninstall did not remove the installer-owned PATH entry'
+    Assert-True (([System.IO.File]::ReadAllText($cleanProfile)) -ceq $cleanSentinel) 'clean uninstall changed unrelated profile content'
+
+    # 2. Upgrade from the current PowerShell release line.
+    $upgradeRoot = Join-Path $runRoot 'upgrade\bin'
+    New-Item -ItemType Directory -Force -Path $upgradeRoot | Out-Null
+    $priorBuild = Join-Path $upgradeRoot 'build.ps1'
+    Copy-Item -LiteralPath $legacySource -Destination $priorBuild -Force
+    $priorBuildHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $priorBuild).Hash
+
+    $legacyProfileBody = @'
+$OutputEncoding = [console]::InputEncoding = [console]::OutputEncoding = New-Object System.Text.UTF8Encoding
+function build {
+    if (Get-Command pwsh.exe -ErrorAction SilentlyContinue) {
+        & pwsh.exe -NoProfile -File "$HOME\bin\build.ps1" @args
+    } else {
+        & "$HOME\bin\build.ps1" @args
+    }
+}
+'@
+    $upgradeProfiles = @(
+        (Join-Path $runRoot 'upgrade\WindowsPowerShell\Microsoft.PowerShell_profile.ps1'),
+        (Join-Path $runRoot 'upgrade\PowerShell\Microsoft.PowerShell_profile.ps1')
+    )
+    foreach ($profile in $upgradeProfiles) {
+        New-Item -ItemType Directory -Force -Path (Split-Path -Parent $profile) | Out-Null
+        $body = "# user-before`r`n" + $legacyProfileBody.TrimEnd() + "`r`n# user-after`r`n"
+        [System.IO.File]::WriteAllText($profile, $body, (New-Object System.Text.UTF8Encoding($false)))
+    }
+
+    Invoke-InstallPowerShell $upgradeRoot $upgradeProfiles | Out-Null
+
+    $upgradeMqb = Join-Path $upgradeRoot 'mqb.exe'
+    $upgradeLegacy = Join-Path $upgradeRoot 'build-legacy.ps1'
+    Assert-True ((Get-FileHash -Algorithm SHA256 -LiteralPath $priorBuild).Hash -ceq $priorBuildHash) 'upgrade modified the existing build.ps1 Golden Reference'
+    Assert-True ((Get-FileHash -Algorithm SHA256 -LiteralPath $upgradeLegacy).Hash -ceq $priorBuildHash) 'upgrade did not preserve the installed legacy build.ps1 as build-legacy.ps1'
+    Assert-True ((Count-UserPathEntry $upgradeRoot) -eq 1) 'upgrade did not add the C++ install root to user PATH'
+
+    $expectedHelp = Get-HelpLine $upgradeMqb
+    foreach ($profile in $upgradeProfiles) {
+        $content = [System.IO.File]::ReadAllText($profile)
+        Assert-True $content.Contains('# user-before') 'upgrade lost user profile prefix content'
+        Assert-True $content.Contains('# user-after') 'upgrade lost user profile suffix content'
+        Assert-True $content.Contains('# >>> MQB v5 C++ default >>>') 'upgrade did not append the managed C++ default profile block'
+
+        $command = '. ' + (Quote-PowerShellLiteral $profile) + '; build --help | Select-Object -First 1'
+        $buildHelp = @(Invoke-WindowsPowerShell $command "profile build shim from $profile")
+        Assert-True ($buildHelp.Count -gt 0 -and $buildHelp[-1] -ceq $expectedHelp) 'PowerShell build function did not resolve to mqb.exe after upgrade'
+    }
+
+    Invoke-Maintenance $upgradeRoot $upgradeProfiles -RestoreLegacy | Out-Null
+    Assert-True (-not (Test-Path -LiteralPath $upgradeMqb -PathType Leaf)) 'rollback left mqb.exe as the default binary'
+    Assert-True (Test-Path -LiteralPath $upgradeLegacy -PathType Leaf) 'rollback removed the preserved legacy implementation'
+    Assert-True ((Get-FileHash -Algorithm SHA256 -LiteralPath $priorBuild).Hash -ceq $priorBuildHash) 'rollback modified the pre-existing build.ps1'
+    Assert-True ((Count-UserPathEntry $upgradeRoot) -eq 0) 'rollback did not remove the installer-owned PATH entry'
+    foreach ($profile in $upgradeProfiles) {
+        $content = [System.IO.File]::ReadAllText($profile)
+        Assert-True (-not $content.Contains('# >>> MQB v5 C++ default >>>')) 'rollback left the C++ default profile block'
+        Assert-True $content.Contains('# >>> MQB v5 legacy rollback >>>') 'rollback did not install the explicit legacy fallback block'
+        Assert-True $content.Contains('# user-before') 'rollback lost user profile prefix content'
+        Assert-True $content.Contains('# user-after') 'rollback lost user profile suffix content'
+    }
+
+    # 3. Clean install can still roll back because the package ships the Golden Reference.
+    $rollbackRoot = Join-Path $runRoot 'clean-rollback\bin'
+    $rollbackProfile = Join-Path $runRoot 'clean-rollback\PowerShell\Microsoft.PowerShell_profile.ps1'
+    Invoke-InstallPowerShell $rollbackRoot @($rollbackProfile) | Out-Null
+    Invoke-Maintenance $rollbackRoot @($rollbackProfile) -RestoreLegacy | Out-Null
+
+    $rollbackLegacy = Join-Path $rollbackRoot 'build-legacy.ps1'
+    Assert-True (Test-Path -LiteralPath $rollbackLegacy -PathType Leaf) 'clean rollback has no legacy implementation to return to'
+    $rollbackContent = [System.IO.File]::ReadAllText($rollbackProfile)
+    Assert-True $rollbackContent.Contains('# >>> MQB v5 legacy rollback >>>') 'clean rollback did not create a legacy profile entry'
+    Assert-True $rollbackContent.Contains('build-legacy.ps1') 'clean rollback profile does not point at the preserved Golden Reference'
+    Assert-True ((Count-UserPathEntry $rollbackRoot) -eq 0) 'clean rollback left a C++ PATH entry behind'
+
+    Write-Host 'installer clean-install / upgrade / rollback validation passed'
+}
+finally {
+    [Environment]::SetEnvironmentVariable('Path', $originalUserPath, 'User')
+    Remove-Item -LiteralPath $runRoot -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -1,0 +1,40 @@
+[CmdletBinding()]
+param(
+    [switch]$RestoreLegacy,
+    [string]$InstallRoot,
+    [string[]]$ProfilePaths,
+    [switch]$SkipUserPath
+)
+
+$ErrorActionPreference = 'Stop'
+
+$engineCandidates = @(
+    (Join-Path $PSScriptRoot 'mqb-install.ps1'),
+    (Join-Path $PSScriptRoot 'install.ps1')
+)
+$engine = $null
+foreach ($candidate in $engineCandidates) {
+    if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+        $engine = $candidate
+        break
+    }
+}
+if ($null -eq $engine) {
+    throw "MQB maintenance installer not found next to this script."
+}
+
+$params = @{
+    Action = $(if ($RestoreLegacy) { 'Rollback' } else { 'Uninstall' })
+}
+if ($PSBoundParameters.ContainsKey('InstallRoot')) {
+    $params.InstallRoot = $InstallRoot
+}
+if ($PSBoundParameters.ContainsKey('ProfilePaths')) {
+    $params.ProfilePaths = $ProfilePaths
+}
+if ($SkipUserPath) {
+    $params.SkipUserPath = $true
+}
+
+& $engine @params
+exit $LASTEXITCODE


### PR DESCRIPTION
## Stable-v5 installer/default-entry cutover

This PR moves the installed default implementation from the PowerShell Golden Reference to native `mqb.exe`, while retaining an explicit rollback path.

### Installed command layout

- `mqb` is the canonical stable-v5 command.
- `build` remains available as a shell-neutral `build.cmd` compatibility alias forwarding argv directly to `mqb.exe`.
- The default per-user root remains `%USERPROFILE%\bin`.

### Upgrade safety

The old installer overwrote the complete Windows PowerShell and PowerShell 7 user profiles. Stable v5 no longer does that.

`install.ps1` now installs/maintains native MQB without overwriting or deleting an existing `%USERPROFILE%\bin\build.ps1`. On first legacy upgrade, that implementation is preserved as `build-legacy.ps1`; on a clean install, the packaged Golden Reference fills the same rollback role.

The installer adds the install root to user PATH idempotently and records whether v5 owns that entry. Known legacy PowerShell `build` functions are migrated with a delimited managed block so the later definition resolves to `mqb.exe`; unrelated/custom `build` functions and unrelated profile content are left untouched.

`install.bat` is now a non-interactive Windows PowerShell wrapper. It no longer changes the user's execution policy and no longer owns `portable_msvc.zip` extraction.

### Rollback / uninstall

`uninstall-mqb.ps1` supports:

- normal uninstall: remove v5-owned native binary/shim/PATH/profile state while preserving pre-existing legacy files and unrelated profile content;
- `-RestoreLegacy`: remove the native default and install an explicit legacy PowerShell `build` fallback, preferring the pre-existing `build.ps1` when available and otherwise using `build-legacy.ps1`.

### Windows installer gate

`.github/workflows/install-cutover.yml` builds a Release `mqb.exe` and validates clean install, `mqb.exe`/`build.cmd` identity, profile preservation, PATH ownership/idempotency, uninstall, upgrade from the existing PowerShell installation shape, PowerShell `build -> mqb.exe`, upgrade rollback, and clean-install rollback.

The C++ V2 path filters also include installer/default-entry files so these changes continue to require the full Debug installed-MSVC CTest baseline.

### Documentation boundary

`README.md` now distinguishes the published `v5.0.0-rc.2` standalone candidate from current post-rc.2 mainline: installer cutover exists on mainline after this PR, but it is not claimed as already published. `docs/V5_INSTALL_CUTOVER.md` is the detailed install/profile/PATH/rollback contract.

### Exact-head validation

Final candidate head: `fd47ab6decdf1366a6b5444adc8717b0049f763c`.

- **Installer Cutover #3:** success. Release `mqb.exe` build plus clean install / idempotent reinstall / uninstall / legacy upgrade / profile migration / `build -> mqb.exe` / upgrade rollback / clean rollback all passed on Windows.
- **C++ V2 #343:** success on the exact head, including the full Debug installed-MSVC CTest suite.
- **C++ Release Candidate #108:** success on the exact head, including Release tests, embedded `5.0.0-rc.2` verification, package staging, SHA-256 generation, and artifact upload. PR prerelease publication remained skipped as designed.
- No unresolved review threads; branch is based directly on current `main` with `behind=0`.

The two preceding functional heads also passed their installer/baseline gates; the final head reran every authoritative gate after README cutover alignment.

### Scope boundary

This PR does **not** publish stable v5 and does not mutate the already-published rc.2 assets. The next release-engineering slice is to generalize the hard-coded RC workflow, package the validated binary together with these installer/rollback files, add stable migration/release notes, and publish `v5.0.0` only from the exact validated artifact.