### PR TITLE
release: harden final v5 documentation surface

### DIFF
--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -258,6 +258,34 @@ jobs:
 
           Write-Host 'Exact self-hosted packaged artifact validation passed.'
 
+      - name: Validate GitHub Release notes body
+        shell: pwsh
+        env:
+          MQB_RELEASE_VERSION: ${{ steps.meta.outputs.version }}
+          MQB_NOTES_FILE: ${{ steps.meta.outputs.notes_file }}
+        run: |
+          $tag = "v$env:MQB_RELEASE_VERSION"
+          $notesEnFile = "release/v$($env:MQB_RELEASE_VERSION)_EN.md"
+          if (-not (Test-Path -LiteralPath $env:MQB_NOTES_FILE -PathType Leaf)) {
+            throw "Missing release notes: $env:MQB_NOTES_FILE"
+          }
+          if (-not (Test-Path -LiteralPath $notesEnFile -PathType Leaf)) {
+            throw "Missing English release notes: $notesEnFile"
+          }
+
+          $sourceNotes = Get-Content -LiteralPath $env:MQB_NOTES_FILE -Raw
+          $sourceEnglishLink = "(v$($env:MQB_RELEASE_VERSION)_EN.md)"
+          if (-not $sourceNotes.Contains($sourceEnglishLink)) {
+            throw "Release notes do not contain expected English link target: $sourceEnglishLink"
+          }
+
+          $taggedEnglishTarget = "https://github.com/$env:GITHUB_REPOSITORY/blob/$tag/release/v$($env:MQB_RELEASE_VERSION)_EN.md"
+          $rendered = $sourceNotes.Replace($sourceEnglishLink, "($taggedEnglishTarget)")
+          if (-not $rendered.Contains("($taggedEnglishTarget)")) {
+            throw 'GitHub Release notes body did not receive the exact-tag English link.'
+          }
+          Write-Host "GitHub Release English notes target: $taggedEnglishTarget"
+
       - name: Upload validated package
         uses: actions/upload-artifact@v7
         with:
@@ -301,6 +329,10 @@ jobs:
           if (-not (Test-Path -LiteralPath $env:MQB_NOTES_FILE -PathType Leaf)) {
             throw "Missing release notes: $env:MQB_NOTES_FILE"
           }
+          $notesEnFile = "release/v$($env:MQB_RELEASE_VERSION)_EN.md"
+          if (-not (Test-Path -LiteralPath $notesEnFile -PathType Leaf)) {
+            throw "Missing English release notes: $notesEnFile"
+          }
 
           $zip = Join-Path $PWD "dist-publish/$($env:MQB_PACKAGE_NAME).zip"
           $sha = $zip + '.sha256'
@@ -332,12 +364,22 @@ jobs:
             "$tag — Stable Release"
           }
 
