### PR TITLE
release: ship runtime-only stable ZIP

### DIFF
--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -5,10 +5,7 @@ on:
     paths:
       - 'VERSION'
       - 'cpp/**'
-      - 'README.md'
-      - 'README_EN.md'
       - 'LICENSE'
-      - 'docs/**'
       - 'install.bat'
       - 'install.ps1'
       - 'uninstall.ps1'
@@ -21,14 +18,13 @@ on:
       - main
     paths:
       - 'VERSION'
+      - '.github/workflows/native-release.yml'
 
 jobs:
   build-test-package:
     runs-on: windows-latest
     permissions:
       contents: read
-    env:
-      GH_TOKEN: ${{ github.token }}
     outputs:
       version: ${{ steps.meta.outputs.version }}
       package_name: ${{ steps.meta.outputs.package_name }}
@@ -109,73 +105,27 @@ jobs:
             -OutputRoot (Join-Path $PWD 'selfhost-out')
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-      - name: Stage release package
+      - name: Stage runtime-only release package
         shell: pwsh
         env:
-          MQB_RELEASE_VERSION: ${{ steps.meta.outputs.version }}
           MQB_PACKAGE_NAME: ${{ steps.meta.outputs.package_name }}
         run: |
           $dist = Join-Path $PWD 'dist'
           $stage = Join-Path $dist $env:MQB_PACKAGE_NAME
-          if (Test-Path -LiteralPath $dist) { Remove-Item -LiteralPath $dist -Recurse -Force }
+          if (Test-Path -LiteralPath $dist) {
+            Remove-Item -LiteralPath $dist -Recurse -Force
+          }
           New-Item -ItemType Directory -Force -Path $stage | Out-Null
 
+          # The stable ZIP is intentionally runtime/install-only. User documentation
+          # stays in the repository and on GitHub Releases; Apache-2.0 LICENSE remains
+          # in the binary redistribution as required by the license.
           Copy-Item 'selfhost-out/stage1/mqb.exe' (Join-Path $stage 'mqb.exe')
           Copy-Item 'VERSION' (Join-Path $stage 'VERSION')
           Copy-Item 'install.bat' (Join-Path $stage 'install.bat')
           Copy-Item 'install.ps1' (Join-Path $stage 'install.ps1')
           Copy-Item 'uninstall.ps1' (Join-Path $stage 'uninstall.ps1')
-          Copy-Item 'README.md' (Join-Path $stage 'README.md')
-          Copy-Item 'README_EN.md' (Join-Path $stage 'README_EN.md')
           Copy-Item 'LICENSE' (Join-Path $stage 'LICENSE')
