### PR TITLE
ci: balance native test shard cost

### DIFF
--- a/tests/native/run_native_tests.ps1
+++ b/tests/native/run_native_tests.ps1
@@ -88,6 +88,82 @@ if ($allTestFiles.Count -ne 67) {
     throw "Native test manifest drift: expected 67 *_tests.cpp files, found $($allTestFiles.Count)."
 }
 
+function Get-TestRelativePath {
+    param([Parameter(Mandatory = $true)][System.IO.FileInfo]$File)
+    return [System.IO.Path]::GetRelativePath($cppRoot, $File.FullName).Replace('\', '/')
+}
+
+# Keep the shard plan deterministic while accounting for the few tests whose
+# nested MQB builds dominate wall time. These are deliberately coarse relative
+# cost classes rather than runner-specific seconds, so normal hosted-runner
+# variance does not churn the plan. Every unlisted test has weight 1.
+#
+# The overrides come from repeated Debug/Release CI observations. In
+# particular, the old modulo split placed build-policy, module-CLI, and static-
+# library E2E tests on the same shard, making it roughly a minute slower than
+# its peers even though all four runners carried similar test counts.
+$testWeightOverrides = [ordered]@{
+    'tests/e2e/mqb_module_cli_e2e_tests.cpp' = 10
+    'tests/e2e/mqb_build_policy_e2e_tests.cpp' = 9
+    'tests/e2e/mqb_static_library_e2e_tests.cpp' = 7
+    'tests/e2e/mqb_cli_e2e_tests.cpp' = 4
+    'tests/e2e/mqb_runtime_subsystem_config_e2e_tests.cpp' = 4
+    'tests/e2e/mqb_dll_target_e2e_tests.cpp' = 3
+    'tests/e2e/mqb_parallel_cli_e2e_tests.cpp' = 3
+    'tests/e2e/mqb_project_config_e2e_tests.cpp' = 3
+    'tests/e2e/mqb_c_source_e2e_tests.cpp' = 2
+    # This test also requires building the process_echo_helper executable once
+    # on whichever shard owns it, so account for that extra compile/link work.
+    'tests/platform/windows/windows_process_runner_tests.cpp' = 4
+}
+
+$relativeTestPaths = @($allTestFiles | ForEach-Object { Get-TestRelativePath -File $_ })
+foreach ($weightedPath in $testWeightOverrides.Keys) {
+    if ($weightedPath -notin $relativeTestPaths) {
+        throw "Native test weight override is stale or missing from the 67-test manifest: $weightedPath"
+    }
+}
+
+$weightedTests = @(
+    $allTestFiles | ForEach-Object {
+        $relative = Get-TestRelativePath -File $_
+        $weight = if ($testWeightOverrides.Contains($relative)) {
+            [int]$testWeightOverrides[$relative]
+        }
+        else {
+            1
+        }
+        [PSCustomObject]@{
+            File = $_
+            Relative = $relative
+            Weight = $weight
+        }
+    } | Sort-Object `
+        @{ Expression = 'Weight'; Descending = $true }, `
+        @{ Expression = 'Relative'; Descending = $false }
+)
+
+$shardPlan = @(
+    for ($index = 0; $index -lt $ShardCount; ++$index) {
+        [PSCustomObject]@{
+            Index = $index
+            Weight = 0
+            Tests = [System.Collections.ArrayList]::new()
+        }
+    }
+)
+foreach ($test in $weightedTests) {
+    $targetShard = @($shardPlan | Sort-Object Weight, Index)[0]
+    [void]$targetShard.Tests.Add($test.File)
+    $targetShard.Weight += $test.Weight
+}
+
+$testFiles = @($shardPlan[$ShardIndex].Tests | Sort-Object FullName)
+if ($testFiles.Count -eq 0) {
+    throw "Native test shard $ShardIndex/$ShardCount selected no tests."
+}
+$selectedShardWeight = $shardPlan[$ShardIndex].Weight
+
 $quote = [char]34
 $versionDefine = 'MQB_VERSION=' + $quote + 'native-tests' + $quote
 $configArg = if ($Configuration -eq 'Debug') { '--debug' } else { '--release' }
@@ -196,17 +272,6 @@ if (-not [string]::IsNullOrWhiteSpace($PrepareSharedProductLibraryPath)) {
     exit 0
 }
 
-$testFiles = @(
-    for ($i = 0; $i -lt $allTestFiles.Count; ++$i) {
-        if (($i % $ShardCount) -eq $ShardIndex) {
-            $allTestFiles[$i]
-        }
-    }
-)
-if ($testFiles.Count -eq 0) {
-    throw "Native test shard $ShardIndex/$ShardCount selected no tests."
-}
-
 function Get-TestOutputName {
     param([Parameter(Mandatory = $true)][string]$RelativePath)
     $stem = [System.IO.Path]::ChangeExtension($RelativePath, $null)
@@ -242,7 +307,11 @@ function Invoke-MqbTestBuild {
 }
 
 Write-Host "MQB-native test graph: $($allTestFiles.Count) total tests / $($testFiles.Count) selected / configuration $Configuration"
-Write-Host "Shard: $ShardIndex of $ShardCount (zero-based index)"
+Write-Host "Shard: $ShardIndex of $ShardCount (zero-based index) / estimated relative weight $selectedShardWeight"
+Write-Host 'Deterministic weighted shard plan:'
+foreach ($shard in $shardPlan) {
+    Write-Host "  shard $($shard.Index): $($shard.Tests.Count) tests / weight $($shard.Weight)"
+}
 Write-Host "Verified shared production manifest: $($productionSources.Count) non-main translation units"
 Write-Host "Builder MQB: $BuilderMqbPath"
 Write-Host "Tested MQB:  $TestMqbPath"
@@ -268,7 +337,7 @@ New-Item -ItemType Directory -Force -Path $workRoot | Out-Null
 $passed = 0
 $failures = @()
 foreach ($testFile in $testFiles) {
-    $relative = [System.IO.Path]::GetRelativePath($cppRoot, $testFile.FullName).Replace('\', '/')
+    $relative = Get-TestRelativePath -File $testFile
     $outputName = Get-TestOutputName -RelativePath $relative
     Write-Host ""
     Write-Host "=== [$($passed + $failures.Count + 1)/$($testFiles.Count)] $relative ==="


### PR DESCRIPTION
## Summary

Keep the full 67-test Debug/Release contract and the existing four Windows runners, but replace modulo-by-index shard selection with deterministic weighted greedy balancing.

## Why

After #64 removed repeated product compilation, shard wall time became dominated by a small number of nested-build E2E tests. The old sorted-index modulo split consistently placed the three heaviest observed tests on shard 3:

- `mqb_build_policy_e2e_tests.cpp`
- `mqb_module_cli_e2e_tests.cpp`
- `mqb_static_library_e2e_tests.cpp`

On the post-#64 main Debug run those three were roughly 38s, 41s, and 30s including their test-entry build/run work, creating a persistent long tail. Release showed the same shape.

## Design

- retain `ShardCount=4`; no additional runners
- retain all 67 tests and existing aggregate/release gates
- assign coarse relative weights only to stable nested-build E2E outliers and the process-runner helper case
- default every other test to weight 1
- sort by descending weight then stable relative path
- greedily place each test onto the currently lightest shard, tie-breaking by shard index
- sort selected tests by path before execution so logs remain deterministic
- validate every explicit weight override against the exact 67-test manifest so renames/deletions cannot leave stale tuning silently behind
- print the complete shard count/weight plan on every run for auditability

The resulting 4-way plan is deterministic and nearly perfectly balanced by estimated cost:

- shard 0: 16 tests / weight 27
- shard 1: 17 tests / weight 27
- shard 2: 16 tests / weight 26
- shard 3: 18 tests / weight 26

The weights are intentionally relative classes, not recorded wall-clock seconds, so normal hosted-runner variance does not churn the topology. A cross-run check confirmed that a one-off 38s `project_config_tests.cpp` compile was runner/cold-build variance (the same test was ~16s on the preceding main run), so that noise was not baked into the weight table.

## Validation

Head: `bd846050c3757079681de4161fcf0d425e031008`

### Native C++

- full 67/67 Debug coverage
- all four weighted shards green
- aggregate `Native C++ gate` green
- shard test steps: ~2m39s / ~2m22s / ~1m39s / ~2m22s
- previous #64 slowest Debug shard: ~2m52s
- new slowest Debug shard: ~2m39s

### Native Release

- full 67/67 Release coverage
- all four weighted shards green
- self-host, runtime-only package staging, exact package/installer lifecycle validation, and artifact upload green
- shard test steps: ~2m18s / ~2m34s / ~2m17s / ~2m25s
- previous #64 slowest Release shard: ~3m08s
- new slowest Release shard: ~2m34s
- Release shard spread tightened to about 17 seconds

The Release pre-build runner happened to be substantially slower in this validation run (~3m56s for Stage 0 + shared library versus ~2m29s in the prior run), but this PR does not change that path. The acceptance metric is therefore the shard section it actually changes, where the long tail is materially reduced without extra runners or reduced coverage.

No build/link/test execution semantics changed; only deterministic test-to-shard assignment changed.