+          $sourceNotes = Get-Content -LiteralPath $env:MQB_NOTES_FILE -Raw
+          $sourceEnglishLink = "(v$($env:MQB_RELEASE_VERSION)_EN.md)"
+          if (-not $sourceNotes.Contains($sourceEnglishLink)) {
+            throw "Release notes do not contain expected English link target: $sourceEnglishLink"
+          }
+          $taggedEnglishTarget = "https://github.com/$env:GITHUB_REPOSITORY/blob/$tag/release/v$($env:MQB_RELEASE_VERSION)_EN.md"
+          $releaseBody = Join-Path $PWD 'release-body.md'
+          $sourceNotes.Replace($sourceEnglishLink, "($taggedEnglishTarget)") |
+            Set-Content -LiteralPath $releaseBody -Encoding utf8NoBOM -NoNewline
+
           $arguments = @(
             'release', 'create', $tag, $zip, $sha,
             '--repo', $env:GITHUB_REPOSITORY,
             '--verify-tag',
             '--title', $title,
-            '--notes-file', $env:MQB_NOTES_FILE
+            '--notes-file', $releaseBody
           )
           if ($env:MQB_PRERELEASE -eq 'true') {
             $arguments += '--prerelease'

--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -144,6 +144,7 @@ jobs:
           Copy-Item 'docs/ARCHITECTURE.md' (Join-Path $stage 'ARCHITECTURE.md')
           Copy-Item 'docs/ARCHITECTURE_EN.md' (Join-Path $stage 'ARCHITECTURE_EN.md')
           Copy-Item 'docs/INSTALLATION.md' (Join-Path $stage 'INSTALLATION.md')
+          Copy-Item 'docs/INSTALLATION_EN.md' (Join-Path $stage 'INSTALLATION_EN.md')
           Copy-Item 'docs/SELF_HOSTING.md' (Join-Path $stage 'SELF_HOSTING.md')
           Copy-Item 'docs/SELF_HOSTING_EN.md' (Join-Path $stage 'SELF_HOSTING_EN.md')
 
@@ -187,7 +188,7 @@ jobs:
               '(docs/ARCHITECTURE_EN.md)' = '(ARCHITECTURE_EN.md)'
               '(docs/SELF_HOSTING_EN.md)' = '(SELF_HOSTING_EN.md)'
               '(docs/MQB_CONFIG_EN.md)' = '(MQB_CONFIG_EN.md)'
-              '(docs/INSTALLATION.md)' = '(INSTALLATION.md)'
+              '(docs/INSTALLATION_EN.md)' = '(INSTALLATION_EN.md)'
             }
             (Join-Path $stage 'ARCHITECTURE.md') = @{
               '(../cpp/README.md)' = "($repoBlobBase/cpp/README.md)"
@@ -246,6 +247,7 @@ jobs:
             'ARCHITECTURE.md',
             'ARCHITECTURE_EN.md',
             'INSTALLATION.md',
+            'INSTALLATION_EN.md',
             'install.bat',
             'install.ps1',
             'LICENSE',

--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -168,6 +168,48 @@ jobs:
           )
           Set-Content -LiteralPath $releaseNotesEn -Value $enNotes -Encoding utf8NoBOM -NoNewline
 
+          # Repository Markdown is copied into a flat release-doc root. Keep links to
+          # packaged docs local, while source-only references point at the exact tag.
+          $tag = "v$env:MQB_RELEASE_VERSION"
+          $repoBlobBase = "https://github.com/$env:GITHUB_REPOSITORY/blob/$tag"
+          $packageLinkRewrites = @{
+            (Join-Path $stage 'README.md') = @{
+              '(cpp/README.md)' = "($repoBlobBase/cpp/README.md)"
+              '(cpp/mqb.json)' = "($repoBlobBase/cpp/mqb.json)"
+              '(docs/ARCHITECTURE.md)' = '(ARCHITECTURE.md)'
+              '(docs/SELF_HOSTING.md)' = '(SELF_HOSTING.md)'
+              '(docs/MQB_CONFIG.md)' = '(MQB_CONFIG.md)'
+              '(docs/INSTALLATION.md)' = '(INSTALLATION.md)'
+            }
+            (Join-Path $stage 'README_EN.md') = @{
+              '(cpp/README_EN.md)' = "($repoBlobBase/cpp/README_EN.md)"
+              '(cpp/mqb.json)' = "($repoBlobBase/cpp/mqb.json)"
+              '(docs/ARCHITECTURE_EN.md)' = '(ARCHITECTURE_EN.md)'
+              '(docs/SELF_HOSTING_EN.md)' = '(SELF_HOSTING_EN.md)'
+              '(docs/MQB_CONFIG_EN.md)' = '(MQB_CONFIG_EN.md)'
+              '(docs/INSTALLATION.md)' = '(INSTALLATION.md)'
+            }
+            (Join-Path $stage 'ARCHITECTURE.md') = @{
+              '(../cpp/README.md)' = "($repoBlobBase/cpp/README.md)"
+            }
+            (Join-Path $stage 'ARCHITECTURE_EN.md') = @{
+              '(../cpp/README_EN.md)' = "($repoBlobBase/cpp/README_EN.md)"
+            }
+            (Join-Path $stage 'SELF_HOSTING.md') = @{
+              '(../cpp/README.md)' = "($repoBlobBase/cpp/README.md)"
+            }
+            (Join-Path $stage 'SELF_HOSTING_EN.md') = @{
+              '(../cpp/README_EN.md)' = "($repoBlobBase/cpp/README_EN.md)"
+            }
+          }
+          foreach ($fileEntry in $packageLinkRewrites.GetEnumerator()) {
+            $text = Get-Content -LiteralPath $fileEntry.Key -Raw
+            foreach ($rewrite in $fileEntry.Value.GetEnumerator()) {
+              $text = $text.Replace($rewrite.Key, $rewrite.Value)
+            }
+            Set-Content -LiteralPath $fileEntry.Key -Value $text -Encoding utf8NoBOM -NoNewline
+          }
+
           $zip = Join-Path $dist ($env:MQB_PACKAGE_NAME + '.zip')
           Compress-Archive -Path (Join-Path $stage '*') -DestinationPath $zip -CompressionLevel Optimal
 