-          Copy-Item 'docs/MQB_CONFIG.md' (Join-Path $stage 'MQB_CONFIG.md')
-          Copy-Item 'docs/MQB_CONFIG_EN.md' (Join-Path $stage 'MQB_CONFIG_EN.md')
-          Copy-Item 'docs/ARCHITECTURE.md' (Join-Path $stage 'ARCHITECTURE.md')
-          Copy-Item 'docs/ARCHITECTURE_EN.md' (Join-Path $stage 'ARCHITECTURE_EN.md')
-          Copy-Item 'docs/INSTALLATION.md' (Join-Path $stage 'INSTALLATION.md')
-          Copy-Item 'docs/INSTALLATION_EN.md' (Join-Path $stage 'INSTALLATION_EN.md')
-          Copy-Item 'docs/SELF_HOSTING.md' (Join-Path $stage 'SELF_HOSTING.md')
-          Copy-Item 'docs/SELF_HOSTING_EN.md' (Join-Path $stage 'SELF_HOSTING_EN.md')
-
-          $tag = "v$env:MQB_RELEASE_VERSION"
-          $repoBlobBase = "https://github.com/$env:GITHUB_REPOSITORY/blob/$tag"
-          $packageLinkRewrites = @{
-            (Join-Path $stage 'README.md') = @{
-              '(cpp/README.md)' = "($repoBlobBase/cpp/README.md)"
-              '(cpp/mqb.json)' = "($repoBlobBase/cpp/mqb.json)"
-              '(docs/ARCHITECTURE.md)' = '(ARCHITECTURE.md)'
-              '(docs/SELF_HOSTING.md)' = '(SELF_HOSTING.md)'
-              '(docs/MQB_CONFIG.md)' = '(MQB_CONFIG.md)'
-              '(docs/INSTALLATION.md)' = '(INSTALLATION.md)'
-            }
-            (Join-Path $stage 'README_EN.md') = @{
-              '(cpp/README_EN.md)' = "($repoBlobBase/cpp/README_EN.md)"
-              '(cpp/mqb.json)' = "($repoBlobBase/cpp/mqb.json)"
-              '(docs/ARCHITECTURE_EN.md)' = '(ARCHITECTURE_EN.md)'
-              '(docs/SELF_HOSTING_EN.md)' = '(SELF_HOSTING_EN.md)'
-              '(docs/MQB_CONFIG_EN.md)' = '(MQB_CONFIG_EN.md)'
-              '(docs/INSTALLATION_EN.md)' = '(INSTALLATION_EN.md)'
-            }
-            (Join-Path $stage 'ARCHITECTURE.md') = @{
-              '(../cpp/README.md)' = "($repoBlobBase/cpp/README.md)"
-            }
-            (Join-Path $stage 'ARCHITECTURE_EN.md') = @{
-              '(../cpp/README_EN.md)' = "($repoBlobBase/cpp/README_EN.md)"
-            }
-            (Join-Path $stage 'SELF_HOSTING.md') = @{
-              '(../cpp/README.md)' = "($repoBlobBase/cpp/README.md)"
-            }
-            (Join-Path $stage 'SELF_HOSTING_EN.md') = @{
-              '(../cpp/README_EN.md)' = "($repoBlobBase/cpp/README_EN.md)"
-            }
-          }
-          foreach ($fileEntry in $packageLinkRewrites.GetEnumerator()) {
-            $text = Get-Content -LiteralPath $fileEntry.Key -Raw
-            foreach ($rewrite in $fileEntry.Value.GetEnumerator()) {
-              $text = $text.Replace($rewrite.Key, $rewrite.Value)
-            }
-            Set-Content -LiteralPath $fileEntry.Key -Value $text -Encoding utf8NoBOM -NoNewline
-          }
 
           $zip = Join-Path $dist ($env:MQB_PACKAGE_NAME + '.zip')
           Compress-Archive -Path (Join-Path $stage '*') -DestinationPath $zip -CompressionLevel Optimal
@@ -187,7 +137,7 @@ jobs:
           Write-Host "Package: $zip"
           Write-Host "SHA256:  $hash"
 
-      - name: Validate exact packaged artifact
+      - name: Validate exact runtime-only packaged artifact
         shell: pwsh
         env:
           MQB_RELEASE_VERSION: ${{ steps.meta.outputs.version }}
@@ -198,8 +148,12 @@ jobs:
           $shaPath = $zip + '.sha256'
           $verifyRoot = Join-Path $dist 'verify-extracted'
 
-          if (-not (Test-Path -LiteralPath $zip -PathType Leaf)) { throw "Missing package: $zip" }
-          if (-not (Test-Path -LiteralPath $shaPath -PathType Leaf)) { throw "Missing checksum: $shaPath" }
+          if (-not (Test-Path -LiteralPath $zip -PathType Leaf)) {
+            throw "Missing package: $zip"
+          }
+          if (-not (Test-Path -LiteralPath $shaPath -PathType Leaf)) {
+            throw "Missing checksum: $shaPath"
+          }
 
           $actualHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $zip).Hash.ToLowerInvariant()
           $expectedShaLine = "$actualHash  $($env:MQB_PACKAGE_NAME).zip"
