### PR TITLE
chore: remove stale pre-v5 ignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,9 +10,6 @@ dist/
 # Local worktrees / caches
 .worktrees/
 .cache/
-test_compile_out/
-test_out/
-test_out2/
 
 # 编译中间产物和可执行文件
 *.exe
@@ -24,8 +21,5 @@ test_out2/
 .vscode/
 .vs/
 .idea/
-msvc_build_scan_*/
-msvc_std_module_cache/
 
-portable_msvc.zip
 portable_msvc/


### PR DESCRIPTION
## Pre-v5 repository cleanup

The current native-only tree no longer creates the old `test_compile_out`, `test_out`, `test_out2`, `msvc_build_scan_*`, or `msvc_std_module_cache` outputs. Repository-wide search finds no current references to them.

This removes those stale `.gitignore` entries so leftover local directories are no longer silently hidden. It also removes the redundant historical `portable_msvc.zip` entry; `*.zip` remains ignored globally, while the active `portable_msvc/` toolchain root remains ignored.

No product, test, installer, self-host, or release code is changed. Current MQB outputs (`.mqb`, `native-dev`, `native-out`, `native-seed`, `native-test-work`, `selfhost-out`, `dist`) remain ignored.

Part of the final repository hygiene audit before stable v5 publication.