### PR TITLE
fix: propagate transitive MSVC references with Unicode-safe path identity

### DIFF
--- a/cpp/src/discovery/SourceDiscovery.cpp
+++ b/cpp/src/discovery/SourceDiscovery.cpp
@@ -54,16 +54,32 @@ struct FileRecord {
         value.begin(),
         value.end(),
         value.begin(),
-        [](const unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+        [](const unsigned char ch) {
+            if (ch >= static_cast<unsigned char>('A')
+                && ch <= static_cast<unsigned char>('Z')) {
+                return static_cast<char>(ch + ('a' - 'A'));
+            }
+            return static_cast<char>(ch);
+        });
     return value;
 }
 
+[[nodiscard]] std::string utf8_path_text(const fs::path& path) {
+    const std::u8string value = path.generic_u8string();
+    std::string result;
+    result.reserve(value.size());
+    for (const char8_t ch : value) {
+        result.push_back(static_cast<char>(ch));
+    }
+    return result;
+}
+
 [[nodiscard]] std::string path_key(const fs::path& path) {
-    return ascii_lower(path.lexically_normal().generic_string());
+    return ascii_lower(utf8_path_text(path.lexically_normal()));
 }
 
 [[nodiscard]] std::string extension_lower(const fs::path& path) {
-    return ascii_lower(path.extension().string());
+    return ascii_lower(utf8_path_text(path.extension()));
 }
 
 [[nodiscard]] bool header_extension(const fs::path& path) {
@@ -81,7 +97,7 @@ struct FileRecord {
 }
 
 [[nodiscard]] bool default_excluded_directory(const fs::path& path) {
-    const std::string name = ascii_lower(path.filename().string());
+    const std::string name = ascii_lower(utf8_path_text(path.filename()));
     return name == ".mqb"
         || name == ".git"
         || name == ".vs"

--- a/cpp/src/orchestration/MsvcModuleCompileCoordinator.cpp
+++ b/cpp/src/orchestration/MsvcModuleCompileCoordinator.cpp
@@ -22,10 +22,18 @@ namespace {
 namespace fs = std::filesystem;
 
 [[nodiscard]] std::string windows_path_key(const fs::path& path) {
-    std::string value = path.lexically_normal().generic_string();
-    std::transform(
-        value.begin(), value.end(), value.begin(),
-        [](const unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+    const std::u8string utf8 = path.lexically_normal().generic_u8string();
+    std::string value;
+    value.reserve(utf8.size());
+    for (const char8_t ch : utf8) {
+        const unsigned char byte = static_cast<unsigned char>(ch);
+        if (byte >= static_cast<unsigned char>('A')
+            && byte <= static_cast<unsigned char>('Z')) {
+            value.push_back(static_cast<char>(byte + ('a' - 'A')));
+        } else {
+            value.push_back(static_cast<char>(byte));
+        }
+    }
     return value;
 }
 
@@ -89,6 +97,58 @@ namespace fs = std::filesystem;
         return HeaderUnitLookupMethod::quote;
     case modules::LookupMethod::by_name:
         return std::nullopt;
+    }
+    return std::nullopt;
+}
+
+[[nodiscard]] std::optional<ModuleCompileError> merge_module_reference(
+    std::vector<ModuleReference>& references,
+    const ModuleReference& incoming,
+    const fs::path& consumer_source) {
+    const auto existing = std::find_if(
+        references.begin(), references.end(),
+        [&](const ModuleReference& reference) {
+            return reference.logical_name == incoming.logical_name;
+        });
+    if (existing == references.end()) {
+        references.push_back(incoming);
+        return std::nullopt;
+    }
+    if (windows_path_key(existing->interface_file)
+        != windows_path_key(incoming.interface_file)) {
+        return failure(
+            ModuleCompileErrorCode::duplicate_reference,
+            "transitive module reference closure resolves logical name '"
+                + incoming.logical_name + "' to different IFC artifacts",
+            consumer_source,
+            incoming.interface_file,
+            incoming.logical_name);
+    }
+    return std::nullopt;
+}
+
+[[nodiscard]] std::optional<ModuleCompileError> merge_header_reference(
+    std::vector<HeaderUnitReference>& references,
+    const HeaderUnitReference& incoming,
+    const fs::path& consumer_source) {
+    const auto existing = std::find_if(
+        references.begin(), references.end(),
+        [&](const HeaderUnitReference& reference) {
+            return reference.header_name == incoming.header_name
+                && reference.lookup_method == incoming.lookup_method;
+        });
+    if (existing == references.end()) {
+        references.push_back(incoming);
+        return std::nullopt;
+    }
+    if (windows_path_key(existing->interface_file)
+        != windows_path_key(incoming.interface_file)) {
+        return failure(
+            ModuleCompileErrorCode::duplicate_reference,
+            "transitive header-unit reference closure resolves one header identity to different IFC artifacts",
+            consumer_source,
+            incoming.interface_file,
+            incoming.header_name);
     }
     return std::nullopt;
 }
@@ -459,6 +519,38 @@ MsvcModuleCompileCoordinator::run(const ModuleCompileWaveRequest& request) const
             .interface_file = provider_request.artifacts.module_interface,
         });
         provider_indices[consumer->second].push_back(source_count + provider->second);
+    }
+
+    // MSVC validates imported IFCs while compiling a downstream module. An IFC
+    // can itself import named modules or header units, so a consumer needs the
+    // reference closure of its direct providers, not only the references named
+    // in the consumer's own P1689 rule. Propagate that closure provider-first
+    // using the already validated dependency levels. Keep direct provider
+    // indices unchanged: fresh rebuild propagation naturally cascades one level
+    // at a time through the same graph.
+    for (const auto& level : level_indices) {
+        for (const std::size_t consumer_index : level) {
+            if (consumer_index >= source_count) continue;
+            for (const std::size_t provider_index : provider_indices[consumer_index]) {
+                if (provider_index >= source_count) continue;
+                for (const auto& reference : module_references[provider_index]) {
+                    if (auto error = merge_module_reference(
+                            module_references[consumer_index],
+                            reference,
+                            request.sources[consumer_index].source)) {
+                        return std::unexpected(std::move(*error));
+                    }
+                }
+                for (const auto& reference : header_references[provider_index]) {
+                    if (auto error = merge_header_reference(
+                            header_references[consumer_index],
+                            reference,
+                            request.sources[consumer_index].source)) {
+                        return std::unexpected(std::move(*error));
+                    }
+                }
+            }
+        }
     }
 
     using CompileAttempt = std::expected<IncrementalCompileResult, IncrementalCompileError>;