@@ -209,29 +163,35 @@ jobs:
           }
 
           Expand-Archive -LiteralPath $zip -DestinationPath $verifyRoot
+
+          $directories = @(Get-ChildItem -LiteralPath $verifyRoot -Directory -Force)
+          if ($directories.Count -ne 0) {
+            $directories | Select-Object -ExpandProperty Name | Write-Host
+            throw 'Release ZIP must be flat and must not contain documentation/resource directories.'
+          }
+
           $expectedFiles = @(
-            'ARCHITECTURE.md',
-            'ARCHITECTURE_EN.md',
-            'INSTALLATION.md',
-            'INSTALLATION_EN.md',
             'install.bat',
             'install.ps1',
             'LICENSE',
-            'MQB_CONFIG.md',
-            'MQB_CONFIG_EN.md',
             'mqb.exe',
-            'README.md',
-            'README_EN.md',
-            'SELF_HOSTING.md',
-            'SELF_HOSTING_EN.md',
             'uninstall.ps1',
             'VERSION'
           ) | Sort-Object
-          $actualFiles = @(Get-ChildItem -LiteralPath $verifyRoot -File | Select-Object -ExpandProperty Name | Sort-Object)
+          $actualFiles = @(Get-ChildItem -LiteralPath $verifyRoot -File -Force | Select-Object -ExpandProperty Name | Sort-Object)
           $manifestDiff = @(Compare-Object -ReferenceObject $expectedFiles -DifferenceObject $actualFiles)
           if ($manifestDiff.Count -ne 0) {
             $manifestDiff | Format-Table | Out-String | Write-Host
-            throw 'Release package manifest differs from the stable native self-hosting contract.'
+            throw 'Release package manifest differs from the runtime-only stable contract.'
+          }
+
+          $forbiddenDocs = @(Get-ChildItem -LiteralPath $verifyRoot -File -Force | Where-Object {
+            $_.Name -match '^(README|RELEASE_NOTES)' -or
+            $_.Extension -in @('.md', '.markdown', '.rst', '.txt')
+          })
+          if ($forbiddenDocs.Count -ne 0) {
+            $forbiddenDocs | Select-Object -ExpandProperty Name | Write-Host
+            throw 'User documentation must not be shipped inside the stable ZIP.'
           }
 
           $selfHostedMqb = Join-Path $PWD 'selfhost-out/stage1/mqb.exe'
@@ -248,35 +208,13 @@ jobs:
           }
 
           $help = @(& $packagedMqb --help 2>&1 | ForEach-Object { $_.ToString() })
-          if ($LASTEXITCODE -ne 0 -or $help.Count -eq 0) { throw 'Packaged mqb.exe --help failed.' }
+          if ($LASTEXITCODE -ne 0 -or $help.Count -eq 0) {
+            throw 'Packaged mqb.exe --help failed.'
+          }
           $expectedHelp = "MQB $env:MQB_RELEASE_VERSION - MSVC Quick Build (C++ refactor)"
           if ($help[0] -ne $expectedHelp) {
             throw "Packaged embedded version mismatch. Expected '$expectedHelp', got '$($help[0])'"
           }
