### PR TITLE
release: require MQB to self-host stable artifacts

### DIFF
--- a/.github/workflows/cpp-release.yml
+++ b/.github/workflows/cpp-release.yml
@@ -10,6 +10,7 @@ on:
       - 'install.ps1'
       - 'uninstall.ps1'
       - 'tests/installer/**'
+      - 'tests/selfhost/**'
       - 'release/**'
       - '.github/workflows/cpp-release.yml'
   push:
@@ -64,7 +65,8 @@ jobs:
           Write-Host "Release version: $version"
           Write-Host "Package: $packageName"
 
-      - name: Configure Release
+      # Stage 0 is only a bootstrap/test vehicle. It is never packaged.
+      - name: Configure bootstrap Release
         shell: pwsh
         env:
           MQB_RELEASE_VERSION: ${{ steps.meta.outputs.version }}
@@ -74,30 +76,42 @@ jobs:
             -DMQB_ENABLE_INSTALLED_MSVC_TESTS=ON `
             "-DMQB_VERSION=$env:MQB_RELEASE_VERSION"
 
-      - name: Build Release
+      - name: Build bootstrap Release
         run: cmake --build cpp/build-release --config Release --parallel
 
-      - name: Test Release
+      - name: Test bootstrap source graph
         run: ctest --test-dir cpp/build-release -C Release --output-on-failure
 
-      - name: Verify embedded release version
+      - name: Verify bootstrap embedded release version
         shell: pwsh
         env:
           MQB_RELEASE_VERSION: ${{ steps.meta.outputs.version }}
         run: |
           $mqb = Join-Path $PWD 'cpp/build-release/apps/mqb/Release/mqb.exe'
           if (-not (Test-Path -LiteralPath $mqb -PathType Leaf)) {
-            throw "Release executable not found: $mqb"
+            throw "Bootstrap executable not found: $mqb"
           }
           $help = @(& $mqb --help 2>&1 | ForEach-Object { $_.ToString() })
           if ($LASTEXITCODE -ne 0 -or $help.Count -eq 0) {
-            throw "mqb --help failed with exit code $LASTEXITCODE"
+            throw "bootstrap mqb --help failed with exit code $LASTEXITCODE"
           }
           $expected = "MQB $env:MQB_RELEASE_VERSION - MSVC Quick Build (C++ refactor)"
           if ($help[0] -ne $expected) {
-            throw "Embedded version mismatch. Expected '$expected', got '$($help[0])'"
+            throw "Bootstrap embedded version mismatch. Expected '$expected', got '$($help[0])'"
           }
           Write-Host $help[0]
+
+      - name: Self-host stable release with MQB
+        shell: pwsh
+        env:
+          MQB_RELEASE_VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          & (Join-Path $PWD 'tests/selfhost/selfhost.ps1') `
+            -BootstrapMqbPath (Join-Path $PWD 'cpp/build-release/apps/mqb/Release/mqb.exe') `
+            -RepoRoot $PWD `
+            -ReleaseVersion $env:MQB_RELEASE_VERSION `
+            -OutputRoot (Join-Path $PWD 'selfhost-out')
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - name: Stage release package
         shell: pwsh
@@ -110,7 +124,8 @@ jobs:
           if (Test-Path -LiteralPath $dist) { Remove-Item -LiteralPath $dist -Recurse -Force }
           New-Item -ItemType Directory -Force -Path $stage | Out-Null
 
-          Copy-Item 'cpp/build-release/apps/mqb/Release/mqb.exe' (Join-Path $stage 'mqb.exe')
+          # Stable releases package Stage 1: the binary produced by MQB itself.
+          Copy-Item 'selfhost-out/stage1/mqb.exe' (Join-Path $stage 'mqb.exe')
           Copy-Item 'install.bat' (Join-Path $stage 'install.bat')
           Copy-Item 'install.ps1' (Join-Path $stage 'install.ps1')
           Copy-Item 'uninstall.ps1' (Join-Path $stage 'uninstall.ps1')
@@ -119,6 +134,7 @@ jobs:
           Copy-Item 'docs/MQB_CONFIG.md' (Join-Path $stage 'MQB_CONFIG.md')
           Copy-Item 'docs/CPP_V2_ARCHITECTURE.md' (Join-Path $stage 'CPP_V2_ARCHITECTURE.md')
           Copy-Item 'docs/V5_INSTALL_CUTOVER.md' (Join-Path $stage 'V5_INSTALL_CUTOVER.md')
+          Copy-Item 'docs/SELF_HOSTING.md' (Join-Path $stage 'SELF_HOSTING.md')
           Copy-Item $env:MQB_NOTES_FILE (Join-Path $stage 'RELEASE_NOTES.md')
 
           $zip = Join-Path $dist ($env:MQB_PACKAGE_NAME + '.zip')
@@ -162,6 +178,7 @@ jobs:
             'mqb.exe',
             'README.md',
             'RELEASE_NOTES.md',
+            'SELF_HOSTING.md',
             'uninstall.ps1',
             'V5_INSTALL_CUTOVER.md'
           ) | Sort-Object
@@ -169,15 +186,15 @@ jobs:
           $manifestDiff = @(Compare-Object -ReferenceObject $expectedFiles -DifferenceObject $actualFiles)
           if ($manifestDiff.Count -ne 0) {
             $manifestDiff | Format-Table | Out-String | Write-Host
-            throw 'Release package manifest differs from the native-only contract.'
+            throw 'Release package manifest differs from the native-only self-hosting contract.'
           }
 
-          $builtMqb = Join-Path $PWD 'cpp/build-release/apps/mqb/Release/mqb.exe'
+          $selfHostedMqb = Join-Path $PWD 'selfhost-out/stage1/mqb.exe'
           $packagedMqb = Join-Path $verifyRoot 'mqb.exe'
-          $builtHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $builtMqb).Hash
+          $selfHostedHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $selfHostedMqb).Hash
           $packagedHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $packagedMqb).Hash
-          if ($builtHash -ne $packagedHash) {
-            throw 'Packaged mqb.exe is not byte-identical to the tested Release binary.'
+          if ($selfHostedHash -ne $packagedHash) {
+            throw 'Packaged mqb.exe is not byte-identical to the validated Stage 1 self-hosted binary.'
           }
 
           $help = @(& $packagedMqb --help 2>&1 | ForEach-Object { $_.ToString() })
@@ -194,7 +211,7 @@ jobs:
             throw "Packaged installer lifecycle failed with exit code $LASTEXITCODE"
           }
 
-          Write-Host 'Exact packaged artifact validation passed.'
+          Write-Host 'Exact self-hosted packaged artifact validation passed.'
 
       - name: Upload validated package
         uses: actions/upload-artifact@v7

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 > - `mqb.json` 是唯一受支持的项目配置格式。
 > - 旧 PowerShell `build.ps1`、`build` compatibility shim、PowerShell profile 注入、legacy rollback、`msvc_list.json` migration、PowerShell-era CLI aliases 均不再支持。
 > - 已发布的 `v5.0.0-rc.2` 仍保留为历史 prerelease；stable release pipeline 只从 native-only mainline 生成并验证发布包，不会为了兼容旧版本重新打包旧实现。
+> - stable release 必须 self-host：最终 ZIP 中的 `mqb.exe` 必须由 MQB 自身构建，而不是由 CMake 直接产出。
 
 ## 主要能力
 
@@ -28,7 +29,9 @@
 
 ## 从源码构建
 
-要求：Windows、CMake 3.25+、Visual Studio 2026 / MSVC、C++23 编译能力。
+要求：Windows、Visual Studio 2026 / MSVC、C++23 编译能力。开发测试还使用 CMake 3.25+ 作为 bootstrap/test harness；稳定版发布的最终 `mqb.exe` 不由 CMake 直接产出。
+
+### 开发 / 测试 bootstrap
 
 ```powershell
 cmake -S cpp -B cpp/build -G "Visual Studio 18 2026" -A x64
