### PR TITLE
feat: support external prebuilt named-module providers

### DIFF
--- a/cpp/include/mqb/config/ProjectConfig.hpp
+++ b/cpp/include/mqb/config/ProjectConfig.hpp
@@ -35,12 +35,17 @@ struct DiscoveryOverrides {
     std::vector<std::filesystem::path> exclude_sources;
 };
 
+struct ModuleOverrides {
+    std::vector<ExternalModuleProvider> external_providers;
+};
+
 struct ProjectConfig {
     int version{1};
     std::filesystem::path file;
     std::filesystem::path project_root;
     BuildOverrides build;
     DiscoveryOverrides discovery;
+    ModuleOverrides modules;
 };
 
 enum class ErrorCode {

--- a/cpp/include/mqb/config/ProjectOptions.hpp
+++ b/cpp/include/mqb/config/ProjectOptions.hpp
@@ -12,6 +12,7 @@ namespace mqb::config {
 struct ProjectOverrides {
     BuildOverrides build;
     DiscoveryOverrides discovery;
+    ModuleOverrides modules;
 };
 
 struct EffectiveProjectOptions {
@@ -34,6 +35,8 @@ struct EffectiveProjectOptions {
     std::vector<std::filesystem::path> discovery_exclude_directories;
     std::vector<std::filesystem::path> discovery_extra_sources;
     std::vector<std::filesystem::path> discovery_exclude_sources;
+
+    std::vector<ExternalModuleProvider> external_module_providers;
 };
 
 [[nodiscard]] EffectiveProjectOptions resolve_project_options(

--- a/cpp/include/mqb/core/CompilerOptions.hpp
+++ b/cpp/include/mqb/core/CompilerOptions.hpp
@@ -16,6 +16,15 @@ enum class RuntimeLibrary {
     mtd,
 };
 
+// Project/toolchain-independent identity for a read-only named-module IFC
+// supplied outside the current source graph. Provider selection remains owned
+// by the P1689 module graph; this registry only carries explicit policy into
+// that owner.
+struct ExternalModuleProvider {
+    std::string logical_name;
+    std::filesystem::path interface_file;
+};
+
 struct CompilerOptions {
     BuildConfiguration configuration{BuildConfiguration::debug};
     Architecture architecture{Architecture::x64};
@@ -31,6 +40,11 @@ struct CompilerOptions {
     std::vector<std::string> defines;
     std::vector<std::filesystem::path> include_directories;
     std::vector<std::string> additional_arguments;
+    // Explicit read-only provider registry. These entries are intentionally not
+    // hashed wholesale into every compile signature: after P1689 resolution,
+    // only the ModuleReference entries actually consumed by a TU participate in
+    // its identity and cache dependencies.
+    std::vector<ExternalModuleProvider> external_module_providers;
 };
 
 } // namespace mqb

--- a/cpp/include/mqb/modules/ModuleDependencyGraph.hpp
+++ b/cpp/include/mqb/modules/ModuleDependencyGraph.hpp
@@ -3,9 +3,11 @@
 #include <expected>
 #include <filesystem>
 #include <optional>
+#include <span>
 #include <string>
 #include <vector>
 
+#include "mqb/core/CompilerOptions.hpp"
 #include "mqb/core/DependencyGraph.hpp"
 #include "mqb/modules/P1689.hpp"
 
@@ -33,6 +35,12 @@ struct ResolvedModuleDependency {
     std::string logical_name;
 };
 
+struct ResolvedExternalModuleDependency {
+    std::filesystem::path consumer_source;
+    std::string logical_name;
+    std::filesystem::path interface_file;
+};
+
 struct PlannedHeaderUnit {
     std::filesystem::path source;
     std::string header_name;
@@ -53,6 +61,9 @@ struct ModuleDependencyPlan {
     std::vector<std::vector<std::filesystem::path>> compile_levels;
     // Named-module imports that were resolved to another source in this plan.
     std::vector<ResolvedModuleDependency> resolved_dependencies;
+    // Explicit read-only external/prebuilt providers selected for consumers.
+    // They do not become compile-level nodes because MQB does not own them.
+    std::vector<ResolvedExternalModuleDependency> resolved_external_dependencies;
     // Unique project-local header-unit producer recipes selected from P1689
     // source-path identities. Execution assigns artifacts in a later layer.
     std::vector<PlannedHeaderUnit> header_units;
@@ -67,6 +78,9 @@ enum class ModuleGraphErrorCode {
     duplicate_source,
     duplicate_interface_provider,
     ambiguous_named_provider,
+    invalid_external_provider,
+    duplicate_external_provider,
+    toolchain_owned_provider,
     header_unit_source_conflict,
     conflicting_header_unit_identity,
     dependency_cycle,
@@ -83,7 +97,9 @@ struct ModuleGraphError {
 class ModuleDependencyGraphBuilder {
 public:
     [[nodiscard]] static std::expected<ModuleDependencyPlan, ModuleGraphError>
-    build(const std::vector<ScannedModuleUnit>& units);
+    build(
+        const std::vector<ScannedModuleUnit>& units,
+        std::span<const ExternalModuleProvider> external_providers = {});
 };
 
 } // namespace mqb::modules

--- a/cpp/src/app/Application.cpp
+++ b/cpp/src/app/Application.cpp
@@ -227,13 +227,17 @@ int Application::run(const std::span<const std::string_view> arguments) {
     compiler_options.defines = std::move(options.defines);
     compiler_options.include_directories = std::move(options.include_directories);
     compiler_options.additional_arguments = std::move(options.compiler_arguments);
+    compiler_options.external_module_providers = options.external_module_providers;
 
-    const bool module_target = discovery_requires_module_pipeline || std::any_of(
-        target_sources.begin(),
-        target_sources.end(),
-        [](const mqb::orchestration::TargetSourceRequest& source) {
-            return mqb::cli::is_module_interface_source(source.source);
-        });
+    const bool has_external_module_providers = !compiler_options.external_module_providers.empty();
+    const bool module_target = has_external_module_providers
+        || discovery_requires_module_pipeline
+        || std::any_of(
+            target_sources.begin(),
+            target_sources.end(),
+            [](const mqb::orchestration::TargetSourceRequest& source) {
+                return mqb::cli::is_module_interface_source(source.source);
+            });
 
     if (options.build.target_kind == mqb::TargetKind::static_library) {
         if (module_target) {
@@ -288,7 +292,8 @@ int Application::run(const std::span<const std::string_view> arguments) {
                 .target_name = target_name,
                 .max_parallel_jobs = compile_jobs,
                 .jobs_explicit = options.jobs.has_value(),
-                .force_named_modules = discovery_requires_module_pipeline,
+                .force_named_modules = discovery_requires_module_pipeline
+                    || has_external_module_providers,
                 .verbose = options.verbose,
                 .run_after_build = options.build.run_after_build,
                 .run_arguments = std::move(options.build.run_arguments),

--- a/cpp/src/app/Cli.cpp
+++ b/cpp/src/app/Cli.cpp
@@ -1,8 +1,10 @@
 #include "Cli.hpp"
 
+#include <algorithm>
 #include <charconv>
 #include <cstddef>
 #include <expected>
+#include <filesystem>
 #include <span>
 #include <string>
 #include <string_view>
@@ -130,6 +132,39 @@ parse_toolchain_preference(const std::string_view value) {
     return std::unexpected(error(
         "unsupported toolchain preference '" + std::string{value}
         + "' (expected auto, vs, or portable)"));
+}
+
+[[nodiscard]] std::expected<ExternalModuleProvider, Error>
+parse_external_module_provider(const std::string_view value) {
+    const std::size_t separator = value.find('=');
+    if (separator == std::string_view::npos || separator == 0 || separator + 1 == value.size()) {
+        return std::unexpected(error(
+            "invalid external module provider '" + std::string{value}
+            + "' (expected <logical-name>=<ifc-path>)"));
+    }
+    return ExternalModuleProvider{
+        .logical_name = std::string{value.substr(0, separator)},
+        .interface_file = std::filesystem::u8path(value.substr(separator + 1)),
+    };
+}
+
+[[nodiscard]] std::expected<void, Error>
+add_external_module_provider(Options& options, const std::string_view value) {
+    auto provider = parse_external_module_provider(value);
+    if (!provider) return std::unexpected(provider.error());
+    const auto duplicate = std::find_if(
+        options.external_module_providers.begin(),
+        options.external_module_providers.end(),
+        [&provider](const ExternalModuleProvider& current) {
+            return current.logical_name == provider->logical_name;
+        });
+    if (duplicate != options.external_module_providers.end()) {
+        return std::unexpected(error(
+            "duplicate --module-ifc provider for logical module '"
+            + provider->logical_name + "'"));
+    }
+    options.external_module_providers.push_back(std::move(*provider));
+    return {};
 }
 
 [[nodiscard]] std::expected<std::string_view, Error>
@@ -324,6 +359,20 @@ parse_arguments(const std::span<const std::string_view> arguments) {
             options.subsystem_override = *subsystem;
             continue;
         }
+        if (argument == "--module-ifc") {
+            auto value = require_value(arguments, index, argument);
+            if (!value) return std::unexpected(value.error());
+            auto added = add_external_module_provider(options, *value);
+            if (!added) return std::unexpected(added.error());
+            continue;
+        }
+        if (argument.starts_with("--module-ifc=")) {
+            auto value = long_equals_value(argument, "--module-ifc=");
+            if (!value) return std::unexpected(value.error());
+            auto added = add_external_module_provider(options, *value);
+            if (!added) return std::unexpected(added.error());
+            continue;
+        }
         if (argument == "--compiler-arg") {
             auto value = require_value(arguments, index, argument);
             if (!value) return std::unexpected(value.error());
@@ -442,6 +491,7 @@ Project configuration:
   MQB searches upward from the invocation directory for the nearest mqb.json.
   Scalar precedence is: explicit CLI > mqb.json > built-in defaults.
   Config paths are relative to mqb.json; CLI paths are relative to the invocation directory.
+  External named-module IFCs may be declared under modules.external as logical-name -> IFC path.
 
 Source selection:
   One positional source       Smart-discover connected C/C++ TUs and reachable project-local named-module providers (default)
@@ -454,8 +504,10 @@ Single-entry discovery follows reachable project-local named imports to project-
 module-interface candidates. Discovery selects candidates only; MSVC P1689 scanning remains
 the authority for module topology and provider validation. Project-local header-unit imports
 stay outside TU discovery but route through the P1689 module pipeline, where their IFCs are
-built and cached automatically. Modules and header units require C++20 or newer. External or
-prebuilt named-module providers and import std remain unsupported and fail closed.
+built and cached automatically. Explicit external/prebuilt named-module IFCs are resolved by
+the same P1689 provider graph and remain read-only. Modules and header units require C++20 or
+newer. import std remains unsupported and fails closed until toolchain-owned std-module policy
+is implemented.
 
 Options:
   --debug                  Explicitly select Debug compile/link preset
@@ -473,6 +525,8 @@ Options:
   -j, --jobs <N>          Maximum concurrent TU scans/compiles (default: hardware concurrency)
   -o, --output <name>     Set target name under .mqb/bin/
   --run                   Run an executable after a successful build
+  --module-ifc <name=path>
+                           Bind one external/prebuilt named module to a read-only IFC
   -I <dir>, -I<dir>       Add an include directory
   -D <value>, -D<value>   Add a preprocessor definition
   -L <dir>, -L<dir>       Add a library search directory

--- a/cpp/src/app/Cli.hpp
+++ b/cpp/src/app/Cli.hpp
@@ -31,6 +31,7 @@ struct Options {
     std::vector<std::string> libraries;
     std::vector<std::string> compiler_arguments;
     std::vector<std::string> linker_arguments;
+    std::vector<ExternalModuleProvider> external_module_providers;
     msvc::ToolchainPreference toolchain_preference{msvc::ToolchainPreference::automatic};
     std::vector<std::filesystem::path> portable_roots;
     std::optional<bool> discovery_override;

--- a/cpp/src/app/ProjectSetup.cpp
+++ b/cpp/src/app/ProjectSetup.cpp
@@ -34,6 +34,15 @@ prepare_project(
         ? project_config->project_root
         : invocation_directory;
 
+    for (auto& provider : options.external_module_providers) {
+        if (provider.interface_file.is_relative()) {
+            provider.interface_file = (
+                invocation_directory / provider.interface_file).lexically_normal();
+        } else {
+            provider.interface_file = provider.interface_file.lexically_normal();
+        }
+    }
+
     mqb::config::ProjectOverrides cli_overrides;
     cli_overrides.build.configuration = options.configuration_override;
     cli_overrides.build.architecture = options.architecture_override;
@@ -50,6 +59,7 @@ prepare_project(
     cli_overrides.build.compiler_arguments = options.compiler_arguments;
     cli_overrides.build.linker_arguments = options.linker_arguments;
     cli_overrides.discovery.enabled = options.discovery_override;
+    cli_overrides.modules.external_providers = options.external_module_providers;
 
     auto effective = mqb::config::resolve_project_options(
         project_config ? &*project_config : nullptr,
@@ -69,6 +79,7 @@ prepare_project(
     options.libraries = effective.libraries;
     options.compiler_arguments = effective.compiler_arguments;
     options.linker_arguments = effective.linker_arguments;
+    options.external_module_providers = effective.external_module_providers;
 
     if (options.build.run_after_build
         && options.build.target_kind != mqb::TargetKind::executable) {

--- a/cpp/src/config/ProjectConfig.cpp
+++ b/cpp/src/config/ProjectConfig.cpp
@@ -551,6 +551,34 @@ decode_discovery(const fs::path& file, const fs::path& root, const JsonValue& va
     return {};
 }
 
+[[nodiscard]] std::expected<void, Error>
+decode_modules(const fs::path& file, const fs::path& root, const JsonValue& value, ModuleOverrides& out) {
+    auto object = require_object(file, value, "modules");
+    if (!object) return std::unexpected(object.error());
+    auto known = reject_unknown(file, **object, {"external"}, "modules");
+    if (!known) return std::unexpected(known.error());
+
+    const auto external_it = (**object).find("external");
+    if (external_it == (**object).end()) return {};
+    auto external = require_object(file, external_it->second, "modules.external");
+    if (!external) return std::unexpected(external.error());
+
+    out.external_providers.reserve((*external)->size());
+    for (const auto& [logical_name, provider_value] : **external) {
+        if (logical_name.empty()) {
+            return std::unexpected(schema_error(
+                file, provider_value, "modules.external logical module name must not be empty"));
+        }
+        auto path = require_string(file, provider_value, "modules.external provider IFC");
+        if (!path) return std::unexpected(path.error());
+        out.external_providers.push_back(ExternalModuleProvider{
+            .logical_name = logical_name,
+            .interface_file = resolve_path(root, *path),
+        });
+    }
+    return {};
+}
+
 } // namespace
 
 std::expected<std::optional<fs::path>, Error>
@@ -596,7 +624,7 @@ ProjectConfigLoader::load(const fs::path& requested_file) {
     if (!root) return std::unexpected(root.error());
     auto object = require_object(file, *root, "project config root");
     if (!object) return std::unexpected(object.error());
-    auto known = reject_unknown(file, **object, {"version", "build", "discovery"}, "root");
+    auto known = reject_unknown(file, **object, {"version", "build", "discovery", "modules"}, "root");
     if (!known) return std::unexpected(known.error());
 
     const auto version_it = (**object).find("version");
@@ -632,6 +660,10 @@ ProjectConfigLoader::load(const fs::path& requested_file) {
     }
     if (auto it = (**object).find("discovery"); it != (**object).end()) {
         auto decoded = decode_discovery(file, config.project_root, it->second, config.discovery);
+        if (!decoded) return std::unexpected(decoded.error());
+    }
+    if (auto it = (**object).find("modules"); it != (**object).end()) {
+        auto decoded = decode_modules(file, config.project_root, it->second, config.modules);
         if (!decoded) return std::unexpected(decoded.error());
     }
     return config;

--- a/cpp/src/config/ProjectOptions.cpp
+++ b/cpp/src/config/ProjectOptions.cpp
@@ -1,5 +1,6 @@
 #include "mqb/config/ProjectOptions.hpp"
 
+#include <algorithm>
 #include <utility>
 
 namespace mqb::config {
@@ -40,6 +41,24 @@ void apply_discovery(
     append_all(effective.discovery_exclude_sources, overrides.exclude_sources);
 }
 
+void apply_modules(
+    EffectiveProjectOptions& effective,
+    const ModuleOverrides& overrides) {
+    for (const auto& provider : overrides.external_providers) {
+        const auto existing = std::find_if(
+            effective.external_module_providers.begin(),
+            effective.external_module_providers.end(),
+            [&provider](const ExternalModuleProvider& current) {
+                return current.logical_name == provider.logical_name;
+            });
+        if (existing == effective.external_module_providers.end()) {
+            effective.external_module_providers.push_back(provider);
+        } else {
+            *existing = provider;
+        }
+    }
+}
+
 } // namespace
 
 EffectiveProjectOptions resolve_project_options(
@@ -49,9 +68,11 @@ EffectiveProjectOptions resolve_project_options(
     if (project_config != nullptr) {
         apply_build(effective, project_config->build);
         apply_discovery(effective, project_config->discovery);
+        apply_modules(effective, project_config->modules);
     }
     apply_build(effective, cli_overrides.build);
     apply_discovery(effective, cli_overrides.discovery);
+    apply_modules(effective, cli_overrides.modules);
     return effective;
 }
 

--- a/cpp/src/modules/ModuleDependencyGraph.cpp
+++ b/cpp/src/modules/ModuleDependencyGraph.cpp
@@ -72,10 +72,16 @@ struct ProviderCandidate {
         && planned.lookup_method == required.lookup_method;
 }
 
+[[nodiscard]] bool toolchain_owned_standard_module(const std::string_view logical_name) noexcept {
+    return logical_name == "std" || logical_name == "std.compat";
+}
+
 } // namespace
 
 std::expected<ModuleDependencyPlan, ModuleGraphError>
-ModuleDependencyGraphBuilder::build(const std::vector<ScannedModuleUnit>& units) {
+ModuleDependencyGraphBuilder::build(
+    const std::vector<ScannedModuleUnit>& units,
+    const std::span<const ExternalModuleProvider> external_providers) {
     DependencyGraph graph;
     std::unordered_map<std::string, std::size_t> unit_by_key;
     std::unordered_map<std::string, fs::path> source_by_key;
@@ -123,6 +129,45 @@ ModuleDependencyGraphBuilder::build(const std::vector<ScannedModuleUnit>& units)
         auto provider = select_provider(logical_name, candidates, units);
         if (!provider) return std::unexpected(provider.error());
         provider_by_name.emplace(logical_name, *provider);
+    }
+
+    std::unordered_map<std::string, fs::path> external_provider_by_name;
+    external_provider_by_name.reserve(external_providers.size());
+    for (const auto& provider : external_providers) {
+        if (provider.logical_name.empty() || provider.interface_file.empty()) {
+            return std::unexpected(graph_failure(
+                ModuleGraphErrorCode::invalid_external_provider,
+                "external/prebuilt module provider requires a non-empty logical name and IFC path",
+                provider.interface_file,
+                provider.logical_name));
+        }
+        if (toolchain_owned_standard_module(provider.logical_name)) {
+            return std::unexpected(graph_failure(
+                ModuleGraphErrorCode::toolchain_owned_provider,
+                "standard-library module '" + provider.logical_name
+                    + "' is toolchain-owned and cannot be supplied through external module configuration",
+                provider.interface_file,
+                provider.logical_name));
+        }
+        if (provider_by_name.contains(provider.logical_name)) {
+            return std::unexpected(graph_failure(
+                ModuleGraphErrorCode::ambiguous_named_provider,
+                "external/prebuilt provider conflicts with a project-local provider for logical module '"
+                    + provider.logical_name + "'",
+                provider.interface_file,
+                provider.logical_name));
+        }
+        const auto [_, inserted] = external_provider_by_name.emplace(
+            provider.logical_name,
+            provider.interface_file.lexically_normal());
+        if (!inserted) {
+            return std::unexpected(graph_failure(
+                ModuleGraphErrorCode::duplicate_external_provider,
+                "multiple external/prebuilt providers are configured for logical module '"
+                    + provider.logical_name + "'",
+                provider.interface_file,
+                provider.logical_name));
+        }
     }
 
     ModuleDependencyPlan plan;
@@ -201,6 +246,15 @@ ModuleDependencyGraphBuilder::build(const std::vector<ScannedModuleUnit>& units)
 
             const auto provider = provider_by_name.find(required.logical_name);
             if (provider == provider_by_name.end()) {
+                const auto external = external_provider_by_name.find(required.logical_name);
+                if (external != external_provider_by_name.end()) {
+                    plan.resolved_external_dependencies.push_back(ResolvedExternalModuleDependency{
+                        .consumer_source = units[consumer_index].source,
+                        .logical_name = required.logical_name,
+                        .interface_file = external->second,
+                    });
+                    continue;
+                }
                 plan.unresolved_requirements.push_back(UnresolvedModuleRequirement{
                     .consumer_source = units[consumer_index].source,
                     .requirement = required,

--- a/cpp/src/orchestration/MsvcModuleCompileCoordinator.cpp
+++ b/cpp/src/orchestration/MsvcModuleCompileCoordinator.cpp
@@ -6,6 +6,7 @@
 #include <filesystem>
 #include <optional>
 #include <string>
+#include <system_error>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -364,6 +365,47 @@ MsvcModuleCompileCoordinator::run(const ModuleCompileWaveRequest& request) const
             .interface_file = provider_request.artifacts.module_interface,
         });
         provider_indices[consumer->second].push_back(provider->second);
+    }
+
+    for (const auto& dependency : request.plan.resolved_external_dependencies) {
+        const auto consumer = source_by_key.find(windows_path_key(dependency.consumer_source));
+        if (consumer == source_by_key.end()) {
+            return std::unexpected(failure(
+                ModuleCompileErrorCode::plan_source_missing,
+                "resolved external module dependency references a consumer absent from the compile request",
+                dependency.consumer_source,
+                dependency.interface_file,
+                dependency.logical_name));
+        }
+        std::error_code ec;
+        const bool regular = fs::is_regular_file(dependency.interface_file, ec);
+        if (ec || !regular) {
+            return std::unexpected(failure(
+                ModuleCompileErrorCode::invalid_provider,
+                "external/prebuilt named-module provider IFC is not an existing regular file",
+                dependency.consumer_source,
+                dependency.interface_file,
+                dependency.logical_name));
+        }
+
+        auto& references = module_references[consumer->second];
+        const auto duplicate = std::find_if(
+            references.begin(), references.end(),
+            [&dependency](const ModuleReference& reference) {
+                return reference.logical_name == dependency.logical_name;
+            });
+        if (duplicate != references.end()) {
+            return std::unexpected(failure(
+                ModuleCompileErrorCode::duplicate_reference,
+                "module dependency plan resolves the same logical name more than once for one consumer",
+                dependency.consumer_source,
+                dependency.interface_file,
+                dependency.logical_name));
+        }
+        references.push_back(ModuleReference{
+            .logical_name = dependency.logical_name,
+            .interface_file = dependency.interface_file,
+        });
     }
 
     for (const auto& dependency : request.plan.resolved_header_unit_dependencies) {

--- a/cpp/src/orchestration/MsvcModuleTargetCoordinator.cpp
+++ b/cpp/src/orchestration/MsvcModuleTargetCoordinator.cpp
@@ -224,7 +224,9 @@ MsvcModuleTargetCoordinator::run(const IncrementalModuleTargetRequest& request) 
         });
     }
 
-    auto plan = modules::ModuleDependencyGraphBuilder::build(scanned_units);
+    auto plan = modules::ModuleDependencyGraphBuilder::build(
+        scanned_units,
+        request.compiler_options.external_module_providers);
     if (!plan) {
         IncrementalModuleTargetError error = failure(
             IncrementalModuleTargetErrorCode::graph_failed,

--- a/cpp/tests/config/project_config_tests.cpp
+++ b/cpp/tests/config/project_config_tests.cpp
@@ -63,6 +63,12 @@ int main() {
     "exclude_dirs": ["tests"],
     "extra_sources": ["src/manual.cpp"],
     "exclude_sources": ["src/legacy.cpp"]
+  },
+  "modules": {
+    "external": {
+      "vendor.math": "prebuilt/vendor.math.ifc",
+      "vendor.text": "prebuilt/vendor text.ifc"
+    }
   }
 })json");
 
@@ -130,6 +136,18 @@ int main() {
                    && loaded->discovery.exclude_sources[0]
                        == (tree.root / "src/legacy.cpp").lexically_normal(),
                "excluded source should resolve from config directory");
+        expect(loaded->modules.external_providers.size() == 2,
+               "modules.external should decode every logical-name to IFC mapping");
+        if (loaded->modules.external_providers.size() == 2) {
+            expect(loaded->modules.external_providers[0].logical_name == "vendor.math"
+                       && loaded->modules.external_providers[0].interface_file
+                           == (tree.root / "prebuilt/vendor.math.ifc").lexically_normal(),
+                   "external module IFC path should resolve relative to mqb.json");
+            expect(loaded->modules.external_providers[1].logical_name == "vendor.text"
+                       && loaded->modules.external_providers[1].interface_file
+                           == (tree.root / "prebuilt/vendor text.ifc").lexically_normal(),
+                   "external provider mapping should preserve names and spaces in config-relative paths");
+        }
     }
 
     write_text(config_file, R"json({"version":1,"build":{"type":"lib"}})json");
@@ -151,7 +169,19 @@ int main() {
                "missing build list fields must remain empty overrides");
         expect(!minimal->discovery.enabled,
                "missing discovery enabled field must remain unset");
+        expect(minimal->modules.external_providers.empty(),
+               "missing modules policy must remain an empty override");
     }
+
+    write_text(config_file, R"json({"version":1,"modules":{"external":{"vendor.math":7}}})json");
+    auto bad_provider_type = mqb::config::ProjectConfigLoader::load(config_file);
+    expect(!bad_provider_type && bad_provider_type.error().code == mqb::config::ErrorCode::schema_error,
+           "external module provider IFC must be a non-empty JSON string");
+
+    write_text(config_file, R"json({"version":1,"modules":{"surprise":{}}})json");
+    auto bad_module_field = mqb::config::ProjectConfigLoader::load(config_file);
+    expect(!bad_module_field && bad_module_field.error().code == mqb::config::ErrorCode::schema_error,
+           "unknown modules fields should be rejected by strict schema");
 
     write_text(config_file, R"json({"version":2})json");
     auto unsupported = mqb::config::ProjectConfigLoader::load(config_file);

--- a/cpp/tests/config/project_options_tests.cpp
+++ b/cpp/tests/config/project_options_tests.cpp
@@ -32,6 +32,8 @@ int main() {
                "smart discovery should be enabled by default");
         expect(!effective.output_name,
                "output should remain unset by default");
+        expect(effective.external_module_providers.empty(),
+               "external module provider registry should be empty by default");
     }
 
     mqb::config::ProjectConfig project;
@@ -48,6 +50,16 @@ int main() {
     project.discovery.exclude_directories = {fs::path{"tests"}};
     project.discovery.extra_sources = {fs::path{"src/config-extra.cpp"}};
     project.discovery.exclude_sources = {fs::path{"src/config-old.cpp"}};
+    project.modules.external_providers = {
+        mqb::ExternalModuleProvider{
+            .logical_name = "vendor.math",
+            .interface_file = fs::path{"config/vendor.math.ifc"},
+        },
+        mqb::ExternalModuleProvider{
+            .logical_name = "config.only",
+            .interface_file = fs::path{"config/config.only.ifc"},
+        },
+    };
 
     {
         const mqb::config::ProjectOverrides cli;
@@ -66,6 +78,10 @@ int main() {
                "project config should disable discovery");
         expect(effective.defines == project.build.defines,
                "project list values should populate effective options");
+        expect(effective.external_module_providers.size() == 2
+                   && effective.external_module_providers[0].logical_name == "vendor.math"
+                   && effective.external_module_providers[1].logical_name == "config.only",
+               "project external module registry should populate effective provider policy");
     }
 
     {
@@ -83,6 +99,16 @@ int main() {
         cli.discovery.exclude_directories = {fs::path{"cli-tests"}};
         cli.discovery.extra_sources = {fs::path{"src/cli-extra.cpp"}};
         cli.discovery.exclude_sources = {fs::path{"src/cli-old.cpp"}};
+        cli.modules.external_providers = {
+            mqb::ExternalModuleProvider{
+                .logical_name = "vendor.math",
+                .interface_file = fs::path{"cli/vendor.math.ifc"},
+            },
+            mqb::ExternalModuleProvider{
+                .logical_name = "cli.only",
+                .interface_file = fs::path{"cli/cli.only.ifc"},
+            },
+        };
 
         const auto effective = mqb::config::resolve_project_options(&project, cli);
         expect(effective.configuration == mqb::BuildConfiguration::debug,
@@ -121,6 +147,22 @@ int main() {
                "discovery extra sources should be additive");
         expect(effective.discovery_exclude_sources.size() == 2,
                "discovery excluded sources should be additive");
+        expect(effective.external_module_providers.size() == 3,
+               "CLI external module providers should override by logical name without dropping config-only providers");
+        if (effective.external_module_providers.size() == 3) {
+            expect(effective.external_module_providers[0].logical_name == "vendor.math"
+                       && effective.external_module_providers[0].interface_file
+                           == fs::path{"cli/vendor.math.ifc"},
+                   "CLI provider should replace the matching config provider in-place");
+            expect(effective.external_module_providers[1].logical_name == "config.only"
+                       && effective.external_module_providers[1].interface_file
+                           == fs::path{"config/config.only.ifc"},
+                   "config-only provider should remain available after CLI override resolution");
+            expect(effective.external_module_providers[2].logical_name == "cli.only"
+                       && effective.external_module_providers[2].interface_file
+                           == fs::path{"cli/cli.only.ifc"},
+                   "CLI-only provider should append deterministically after config registry entries");
+        }
     }
 
     if (failures != 0) {

--- a/cpp/tests/e2e/mqb_module_cli_e2e_tests.cpp
+++ b/cpp/tests/e2e/mqb_module_cli_e2e_tests.cpp
@@ -114,6 +114,37 @@ struct TempTree {
     return std::move(*result);
 }
 
+[[nodiscard]] std::expected<mqb::process::ProcessResult, std::string> run_external_cli_mqb(
+    mqb::platform::windows::WindowsProcessRunner& runner,
+    const fs::path& mqb,
+    const fs::path& root,
+    const fs::path& interface_file,
+    const std::string& output_name) {
+    mqb::process::ProcessSpec spec;
+    spec.executable = mqb;
+    spec.arguments = {
+        "main.cpp",
+        "--module-ifc",
+        "math=" + interface_file.generic_string(),
+        "--env",
+        "vs",
+        "--std",
+        "latest",
+        "--jobs",
+        "2",
+        "--verbose",
+        "-o",
+        output_name,
+        "--run",
+    };
+    spec.working_directory = root;
+    spec.capture_stdout = true;
+    spec.capture_stderr = true;
+    auto result = runner.run(spec);
+    if (!result) return std::unexpected("failed to launch mqb: " + result.error().message);
+    return std::move(*result);
+}
+
 } // namespace
 
 int main(const int argc, char* argv[]) {
@@ -458,6 +489,232 @@ int main(const int argc, char* argv[]) {
                 const auto repaired_header_ifc = first_ifc(tree.root);
                 expect(repaired_header_ifc.has_value() && fs::is_regular_file(*repaired_header_ifc),
                        "missing header IFC should be recreated by the public CLI");
+            }
+        }
+    }
+
+    // Build one named module in an independent project, then consume only its
+    // read-only IFC from a second project. This proves that external providers
+    // are not source-discovered, are not scheduled as MQB-owned compile nodes,
+    // and still participate in consumer cache freshness.
+    {
+        TempTree provider_tree{
+            .root = fs::temp_directory_path()
+                / ("mqb_external_provider_e2e_" + std::to_string(unique)),
+        };
+        TempTree consumer_tree{
+            .root = fs::temp_directory_path()
+                / ("mqb_external_consumer_e2e_" + std::to_string(unique)),
+        };
+        TempTree cli_consumer_tree{
+            .root = fs::temp_directory_path()
+                / ("mqb_external_cli_consumer_e2e_" + std::to_string(unique)),
+        };
+        fs::create_directories(provider_tree.root);
+        fs::create_directories(consumer_tree.root);
+        fs::create_directories(cli_consumer_tree.root);
+
+        write_text(
+            provider_tree.root / "math.ixx",
+            "export module math;\n"
+            "export constexpr int answer() { return 42; }\n");
+        write_text(
+            provider_tree.root / "main.cpp",
+            "import math;\n"
+            "int main() { return answer() >= 40 ? 0 : 1; }\n");
+
+        auto provider_cold = run_mqb(
+            runner,
+            mqb_executable,
+            provider_tree.root,
+            "2",
+            true,
+            "external-provider");
+        expect(provider_cold.has_value(), "prebuilt provider project should launch");
+        if (provider_cold) {
+            if (provider_cold->exit_code != 0) dump_failure(*provider_cold);
+            expect(provider_cold->exit_code == 0,
+                   "independent provider project should build a real VS named-module IFC");
+        }
+
+        auto external_ifc = first_ifc(provider_tree.root);
+        expect(external_ifc.has_value() && fs::is_regular_file(*external_ifc),
+               "independent provider build should yield a reusable IFC");
+        if (external_ifc) {
+            write_text(
+                consumer_tree.root / "main.cpp",
+                "import math;\n"
+                "int main() { return answer() >= 42 ? 0 : 1; }\n");
+            const std::string config_text =
+                "{\n"
+                "  \"version\": 1,\n"
+                "  \"modules\": {\n"
+                "    \"external\": {\n"
+                "      \"math\": \"" + external_ifc->generic_string() + "\"\n"
+                "    }\n"
+                "  }\n"
+                "}\n";
+            write_text(consumer_tree.root / "mqb.json", config_text);
+
+            auto external_cold = run_mqb(
+                runner,
+                mqb_executable,
+                consumer_tree.root,
+                "2",
+                false,
+                "external-config");
+            expect(external_cold.has_value(), "external config consumer should launch");
+            if (external_cold) {
+                if (external_cold->exit_code != 0) dump_failure(*external_cold);
+                expect(external_cold->exit_code == 0,
+                       "mqb.json external provider consumer should build and run");
+                expect(external_cold->stdout_text.find("  pipeline: named-modules")
+                           != std::string::npos,
+                       "external-only consumer should route through P1689 named-module pipeline");
+                expect(external_cold->stdout_text.find("[compile] main.cpp") != std::string::npos,
+                       "cold external consumer should compile its ordinary TU");
+                expect(external_cold->stdout_text.find("math.ixx") == std::string::npos,
+                       "external IFC provider source must not become a consumer compile node");
+                expect(external_cold->stdout_text.find("[run] external-config.exe")
+                           != std::string::npos,
+                       "external config consumer should preserve --run behavior");
+            }
+
+            auto external_warm = run_mqb(
+                runner,
+                mqb_executable,
+                consumer_tree.root,
+                "1",
+                false,
+                "external-config");
+            expect(external_warm.has_value(), "warm external config consumer should launch");
+            if (external_warm) {
+                if (external_warm->exit_code != 0) dump_failure(*external_warm);
+                expect(external_warm->exit_code == 0,
+                       "unchanged external provider consumer should remain runnable");
+                expect(contains_line(external_warm->stdout_text, "[up-to-date] main.cpp"),
+                       "unchanged external IFC should preserve consumer compile cache");
+                expect(contains_line(external_warm->stdout_text, "[up-to-date] external-config.exe"),
+                       "warm external consumer should preserve link cache across job-count changes");
+            }
+
+            write_text(
+                cli_consumer_tree.root / "main.cpp",
+                "import math;\n"
+                "int main() { return answer() >= 42 ? 0 : 1; }\n");
+            auto cli_external = run_external_cli_mqb(
+                runner,
+                mqb_executable,
+                cli_consumer_tree.root,
+                *external_ifc,
+                "external-cli");
+            expect(cli_external.has_value(), "--module-ifc consumer should launch");
+            if (cli_external) {
+                if (cli_external->exit_code != 0) dump_failure(*cli_external);
+                expect(cli_external->exit_code == 0,
+                       "--module-ifc should build and run a real external IFC consumer");
+                expect(cli_external->stdout_text.find("  pipeline: named-modules")
+                           != std::string::npos,
+                       "CLI external provider should force P1689 routing");
+            }
+
+            std::error_code time_error;
+            const auto old_ifc_time = fs::last_write_time(*external_ifc, time_error);
+            expect(!time_error, "external provider replacement fixture requires original IFC timestamp");
+            write_text(
+                provider_tree.root / "math.ixx",
+                "export module math;\n"
+                "export constexpr int answer() { return 43; }\n");
+            time_error.clear();
+            fs::last_write_time(
+                provider_tree.root / "math.ixx",
+                old_ifc_time + std::chrono::seconds{2},
+                time_error);
+            expect(!time_error,
+                   "test should make external provider source deterministically newer than its IFC");
+
+            auto provider_rebuilt = run_mqb(
+                runner,
+                mqb_executable,
+                provider_tree.root,
+                "2",
+                true,
+                "external-provider");
+            expect(provider_rebuilt.has_value(), "external provider replacement build should launch");
+            if (provider_rebuilt) {
+                if (provider_rebuilt->exit_code != 0) dump_failure(*provider_rebuilt);
+                expect(provider_rebuilt->exit_code == 0,
+                       "provider source mutation should replace the real prebuilt IFC");
+                expect(provider_rebuilt->stdout_text.find("[compile] math.ixx")
+                           != std::string::npos,
+                       "provider replacement fixture should actually rebuild the module interface");
+            }
+
+            auto rebuilt_external_ifc = first_ifc(provider_tree.root);
+            expect(rebuilt_external_ifc.has_value() && fs::is_regular_file(*rebuilt_external_ifc),
+                   "provider replacement should leave a reusable IFC");
+            if (rebuilt_external_ifc) {
+                expect(rebuilt_external_ifc->lexically_normal() == external_ifc->lexically_normal(),
+                       "same provider identity should replace the IFC at a stable artifact path");
+                const fs::path consumer_executable =
+                    consumer_tree.root / ".mqb" / "bin" / "external-config.exe";
+                time_error.clear();
+                const auto consumer_time = fs::last_write_time(consumer_executable, time_error);
+                expect(!time_error,
+                       "external provider freshness fixture requires consumer executable timestamp");
+                if (!time_error) {
+                    time_error.clear();
+                    fs::last_write_time(
+                        *rebuilt_external_ifc,
+                        consumer_time + std::chrono::seconds{2},
+                        time_error);
+                    expect(!time_error,
+                           "test should make replacement IFC deterministically newer than consumer outputs");
+                }
+
+                auto external_replacement = run_mqb(
+                    runner,
+                    mqb_executable,
+                    consumer_tree.root,
+                    "2",
+                    false,
+                    "external-config");
+                expect(external_replacement.has_value(),
+                       "external provider replacement consumer should launch");
+                if (external_replacement) {
+                    if (external_replacement->exit_code != 0) dump_failure(*external_replacement);
+                    expect(external_replacement->exit_code == 0,
+                           "replacement external IFC should rebuild and run its consumer");
+                    expect(external_replacement->stdout_text.find("[compile] main.cpp")
+                               != std::string::npos,
+                           "replacement external IFC must invalidate the consumer compile cache");
+                    expect(external_replacement->stdout_text.find("[link] external-config.exe")
+                               != std::string::npos,
+                           "external IFC replacement should relink the final executable");
+                }
+
+                time_error.clear();
+                fs::remove(*rebuilt_external_ifc, time_error);
+                expect(!time_error, "test should be able to remove the external provider IFC");
+                auto external_missing = run_mqb(
+                    runner,
+                    mqb_executable,
+                    consumer_tree.root,
+                    "1",
+                    false,
+                    "external-config");
+                expect(external_missing.has_value(), "missing external IFC consumer should launch");
+                if (external_missing) {
+                    expect(external_missing->exit_code != 0,
+                           "missing configured external IFC must fail closed");
+                    expect(external_missing->stdout_text.find("[link] external-config.exe")
+                               == std::string::npos,
+                           "missing external IFC must fail before final link");
+                    expect(external_missing->stderr_text.find(
+                               "external/prebuilt named-module provider IFC is not an existing regular file")
+                               != std::string::npos,
+                           "missing external IFC should surface the MQB-owned provider diagnostic");
+                }
             }
         }
     }

--- a/cpp/tests/modules/module_dependency_resolution_tests.cpp
+++ b/cpp/tests/modules/module_dependency_resolution_tests.cpp
@@ -62,6 +62,21 @@ void expect(const bool condition, const std::string_view message) {
         });
 }
 
+[[nodiscard]] bool has_external_edge(
+    const mqb::modules::ModuleDependencyPlan& plan,
+    const fs::path& consumer,
+    const fs::path& interface_file,
+    const std::string_view logical_name) {
+    return std::any_of(
+        plan.resolved_external_dependencies.begin(),
+        plan.resolved_external_dependencies.end(),
+        [&](const mqb::modules::ResolvedExternalModuleDependency& dependency) {
+            return dependency.consumer_source == consumer
+                && dependency.interface_file == interface_file
+                && dependency.logical_name == logical_name;
+        });
+}
+
 } // namespace
 
 int main() {
@@ -104,6 +119,70 @@ int main() {
                    "ordinary consumer should reference the selected interface provider");
             expect(!has_edge(*plan, "consumer.cpp", "M_impl.cpp", "M"),
                    "non-interface same-name unit must not leak into provider resolution");
+        }
+    }
+
+    {
+        const std::vector units{
+            unit("consumer.cpp", {}, {require_named("vendor.math")}),
+        };
+        const std::vector external{
+            mqb::ExternalModuleProvider{
+                .logical_name = "vendor.math",
+                .interface_file = "prebuilt/vendor.math.ifc",
+            },
+        };
+        const auto plan = ModuleDependencyGraphBuilder::build(units, external);
+        expect(plan.has_value(), "explicit external provider should resolve a named requirement");
+        if (plan) {
+            expect(plan->unresolved_requirements.empty(),
+                   "configured external provider should remove the matching unresolved requirement");
+            expect(plan->resolved_external_dependencies.size() == 1,
+                   "external provider should create one typed external dependency");
+            expect(has_external_edge(
+                       *plan, "consumer.cpp", "prebuilt/vendor.math.ifc", "vendor.math"),
+                   "external dependency should retain consumer, logical name, and exact IFC identity");
+            expect(plan->compile_levels.size() == 1 && plan->compile_levels.front().size() == 1,
+                   "read-only external provider must not become an MQB compile-level node");
+        }
+    }
+
+    {
+        const std::vector units{
+            unit("local.ixx", {provide("vendor.math")}),
+            unit("consumer.cpp", {}, {require_named("vendor.math")}),
+        };
+        const std::vector external{
+            mqb::ExternalModuleProvider{
+                .logical_name = "vendor.math",
+                .interface_file = "prebuilt/vendor.math.ifc",
+            },
+        };
+        const auto plan = ModuleDependencyGraphBuilder::build(units, external);
+        expect(!plan.has_value(),
+               "project-local and configured external providers for one logical name must be ambiguous");
+        if (!plan) {
+            expect(plan.error().code == mqb::modules::ModuleGraphErrorCode::ambiguous_named_provider,
+                   "local/external provider conflict should preserve named-provider ambiguity diagnostics");
+        }
+    }
+
+    {
+        const std::vector units{
+            unit("consumer.cpp", {}, {require_named("std")}),
+        };
+        const std::vector external{
+            mqb::ExternalModuleProvider{
+                .logical_name = "std",
+                .interface_file = "prebuilt/std.ifc",
+            },
+        };
+        const auto plan = ModuleDependencyGraphBuilder::build(units, external);
+        expect(!plan.has_value(),
+               "standard-library modules must not be smuggled through generic external provider policy");
+        if (!plan) {
+            expect(plan.error().code == mqb::modules::ModuleGraphErrorCode::toolchain_owned_provider,
+                   "import std boundary should remain explicitly toolchain-owned for the next slice");
         }
     }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -134,7 +134,7 @@ core  <---- shared typed build model, planner, cache and artifact rules
 
 ### `modules`
 
-`modules` 负责 P1689 typed model 与 module dependency graph。provider ownership 只有一个权威实现；named modules 与 header units 必须保持类型区别。
+`modules` 负责 P1689 typed model 与 module dependency graph。provider ownership 只有一个权威实现；named modules 与 header units 必须保持类型区别。项目内 provider 与显式 external/prebuilt provider 的选择、冲突和歧义也只在这里裁决；discovery/orchestration 不允许通过猜测 IFC 路径来补 provider。
 
 ### `orchestration`
 
@@ -184,9 +184,11 @@ core  <---- shared typed build model, planner, cache and artifact rules
 13. module provider selection 只有一个 owner。
 14. header units 与 named modules 类型分离。
 15. unsupported module requirements fail closed。
-16. stable v5 只有一个 native parser、一个 native executor、一个 C++ 源码树。
-17. `cpp/include`、`cpp/src`、`cpp/tests` 分别只有一个物理根。
-18. 不允许为了“方便”重新制造组件级 `include/src/tests`。
+16. external/prebuilt named-module IFC 只能通过 typed project/CLI policy 显式声明；它是只读 dependency，不能变成 MQB-owned writable artifact。
+17. `std` / `std.compat` provider 属于 toolchain policy，不能由 generic external-provider 配置伪造。
+18. stable v5 只有一个 native parser、一个 native executor、一个 C++ 源码树。
+19. `cpp/include`、`cpp/src`、`cpp/tests` 分别只有一个物理根。
+20. 不允许为了“方便”重新制造组件级 `include/src/tests`。
 
 ## 6. Project configuration
 
@@ -198,7 +200,7 @@ mqb.json relative path ---> directory containing mqb.json
 artifact project root ----> directory containing mqb.json (when present)
 ```
 
-Scalar precedence：`explicit CLI > mqb.json > built-in defaults`。List-like inputs additive 且 deterministic。
+Scalar precedence：`explicit CLI > mqb.json > built-in defaults`。List-like inputs additive 且 deterministic。External module provider registry 以 logical module name 为 key：`mqb.json` 可在 `modules.external` 中声明 `name -> IFC path`，CLI 可重复使用 `--module-ifc name=path.ifc`；同名 CLI 项定点覆盖 config，CLI 自身重复同名项则 fail closed。
 
 MQB 自身的 `cpp/mqb.json` 也是自构建 production manifest。当前物理结构只需要两个 include roots：
 
@@ -225,15 +227,19 @@ bounded /scanDependencies
 P1689 typed rules
        ↓
 ModuleDependencyGraphBuilder
+       ├─ project-local provider -> graph compile dependency
+       └─ explicit external IFC  -> read-only typed ModuleReference
        ↓
-dynamic IFC assignment
+dynamic IFC assignment (MQB-owned providers only)
        ↓
 dependency-level compile waves
        ↓
 incremental final link
 ```
 
-稳定版支持 project-local named modules 与 project-local header units。External/prebuilt named-module providers 与 `import std` 当前仍 fail closed，并由 Issue #16 独立跟踪。
+稳定版支持 project-local named modules、project-local header units，以及显式配置的 external/prebuilt named-module IFC provider。External IFC 不参与 source discovery，不加入 compile levels，也不由 MQB 写入；实际 consumer 通过现有 `ModuleReference` 进入 compile signature 和 `/sourceDependencies` cache dependency，因此 provider 替换会失效对应 consumer cache，provider 缺失会在进入编译器前 fail closed。
+
+`import std` / `std.compat` 仍未在这一层实现：标准库 module provider 明确保留给 toolchain-owned policy，不允许借 generic external provider 逃逸。Issue #16 的下一 slice 单独负责其 VS/MSVC discovery、version identity 与 cold/warm E2E。
 
 ## 8. Build identity 与 artifact layout
 

--- a/docs/ARCHITECTURE_EN.md
+++ b/docs/ARCHITECTURE_EN.md
@@ -10,8 +10,12 @@ MQB is one native C++23 executable, not a collection of independently shipped li
 - responsibilities are mirrored underneath those roots;
 - component-local `include/src/tests` trees are forbidden.
 
-Logical dependency boundaries remain equally strict: `core` is toolchain-independent, `config` owns project policy, `discovery` selects source candidates, `modules` owns P1689 topology, `orchestration` composes build pipelines, `msvc` owns MSVC primitives, `process` is platform-neutral, and `platform/windows` owns the Windows execution boundary.
+Logical dependency boundaries remain equally strict: `core` is toolchain-independent, `config` owns project policy, `discovery` selects source candidates, `modules` owns P1689 topology and provider selection, `orchestration` composes build pipelines, `msvc` owns MSVC primitives, `process` is platform-neutral, and `platform/windows` owns the Windows execution boundary.
 
-See [`cpp/README_EN.md`](../cpp/README_EN.md) for the enforced physical layout contract.
+External/prebuilt named-module providers are explicit typed policy, never filesystem guesses. `mqb.json` uses `modules.external` as a logical-name-to-IFC map; the CLI uses repeatable `--module-ifc name=path.ifc`, with CLI entries overriding config by logical name. The P1689 module graph remains the sole provider owner: project-local and configured external providers for the same logical name are an ambiguity error. External IFCs are read-only dependencies, never MQB-owned compile nodes or writable artifacts, and resolved consumers reuse the existing typed `ModuleReference` signature/cache machinery.
+
+`std` and `std.compat` are deliberately excluded from generic external-provider policy. Standard-library modules remain toolchain-owned and fail closed until the separate Issue #16 `import std` slice adds supported MSVC discovery, version identity, and cold/warm coverage.
+
+See [`cpp/README_EN.md`](../cpp/README_EN.md) for the enforced physical layout contract and [`ARCHITECTURE.md`](ARCHITECTURE.md) for the detailed invariants and module pipeline.
 
 MQB is also its own development, test, and release build system. CMake/CTest are not part of the current authoritative chain. The stable gate is pinned seed → MQB-built Stage 0 → 67 Release tests → Stage 1 → clean Stage 2, with exact artifact and installer validation. See [`SELF_HOSTING_EN.md`](SELF_HOSTING_EN.md) for the full contract.


### PR DESCRIPTION
## Summary

Completes the Issue #16 **external/prebuilt named-module provider** slice without weakening the P1689 ownership boundary.

- add typed `logical module -> read-only IFC` policy
- support `mqb.json` via `modules.external`
- support repeatable CLI `--module-ifc <name=path>` with CLI-over-config precedence by logical name
- resolve configured providers only in `ModuleDependencyGraphBuilder`
- reject local/external provider ambiguity and duplicate provider declarations instead of guessing
- keep `std` / `std.compat` toolchain-owned so generic external policy cannot impersonate standard-library modules
- feed resolved external IFCs through existing typed `ModuleReference` compile/cache machinery
- fail early when a configured IFC is missing instead of emitting a broken compiler reference
- preserve the 67-test-file native manifest while extending existing config/module/E2E coverage

## Real VS coverage

The public module CLI E2E now builds a real independent named-module provider, consumes its IFC from another project through both `mqb.json` and `--module-ifc`, verifies warm cache reuse, replaces the provider IFC and verifies consumer rebuild/relink, then deletes the IFC and verifies fail-closed diagnostics before link.

## Validation

At head `89b04251497995cc701f53aebdc6a9f03deaee9c`:

- Native C++: **success** — current Debug MQB builds with MQB and all 67 native Debug tests pass
- Native Release: **success** — Release tests/self-host/package validation pass
- Native Installer: **success**

## Issue #16 scope

This PR closes only **External/prebuilt named-module providers**. The separate toolchain-owned `import std` implementation is stacked in PR #59.

Refs #16