-
-          $packageRoot = [IO.Path]::GetFullPath($verifyRoot).TrimEnd('\')
-          $rootPrefix = $packageRoot + [IO.Path]::DirectorySeparatorChar
-          $linkPattern = '\[[^\]]+\]\(([^)]+)\)'
-          foreach ($markdown in @(Get-ChildItem -LiteralPath $verifyRoot -Filter '*.md' -File)) {
-            $markdownText = Get-Content -LiteralPath $markdown.FullName -Raw
-            foreach ($match in [regex]::Matches($markdownText, $linkPattern)) {
-              $target = $match.Groups[1].Value.Trim()
-              if ([string]::IsNullOrWhiteSpace($target) -or $target.StartsWith('#')) { continue }
-              if ($target -match '^[A-Za-z][A-Za-z0-9+.-]*:') { continue }
-
-              $pathPart = ($target -split '#', 2)[0]
-              if ([string]::IsNullOrWhiteSpace($pathPart)) { continue }
-              $resolved = [IO.Path]::GetFullPath((Join-Path $verifyRoot $pathPart))
-              if (-not [string]::Equals($resolved, $packageRoot, [StringComparison]::OrdinalIgnoreCase) -and
-                  -not $resolved.StartsWith($rootPrefix, [StringComparison]::OrdinalIgnoreCase)) {
-                throw "Packaged Markdown link escapes package root: $($markdown.Name) -> $target"
-              }
-              if (-not (Test-Path -LiteralPath $resolved -PathType Leaf)) {
-                throw "Broken packaged Markdown link: $($markdown.Name) -> $target"
-              }
-            }
-          }
-          Write-Host 'Packaged Markdown relative-link validation passed.'
 
           & (Join-Path $PWD 'tests/installer/native_installer_lifecycle.ps1') `
             -MqbPath $packagedMqb `
@@ -285,7 +223,7 @@ jobs:
             throw "Packaged installer lifecycle failed with exit code $LASTEXITCODE"
           }
 
-          Write-Host 'Exact self-hosted packaged artifact validation passed.'
+          Write-Host 'Exact runtime-only self-hosted package validation passed.'
 
       - name: Upload validated package
         uses: actions/upload-artifact@v7
@@ -320,14 +258,19 @@ jobs:
           path: dist-publish
 
       - name: Verify publication inputs and immutable identity
+        id: preflight
         shell: pwsh
         run: |
           $tag = "v$env:MQB_RELEASE_VERSION"
           $zip = Join-Path $PWD "dist-publish/$($env:MQB_PACKAGE_NAME).zip"
           $sha = $zip + '.sha256'
 
-          if (-not (Test-Path -LiteralPath $zip -PathType Leaf)) { throw "Missing validated package: $zip" }
-          if (-not (Test-Path -LiteralPath $sha -PathType Leaf)) { throw "Missing validated checksum: $sha" }
+          if (-not (Test-Path -LiteralPath $zip -PathType Leaf)) {
+            throw "Missing validated package: $zip"
+          }
+          if (-not (Test-Path -LiteralPath $sha -PathType Leaf)) {
+            throw "Missing validated checksum: $sha"
+          }
 
           $hash = (Get-FileHash -Algorithm SHA256 -LiteralPath $zip).Hash.ToLowerInvariant()
           $expected = "$hash  $($env:MQB_PACKAGE_NAME).zip"
@@ -338,16 +281,21 @@ jobs:
 
           & gh release view $tag --repo $env:GITHUB_REPOSITORY *> $null
           if ($LASTEXITCODE -eq 0) {
-            throw "Release $tag already exists. Refusing to overwrite an existing release."
+            Write-Host "Release $tag already exists; immutable publication is already complete."
+            'publish=false' >> $env:GITHUB_OUTPUT
+            exit 0
           }
 
           & gh api "repos/$env:GITHUB_REPOSITORY/git/ref/tags/$tag" *> $null
           if ($LASTEXITCODE -eq 0) {
             throw "Tag $tag already exists without a release. Refusing ambiguous publication."
           }
+
+          'publish=true' >> $env:GITHUB_OUTPUT
           exit 0
 
       - name: Publish validated GitHub release
