### PR TITLE
release: align final v5 docs and bilingual package

### DIFF
--- a/.github/workflows/native-ci.yml
+++ b/.github/workflows/native-ci.yml
@@ -8,6 +8,8 @@ on:
     paths:
       - 'cpp/**'
       - 'README.md'
+      - 'README_EN.md'
+      - 'LICENSE'
       - 'docs/**'
       - 'install.bat'
       - 'install.ps1'

--- a/.github/workflows/native-installer.yml
+++ b/.github/workflows/native-installer.yml
@@ -11,6 +11,8 @@ on:
       - 'tests/native/**'
       - 'docs/INSTALLATION.md'
       - 'README.md'
+      - 'README_EN.md'
+      - 'LICENSE'
       - 'release/**'
       - '.github/workflows/native-installer.yml'
   push:
@@ -25,6 +27,8 @@ on:
       - 'tests/native/**'
       - 'docs/INSTALLATION.md'
       - 'README.md'
+      - 'README_EN.md'
+      - 'LICENSE'
       - 'release/**'
       - '.github/workflows/native-installer.yml'
 

--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - 'cpp/**'
       - 'README.md'
+      - 'README_EN.md'
+      - 'LICENSE'
       - 'docs/**'
       - 'install.bat'
       - 'install.ps1'
@@ -120,6 +122,7 @@ jobs:
       - name: Stage release package
         shell: pwsh
         env:
+          MQB_RELEASE_VERSION: ${{ steps.meta.outputs.version }}
           MQB_PACKAGE_NAME: ${{ steps.meta.outputs.package_name }}
           MQB_NOTES_FILE: ${{ steps.meta.outputs.notes_file }}
         run: |
@@ -134,12 +137,36 @@ jobs:
           Copy-Item 'install.ps1' (Join-Path $stage 'install.ps1')
           Copy-Item 'uninstall.ps1' (Join-Path $stage 'uninstall.ps1')
           Copy-Item 'README.md' (Join-Path $stage 'README.md')
+          Copy-Item 'README_EN.md' (Join-Path $stage 'README_EN.md')
           Copy-Item 'LICENSE' (Join-Path $stage 'LICENSE')
           Copy-Item 'docs/MQB_CONFIG.md' (Join-Path $stage 'MQB_CONFIG.md')
+          Copy-Item 'docs/MQB_CONFIG_EN.md' (Join-Path $stage 'MQB_CONFIG_EN.md')
           Copy-Item 'docs/ARCHITECTURE.md' (Join-Path $stage 'ARCHITECTURE.md')
+          Copy-Item 'docs/ARCHITECTURE_EN.md' (Join-Path $stage 'ARCHITECTURE_EN.md')
           Copy-Item 'docs/INSTALLATION.md' (Join-Path $stage 'INSTALLATION.md')
           Copy-Item 'docs/SELF_HOSTING.md' (Join-Path $stage 'SELF_HOSTING.md')
-          Copy-Item $env:MQB_NOTES_FILE (Join-Path $stage 'RELEASE_NOTES.md')
+          Copy-Item 'docs/SELF_HOSTING_EN.md' (Join-Path $stage 'SELF_HOSTING_EN.md')
+
+          $releaseNotes = Join-Path $stage 'RELEASE_NOTES.md'
+          $releaseNotesEn = Join-Path $stage 'RELEASE_NOTES_EN.md'
+          $notesEnFile = "release/v$($env:MQB_RELEASE_VERSION)_EN.md"
+          if (-not (Test-Path -LiteralPath $notesEnFile -PathType Leaf)) {
+            throw "English release notes not found: $notesEnFile"
+          }
+          Copy-Item $env:MQB_NOTES_FILE $releaseNotes
+          Copy-Item $notesEnFile $releaseNotesEn
+
+          $zhNotes = (Get-Content -LiteralPath $releaseNotes -Raw).Replace(
+            "(v$($env:MQB_RELEASE_VERSION)_EN.md)",
+            '(RELEASE_NOTES_EN.md)'
+          )
+          Set-Content -LiteralPath $releaseNotes -Value $zhNotes -Encoding utf8NoBOM -NoNewline
+
+          $enNotes = (Get-Content -LiteralPath $releaseNotesEn -Raw).Replace(
+            "(v$($env:MQB_RELEASE_VERSION).md)",
+            '(RELEASE_NOTES.md)'
+          )
+          Set-Content -LiteralPath $releaseNotesEn -Value $enNotes -Encoding utf8NoBOM -NoNewline
 
           $zip = Join-Path $dist ($env:MQB_PACKAGE_NAME + '.zip')
           Compress-Archive -Path (Join-Path $stage '*') -DestinationPath $zip -CompressionLevel Optimal