@@ -36,7 +39,28 @@ cmake --build cpp/build --config Release --target mqb
 .\cpp\build\apps\mqb\Release\mqb.exe --help
 ```
 
-开发构建默认版本为 `5.0.0-dev`。发布版本由 `release/VERSION` 统一定义，并由 Native Release workflow 显式写入二进制。
+开发构建默认版本为 `5.0.0-dev`。发布版本由 `release/VERSION` 统一定义。
+
+### 用 MQB 构建 MQB
+
+仓库中的 [`cpp/mqb.json`](cpp/mqb.json) 是 MQB 自身的 native project description。给定一个可运行的 MQB binary，可完全绕过 `CMakeLists.txt` 构建 MQB：
+
+```powershell
+$version = (Get-Content .\release\VERSION -Raw).Trim()
+$define = 'MQB_VERSION=\"' + $version + '\"'
+
+Push-Location .\cpp
+& C:\path\to\mqb.exe apps\mqb\main.cpp --env vs -D $define
+Pop-Location
+```
+
+输出为：
+
+```text
+cpp\.mqb\bin\mqb.exe
+```
+
+Stable release workflow 使用两代自举闭包：bootstrap Stage 0 用 MQB 构建 Stage 1；清空 `cpp/.mqb` 后，再由 Stage 1 构建 Stage 2。最终发布 **Stage 1**，并要求 Stage 1/Stage 2 都报告相同 stable version。完整契约见 [`docs/SELF_HOSTING.md`](docs/SELF_HOSTING.md)。
 
 ### 完整测试
 
@@ -241,7 +265,8 @@ Optional executable run
 
 - `v5.0.0-rc.2`：已经发布的历史 C++ Release Candidate；不会被追写。
 - `release/VERSION`：当前 stable release target 为 `5.0.0`；对应 release notes 为 `release/v5.0.0.md`。
-- `Native Release`：PR 上构建、完整 Release 测试、打包、checksum、解包 manifest、byte identity 与 packaged-installer lifecycle 全部通过后才上传 artifact。
+- `Native Release`：PR 上完成 bootstrap Release tests 后，必须通过 Stage 0 → Stage 1 → clean Stage 1 → Stage 2 的 MQB self-host closure；只有 Stage 1 可以进入最终 ZIP。
+- 最终 ZIP 继续经过 checksum、解包 manifest、Stage 1 byte identity 与 packaged-installer lifecycle 验证后才上传 artifact。
 - 正式发布只由匹配 `release/VERSION` 的 `vX.Y.Z` tag 触发；发布 job 直接下载同一 workflow run 已验证的 artifact，不做二次 rebuild。
 - Issue #16：独立跟踪 external/prebuilt named-module providers 与 `import std`。
 

--- a/cpp/mqb.json
+++ b/cpp/mqb.json
@@ -1,0 +1,83 @@
+{
+  "version": 1,
+  "build": {
+    "configuration": "release",
+    "architecture": "x64",
+    "standard": "23",
+    "type": "exe",
+    "runtime": "MT",
+    "subsystem": "console",
+    "output": "mqb",
+    "include_dirs": [
+      "apps/mqb",
+      "backends/msvc/include",
+      "config/include",
+      "core/include",
+      "discovery/include",
+      "json/include",
+      "modules/include",
+      "orchestration/include",
+      "platform/windows/include",
+      "process/include"
+    ],
+    "compiler_args": [
+      "/W4",
+      "/permissive-"
+    ]
+  },
+  "discovery": {
+    "enabled": true,
+    "exclude_dirs": [
+      "backends/msvc/tests",
+      "config/tests",
+      "discovery/tests",
+      "json/tests",
+      "modules/tests",
+      "orchestration/tests",
+      "tests"
+    ],
+    "extra_sources": [
+      "apps/mqb/Cli.cpp",
+      "apps/mqb/ModuleCliTarget.cpp",
+      "apps/mqb/StaticCliTarget.cpp",
+      "backends/msvc/src/MsvcCompileExecutor.cpp",
+      "backends/msvc/src/MsvcCompiler.cpp",
+      "backends/msvc/src/MsvcLibrarian.cpp",
+      "backends/msvc/src/MsvcLibraryResolver.cpp",
+      "backends/msvc/src/MsvcLinker.cpp",
+      "backends/msvc/src/MsvcModuleDependencyScanner.cpp",
+      "backends/msvc/src/MsvcSourceDependenciesReader.cpp",
+      "backends/msvc/src/MsvcToolchainLocator.cpp",
+      "config/src/ProjectConfig.cpp",
+      "config/src/ProjectOptions.cpp",
+      "core/src/ArchiveCache.cpp",
+      "core/src/ArchiveCacheFile.cpp",
+      "core/src/BuildPlanner.cpp",
+      "core/src/BuildSignature.cpp",
+      "core/src/BuildTypes.cpp",
+      "core/src/CompileCache.cpp",
+      "core/src/CompileCacheFile.cpp",
+      "core/src/DependencyGraph.cpp",
+      "core/src/LinkCache.cpp",
+      "core/src/LinkCacheFile.cpp",
+      "core/src/ProjectArtifactLayout.cpp",
+      "core/src/TranslationUnitClassifier.cpp",
+      "discovery/src/ModuleSyntax.cpp",
+      "discovery/src/SourceDiscovery.cpp",
+      "json/src/Json.cpp",
+      "modules/src/ModuleDependencyGraph.cpp",
+      "modules/src/P1689.cpp",
+      "orchestration/src/BoundedWorkScheduler.cpp",
+      "orchestration/src/MsvcIncrementalArchiveCoordinator.cpp",
+      "orchestration/src/MsvcIncrementalCompileCoordinator.cpp",
+      "orchestration/src/MsvcIncrementalLinkCoordinator.cpp",
+      "orchestration/src/MsvcIncrementalStaticTargetCoordinator.cpp",
+      "orchestration/src/MsvcIncrementalTargetCoordinator.cpp",
+      "orchestration/src/MsvcModuleCompileCoordinator.cpp",
+      "orchestration/src/MsvcModuleTargetCoordinator.cpp",
+      "orchestration/src/MsvcTargetRouter.cpp",
+      "platform/windows/src/CommandLine.cpp",
+      "platform/windows/src/WindowsProcessRunner.cpp"
+    ]
+  }
+}

--- a/cpp/mqb.json
+++ b/cpp/mqb.json
@@ -29,6 +29,7 @@
     "enabled": true,
     "exclude_dirs": [
       "backends/msvc/tests",
+      "build-release",
       "config/tests",
       "discovery/tests",
       "json/tests",

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -1,0 +1,86 @@
+# MQB stable self-hosting contract
+
+A stable MQB release must be able to build MQB itself without consulting `CMakeLists.txt` for the self-host build.
+
+This is a release-blocking contract, not an optional demonstration.
+
+## What "self-hosted release" means
+
+The release workflow uses three logical stages:
+
+1. **Stage 0 — bootstrap/test binary**
+   - built by CMake on the Windows CI runner;
+   - used to run the existing full Release CTest suite;
+   - used only to start the self-host chain;
+   - **never packaged or published**.
+2. **Stage 1 — self-hosted release candidate**
+   - built by Stage 0 by invoking MQB on `cpp/apps/mqb/main.cpp`;
+   - build policy and production source manifest come from `cpp/mqb.json`;
+   - `CMakeLists.txt` is not read or invoked for this build;
+   - this is the `mqb.exe` that is placed in the stable ZIP.
+3. **Stage 2 — closure proof**
+   - after Stage 1 is copied outside the project build state, `cpp/.mqb` is deleted;
+   - Stage 1 then builds MQB again from the same source/config from a clean MQB state;
+   - Stage 2 must report the same release version.
+
+The required chain is therefore:
+
+```text
+bootstrap Stage 0
+      |
+      | mqb + cpp/mqb.json
+      v
+self-hosted Stage 1  ---> stable package mqb.exe
+      |
+      | delete cpp/.mqb, then mqb + cpp/mqb.json
+      v
+Stage 2 closure proof
+```
+
+The stable package is rejected if Stage 0 cannot build Stage 1, if Stage 1 cannot build Stage 2, or if either self-hosted binary reports the wrong embedded version.
+
+## Native project description
+
+`cpp/mqb.json` is the native project description for building MQB with MQB. It declares:
+
+- Release configuration;
+- x64 architecture;
+- C++23;
+- executable target;
+- static `MT` runtime;
+- console subsystem;
+- MQB's production include roots;
+- `/W4` and `/permissive-`;
+- the complete production translation-unit set outside tests.
+
+`tests/selfhost/selfhost.ps1` independently enumerates the production source directories and requires the `mqb.json` entry source plus `discovery.extra_sources` to exactly cover that set. Adding or removing a production `.cpp` without updating the native self-host manifest fails the gate.
+
+The release version remains sourced from `release/VERSION`. The self-host harness supplies it as the structured `MQB_VERSION` preprocessor definition, so `cpp/mqb.json` does not duplicate the release number.
+
+## Manual self-build
+
+Given an MQB executable and a checkout of the matching source tag, a self-build can be performed without CMake:
+
+```powershell
+$version = (Get-Content ..\release\VERSION -Raw).Trim()
+$define = 'MQB_VERSION=\"' + $version + '\"'
+
+Set-Location cpp
+& C:\path\to\mqb.exe apps\mqb\main.cpp --env vs -D $define
+```
+
+The native self-host result is:
+
+```text
+cpp\.mqb\bin\mqb.exe
+```
+
+Running that result with `--help` must report the same version. Running the same command again with that newly built executable from a clean `cpp/.mqb` state is the closure proof used by CI.
+
+## Release artifact rule
+
+The stable ZIP must contain the Stage 1 binary, not the Stage 0 bootstrap binary.
+
+Before upload, the release workflow verifies that the ZIP's `mqb.exe` is byte-identical to the validated Stage 1 executable, then runs the normal packaged install/reinstall/uninstall lifecycle against that exact ZIP.
+
+CMake remains useful as a development/test bootstrap and for the existing unit/integration test graph, but it is not the producer of the `mqb.exe` shipped in a stable release.

--- a/release/v5.0.0.md
+++ b/release/v5.0.0.md
@@ -21,6 +21,17 @@ This release is a clean break from the former PowerShell implementation. Stable 
 - project-local named modules and project-local header units with P1689-based topology
 - structured `--run -- arg1 "arg 2"` program arguments
 - native install, reinstall, and uninstall lifecycle
+- stable-release self-hosting: the `mqb.exe` in the ZIP is built by MQB itself, not by CMake
+
+## Self-hosted stable artifact
+
+Stable publication requires a two-generation self-host closure.
+
+The CI test/bootstrap binary (Stage 0) first runs the full Release test graph. Stage 0 then invokes MQB with the checked-in `cpp/mqb.json` project description to build Stage 1 without reading or invoking `CMakeLists.txt`. Stage 1 is copied aside, all `cpp/.mqb` state is deleted, and Stage 1 must rebuild MQB again as Stage 2 from a clean state.
+
+Both self-hosted generations must report `MQB 5.0.0`. The stable ZIP packages **Stage 1**, not the Stage 0 bootstrap executable. Before upload, the ZIP's `mqb.exe` is required to be byte-identical to the validated Stage 1 binary.
+
+The complete contract and manual self-build command are documented in `SELF_HOSTING.md` inside the release package and in `docs/SELF_HOSTING.md` in the repository.
 
 ## Breaking changes from the PowerShell line
 
@@ -59,7 +70,7 @@ powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$HOME\bin\uninstall-mqb
 
 ## Package integrity
 
-The release workflow builds and runs the full Release installed-MSVC test suite, verifies the embedded version, creates the ZIP and SHA-256 file, extracts that exact ZIP, verifies its manifest and checksum, and runs the native install/reinstall/uninstall regression against the extracted package before upload.
+The release workflow runs the full Release installed-MSVC test suite on the bootstrap build, verifies the embedded version, proves the two-stage MQB self-host closure, packages the Stage 1 self-hosted binary, creates the ZIP and SHA-256 file, extracts that exact ZIP, verifies its manifest and checksum, and runs the native install/reinstall/uninstall regression against the extracted package before upload.
 
 For tag publication, the workflow requires the pushed tag to exactly match `release/VERSION` and publishes the already-validated workflow artifact without rebuilding it.
 

--- a/tests/selfhost/selfhost.ps1
+++ b/tests/selfhost/selfhost.ps1
@@ -89,8 +89,14 @@ function Invoke-SelfBuild {
     try {
         Write-Host "[$Label] builder: $Builder"
         Write-Host "[$Label] release define: $VersionDefine"
-        & $Builder 'apps/mqb/main.cpp' '--env' 'vs' '--verbose' '-D' $VersionDefine
+
+        # Keep the native process output visible without allowing PowerShell's
+        # function-output semantics to mix log lines into the returned path.
+        $buildOutput = @(& $Builder 'apps/mqb/main.cpp' '--env' 'vs' '--verbose' '-D' $VersionDefine 2>&1)
         $exitCode = $LASTEXITCODE
+        foreach ($line in $buildOutput) {
+            Write-Host $line
+        }
         if ($exitCode -ne 0) {
             throw "$Label self-build failed with exit code $exitCode"
         }

--- a/tests/selfhost/selfhost.ps1
+++ b/tests/selfhost/selfhost.ps1
@@ -88,7 +88,7 @@ function Invoke-SelfBuild {
     Push-Location $CppRoot
     try {
         Write-Host "[$Label] builder: $Builder"
-        & $Builder 'apps/mqb/main.cpp' '--env' 'vs' '-D' $VersionDefine
+        & $Builder 'apps/mqb/main.cpp' '--env' 'vs' '--verbose' '-D' $VersionDefine
         $exitCode = $LASTEXITCODE
         if ($exitCode -ne 0) {
             throw "$Label self-build failed with exit code $exitCode"
@@ -133,8 +133,9 @@ if (Test-Path -LiteralPath $mqbState) {
     Remove-Item -LiteralPath $mqbState -Recurse -Force
 }
 
-# The compiler receives this as /DMQB_VERSION=\"X.Y.Z\".
-$versionDefine = 'MQB_VERSION=\"' + $ReleaseVersion + '\"'
+# Keep literal quotes in the structured define value. MQB's Windows argv encoder
+# is responsible for escaping them when constructing cl.exe's command line.
+$versionDefine = 'MQB_VERSION="' + $ReleaseVersion + '"'
 
 # Stage 0 may come from the bootstrap build system. It is never packaged.
 $stage1Built = Invoke-SelfBuild `