+        if: steps.preflight.outputs.publish == 'true'
         shell: pwsh
         run: |
           $tag = "v$env:MQB_RELEASE_VERSION"

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -24,6 +24,21 @@ MQB 的 stable Windows 包安装一个命令：`mqb`，对应原生可执行文�
 mqb --help
 ```
 
+## 发布 ZIP 内容
+
+Stable ZIP 是扁平的 runtime-only 包，精确包含：
+
+```text
+mqb.exe
+VERSION
+install.bat
+install.ps1
+uninstall.ps1
+LICENSE
+```
+
+README、配置、架构、安装说明、自举说明和 release notes 等文档不放进 ZIP；请直接在仓库和 GitHub Release 页面阅读。`LICENSE` 作为 Apache-2.0 二进制再分发所需的许可证副本保留在包中。
+
 ## 安装器拥有的文件
 
 默认安装目录中，MQB installer 只管理：
@@ -88,6 +103,6 @@ msvc-quick-build-vX.Y.Z-windows-x64.zip
 msvc-quick-build-vX.Y.Z-windows-x64.zip.sha256
 ```
 
-Release workflow 在发布前验证 binary、package manifest、checksum、installer lifecycle 与 self-host closure。自举和发布门禁的技术细节见 [`SELF_HOSTING.md`](SELF_HOSTING.md)。
+Release workflow 在发布前验证 Stage 1 binary identity、runtime-only package manifest、checksum、installer lifecycle 与 self-host closure。自举和发布门禁的技术细节见 [`SELF_HOSTING.md`](SELF_HOSTING.md)。
 
 用户使用方式见仓库根目录 [`README.md`](../README.md)。

--- a/docs/INSTALLATION_EN.md
+++ b/docs/INSTALLATION_EN.md
@@ -24,6 +24,21 @@ After installation, a new terminal should be able to run:
 mqb --help
 ```
 
+## Release ZIP contents
+
+The stable ZIP is a flat, runtime-only package containing exactly:
+
+```text
+mqb.exe
+VERSION
+install.bat
+install.ps1
+uninstall.ps1
+LICENSE
+```
+
+Documentation such as READMEs, configuration, architecture, installation, self-hosting, and release notes is not shipped inside the ZIP; read it directly in the repository and on GitHub Releases. `LICENSE` remains as the Apache-2.0 license copy required for binary redistribution.
+
 ## Installer-owned files
 
 In the default installation directory, the MQB installer manages only:
@@ -88,6 +103,6 @@ msvc-quick-build-vX.Y.Z-windows-x64.zip
 msvc-quick-build-vX.Y.Z-windows-x64.zip.sha256
 ```
 
-Before publication, the release workflow validates the binary, package manifest, checksum, installer lifecycle, and self-host closure. See [`SELF_HOSTING_EN.md`](SELF_HOSTING_EN.md) for the technical release gates.
+Before publication, the release workflow validates Stage 1 binary identity, the runtime-only package manifest, checksum, installer lifecycle, and self-host closure. See [`SELF_HOSTING_EN.md`](SELF_HOSTING_EN.md) for the technical release gates.
 
 For normal usage, return to the root [`README_EN.md`](../README_EN.md).

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -55,7 +55,7 @@ Stable candidate 必须在同一候选提交上证明：
 5. 清空 build state 后，Stage 1 能构建 Stage 2；
 6. Stage 1 / Stage 2 报告正确的 release version；
 7. ZIP 中 `mqb.exe` 与已验证 Stage 1 binary byte-identical；
-8. package manifest 与 SHA-256 sidecar 正确；
+8. ZIP 只包含 runtime / installer payload 与 Apache-2.0 `LICENSE`，且 manifest 与 SHA-256 sidecar 精确匹配；
 9. packaged installer 的 install / reinstall / uninstall lifecycle 通过。
 
 任何一项失败都阻止 publication。