@@ -175,15 +202,20 @@ jobs:
           Expand-Archive -LiteralPath $zip -DestinationPath $verifyRoot
           $expectedFiles = @(
             'ARCHITECTURE.md',
+            'ARCHITECTURE_EN.md',
             'INSTALLATION.md',
             'install.bat',
             'install.ps1',
             'LICENSE',
             'MQB_CONFIG.md',
+            'MQB_CONFIG_EN.md',
             'mqb.exe',
             'README.md',
+            'README_EN.md',
             'RELEASE_NOTES.md',
+            'RELEASE_NOTES_EN.md',
             'SELF_HOSTING.md',
+            'SELF_HOSTING_EN.md',
             'uninstall.ps1'
           ) | Sort-Object
           $actualFiles = @(Get-ChildItem -LiteralPath $verifyRoot -File | Select-Object -ExpandProperty Name | Sort-Object)
@@ -206,6 +238,15 @@ jobs:
           $expectedHelp = "MQB $env:MQB_RELEASE_VERSION - MSVC Quick Build (C++ refactor)"
           if ($help[0] -ne $expectedHelp) {
             throw "Packaged embedded version mismatch. Expected '$expectedHelp', got '$($help[0])'"
+          }
+
+          $zhNotes = Get-Content -LiteralPath (Join-Path $verifyRoot 'RELEASE_NOTES.md') -Raw
+          $enNotes = Get-Content -LiteralPath (Join-Path $verifyRoot 'RELEASE_NOTES_EN.md') -Raw
+          if (-not $zhNotes.Contains('(RELEASE_NOTES_EN.md)')) {
+            throw 'Packaged Chinese release notes do not link to RELEASE_NOTES_EN.md.'
+          }
+          if (-not $enNotes.Contains('(RELEASE_NOTES.md)')) {
+            throw 'Packaged English release notes do not link to RELEASE_NOTES.md.'
           }
 
           & (Join-Path $PWD 'tests/installer/native_installer_lifecycle.ps1') `

--- a/README.md
+++ b/README.md
@@ -115,12 +115,14 @@ native-dev\debug\mqb.exe
 
 ### 只构建 MQB
 
-[`cpp/mqb.json`](cpp/mqb.json) 是 MQB 自身的 production manifest。当前 manifest 精确描述 42 个 production translation units，并且只需要两个 include roots：
+[`cpp/mqb.json`](cpp/mqb.json) 是 MQB 自身的 production manifest。当前 manifest 与 `cpp/src/**/*.cpp` 的实际 production source set 保持精确一致，并且只需要两个 include roots：
 
 ```text
 include
 src/app
 ```
+
+production TU 数量不是稳定契约；native build/test driver 按真实 source-set identity 校验 manifest，而不是依赖 hard-coded magic count。
 
 手工构建：
 
@@ -144,7 +146,7 @@ cpp\.mqb\bin\mqb.exe
 
 `tests/native/run_native_tests.ps1` 是权威 native test driver：
 
-1. 从 `cpp/mqb.json` 读取 41 个 non-main production translation units；
+1. 从 `cpp/mqb.json` 读取全部 non-main production translation units，并与真实 `cpp/src/**/*.cpp` non-main source set 做一致性校验；
 2. 只从统一的 `cpp/tests/` 树枚举并要求恰好 67 个 `*_tests.cpp`；
 3. 使用当前 MQB 构建每个测试可执行文件；
 4. 对 CLI E2E tests 传入当前 MQB 本身；
@@ -166,7 +168,7 @@ cpp\.mqb\bin\mqb.exe
 
 ```text
 pinned historical MQB seed
-        ↓  MQB 构建当前 42-TU 源码
+        ↓  MQB 构建当前 production source set
 Stage 0
         ↓  MQB 构建并运行 67/67 Release tests
 Stage 0 → Stage 1

--- a/README_EN.md
+++ b/README_EN.md
@@ -115,12 +115,14 @@ native-dev\debug\mqb.exe
 
 ### Building MQB Only
 
-[`cpp/mqb.json`](cpp/mqb.json) is MQB's self-hosting production manifest. The current manifest precisely describes 42 production translation units and requires only two include roots:
+[`cpp/mqb.json`](cpp/mqb.json) is MQB's self-hosting production manifest. The current manifest exactly matches the actual `cpp/src/**/*.cpp` production source set and requires only two include roots:
 
 ```text
 include
 src/app
 ```
+
+The production TU count is intentionally not a stable contract; native build/test drivers validate manifest identity against the real source set instead of relying on a hard-coded magic count.
 
 Manual build:
 
@@ -144,7 +146,7 @@ cpp\.mqb\bin\mqb.exe
 
 `tests/native/run_native_tests.ps1` is the authoritative native test driver:
 