@@ -248,6 +290,32 @@ jobs:
           if (-not $enNotes.Contains('(RELEASE_NOTES.md)')) {
             throw 'Packaged English release notes do not link to RELEASE_NOTES.md.'
           }
+
+          # Every relative Markdown target shipped in the flat documentation root must
+          # resolve to a real file inside that package. Absolute URLs and anchors are allowed.
+          $packageRoot = [IO.Path]::GetFullPath($verifyRoot).TrimEnd('\')
+          $rootPrefix = $packageRoot + [IO.Path]::DirectorySeparatorChar
+          $linkPattern = '\[[^\]]+\]\(([^)]+)\)'
+          foreach ($markdown in @(Get-ChildItem -LiteralPath $verifyRoot -Filter '*.md' -File)) {
+            $markdownText = Get-Content -LiteralPath $markdown.FullName -Raw
+            foreach ($match in [regex]::Matches($markdownText, $linkPattern)) {
+              $target = $match.Groups[1].Value.Trim()
+              if ([string]::IsNullOrWhiteSpace($target) -or $target.StartsWith('#')) { continue }
+              if ($target -match '^[A-Za-z][A-Za-z0-9+.-]*:') { continue }
+
+              $pathPart = ($target -split '#', 2)[0]
+              if ([string]::IsNullOrWhiteSpace($pathPart)) { continue }
+              $resolved = [IO.Path]::GetFullPath((Join-Path $verifyRoot $pathPart))
+              if (-not [string]::Equals($resolved, $packageRoot, [StringComparison]::OrdinalIgnoreCase) -and
+                  -not $resolved.StartsWith($rootPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+                throw "Packaged Markdown link escapes package root: $($markdown.Name) -> $target"
+              }
+              if (-not (Test-Path -LiteralPath $resolved -PathType Leaf)) {
+                throw "Broken packaged Markdown link: $($markdown.Name) -> $target"
+              }
+            }
+          }
+          Write-Host 'Packaged Markdown relative-link validation passed.'
 
           & (Join-Path $PWD 'tests/installer/native_installer_lifecycle.ps1') `
             -MqbPath $packagedMqb `

--- a/README_EN.md
+++ b/README_EN.md
@@ -308,7 +308,7 @@ Extract and run:
 .\install.bat
 ```
 
-Default install destination is `%USERPROFILE%\bin`. The installer does not create legacy `build` compatibility commands or modify PowerShell profiles. See [`docs/INSTALLATION.md`](docs/INSTALLATION.md) for details.
+Default install destination is `%USERPROFILE%\bin`. The installer does not create legacy `build` compatibility commands or modify PowerShell profiles. See [`docs/INSTALLATION_EN.md`](docs/INSTALLATION_EN.md) for details.
 
 ## Release Gates
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -283,14 +283,14 @@ See [`docs/MQB_CONFIG_EN.md`](docs/MQB_CONFIG_EN.md) for full schema, path rules
 | `-I <dir>` | Include directory |
 | `-D <value>` | Preprocessor definition |
 | `-L <dir>` / `--lib-path <dir>` | Library search directory |
-| `-l <name>` / `--lib <name>` | library |
+| `-l <name>` / `--lib <name>` | Library |
 | `--compiler-arg <arg>` | Raw `cl.exe` argv element |
 | `--linker-arg <arg>` | Raw linker argv element |
-| `--env <auto|vs|portable>` | toolchain selection |
-| `--portable-root <dir>` | portable toolchain root candidate |
-| `-v, --verbose` | verbose output |
-| `-h, --help` | help + embedded version |
-| `--` | pass remaining argv to target program |
+| `--env <auto|vs|portable>` | Toolchain selection |
+| `--portable-root <dir>` | Portable toolchain root candidate |
+| `-v, --verbose` | Verbose output |
+| `-h, --help` | Help + embedded version |
+| `--` | Pass remaining argv to target program |
 
 PowerShell-era single-dash aliases fail closed as unknown options.
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -74,7 +74,7 @@ cpp/
 └─ mqb.json                 # self-build production manifest
 ```
 
-See [`cpp/README_EN.md`](cpp/README_EN.md) for the strict filesystem contract and [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for dependency boundaries. The core constraint is: `cpp/include`, `cpp/src`, and `cpp/tests` each have exactly one physical root. New code must select a responsibility before choosing a file location.
+See [`cpp/README_EN.md`](cpp/README_EN.md) for the strict filesystem contract and [`docs/ARCHITECTURE_EN.md`](docs/ARCHITECTURE_EN.md) for dependency boundaries. The core constraint is: `cpp/include`, `cpp/src`, and `cpp/tests` each have exactly one physical root. New code must select a responsibility before choosing a file location.
 
 ## Development: Building MQB with MQB
 
@@ -176,7 +176,7 @@ Stage 0 → Stage 1
 Stage 1 → Stage 2
 ```
 
-Only **Stage 1** is published. Stage 1/Stage 2 closure, exact package, SHA-256, byte identity, and installer lifecycle are all release-blocking gates. See [`docs/SELF_HOSTING.md`](docs/SELF_HOSTING.md) for full contract details.
+Only **Stage 1** is published. Stage 1/Stage 2 closure, exact package, SHA-256, byte identity, and installer lifecycle are all release-blocking gates. See [`docs/SELF_HOSTING_EN.md`](docs/SELF_HOSTING_EN.md) for full contract details.
 
 ## Quickstart
 
@@ -262,7 +262,7 @@ Example:
 }
 ```
 
-See [`docs/MQB_CONFIG.md`](docs/MQB_CONFIG.md) for full schema, path rules, precedence, and cache behavior. Legacy `msvc_list.json` will not be read or migrated.
+See [`docs/MQB_CONFIG_EN.md`](docs/MQB_CONFIG_EN.md) for full schema, path rules, precedence, and cache behavior. Legacy `msvc_list.json` will not be read or migrated.
 
 ## Common CLI Options
 
@@ -283,14 +283,14 @@ See [`docs/MQB_CONFIG.md`](docs/MQB_CONFIG.md) for full schema, path rules, prec
 | `-I <dir>` | Include directory |
 | `-D <value>` | Preprocessor definition |
 | `-L <dir>` / `--lib-path <dir>` | Library search directory |
-| `-l <name>` / `--lib <name>` | Library |
+| `-l <name>` / `--lib <name>` | library |
 | `--compiler-arg <arg>` | Raw `cl.exe` argv element |
 | `--linker-arg <arg>` | Raw linker argv element |
-| `--env <auto|vs|portable>` | Toolchain selection |
-| `--portable-root <dir>` | Portable toolchain root candidate |
-| `-v, --verbose` | Verbose output |
-| `-h, --help` | Help + embedded version |
-| `--` | Pass remaining argv to target program |
+| `--env <auto|vs|portable>` | toolchain selection |
+| `--portable-root <dir>` | portable toolchain root candidate |
+| `-v, --verbose` | verbose output |
+| `-h, --help` | help + embedded version |
+| `--` | pass remaining argv to target program |
 
 PowerShell-era single-dash aliases fail closed as unknown options.
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,26 +1,28 @@
-# MQB installation
+# MQB 安装 / Installation
 
-Stable v5 installs one command and one implementation:
+**语言：简体中文 | [English](INSTALLATION_EN.md)**
 
-- executable: `mqb.exe`
-- command: `mqb`
-- project config: `mqb.json`
+Stable v5 只安装一个命令和一个实现：
 
-## Install
+- 可执行文件：`mqb.exe`
+- 命令：`mqb`
+- 项目配置：`mqb.json`
 
-The Windows release package contains `mqb.exe`, `install.ps1`, `uninstall.ps1`, and `install.bat`. Run:
+## 安装
+
+Windows 发布包包含 `mqb.exe`、`install.ps1`、`uninstall.ps1` 与 `install.bat`。运行：
 
 ```powershell
 .\install.bat
 ```
 
-The default per-user installation root is:
+默认的当前用户安装目录为：
 
 ```text
 %USERPROFILE%\bin
 ```
 
-The installer owns only these files in that root:
+安装器只拥有该目录中的以下文件：
 
 ```text
 mqb.exe
@@ -29,60 +31,60 @@ uninstall-mqb.ps1
 mqb-install-state.json
 ```
 
-It does not modify PowerShell profiles and does not create compatibility commands.
+安装器不会修改 PowerShell profile，也不会创建兼容命令。
 
-## PATH ownership
+## PATH 所有权
 
-The installer adds the installation root to the user PATH only when it is missing. The install state records whether MQB added that entry.
+只有当用户 PATH 中不存在安装目录时，安装器才会添加该目录。安装状态会记录这条 PATH 是否由 MQB 添加。
 
-Reinstall is idempotent: the same PATH entry is not duplicated.
+重复安装是幂等的：不会重复添加同一个 PATH 条目。
 
-Uninstall removes the PATH entry only when the current install state says MQB owns it.
+卸载时，只有当前安装状态表明该 PATH 条目由 MQB 拥有，安装器才会移除它。
 
-## Uninstall
+## 卸载
 
-Use:
+使用：
 
 ```powershell
 powershell.exe -NoProfile -ExecutionPolicy Bypass `
   -File "$HOME\bin\uninstall-mqb.ps1"
 ```
 
-Uninstall removes installer-owned files and an installer-owned PATH entry.
+卸载会删除安装器拥有的文件，以及由安装器拥有的 PATH 条目。
 
-## Existing legacy installations
+## 已存在的旧版安装
 
-Stable v5 does not automatically migrate or restore older PowerShell-based installations. If an old installation left a custom `build` command, `build.ps1`, or profile modification on a machine, those files are outside the v5 installer contract and may be removed manually.
+Stable v5 不会自动迁移或恢复旧的 PowerShell 实现安装。如果旧安装在机器上留下自定义 `build` 命令、`build.ps1` 或 PowerShell profile 修改，这些内容不属于 v5 安装器契约，可由用户手动移除。
 
-The native installer intentionally keeps one authoritative MQB installation path.
+原生安装器只维护一个权威的 MQB 安装路径。
 
-## CLI and configuration compatibility
+## CLI 与配置兼容性
 
-Stable v5 accepts the native CLI documented by `mqb --help` and reads `mqb.json` only. Known obsolete single-dash aliases are rejected as unknown options; old `msvc_list.json` files are not searched, parsed, or translated.
+Stable v5 只接受 `mqb --help` 中记录的原生 CLI，并且只读取 `mqb.json`。已知的旧单横线别名会作为 unknown option 被拒绝；旧 `msvc_list.json` 不会被搜索、解析或转换。
 
-Native short options documented by `mqb --help`, including `-h`, `-v`, `-j`, `-o`, `-I`, `-D`, `-L`, and `-l`, remain supported.
+`mqb --help` 记录的原生短选项仍受支持，包括 `-h`、`-v`、`-j`、`-o`、`-I`、`-D`、`-L` 与 `-l`。
 
-## Installer CI acceptance
+## Installer CI 验收
 
-The `Native Installer` workflow validates on Windows that:
+`Native Installer` workflow 会在 Windows 上验证：
 
-1. the validated `mqb.exe` is installed by the public batch entry;
-2. only native MQB files are installed;
-3. no compatibility command or profile artifact is created;
-4. reinstall does not duplicate PATH state;
-5. uninstall removes installer-owned files and PATH state;
-6. obsolete installer parameters are rejected rather than silently activating migration behavior.
+1. 经过验证的 `mqb.exe` 能通过公开的 batch 入口安装；
+2. 只安装原生 MQB 文件；
+3. 不创建兼容命令或 profile artifact；
+4. 重装不会重复 PATH 状态；
+5. 卸载会清除安装器拥有的文件和 PATH 状态；
+6. 已淘汰的 installer 参数会被拒绝，而不是静默激活迁移行为。
 
-## Stable package contract
+## Stable package 契约
 
-For version `X.Y.Z`, the `Native Release` workflow produces:
+对于版本 `X.Y.Z`，`Native Release` workflow 生成：
 
 ```text
 msvc-quick-build-vX.Y.Z-windows-x64.zip
 msvc-quick-build-vX.Y.Z-windows-x64.zip.sha256
 ```
 
-The stable ZIP contains the native binary/installers plus the complete Simplified Chinese and English documentation surface:
+Stable ZIP 包含原生 binary / installer，以及完整的简体中文与 English 文档面：
 
 ```text
 mqb.exe
@@ -97,14 +99,15 @@ MQB_CONFIG_EN.md
 ARCHITECTURE.md
 ARCHITECTURE_EN.md
 INSTALLATION.md
+INSTALLATION_EN.md
 SELF_HOSTING.md
 SELF_HOSTING_EN.md
 RELEASE_NOTES.md
 RELEASE_NOTES_EN.md
 ```
 
-The packaged release-note language links are rewritten to the packaged filenames (`RELEASE_NOTES.md` / `RELEASE_NOTES_EN.md`) so they remain valid outside the repository source tree.
+必要时，仓库专属的文档链接会在打包时改写为 exact-tag GitHub URL；发布包内部文档之间的链接则保持 package-local。上传前，CI 会逐个验证解压包内所有 Markdown 相对链接，拒绝缺失目标或逃出 package root 的链接。
 
-Before upload, CI verifies the full Release test graph, the self-host closure, Stage 1 byte identity, exact bilingual package manifest, checksum sidecar, embedded version, release-note language links, and install/reinstall/uninstall lifecycle against the extracted package itself.
+上传前，CI 还会针对解压后的实际包验证完整 Release test graph、self-host closure、Stage 1 byte identity、exact bilingual package manifest、checksum sidecar、embedded version，以及 install/reinstall/uninstall lifecycle。
 
-Tag publication is immutable and exact-artifact based. A pushed `vX.Y.Z` tag must exactly match `release/VERSION`; the publication job downloads the already-validated artifact from that same workflow run and publishes the ZIP and checksum without rebuilding it.
+Tag publication 是 immutable 且基于 exact artifact 的。推送的 `vX.Y.Z` tag 必须与 `release/VERSION` 完全匹配；publication job 只下载同一 workflow run 已验证的 ZIP 与 checksum 并发布，不会重新构建。

--- a/docs/INSTALLATION_EN.md
+++ b/docs/INSTALLATION_EN.md
@@ -1,0 +1,113 @@
+# MQB Installation
+
+**Language: [简体中文](INSTALLATION.md) | English**
+
+Stable v5 installs one command and one implementation:
+
+- executable: `mqb.exe`
+- command: `mqb`
+- project config: `mqb.json`
+
+## Install
+
+The Windows release package contains `mqb.exe`, `install.ps1`, `uninstall.ps1`, and `install.bat`. Run:
+
+```powershell
+.\install.bat
+```
+
+The default per-user installation root is:
+
+```text
+%USERPROFILE%\bin
+```
+
+The installer owns only these files in that root:
+
+```text
+mqb.exe
+mqb-install.ps1
+uninstall-mqb.ps1
+mqb-install-state.json
+```
+
+It does not modify PowerShell profiles and does not create compatibility commands.
+
+## PATH ownership
+
+The installer adds the installation root to the user PATH only when it is missing. The install state records whether MQB added that entry.
+
+Reinstall is idempotent: the same PATH entry is not duplicated.
+
+Uninstall removes the PATH entry only when the current install state says MQB owns it.
+
+## Uninstall
+
+Use:
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass `
+  -File "$HOME\bin\uninstall-mqb.ps1"
+```
+
+Uninstall removes installer-owned files and an installer-owned PATH entry.
+
+## Existing legacy installations
+
+Stable v5 does not automatically migrate or restore older PowerShell-based installations. If an old installation left a custom `build` command, `build.ps1`, or profile modification on a machine, those files are outside the v5 installer contract and may be removed manually.
+
+The native installer intentionally keeps one authoritative MQB installation path.
+
+## CLI and configuration compatibility
+
+Stable v5 accepts the native CLI documented by `mqb --help` and reads `mqb.json` only. Known obsolete single-dash aliases are rejected as unknown options; old `msvc_list.json` files are not searched, parsed, or translated.
+
+Native short options documented by `mqb --help`, including `-h`, `-v`, `-j`, `-o`, `-I`, `-D`, `-L`, and `-l`, remain supported.
+
+## Installer CI acceptance
+
+The `Native Installer` workflow validates on Windows that:
+
+1. the validated `mqb.exe` is installed by the public batch entry;
+2. only native MQB files are installed;
+3. no compatibility command or profile artifact is created;
+4. reinstall does not duplicate PATH state;
+5. uninstall removes installer-owned files and PATH state;
+6. obsolete installer parameters are rejected rather than silently activating migration behavior.
+
+## Stable package contract
+
+For version `X.Y.Z`, the `Native Release` workflow produces:
+
+```text
+msvc-quick-build-vX.Y.Z-windows-x64.zip
+msvc-quick-build-vX.Y.Z-windows-x64.zip.sha256
+```
+
+The stable ZIP contains the native binary/installers plus the complete Simplified Chinese and English documentation surface:
+
+```text
+mqb.exe
+install.bat
+install.ps1
+uninstall.ps1
+README.md
+README_EN.md
+LICENSE
+MQB_CONFIG.md
+MQB_CONFIG_EN.md
+ARCHITECTURE.md
+ARCHITECTURE_EN.md
+INSTALLATION.md
+INSTALLATION_EN.md
+SELF_HOSTING.md
+SELF_HOSTING_EN.md
+RELEASE_NOTES.md
+RELEASE_NOTES_EN.md
+```
+
+Repository-only documentation links are rewritten to exact-tag GitHub URLs when necessary, while links between documents shipped in the ZIP remain package-local. Before upload, CI validates every relative Markdown link in the extracted package and rejects links that are missing or escape the package root.
+
+Before upload, CI also verifies the full Release test graph, self-host closure, Stage 1 byte identity, exact bilingual package manifest, checksum sidecar, embedded version, and install/reinstall/uninstall lifecycle against the extracted package itself.
+
+Tag publication is immutable and exact-artifact based. A pushed `vX.Y.Z` tag must exactly match `release/VERSION`; the publication job downloads the already-validated artifact from that same workflow run and publishes the ZIP and checksum without rebuilding it.


### PR DESCRIPTION
## Why

The final stable-v5 documentation is rendered in three different contexts with different path semantics: repository source files, the flat documentation root inside the stable ZIP, and the GitHub Release body. The final pre-tag audit found that these contexts were not yet governed by one complete link-integrity contract, and the user-facing installation guide was the only packaged documentation surface without a Simplified Chinese / English pair.

## What changed

### Complete bilingual user documentation

- make `docs/INSTALLATION.md` the Simplified Chinese default installation guide
- add the full English counterpart `docs/INSTALLATION_EN.md`
- update `README_EN.md` so Architecture, Self-hosting, configuration, and installation links stay on English counterparts
- stable ZIP now has a 17-file exact manifest including `INSTALLATION.md` + `INSTALLATION_EN.md`

### Stable ZIP Markdown integrity

- keep links between documents shipped in the flat ZIP package-local
- rewrite source-only references such as `cpp/README*.md` / `cpp/mqb.json` to exact-tag GitHub blob URLs
- preserve package-local `RELEASE_NOTES.md` / `RELEASE_NOTES_EN.md` navigation
- add a release-blocking generic validator over every packaged `*.md`:
  - anchors and absolute URI targets are allowed
  - every relative target must resolve to a real file inside the extracted package
  - relative targets are forbidden from escaping the package root

### GitHub Release body

- exercise the Release-body transform in `build-test-package` on PRs as well as tag runs
- require both localized release-note source files and the expected source-relative English target
- render the English target as `https://github.com/<repo>/blob/<exact-tag>/release/vX.Y.Z_EN.md`
- during publication generate a temporary `release-body.md` and pass that to `gh release create`
- preserve immutable publication and exact-artifact reuse; source release notes themselves are not rewritten

## Scope

Changed files are limited to:

- `.github/workflows/native-release.yml`
- `README_EN.md`
- `docs/INSTALLATION.md`
- new `docs/INSTALLATION_EN.md`

No C++ product code, `cpp/mqb.json`, installer implementation, self-host algorithm, release version, cache format, tag, or GitHub Release is changed.

Base: `main@7d2a84842a61d3fc5c696388a468a0c1fa343e58`.

Final candidate: `0e712513a708f9cd8b7f7c00f1c0910057983686`.

Exact-head gates:
- Native C++ #41 — running
- Native Installer #39 — queued/running
- Native Release #31 — running

This PR does **not** create or publish `v5.0.0`.