@@ -69,13 +69,26 @@ msvc-quick-build-vX.Y.Z-windows-x64.zip
 msvc-quick-build-vX.Y.Z-windows-x64.zip.sha256
 ```
 
-ZIP 包含已经验证的 Stage 1 `mqb.exe`、`VERSION`、安装脚本、许可证和面向用户的文档；不包含历史 seed、Stage 0 或仓库内 release notes 副本。
+ZIP 是**扁平、runtime-only** 发布包，精确包含：
+
+```text
+mqb.exe
+VERSION
+install.bat
+install.ps1
+uninstall.ps1
+LICENSE
+```
+
+README、架构、配置、安装说明、自举说明和 release notes 等用户文档**不进入 ZIP**；它们保留在仓库与 GitHub Release 页面。`LICENSE` 作为 Apache-2.0 二进制再分发所需的许可证副本继续随包发布。
+
+历史 seed、Stage 0、Stage 2、测试文件和源码同样不会进入正式 ZIP。
 
 安装行为见 [`INSTALLATION.md`](INSTALLATION.md)。
 
 ## 6. Publication
 
-发布由根 `VERSION` 的变更驱动：
+正常 stable publication 由根 `VERSION` 的变更驱动：
 
 1. `VERSION` 变更随候选提交合入 `main`；
 2. `Native Release` 在该 exact `main` commit 上重新执行完整 build/test/self-host/package gate；
@@ -83,7 +96,9 @@ ZIP 包含已经验证的 Stage 1 `mqb.exe`、`VERSION`、安装脚本、许可�
 4. Release notes 由 GitHub 根据自上一个 tag 以来的 PR/commit 历史生成，不再保存在源码树中；
 5. publication 阶段不 rebuild binary。
 
-已存在的 tag 或 Release 不会被覆盖。历史 tag 与二进制资产保持不可变；GitHub Release 的说明文字可以独立维护，不需要改源码或重写 tag。
+Release workflow 自身的修复也可以重新触发同一版本的 gate，用于恢复一次失败但尚未发布的 release。若同版本 GitHub Release 已经存在，publication 会安全跳过；若只存在 tag 而没有 Release，则失败关闭，不猜测或覆盖历史状态。
+
+已有 Release/tag 与二进制资产保持不可变，不会被 workflow 覆盖。
 
 ## 7. 日常开发与发布
 
@@ -93,6 +108,6 @@ ZIP 包含已经验证的 Stage 1 `mqb.exe`、`VERSION`、安装脚本、许可�
 .\tests\native\develop.ps1
 ```
 
-Stable release 在此基础上额外要求 pinned-seed bootstrap、Stage 1/Stage 2 closure、exact package/checksum 和 installer lifecycle。
+Stable release 在此基础上额外要求 pinned-seed bootstrap、Stage 1/Stage 2 closure、exact runtime-only package/checksum 和 installer lifecycle。
 
 开发流程见 [`DEVELOPMENT.md`](DEVELOPMENT.md)，内部构建模型见 [`ARCHITECTURE.md`](ARCHITECTURE.md)。

--- a/docs/SELF_HOSTING_EN.md
+++ b/docs/SELF_HOSTING_EN.md
@@ -55,7 +55,7 @@ A stable candidate must prove, on the same candidate commit, that:
 5. after clearing build state, Stage 1 can build Stage 2;
 6. Stage 1 and Stage 2 report the correct release version;
 7. `mqb.exe` inside the ZIP is byte-identical to the validated Stage 1 binary;
-8. the package manifest and SHA-256 sidecar are correct;
+8. the ZIP contains only the runtime/installer payload plus the Apache-2.0 `LICENSE`, with an exact manifest and SHA-256 sidecar;
 9. the packaged installer passes install / reinstall / uninstall lifecycle validation.
 
 Any failure blocks publication.