-1. Reads 41 non-main production translation units from `cpp/mqb.json`;
+1. Reads all non-main production translation units from `cpp/mqb.json` and verifies that set against the actual non-main `cpp/src/**/*.cpp` source set;
 2. Enumerates and requires exactly 67 `*_tests.cpp` files from the unified `cpp/tests/` tree;
 3. Builds each test executable using the current MQB;
 4. Passes the current MQB itself to CLI E2E tests;
@@ -166,7 +168,7 @@ The first stable v5 uses historical `v5.0.0-rc.2` `mqb.exe` as pinned seed, vali
 
 ```text
 pinned historical MQB seed
-        ↓  MQB builds current 42-TU source
+        ↓  MQB builds current production source set
 Stage 0
         ↓  MQB builds and runs 67/67 Release tests
 Stage 0 → Stage 1

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -78,11 +78,11 @@ The `Native Installer` workflow validates on Windows that:
 For version `X.Y.Z`, the `Native Release` workflow produces:
 
 ```text
-vscode-msvc-quick-build-vX.Y.Z-windows-x64.zip
-vscode-msvc-quick-build-vX.Y.Z-windows-x64.zip.sha256
+msvc-quick-build-vX.Y.Z-windows-x64.zip
+msvc-quick-build-vX.Y.Z-windows-x64.zip.sha256
 ```
 
-The stable ZIP contains:
+The stable ZIP contains the native binary/installers plus the complete Simplified Chinese and English documentation surface:
 
 ```text
 mqb.exe
@@ -95,11 +95,16 @@ LICENSE
 MQB_CONFIG.md
 MQB_CONFIG_EN.md
 ARCHITECTURE.md
+ARCHITECTURE_EN.md
 INSTALLATION.md
 SELF_HOSTING.md
+SELF_HOSTING_EN.md
 RELEASE_NOTES.md
+RELEASE_NOTES_EN.md
 ```
 
-Before upload, CI verifies the full Release test graph, the self-host closure, Stage 1 byte identity, exact package manifest, checksum sidecar, embedded version, and install/reinstall/uninstall lifecycle against the extracted package itself.
+The packaged release-note language links are rewritten to the packaged filenames (`RELEASE_NOTES.md` / `RELEASE_NOTES_EN.md`) so they remain valid outside the repository source tree.
+
+Before upload, CI verifies the full Release test graph, the self-host closure, Stage 1 byte identity, exact bilingual package manifest, checksum sidecar, embedded version, release-note language links, and install/reinstall/uninstall lifecycle against the extracted package itself.
 
 Tag publication is immutable and exact-artifact based. A pushed `vX.Y.Z` tag must exactly match `release/VERSION`; the publication job downloads the already-validated artifact from that same workflow run and publishes the ZIP and checksum without rebuilding it.

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -67,10 +67,12 @@ cpp/
 
 `tests/native/build_mqb.ps1` 会读取此文件，并要求：
 
-- `src/app/main.cpp` 加上 `discovery.extra_sources` 恰好组成 42 个 production translation units；
+- `src/app/main.cpp` 加上 `discovery.extra_sources` 与 `cpp/src/**/*.cpp` 的实际 production source set 完全一致；
 - 每个源文件真实存在；
 - 构建产物能运行；
 - 内嵌版本与请求版本完全一致。
+
+production TU 数量不是稳定契约，也不使用 hard-coded magic count；文件职责拆分只需保持 manifest 与真实 production source set 一致。
 
 release version 唯一来源仍是 `release/VERSION`。构建 driver 通过结构化 `MQB_VERSION="<version>"` definition 注入版本，因此 `cpp/mqb.json` 不重复保存版本号。
 
@@ -80,7 +82,7 @@ release version 唯一来源仍是 `release/VERSION`。构建 driver 通过结�
 
 它会：
 
-1. 从 `cpp/mqb.json` 取得 41 个 non-main production translation units；
+1. 从 `cpp/mqb.json` 取得全部 non-main production translation units，并与 `cpp/src/**/*.cpp` 的实际 non-main source set 做一致性校验；
 2. 递归枚举 `cpp/tests/` 并强制要求恰好存在 67 个 `*_tests.cpp`；
 3. 用当前 MQB 为每个 test entry 构建独立测试可执行文件；
 4. 复用 `.mqb` incremental object/cache；

--- a/docs/SELF_HOSTING_EN.md
+++ b/docs/SELF_HOSTING_EN.md
@@ -59,10 +59,12 @@ cpp/
 
 `tests/native/build_mqb.ps1` reads this file and requires:
 
-- `src/app/main.cpp` plus `discovery.extra_sources` must form exactly 42 production translation units;
+- `src/app/main.cpp` plus `discovery.extra_sources` must exactly match the actual `cpp/src/**/*.cpp` production source set;
 - Every source file actually exists;
 - Build outputs can be executed;
 - Embedded version matches requested version exactly.
+
+The production TU count is intentionally not a stable contract or hard-coded magic number; responsibility-driven file splits only need to keep the manifest identical to the actual production source set.
 
 The single source of release version truth remains `release/VERSION`. Build drivers inject the version via structured `MQB_VERSION="<version>"` definitions, so `cpp/mqb.json` does not duplicate version numbers.
 
@@ -72,7 +74,7 @@ The single source of release version truth remains `release/VERSION`. Build driv
 
 It will:
 
-1. Retrieve 41 non-main production translation units from `cpp/mqb.json`;
+1. Retrieve all non-main production translation units from `cpp/mqb.json` and verify that set against the actual non-main `cpp/src/**/*.cpp` source set;
 2. Recursively enumerate `cpp/tests/` and enforce exactly 67 `*_tests.cpp` entries;
 3. Build an independent test executable for each test entry using current MQB;
 4. Reuse `.mqb` incremental object/cache;

--- a/release/v5.0.0.md
+++ b/release/v5.0.0.md
@@ -33,7 +33,7 @@ Stable v5 的开发/测试/发布链不使用 CMake 或 CTest 生成或执行 MQ
 
 ```text
 固定历史 seed MQB（SHA-256 verified）