--- a/tests/selfhost/selfhost.ps1
+++ b/tests/selfhost/selfhost.ps1
@@ -35,7 +35,7 @@ function Assert-MqbVersion {
     if ($help[0] -ne $expected) {
         throw "$Label version mismatch. Expected '$expected', got '$($help[0])'"
     }
-    Write-Host "$Label: $($help[0])"
+    Write-Host "${Label}: $($help[0])"
 }
 
 function Assert-SelfHostSourceManifest {

--- a/tests/selfhost/selfhost.ps1
+++ b/tests/selfhost/selfhost.ps1
@@ -1,0 +1,176 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$BootstrapMqbPath,
+    [Parameter(Mandatory = $true)][string]$RepoRoot,
+    [Parameter(Mandatory = $true)][string]$ReleaseVersion,
+    [string]$OutputRoot
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+function Get-FullPath {
+    param([Parameter(Mandatory = $true)][string]$Path)
+    return [System.IO.Path]::GetFullPath($Path)
+}
+
+function Assert-MqbVersion {
+    param(
+        [Parameter(Mandatory = $true)][string]$MqbPath,
+        [Parameter(Mandatory = $true)][string]$ExpectedVersion,
+        [Parameter(Mandatory = $true)][string]$Label
+    )
+
+    if (-not (Test-Path -LiteralPath $MqbPath -PathType Leaf)) {
+        throw "$Label executable not found: $MqbPath"
+    }
+
+    $help = @(& $MqbPath --help 2>&1 | ForEach-Object { $_.ToString() })
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne 0 -or $help.Count -eq 0) {
+        throw "$Label --help failed with exit code $exitCode"
+    }
+
+    $expected = "MQB $ExpectedVersion - MSVC Quick Build (C++ refactor)"
+    if ($help[0] -ne $expected) {
+        throw "$Label version mismatch. Expected '$expected', got '$($help[0])'"
+    }
+    Write-Host "$Label: $($help[0])"
+}
+
+function Assert-SelfHostSourceManifest {
+    param([Parameter(Mandatory = $true)][string]$CppRoot)
+
+    $configPath = Join-Path $CppRoot 'mqb.json'
+    $config = Get-Content -LiteralPath $configPath -Raw | ConvertFrom-Json
+
+    $declared = @('apps/mqb/main.cpp') + @($config.discovery.extra_sources)
+    $declared = @($declared | ForEach-Object { $_.Replace('\', '/') } | Sort-Object -Unique)
+
+    $sourceRoots = @(
+        'apps/mqb',
+        'backends/msvc/src',
+        'config/src',
+        'core/src',
+        'discovery/src',
+        'json/src',
+        'modules/src',
+        'orchestration/src',
+        'platform/windows/src'
+    )
+
+    $actual = @()
+    foreach ($relativeRoot in $sourceRoots) {
+        $root = Join-Path $CppRoot $relativeRoot
+        $actual += Get-ChildItem -LiteralPath $root -File -Filter '*.cpp' | ForEach-Object {
+            [System.IO.Path]::GetRelativePath($CppRoot, $_.FullName).Replace('\', '/')
+        }
+    }
+    $actual = @($actual | Sort-Object -Unique)
+
+    $diff = @(Compare-Object -ReferenceObject $actual -DifferenceObject $declared)
+    if ($diff.Count -ne 0) {
+        $diff | Format-Table | Out-String | Write-Host
+        throw 'cpp/mqb.json does not exactly cover the production MQB translation-unit set.'
+    }
+
+    Write-Host "Self-host source manifest covers all $($actual.Count) production translation units."
+}
+
+function Invoke-SelfBuild {
+    param(
+        [Parameter(Mandatory = $true)][string]$Builder,
+        [Parameter(Mandatory = $true)][string]$CppRoot,
+        [Parameter(Mandatory = $true)][string]$VersionDefine,
+        [Parameter(Mandatory = $true)][string]$Label
+    )
+
+    Push-Location $CppRoot
+    try {
+        Write-Host "[$Label] builder: $Builder"
+        & $Builder 'apps/mqb/main.cpp' '--env' 'vs' '-D' $VersionDefine
+        $exitCode = $LASTEXITCODE
+        if ($exitCode -ne 0) {
+            throw "$Label self-build failed with exit code $exitCode"
+        }
+    }
+    finally {
+        Pop-Location
+    }
+
+    $result = Join-Path $CppRoot '.mqb/bin/mqb.exe'
+    if (-not (Test-Path -LiteralPath $result -PathType Leaf)) {
+        throw "$Label did not produce $result"
+    }
+    return $result
+}
+
+$RepoRoot = Get-FullPath $RepoRoot
+$BootstrapMqbPath = Get-FullPath $BootstrapMqbPath
+$cppRoot = Join-Path $RepoRoot 'cpp'
+if ([string]::IsNullOrWhiteSpace($OutputRoot)) {
+    $OutputRoot = Join-Path $RepoRoot 'selfhost-out'
+}
+$OutputRoot = Get-FullPath $OutputRoot
+
+if (-not (Test-Path -LiteralPath $BootstrapMqbPath -PathType Leaf)) {
+    throw "Bootstrap MQB not found: $BootstrapMqbPath"
+}
+if (-not (Test-Path -LiteralPath (Join-Path $cppRoot 'mqb.json') -PathType Leaf)) {
+    throw 'cpp/mqb.json is required for self-hosting.'
+}
+
+Assert-SelfHostSourceManifest -CppRoot $cppRoot
+Assert-MqbVersion -MqbPath $BootstrapMqbPath -ExpectedVersion $ReleaseVersion -Label 'Stage 0 bootstrap'
+
+if (Test-Path -LiteralPath $OutputRoot) {
+    Remove-Item -LiteralPath $OutputRoot -Recurse -Force
+}
+New-Item -ItemType Directory -Force -Path $OutputRoot | Out-Null
+
+$mqbState = Join-Path $cppRoot '.mqb'
+if (Test-Path -LiteralPath $mqbState) {
+    Remove-Item -LiteralPath $mqbState -Recurse -Force
+}
+
+# The compiler receives this as /DMQB_VERSION=\"X.Y.Z\".
+$versionDefine = 'MQB_VERSION=\"' + $ReleaseVersion + '\"'
+
+# Stage 0 may come from the bootstrap build system. It is never packaged.
+$stage1Built = Invoke-SelfBuild `
+    -Builder $BootstrapMqbPath `
+    -CppRoot $cppRoot `
+    -VersionDefine $versionDefine `
+    -Label 'Stage 0 -> Stage 1'
+
+$stage1Dir = Join-Path $OutputRoot 'stage1'
+New-Item -ItemType Directory -Force -Path $stage1Dir | Out-Null
+$stage1 = Join-Path $stage1Dir 'mqb.exe'
+Copy-Item -LiteralPath $stage1Built -Destination $stage1 -Force
+Assert-MqbVersion -MqbPath $stage1 -ExpectedVersion $ReleaseVersion -Label 'Stage 1 self-hosted release candidate'
+
+$stage1Hash = (Get-FileHash -Algorithm SHA256 -LiteralPath $stage1).Hash.ToLowerInvariant()
+Write-Host "Stage 1 SHA256: $stage1Hash"
+
+# Prove closure: discard every Stage-0-produced MQB cache/object/output and use the
+# self-hosted Stage 1 executable to rebuild the same source/config from a clean state.
+if (Test-Path -LiteralPath $mqbState) {
+    Remove-Item -LiteralPath $mqbState -Recurse -Force
+}
+
+$stage2Built = Invoke-SelfBuild `
+    -Builder $stage1 `
+    -CppRoot $cppRoot `
+    -VersionDefine $versionDefine `
+    -Label 'Stage 1 -> Stage 2'
+
+$stage2Dir = Join-Path $OutputRoot 'stage2'
+New-Item -ItemType Directory -Force -Path $stage2Dir | Out-Null
+$stage2 = Join-Path $stage2Dir 'mqb.exe'
+Copy-Item -LiteralPath $stage2Built -Destination $stage2 -Force
+Assert-MqbVersion -MqbPath $stage2 -ExpectedVersion $ReleaseVersion -Label 'Stage 2 closure proof'
+
+$stage2Hash = (Get-FileHash -Algorithm SHA256 -LiteralPath $stage2).Hash.ToLowerInvariant()
+Write-Host "Stage 2 SHA256: $stage2Hash"
+Write-Host 'MQB self-host closure passed: the self-hosted release candidate can build MQB again from a clean state.'
+exit 0

--- a/tests/selfhost/selfhost.ps1
+++ b/tests/selfhost/selfhost.ps1
@@ -88,6 +88,7 @@ function Invoke-SelfBuild {
     Push-Location $CppRoot
     try {
         Write-Host "[$Label] builder: $Builder"
+        Write-Host "[$Label] release define: $VersionDefine"
         & $Builder 'apps/mqb/main.cpp' '--env' 'vs' '--verbose' '-D' $VersionDefine
         $exitCode = $LASTEXITCODE
         if ($exitCode -ne 0) {
@@ -133,9 +134,10 @@ if (Test-Path -LiteralPath $mqbState) {
     Remove-Item -LiteralPath $mqbState -Recurse -Force
 }
 
-# Keep literal quotes in the structured define value. MQB's Windows argv encoder
-# is responsible for escaping them when constructing cl.exe's command line.
-$versionDefine = 'MQB_VERSION="' + $ReleaseVersion + '"'
+# Construct the structured /D payload with literal quote characters. Do not
+# pre-escape them for a shell: MQB's Windows argv encoder owns that escaping.
+$quote = [char]34
+$versionDefine = 'MQB_VERSION=' + $quote + $ReleaseVersion + $quote
 
 # Stage 0 may come from the bootstrap build system. It is never packaged.
 $stage1Built = Invoke-SelfBuild `


### PR DESCRIPTION
## Goal

Make self-hosting a release-blocking stable-v5 condition: the `mqb.exe` shipped in the stable ZIP must be built by MQB itself rather than copied from the CMake bootstrap build.

## Self-host chain

The release pipeline now distinguishes three stages:

1. **Stage 0** — CMake bootstrap/test binary. It runs the existing full Release CTest graph and is never packaged.
2. **Stage 1** — Stage 0 invokes MQB against `cpp/apps/mqb/main.cpp` using the checked-in `cpp/mqb.json`. This build does not read or invoke CMakeLists. Stage 1 is the stable release candidate and the only binary eligible for packaging.
3. **Stage 2** — after Stage 1 is copied aside and `cpp/.mqb` is deleted, Stage 1 rebuilds MQB again from a clean MQB state. Stage 2 proves self-host closure.

Both Stage 1 and Stage 2 must report the release version from `release/VERSION`.

## Native project description

`cpp/mqb.json` declares the production self-build policy:

- Release / x64 / C++23 / executable
- static MT runtime
- console subsystem
- all production include roots
- `/W4` and `/permissive-`
- the full production translation-unit set via the entry source plus `discovery.extra_sources`

The self-host harness independently enumerates the production source directories and fails if the config does not exactly cover every production `.cpp`. The validated manifest covers all 42 production translation units.

## Release artifact rule

- CMake Stage 0 is bootstrap-only and cannot enter the ZIP.
- `selfhost-out/stage1/mqb.exe` is packaged as `mqb.exe`.
- package validation requires the ZIP binary to be byte-identical to Stage 1.
- the existing exact ZIP manifest/checksum/installer lifecycle validation still runs after self-hosting.

## Documentation

- add `docs/SELF_HOSTING.md`
- document manual MQB→MQB build in README
- update stable `v5.0.0` notes to state that the shipped executable is self-hosted
- package `SELF_HOSTING.md` with the stable artifact

## Exact-head validation

Final candidate head: `97660b0a9c6797b15728acfeb06aa01db1fcaaa8`.

- **Native Installer #19:** success.
- **C++ V2 #359:** success, including the full Debug installed-MSVC test graph.
- **Native Release #121:** success.
  - bootstrap Release build: success
  - full Release installed-MSVC CTest: success
  - Stage 0 embedded `MQB 5.0.0`: success
  - production self-host source manifest: exactly 42 translation units
  - **Stage 0 → Stage 1 MQB self-build: success**
  - Stage 1 embedded `MQB 5.0.0`: success
  - delete `cpp/.mqb`
  - **Stage 1 → Stage 2 clean MQB self-build: success**
  - Stage 2 embedded `MQB 5.0.0`: success
  - self-host closure: success
  - stable package stages Stage 1, not Stage 0
  - ZIP manifest/checksum validation: success
  - packaged `mqb.exe` byte-identical to validated Stage 1: success
  - install/reinstall/uninstall from the extracted package: success
  - validated artifact upload: success
- Final artifact: `vscode-msvc-quick-build-v5.0.0-windows-x64`, produced from exact head `97660b0a9c6797b15728acfeb06aa01db1fcaaa8`.
- Artifact digest: `sha256:f54e8424f1e77f94669c56b368bed99da5e93c1693d0fbc55692b4b9c9fcaf30`.
- Branch is directly based on current main with `behind=0`.
- No unresolved review threads.

Earlier diagnostic runs caught only harness issues: PowerShell label interpolation, shell-style over-escaping of the structured version define, and native stdout leaking into a PowerShell function return value. The last diagnostic run already proved Stage 0 → Stage 1 completed successfully; the final head then proved the full Stage 1 → Stage 2 closure and package chain.

## Acceptance

- [x] Stage 0 → Stage 1 succeeds without CMake in the Stage 1 build
- [x] Stage 1 → Stage 2 succeeds after deleting all prior `.mqb` state
- [x] both self-hosted generations embed the intended release version
- [x] the stable package contains Stage 1, not Stage 0
- [x] Debug, installer, and full Release/package gates remain green

This PR does not create the `v5.0.0` tag or publish the stable release. After merge, the remaining work is the final repository/release-metadata audit before creating the stable tag.