@@ -69,13 +69,26 @@ msvc-quick-build-vX.Y.Z-windows-x64.zip
 msvc-quick-build-vX.Y.Z-windows-x64.zip.sha256
 ```
 
-The ZIP contains the validated Stage 1 `mqb.exe`, `VERSION`, installer scripts, license, and user-facing documentation. It does not contain the historical seed, Stage 0, or repository copies of release notes.
+The ZIP is a **flat, runtime-only** package containing exactly:
+
+```text
+mqb.exe
+VERSION
+install.bat
+install.ps1
+uninstall.ps1
+LICENSE
+```
+
+User documentation such as READMEs, architecture, configuration, installation, self-hosting, and release notes is **not shipped inside the ZIP**. It remains in the repository and on GitHub Releases. `LICENSE` remains in the binary redistribution as the required Apache-2.0 license copy.
+
+The historical seed, Stage 0, Stage 2, tests, and source code are not included either.
 
 See [`INSTALLATION_EN.md`](INSTALLATION_EN.md) for installation behavior.
 
 ## 6. Publication
 
-Publication is driven by a change to the root `VERSION` file:
+Normal stable publication is driven by a change to the root `VERSION` file:
 
 1. the candidate commit containing the new `VERSION` is merged into `main`;
 2. `Native Release` reruns the complete build/test/self-host/package gate on that exact `main` commit;
@@ -83,7 +96,9 @@ Publication is driven by a change to the root `VERSION` file:
 4. GitHub generates release notes from PR/commit history since the previous tag, so release notes no longer live in the source tree;
 5. publication does not rebuild the binary.
 
-Existing tags or Releases are never overwritten. Historical tags and binary assets remain immutable; GitHub Release description text can be maintained independently without changing source or rewriting a tag.
+A release-workflow repair may also rerun the same version gate to recover from a failed, not-yet-published release. If that version's GitHub Release already exists, publication is skipped safely. If only the tag exists without a Release, the workflow fails closed instead of guessing or overwriting historical state.
+
+Existing Releases/tags and binary assets remain immutable and are never overwritten by the workflow.
 
 ## 7. Development vs. release
 
@@ -93,6 +108,6 @@ Day-to-day development normally uses:
 .\tests\native\develop.ps1
 ```
 
-Stable release adds pinned-seed bootstrap, Stage 1/Stage 2 closure, exact package/checksum validation, and installer lifecycle gates.
+Stable release adds pinned-seed bootstrap, Stage 1/Stage 2 closure, exact runtime-only package/checksum validation, and installer lifecycle gates.
 
 See [`DEVELOPMENT_EN.md`](DEVELOPMENT_EN.md) for development workflow and [`ARCHITECTURE_EN.md`](ARCHITECTURE_EN.md) for the internal build model.


### PR DESCRIPTION
## Summary

Make the stable Windows ZIP a strict runtime/install payload and repair the failed v5.1.0 publication path.

## Package contract

The ZIP now contains exactly six flat files:

- `mqb.exe`
- `VERSION`
- `install.bat`
- `install.ps1`
- `uninstall.ps1`
- `LICENSE`

README, configuration, architecture, installation, self-hosting, release-note, and other user documentation are no longer copied or rewritten into the ZIP. `LICENSE` remains because Apache-2.0 binary redistribution requires the license copy.

The exact-package gate now rejects directories, any manifest drift, and Markdown/text documentation in the archive while continuing to prove Stage 1 binary byte identity, embedded version identity, checksum integrity, and installer lifecycle.

## v5.1.0 recovery

`main@dc897a5064a960318645a130415c32dfbdb37bc1` already passed the Release native tests and Stage 0 -> Stage 1 -> clean Stage 2 self-host closure, then failed only in `Validate exact packaged artifact`; publication was skipped.

`VERSION` is already `5.1.0`, and neither `v5.1.0` tag nor GitHub Release exists. This workflow repair therefore also makes changes to `native-release.yml` retrigger the release gate on `main`.

Publication remains immutable:

- existing Release for the version => safe skip
- existing tag without Release => fail closed
- neither exists => publish the already-validated ZIP + SHA-256 sidecar
- publication never rebuilds the binary

## Documentation

Chinese and English installation/self-hosting docs now state the same runtime-only six-file package contract and the recovery/immutability behavior.

## Scope

No C++ product code, CLI behavior, cache semantics, installer implementation, version number, or self-host algorithm changes.
