### PR TITLE
ci: fix stable release workflow cross-gating

### DIFF
--- a/.github/workflows/native-ci.yml
+++ b/.github/workflows/native-ci.yml
@@ -17,7 +17,7 @@ on:
       - 'release/**'
       - '.github/workflows/native-ci.yml'
       - '.github/workflows/native-installer.yml'
-      - '.github/workflows/cpp-release.yml'
+      - '.github/workflows/native-release.yml'
 
 jobs:
   build-and-test:

--- a/README.md
+++ b/README.md
@@ -256,6 +256,8 @@ Optional executable run
 3. `Native Release`：完整 Release tests、Stage 0 → Stage 1 → clean Stage 1 → Stage 2 self-host closure、exact package manifest、SHA-256、Stage 1 byte identity 与 packaged-installer validation；
 4. 匹配 `release/VERSION` 的 `vX.Y.Z` tag 才能触发 publication；publication job 只发布同一 workflow run 已验证的 artifact，不二次 rebuild。
 
+三条稳定 workflow 的定义文件都属于 `Native C++` 的 PR 触发范围；release / installer workflow 的变更不能绕过 Debug installed-MSVC gate。
+
 历史 `v5.0.0-rc.1` / `v5.0.0-rc.2` release notes 保留原样。Issue #16 独立跟踪 external/prebuilt named-module providers 与 `import std`。
 
 ## License


### PR DESCRIPTION
## Goal

Fix the final release-governance defect found after the stable-readiness rename: changes to the real `native-release.yml` must trigger the authoritative `Native C++` Debug gate.

## Change

- replace stale `.github/workflows/cpp-release.yml` in `Native C++` pull-request paths with `.github/workflows/native-release.yml`
- document the cross-gating invariant in README: stable release/installer workflow changes cannot bypass the Debug installed-MSVC gate

This PR changes no MQB engine behavior and does not create or publish `v5.0.0`.

## Exact-head validation

Final candidate head: `c064ed35375a313c075b2928f9047bd86738d8c1`.

- **Native Installer #3:** success, including install/reinstall/uninstall lifecycle.
- **Native C++ #3:** success, including the full Debug installed-MSVC test graph.
- **Native Release #2:** success.
  - release metadata + bootstrap Release build/tests: success
  - embedded `MQB 5.0.0`: success
  - Stage 0 → Stage 1 self-build: success
  - clean Stage 1 → Stage 2 self-host closure: success
  - Stage 1 stable package staging: success
  - exact manifest/checksum + Stage 1 byte identity: success
  - packaged installer lifecycle: success
  - artifact upload: success
  - publication skipped by design on PR
- Artifact: `vscode-msvc-quick-build-v5.0.0-windows-x64`
- Artifact digest: `sha256:3f4a2a95b683922fd4514de8019bc699b7d448a6c079951bf0b0592f3f04cf54`
- Branch is directly based on current main with `behind=0`.
- No unresolved review threads.

## Acceptance

- [x] Native C++ passes on the exact head
- [x] Native Installer passes on the exact head
- [x] Native Release passes on the exact head, including Stage 1/Stage 2 self-host closure and exact package validation
- [x] branch remains `behind=0`
- [x] no unresolved review threads

Stable tag remains frozen until this governance fix is merged and the repository About Description/Topics audit blocker is cleared.