--- a/cpp/tests/discovery/source_discovery_tests.cpp
+++ b/cpp/tests/discovery/source_discovery_tests.cpp
@@ -159,6 +159,63 @@ int main() {
                "discovery output ordering should be deterministic");
     }
 
+    {
+        TempTree traversal_tree{
+            .root = fs::temp_directory_path()
+                / ("mqb_source_discovery_deep_" + std::to_string(unique)),
+        };
+        const fs::path deep_entry = traversal_tree.root / "a" / "b" / "c" / "main.cpp";
+        const fs::path root_header = traversal_tree.root / "tail.hpp";
+        const fs::path root_source = traversal_tree.root / "tail.cpp";
+        write_text(
+            deep_entry,
+            "#include \"../../../tail.hpp\"\n"
+            "int main() { return tail(); }\n");
+        write_text(root_header, "#pragma once\nint tail();\n");
+        write_text(root_source, "#include \"tail.hpp\"\nint tail() { return 0; }\n");
+
+        const auto traversal = mqb::discovery::SourceDiscovery::discover({
+            .project_root = traversal_tree.root,
+            .entry = deep_entry,
+            .include_directories = {},
+        });
+        expect(traversal.has_value(),
+               "discovery should resume at parent directories after finishing a deep subtree");
+        if (traversal) {
+            expect(traversal->indexed_files == 3,
+                   "deep-subtree traversal should still index root-level header and source files");
+            expect(contains_source(traversal->sources, root_source),
+                   "root-level source reached after a deep subtree should participate in discovery");
+        }
+    }
+
+    {
+        TempTree unicode_tree{
+            .root = fs::temp_directory_path()
+                / ("mqb_source_discovery_unicode_" + std::to_string(unique)),
+        };
+        const fs::path unicode_entry = unicode_tree.root / "main.cpp";
+        const fs::path unicode_source =
+            unicode_tree.root / L"\u68c0\u6d4bsmart_handle.cpp";
+        write_text(unicode_entry, "int main() { return 0; }\n");
+        write_text(unicode_source, "int unicode_probe() { return 0; }\n");
+
+        const auto unicode_discovery = mqb::discovery::SourceDiscovery::discover({
+            .project_root = unicode_tree.root,
+            .entry = unicode_entry,
+            .include_directories = {},
+        });
+        expect(unicode_discovery.has_value(),
+               "discovery should index Unicode filenames without narrow path conversion");
+        if (unicode_discovery) {
+            expect(unicode_discovery->indexed_files == 2,
+                   "Unicode-named translation unit should be indexed");
+            expect(unicode_discovery->sources.size() == 1
+                       && unicode_discovery->sources.front() == unicode_entry,
+                   "disconnected Unicode-named source should not change selected closure");
+        }
+    }
+
     const auto invalid_root = mqb::discovery::SourceDiscovery::discover({
         .project_root = tree.root / "missing-root",
         .entry = main_source,

--- a/cpp/tests/orchestration/module_compile_coordinator_tests.cpp
+++ b/cpp/tests/orchestration/module_compile_coordinator_tests.cpp
@@ -325,6 +325,109 @@ int main() {
                "downstream provider rebuild should propagate as explicit_rebuild");
     }
 
+    {
+        const fs::path std_source = root / "transitive" / "std.ixx";
+        const fs::path partition_source = root / "transitive" / "M-part.ixx";
+        const fs::path primary_source = root / "transitive" / "M.ixx";
+        write_text(std_source, "export module std;\n");
+        write_text(partition_source, "export module M:part; import std;\n");
+        write_text(primary_source, "export module M; export import :part;\n");
+
+        auto std_artifacts = layout->for_source(std_source);
+        auto partition_artifacts = layout->for_source(partition_source);
+        auto primary_artifacts = layout->for_source(primary_source);
+        expect(std_artifacts && partition_artifacts && primary_artifacts,
+               "transitive module-reference fixture should receive unique artifacts");
+        if (!std_artifacts || !partition_artifacts || !primary_artifacts) return 1;
+
+        mqb::modules::ModuleDependencyPlan transitive_plan;
+        transitive_plan.compile_levels = {
+            {std_source},
+            {partition_source},
+            {primary_source},
+        };
+        transitive_plan.resolved_dependencies = {
+            mqb::modules::ResolvedModuleDependency{
+                .consumer_source = partition_source,
+                .provider_source = std_source,
+                .logical_name = "std",
+            },
+            mqb::modules::ResolvedModuleDependency{
+                .consumer_source = primary_source,
+                .provider_source = partition_source,
+                .logical_name = "M:part",
+            },
+        };
+
+        mqb::orchestration::ModuleCompileWaveRequest transitive_request;
+        transitive_request.sources = {
+            mqb::orchestration::ModuleCompileSourceRequest{
+                .source = primary_source,
+                .artifacts = *primary_artifacts,
+                .kind = mqb::TranslationUnitKind::module_interface,
+            },
+            mqb::orchestration::ModuleCompileSourceRequest{
+                .source = partition_source,
+                .artifacts = *partition_artifacts,
+                .kind = mqb::TranslationUnitKind::module_interface,
+            },
+            mqb::orchestration::ModuleCompileSourceRequest{
+                .source = std_source,
+                .artifacts = *std_artifacts,
+                .kind = mqb::TranslationUnitKind::module_interface,
+            },
+        };
+        transitive_request.plan = transitive_plan;
+        transitive_request.compiler_options = options;
+        transitive_request.working_directory = root;
+        transitive_request.max_parallel_compiles = 2;
+
+        const int calls_before_transitive = runner.calls();
+        const auto transitive = modules.run(transitive_request);
+        expect(transitive.has_value(),
+               "transitive named-module reference closure should compile successfully");
+        if (!transitive) return 1;
+        expect(runner.calls() == calls_before_transitive + 3,
+               "cold transitive fixture should compile all three dependency levels exactly once");
+
+        const auto transitive_records = runner.records();
+        expect(has_reference_argument(
+                   transitive_records,
+                   partition_source,
+                   "std",
+                   std_artifacts->module_interface),
+               "direct partition consumer should receive /reference std=<IFC>");
+        expect(has_reference_argument(
+                   transitive_records,
+                   primary_source,
+                   "M:part",
+                   partition_artifacts->module_interface),
+               "primary interface should receive its direct partition reference");
+        expect(has_reference_argument(
+                   transitive_records,
+                   primary_source,
+                   "std",
+                   std_artifacts->module_interface),
+               "primary interface should inherit the partition's transitive std reference");
+    }
+
+    {
+        auto unicode_collision = request;
+        const fs::path unicode_artifact =
+            root / L"\u4ea7\u7269" / L"\u5171\u4eab.obj";
+        unicode_collision.sources[0].artifacts.object = unicode_artifact;
+        unicode_collision.sources[1].artifacts.object = unicode_artifact;
+
+        const int calls_before_unicode_collision = runner.calls();
+        const auto collision = modules.run(unicode_collision);
+        expect(!collision
+                   && collision.error().code
+                       == mqb::orchestration::ModuleCompileErrorCode::artifact_collision,
+               "Unicode artifact paths should participate in collision detection without narrow conversion");
+        expect(runner.calls() == calls_before_unicode_collision,
+               "Unicode artifact collision should fail before launching the compiler");
+    }
+
     auto unsupported = request;
     unsupported.plan.unresolved_requirements.push_back(
         mqb::modules::UnresolvedModuleRequirement{


### PR DESCRIPTION
## Summary

Compatibility hardening driven by the real `Iviesever/IvyGUI` graph after Issue #16 `import std` support.

This PR fixes two independent blockers exposed by IvyGUI on VS2026/MSVC 14.51:

1. **Transitive MSVC module references.** A primary interface can import/re-export a provider IFC whose own named-module or header-unit imports still need to be visible when MSVC validates that IFC. The coordinator previously emitted only direct P1689 references, which can produce C2230/C1199 downstream.
2. **Unicode Windows path identity.** Source discovery and module-artifact identity used `std::filesystem::path::generic_string()`. With IvyGUI's Chinese filenames this takes the locale-dependent narrow conversion path and can stall catastrophically before discovery completes.

The implementation now:

- propagates provider-first transitive named-module/header-unit reference closure over the already validated dependency levels
- keeps the direct provider graph unchanged for rebuild propagation
- deduplicates equal reference identities and fails closed when one logical identity resolves to different IFC artifacts
- uses `generic_u8string()` plus ASCII-only case folding for internal Windows path keys instead of locale-dependent `generic_string()` conversion
- applies the Unicode-safe identity rule both to `SourceDiscovery` and `MsvcModuleCompileCoordinator`
- adds regressions for deep discovery traversal, a Chinese-named translation unit, `std -> M:part -> M` transitive references, and a Chinese artifact-path collision that must fail before launching the compiler

## Unicode root-cause proof

The pathological IvyGUI single-entry run was isolated with progressively smaller probes:

- native Win32 enumeration of `gui/` returned all 15 entries in **0 ms**
- the first problematic entries were Chinese filenames such as `检测smart_handle.cpp`
- a no-I/O micro-probe on the same Unicode path measured:
  - `lexically_relative()` — **0 ms**
  - `path.native()` — **0 ms**
  - `generic_u8string()` — **0 ms**
  - `generic_string()` — stalled until the diagnostic run was cancelled

This rules out directory enumeration and identifies locale-dependent narrow `filesystem::path` conversion as the discovery stall.

## Real IvyGUI acceptance

Using only `gui/example_render.cpp` as the public MQB entry, smart discovery found **36 translation units from 43 indexed C/C++ files** and selected the named-module pipeline.

On the validated source tree represented by this PR:

- cold jobs=1: **27.7507707 s**, final `.mqb/bin/IvyGUI-j1.exe` produced
- `.mqb` removed
- cold jobs=4: **20.2567905 s**, final `.mqb/bin/IvyGUI-j4.exe` produced

Both builds used normal smart discovery rather than an explicit 36-source manifest.

## Final shape

PR #59 is merged to `main` as `0da38e1b79f19d10145eceb62bb6648dab9d9d9b`. This PR now targets `main` directly.

Current exact head: `3fa2e373fc1a99b5e3f3f2d444f3f9aec21e7b02`
Current shape: **1 commit / 4 files / +276 -8**, mergeable.

## Exact-head gates

- Native C++: **success** — current Debug MQB self-build and all 67 native Debug tests pass
- Native Release/self-host/package: **success**
- Native Installer: **success**
- real IvyGUI single-entry cold jobs=1/jobs=4 acceptance: **success**

Ready to merge.

Refs #16