-        ↓  MQB 构建当前 42-TU 源码
+        ↓  MQB 构建当前 production source set
 Stage 0（当前源码 / Release test generation）
         ↓  Stage 0 用 MQB 构建并运行 67/67 Release tests
 Stage 0 → Stage 1（MQB 构建 MQB）

--- a/release/v5.0.0_EN.md
+++ b/release/v5.0.0_EN.md
@@ -14,7 +14,7 @@ For the first stable release, CI solves the bootstrap problem with the historica
 
 ```text
 pinned historical seed MQB (SHA-256 verified)
-        ↓  MQB builds current 42-TU source set
+        ↓  MQB builds current production source set
 Stage 0 (current source / Release test generation)
         ↓  Stage 0 builds and runs 67/67 Release tests with MQB
 Stage 0 → Stage 1 (MQB builds MQB)


### PR DESCRIPTION
## Why

The pre-v5 audit found two release-surface drifts after #53 and the later bilingual documentation split:

1. Stable docs still hard-coded the old `42` production / `41` non-main TU counts even though native drivers now validate exact production source-set identity and file-count changes are intentionally not a stable contract.
2. The source tree had been split into Simplified Chinese + English files, but the stable ZIP still packaged only the Chinese/default files. Those files link to their `_EN.md` counterparts, so the shipped package would contain broken language navigation. `INSTALLATION.md` also still named the old `vscode-msvc-quick-build-*` artifact.

## What changed

### Source-set contract

- remove all stale `42-TU` / `42 production` / `41 non-main` claims from the root README, self-hosting docs, and stable v5 release notes in both languages
- document the real invariant: `src/app/main.cpp + discovery.extra_sources` must exactly match the actual `cpp/src/**/*.cpp` production source set
- document that the native test driver consumes all non-main production TUs and validates that set against the actual source tree
- explicitly state that production TU count is not a stable contract or hard-coded magic number

### Stable bilingual package

- package `README_EN.md`, `MQB_CONFIG_EN.md`, `ARCHITECTURE_EN.md`, `SELF_HOSTING_EN.md`, and `RELEASE_NOTES_EN.md` alongside the default Simplified Chinese documents
- rewrite the two release-note language links to the packaged `RELEASE_NOTES.md` / `RELEASE_NOTES_EN.md` filenames
- validate those links during exact package validation
- expand the exact stable ZIP manifest to the full bilingual documentation surface
- fix `INSTALLATION.md` to use `msvc-quick-build-vX.Y.Z-windows-x64.zip` and describe the exact bilingual manifest

### CI ownership

- add `README_EN.md` and root `LICENSE` to the Native C++, Native Installer, and Native Release PR trigger surfaces
- preserve the existing product, installer, self-hosting, exact-artifact and tag-only publication semantics

## Scope

No C++ product behavior, `cpp/mqb.json`, native test logic, installer implementation, cache format, or self-host algorithm changes. The release workflow changes only the documented package surface and its exact validation.

Base: `main@432155a16576f55d5af29f1def34a8c0ab1e7a57` (Apache-2.0 #55 merge).

Final exact-head evidence will be recorded here after Native C++ / Native Installer / Native Release complete. This PR does **not** create or publish `v5.0.0`.