### PR TITLE
ci: run paired native subshards per Windows runner

### DIFF
--- a/.github/workflows/native-ci.yml
+++ b/.github/workflows/native-ci.yml
@@ -109,9 +109,10 @@ jobs:
       - name: Run two MQB-native Debug subshards
         shell: pwsh
         run: |
-          $mqb = Join-Path $PWD 'native-out/debug/mqb.exe'
-          $library = Join-Path $PWD 'native-out/debug/native-test-product.lib'
-          $testScript = Join-Path $PWD 'tests/native/run_native_tests.ps1'
+          $repoRoot = $PWD.Path
+          $mqb = Join-Path $repoRoot 'native-out/debug/mqb.exe'
+          $library = Join-Path $repoRoot 'native-out/debug/native-test-product.lib'
+          $testScript = Join-Path $repoRoot 'tests/native/run_native_tests.ps1'
           if (-not (Test-Path -LiteralPath $mqb -PathType Leaf)) {
             throw "Downloaded Debug MQB missing: $mqb"
           }
@@ -123,47 +124,73 @@ jobs:
           # weighted subshards concurrently inside each runner. The global
           # ShardCount=8 plan remains deterministic; outer runner N owns
           # subshards 2N and 2N+1, so every one of the 67 tests runs exactly once.
+          #
+          # Each subshard gets its own pwsh.exe process instead of an in-process
+          # parallel runspace because run_native_tests.ps1 intentionally uses
+          # `exit` to communicate success/failure. Process isolation preserves
+          # that contract and makes the child exit code unambiguous.
           $outerShard = [int]'${{ matrix.shard }}'
           $firstSubshard = $outerShard * 2
           $subshards = @($firstSubshard, $firstSubshard + 1)
+          $logRoot = Join-Path $repoRoot "native-test-work/debug/outer-$outerShard-of-4/subshard-logs"
+          New-Item -ItemType Directory -Force -Path $logRoot | Out-Null
+          $pwshExe = (Get-Command pwsh -ErrorAction Stop).Source
 
-          $results = @(
-            $subshards | ForEach-Object -Parallel {
-              $subshard = [int]$_
-              $rawOutput = @()
-              $exitCode = 1
-              try {
-                $rawOutput = @(& $using:testScript `
-                  -BuilderMqbPath $using:mqb `
-                  -TestMqbPath $using:mqb `
-                  -RepoRoot $using:PWD `
-                  -Configuration Debug `
-                  -ShardIndex $subshard `
-                  -ShardCount 8 `
-                  -SharedProductLibraryPath $using:library *>&1)
-                $exitCode = $LASTEXITCODE
-                if ($null -eq $exitCode) { $exitCode = 0 }
-              }
-              catch {
-                $rawOutput += $_
-                $exitCode = 1
-              }
+          $children = @(
+            foreach ($subshard in $subshards) {
+              $stdout = Join-Path $logRoot "subshard-$subshard.stdout.log"
+              $stderr = Join-Path $logRoot "subshard-$subshard.stderr.log"
+              $arguments = @(
+                '-NoLogo',
+                '-NoProfile',
+                '-NonInteractive',
+                '-File', $testScript,
+                '-BuilderMqbPath', $mqb,
+                '-TestMqbPath', $mqb,
+                '-RepoRoot', $repoRoot,
+                '-Configuration', 'Debug',
+                '-ShardIndex', [string]$subshard,
+                '-ShardCount', '8',
+                '-SharedProductLibraryPath', $library
+              )
+              $process = Start-Process `
+                -FilePath $pwshExe `
+                -ArgumentList $arguments `
+                -PassThru `
+                -NoNewWindow `
+                -RedirectStandardOutput $stdout `
+                -RedirectStandardError $stderr
 
               [PSCustomObject]@{
                 Index = $subshard
-                ExitCode = [int]$exitCode
-                Output = [string[]]@($rawOutput | ForEach-Object { $_.ToString() })
+                Process = $process
+                Stdout = $stdout
+                Stderr = $stderr
               }
-            } -ThrottleLimit 2
+            }
           )
 
+          foreach ($child in $children) {
+            $child.Process.WaitForExit()
+          }
+
           $failed = $false
-          foreach ($result in @($results | Sort-Object Index)) {
+          foreach ($child in @($children | Sort-Object Index)) {
             Write-Host ""
-            Write-Host "===== Debug subshard $($result.Index)/8 ====="
-            foreach ($line in @($result.Output)) { Write-Host $line }
-            if ($result.ExitCode -ne 0) {
-              Write-Host "FAIL: Debug subshard $($result.Index)/8 exited $($result.ExitCode)"
+            Write-Host "===== Debug subshard $($child.Index)/8 ====="
+            if (Test-Path -LiteralPath $child.Stdout) {
+              Get-Content -LiteralPath $child.Stdout | ForEach-Object { Write-Host $_ }
+            }
+            if (Test-Path -LiteralPath $child.Stderr) {
+              $stderrLines = @(Get-Content -LiteralPath $child.Stderr)
+              if ($stderrLines.Count -ne 0) {
+                Write-Host "----- stderr -----"
+                $stderrLines | ForEach-Object { Write-Host $_ }
+              }
+            }
+            $exitCode = $child.Process.ExitCode
+            if ($exitCode -ne 0) {
+              Write-Host "FAIL: Debug subshard $($child.Index)/8 exited $exitCode"
               $failed = $true
             }
           }

--- a/.github/workflows/native-ci.yml
+++ b/.github/workflows/native-ci.yml
@@ -94,7 +94,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [0, 1, 2, 3]
+        include:
+          - shard: 0
+            subshard_a: 0
+            subshard_b: 1
+          - shard: 1
+            subshard_a: 2
+            subshard_b: 3
+          - shard: 2
+            subshard_a: 4
+            subshard_b: 5
+          - shard: 3
+            subshard_a: 6
+            subshard_b: 7
 
     steps:
       - name: Checkout
@@ -121,54 +133,64 @@ jobs:
           }
 
           # Keep the four hosted runners from #63/#65, but run two independent
-          # weighted subshards concurrently inside each runner. The global
-          # ShardCount=8 plan remains deterministic; outer runner N owns
-          # subshards 2N and 2N+1, so every one of the 67 tests runs exactly once.
-          #
-          # Each subshard gets its own pwsh.exe process instead of an in-process
-          # parallel runspace because run_native_tests.ps1 intentionally uses
-          # `exit` to communicate success/failure. Process isolation preserves
-          # that contract and makes the child exit code unambiguous.
+          # weighted subshards concurrently inside each runner. Pair ownership
+          # is encoded directly in the matrix so coverage identity does not
+          # depend on PowerShell arithmetic or pipeline state.
           $outerShard = [int]'${{ matrix.shard }}'
-          $firstSubshard = $outerShard * 2
-          $subshards = @($firstSubshard, $firstSubshard + 1)
+          $subshardA = [int]'${{ matrix.subshard_a }}'
+          $subshardB = [int]'${{ matrix.subshard_b }}'
+          if ($subshardB -ne ($subshardA + 1) -or $subshardA -ne ($outerShard * 2)) {
+            throw "Invalid outer/subshard mapping: outer=$outerShard pair=$subshardA,$subshardB"
+          }
+
           $logRoot = Join-Path $repoRoot "native-test-work/debug/outer-$outerShard-of-4/subshard-logs"
           New-Item -ItemType Directory -Force -Path $logRoot | Out-Null
           $pwshExe = (Get-Command pwsh -ErrorAction Stop).Source
 
-          $children = @(
-            foreach ($subshard in $subshards) {
-              $stdout = Join-Path $logRoot "subshard-$subshard.stdout.log"
-              $stderr = Join-Path $logRoot "subshard-$subshard.stderr.log"
-              $arguments = @(
-                '-NoLogo',
-                '-NoProfile',
-                '-NonInteractive',
-                '-File', $testScript,
-                '-BuilderMqbPath', $mqb,
-                '-TestMqbPath', $mqb,
-                '-RepoRoot', $repoRoot,
-                '-Configuration', 'Debug',
-                '-ShardIndex', [string]$subshard,
-                '-ShardCount', '8',
-                '-SharedProductLibraryPath', $library
-              )
-              $process = Start-Process `
-                -FilePath $pwshExe `
-                -ArgumentList $arguments `
-                -PassThru `
-                -NoNewWindow `
-                -RedirectStandardOutput $stdout `
-                -RedirectStandardError $stderr
+          function Start-NativeSubshard {
+            param([Parameter(Mandatory = $true)][int]$Index)
 
-              [PSCustomObject]@{
-                Index = $subshard
-                Process = $process
-                Stdout = $stdout
-                Stderr = $stderr
-              }
+            $stdout = Join-Path $logRoot "subshard-$Index.stdout.log"
+            $stderr = Join-Path $logRoot "subshard-$Index.stderr.log"
+            Remove-Item -LiteralPath $stdout, $stderr -Force -ErrorAction SilentlyContinue
+            $arguments = @(
+              '-NoLogo',
+              '-NoProfile',
+              '-NonInteractive',
+              '-File', $testScript,
+              '-BuilderMqbPath', $mqb,
+              '-TestMqbPath', $mqb,
+              '-RepoRoot', $repoRoot,
+              '-Configuration', 'Debug',
+              '-ShardIndex', [string]$Index,
+              '-ShardCount', '8',
+              '-SharedProductLibraryPath', $library
+            )
+            $process = Start-Process `
+              -FilePath $pwshExe `
+              -ArgumentList $arguments `
+              -PassThru `
+              -NoNewWindow `
+              -RedirectStandardOutput $stdout `
+              -RedirectStandardError $stderr
+
+            Write-Host "Started Debug subshard $Index/8 as PID $($process.Id)"
+            return [PSCustomObject]@{
+              Index = $Index
+              Process = $process
+              Stdout = $stdout
+              Stderr = $stderr
             }
-          )
+          }
+
+          Write-Host "Outer Debug shard $outerShard/4 owns subshards $subshardA/8 and $subshardB/8"
+          $childA = Start-NativeSubshard -Index $subshardA
+          $childB = Start-NativeSubshard -Index $subshardB
+          $children = @($childA, $childB)
+          $uniqueIndices = @($children | Select-Object -ExpandProperty Index -Unique)
+          if ($uniqueIndices.Count -ne 2) {
+            throw "Subshard identity collision before execution: $($uniqueIndices -join ',')"
+          }
 
           foreach ($child in $children) {
             $child.Process.WaitForExit()
@@ -189,8 +211,8 @@ jobs:
               }
             }
             $exitCode = $child.Process.ExitCode
+            Write-Host "Debug subshard $($child.Index)/8 exit code: $exitCode"
             if ($exitCode -ne 0) {
-              Write-Host "FAIL: Debug subshard $($child.Index)/8 exited $exitCode"
               $failed = $true
             }
           }

--- a/.github/workflows/native-ci.yml
+++ b/.github/workflows/native-ci.yml
@@ -106,26 +106,68 @@ jobs:
           name: native-debug-mqb
           path: native-out/debug
 
-      - name: Run MQB-native Debug test shard
+      - name: Run two MQB-native Debug subshards
         shell: pwsh
         run: |
           $mqb = Join-Path $PWD 'native-out/debug/mqb.exe'
           $library = Join-Path $PWD 'native-out/debug/native-test-product.lib'
+          $testScript = Join-Path $PWD 'tests/native/run_native_tests.ps1'
           if (-not (Test-Path -LiteralPath $mqb -PathType Leaf)) {
             throw "Downloaded Debug MQB missing: $mqb"
           }
           if (-not (Test-Path -LiteralPath $library -PathType Leaf)) {
             throw "Downloaded shared Debug native-test product library missing: $library"
           }
-          & (Join-Path $PWD 'tests/native/run_native_tests.ps1') `
-            -BuilderMqbPath $mqb `
-            -TestMqbPath $mqb `
-            -RepoRoot $PWD `
-            -Configuration Debug `
-            -ShardIndex ${{ matrix.shard }} `
-            -ShardCount 4 `
-            -SharedProductLibraryPath $library
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+          # Keep the four hosted runners from #63/#65, but run two independent
+          # weighted subshards concurrently inside each runner. The global
+          # ShardCount=8 plan remains deterministic; outer runner N owns
+          # subshards 2N and 2N+1, so every one of the 67 tests runs exactly once.
+          $outerShard = [int]'${{ matrix.shard }}'
+          $firstSubshard = $outerShard * 2
+          $subshards = @($firstSubshard, $firstSubshard + 1)
+
+          $results = @(
+            $subshards | ForEach-Object -Parallel {
+              $subshard = [int]$_
+              $rawOutput = @()
+              $exitCode = 1
+              try {
+                $rawOutput = @(& $using:testScript `
+                  -BuilderMqbPath $using:mqb `
+                  -TestMqbPath $using:mqb `
+                  -RepoRoot $using:PWD `
+                  -Configuration Debug `
+                  -ShardIndex $subshard `
+                  -ShardCount 8 `
+                  -SharedProductLibraryPath $using:library *>&1)
+                $exitCode = $LASTEXITCODE
+                if ($null -eq $exitCode) { $exitCode = 0 }
+              }
+              catch {
+                $rawOutput += $_
+                $exitCode = 1
+              }
+
+              [PSCustomObject]@{
+                Index = $subshard
+                ExitCode = [int]$exitCode
+                Output = [string[]]@($rawOutput | ForEach-Object { $_.ToString() })
+              }
+            } -ThrottleLimit 2
+          )
+
+          $failed = $false
+          foreach ($result in @($results | Sort-Object Index)) {
+            Write-Host ""
+            Write-Host "===== Debug subshard $($result.Index)/8 ====="
+            foreach ($line in @($result.Output)) { Write-Host $line }
+            if ($result.ExitCode -ne 0) {
+              Write-Host "FAIL: Debug subshard $($result.Index)/8 exited $($result.ExitCode)"
+              $failed = $true
+            }
+          }
+          if ($failed) { exit 1 }
 
   build-and-test:
     name: Native C++ gate

--- a/.github/workflows/native-ci.yml
+++ b/.github/workflows/native-ci.yml
@@ -118,105 +118,23 @@ jobs:
           name: native-debug-mqb
           path: native-out/debug
 
-      - name: Run two MQB-native Debug subshards
+      - name: Run paired MQB-native Debug subshards
         shell: pwsh
         run: |
-          $repoRoot = $PWD.Path
-          $mqb = Join-Path $repoRoot 'native-out/debug/mqb.exe'
-          $library = Join-Path $repoRoot 'native-out/debug/native-test-product.lib'
-          $testScript = Join-Path $repoRoot 'tests/native/run_native_tests.ps1'
-          if (-not (Test-Path -LiteralPath $mqb -PathType Leaf)) {
-            throw "Downloaded Debug MQB missing: $mqb"
-          }
-          if (-not (Test-Path -LiteralPath $library -PathType Leaf)) {
-            throw "Downloaded shared Debug native-test product library missing: $library"
-          }
-
-          # Keep the four hosted runners from #63/#65, but run two independent
-          # weighted subshards concurrently inside each runner. Pair ownership
-          # is encoded directly in the matrix so coverage identity does not
-          # depend on PowerShell arithmetic or pipeline state.
-          $outerShard = [int]'${{ matrix.shard }}'
-          $subshardA = [int]'${{ matrix.subshard_a }}'
-          $subshardB = [int]'${{ matrix.subshard_b }}'
-          if ($subshardB -ne ($subshardA + 1) -or $subshardA -ne ($outerShard * 2)) {
-            throw "Invalid outer/subshard mapping: outer=$outerShard pair=$subshardA,$subshardB"
-          }
-
-          $logRoot = Join-Path $repoRoot "native-test-work/debug/outer-$outerShard-of-4/subshard-logs"
-          New-Item -ItemType Directory -Force -Path $logRoot | Out-Null
-          $pwshExe = (Get-Command pwsh -ErrorAction Stop).Source
-
-          function Start-NativeSubshard {
-            param([Parameter(Mandatory = $true)][int]$Index)
-
-            $stdout = Join-Path $logRoot "subshard-$Index.stdout.log"
-            $stderr = Join-Path $logRoot "subshard-$Index.stderr.log"
-            Remove-Item -LiteralPath $stdout, $stderr -Force -ErrorAction SilentlyContinue
-            $arguments = @(
-              '-NoLogo',
-              '-NoProfile',
-              '-NonInteractive',
-              '-File', $testScript,
-              '-BuilderMqbPath', $mqb,
-              '-TestMqbPath', $mqb,
-              '-RepoRoot', $repoRoot,
-              '-Configuration', 'Debug',
-              '-ShardIndex', [string]$Index,
-              '-ShardCount', '8',
-              '-SharedProductLibraryPath', $library
-            )
-            $process = Start-Process `
-              -FilePath $pwshExe `
-              -ArgumentList $arguments `
-              -PassThru `
-              -NoNewWindow `
-              -RedirectStandardOutput $stdout `
-              -RedirectStandardError $stderr
-
-            Write-Host "Started Debug subshard $Index/8 as PID $($process.Id)"
-            return [PSCustomObject]@{
-              Index = $Index
-              Process = $process
-              Stdout = $stdout
-              Stderr = $stderr
-            }
-          }
-
-          Write-Host "Outer Debug shard $outerShard/4 owns subshards $subshardA/8 and $subshardB/8"
-          $childA = Start-NativeSubshard -Index $subshardA
-          $childB = Start-NativeSubshard -Index $subshardB
-          $children = @($childA, $childB)
-          $uniqueIndices = @($children | Select-Object -ExpandProperty Index -Unique)
-          if ($uniqueIndices.Count -ne 2) {
-            throw "Subshard identity collision before execution: $($uniqueIndices -join ',')"
-          }
-
-          foreach ($child in $children) {
-            $child.Process.WaitForExit()
-          }
-
-          $failed = $false
-          foreach ($child in @($children | Sort-Object Index)) {
-            Write-Host ""
-            Write-Host "===== Debug subshard $($child.Index)/8 ====="
-            if (Test-Path -LiteralPath $child.Stdout) {
-              Get-Content -LiteralPath $child.Stdout | ForEach-Object { Write-Host $_ }
-            }
-            if (Test-Path -LiteralPath $child.Stderr) {
-              $stderrLines = @(Get-Content -LiteralPath $child.Stderr)
-              if ($stderrLines.Count -ne 0) {
-                Write-Host "----- stderr -----"
-                $stderrLines | ForEach-Object { Write-Host $_ }
-              }
-            }
-            $exitCode = $child.Process.ExitCode
-            Write-Host "Debug subshard $($child.Index)/8 exit code: $exitCode"
-            if ($exitCode -ne 0) {
-              $failed = $true
-            }
-          }
-          if ($failed) { exit 1 }
+          $mqb = Join-Path $PWD 'native-out/debug/mqb.exe'
+          $library = Join-Path $PWD 'native-out/debug/native-test-product.lib'
+          & (Join-Path $PWD 'tests/native/run_paired_native_subshards.ps1') `
+            -BuilderMqbPath $mqb `
+            -TestMqbPath $mqb `
+            -RepoRoot $PWD `
+            -Configuration Debug `
+            -SharedProductLibraryPath $library `
+            -OuterShardIndex ${{ matrix.shard }} `
+            -OuterShardCount 4 `
+            -SubshardA ${{ matrix.subshard_a }} `
+            -SubshardB ${{ matrix.subshard_b }} `
+            -ShardCount 8
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
   build-and-test:
     name: Native C++ gate

--- a/.github/workflows/native-release.yml
+++ b/.github/workflows/native-release.yml
@@ -124,7 +124,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [0, 1, 2, 3]
+        include:
+          - shard: 0
+            subshard_a: 0
+            subshard_b: 1
+          - shard: 1
+            subshard_a: 2
+            subshard_b: 3
+          - shard: 2
+            subshard_a: 4
+            subshard_b: 5
+          - shard: 3
+            subshard_a: 6
+            subshard_b: 7
 
     steps:
       - name: Checkout
@@ -136,25 +148,22 @@ jobs:
           name: native-release-stage0
           path: native-out/release/stage0
 
-      - name: Run MQB-native Release test shard
+      - name: Run paired MQB-native Release subshards
         shell: pwsh
         run: |
           $mqb = Join-Path $PWD 'native-out/release/stage0/mqb.exe'
           $library = Join-Path $PWD 'native-out/release/stage0/native-test-product.lib'
-          if (-not (Test-Path -LiteralPath $mqb -PathType Leaf)) {
-            throw "Downloaded Stage 0 MQB missing: $mqb"
-          }
-          if (-not (Test-Path -LiteralPath $library -PathType Leaf)) {
-            throw "Downloaded shared Release native-test product library missing: $library"
-          }
-          & (Join-Path $PWD 'tests/native/run_native_tests.ps1') `
+          & (Join-Path $PWD 'tests/native/run_paired_native_subshards.ps1') `
             -BuilderMqbPath $mqb `
             -TestMqbPath $mqb `
             -RepoRoot $PWD `
             -Configuration Release `
-            -ShardIndex ${{ matrix.shard }} `
-            -ShardCount 4 `
-            -SharedProductLibraryPath $library
+            -SharedProductLibraryPath $library `
+            -OuterShardIndex ${{ matrix.shard }} `
+            -OuterShardCount 4 `
+            -SubshardA ${{ matrix.subshard_a }} `
+            -SubshardB ${{ matrix.subshard_b }} `
+            -ShardCount 8
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
   build-test-package:

--- a/tests/native/run_paired_native_subshards.ps1
+++ b/tests/native/run_paired_native_subshards.ps1
@@ -1,0 +1,129 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$BuilderMqbPath,
+    [Parameter(Mandatory = $true)][string]$TestMqbPath,
+    [Parameter(Mandatory = $true)][string]$RepoRoot,
+    [ValidateSet('Debug', 'Release')][string]$Configuration,
+    [Parameter(Mandatory = $true)][string]$SharedProductLibraryPath,
+    [ValidateRange(0, 63)][int]$OuterShardIndex,
+    [ValidateRange(1, 64)][int]$OuterShardCount = 4,
+    [ValidateRange(0, 63)][int]$SubshardA,
+    [ValidateRange(0, 63)][int]$SubshardB,
+    [ValidateRange(1, 64)][int]$ShardCount = 8
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+function Get-FullPath {
+    param([Parameter(Mandatory = $true)][string]$Path)
+    return [System.IO.Path]::GetFullPath($Path)
+}
+
+if ($OuterShardIndex -ge $OuterShardCount) {
+    throw "OuterShardIndex must be smaller than OuterShardCount: $OuterShardIndex >= $OuterShardCount"
+}
+if ($SubshardA -ge $ShardCount -or $SubshardB -ge $ShardCount) {
+    throw "Subshard index must be smaller than ShardCount $ShardCount: $SubshardA,$SubshardB"
+}
+if ($SubshardB -ne ($SubshardA + 1) -or $SubshardA -ne ($OuterShardIndex * 2)) {
+    throw "Invalid outer/subshard mapping: outer=$OuterShardIndex pair=$SubshardA,$SubshardB"
+}
+if ($ShardCount -ne ($OuterShardCount * 2)) {
+    throw "Paired native shards require ShardCount == 2 * OuterShardCount: $ShardCount vs $OuterShardCount"
+}
+
+$RepoRoot = Get-FullPath $RepoRoot
+$BuilderMqbPath = Get-FullPath $BuilderMqbPath
+$TestMqbPath = Get-FullPath $TestMqbPath
+$SharedProductLibraryPath = Get-FullPath $SharedProductLibraryPath
+$testScript = Join-Path $RepoRoot 'tests/native/run_native_tests.ps1'
+foreach ($path in @($BuilderMqbPath, $TestMqbPath, $SharedProductLibraryPath, $testScript)) {
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+        throw "Required paired native-test input not found: $path"
+    }
+}
+
+# run_native_tests.ps1 intentionally communicates success/failure with `exit`.
+# Launch each subshard in its own pwsh.exe process so that exit remains local to
+# the child and the parent can audit each PID, output stream, and exit code.
+$configurationKey = $Configuration.ToLowerInvariant()
+$logRoot = Join-Path $RepoRoot "native-test-work/$configurationKey/outer-$OuterShardIndex-of-$OuterShardCount/subshard-logs"
+New-Item -ItemType Directory -Force -Path $logRoot | Out-Null
+$pwshExe = (Get-Command pwsh -ErrorAction Stop).Source
+
+function Start-NativeSubshard {
+    param([Parameter(Mandatory = $true)][int]$Index)
+
+    $stdout = Join-Path $logRoot "subshard-$Index.stdout.log"
+    $stderr = Join-Path $logRoot "subshard-$Index.stderr.log"
+    Remove-Item -LiteralPath $stdout, $stderr -Force -ErrorAction SilentlyContinue
+    $arguments = @(
+        '-NoLogo',
+        '-NoProfile',
+        '-NonInteractive',
+        '-File', $testScript,
+        '-BuilderMqbPath', $BuilderMqbPath,
+        '-TestMqbPath', $TestMqbPath,
+        '-RepoRoot', $RepoRoot,
+        '-Configuration', $Configuration,
+        '-ShardIndex', [string]$Index,
+        '-ShardCount', [string]$ShardCount,
+        '-SharedProductLibraryPath', $SharedProductLibraryPath
+    )
+    $process = Start-Process `
+        -FilePath $pwshExe `
+        -ArgumentList $arguments `
+        -PassThru `
+        -NoNewWindow `
+        -RedirectStandardOutput $stdout `
+        -RedirectStandardError $stderr
+
+    Write-Host "Started $Configuration subshard $Index/$ShardCount as PID $($process.Id)"
+    return [PSCustomObject]@{
+        Index = $Index
+        Process = $process
+        Stdout = $stdout
+        Stderr = $stderr
+    }
+}
+
+Write-Host "Outer $Configuration shard $OuterShardIndex/$OuterShardCount owns subshards $SubshardA/$ShardCount and $SubshardB/$ShardCount"
+$childA = Start-NativeSubshard -Index $SubshardA
+$childB = Start-NativeSubshard -Index $SubshardB
+$children = @($childA, $childB)
+$uniqueIndices = @($children | Select-Object -ExpandProperty Index -Unique)
+if ($uniqueIndices.Count -ne 2) {
+    throw "Subshard identity collision before execution: $($uniqueIndices -join ',')"
+}
+
+foreach ($child in $children) {
+    $child.Process.WaitForExit()
+}
+
+$failed = $false
+foreach ($child in @($children | Sort-Object Index)) {
+    Write-Host ''
+    Write-Host "===== $Configuration subshard $($child.Index)/$ShardCount ====="
+    if (Test-Path -LiteralPath $child.Stdout) {
+        Get-Content -LiteralPath $child.Stdout | ForEach-Object { Write-Host $_ }
+    }
+    if (Test-Path -LiteralPath $child.Stderr) {
+        $stderrLines = @(Get-Content -LiteralPath $child.Stderr)
+        if ($stderrLines.Count -ne 0) {
+            Write-Host '----- stderr -----'
+            $stderrLines | ForEach-Object { Write-Host $_ }
+        }
+    }
+    $exitCode = $child.Process.ExitCode
+    Write-Host "$Configuration subshard $($child.Index)/$ShardCount exit code: $exitCode"
+    if ($exitCode -ne 0) {
+        $failed = $true
+    }
+}
+
+if ($failed) {
+    exit 1
+}
+Write-Host "Paired $Configuration native subshards passed."
+exit 0

--- a/tests/native/run_paired_native_subshards.ps1
+++ b/tests/native/run_paired_native_subshards.ps1
@@ -24,7 +24,7 @@ if ($OuterShardIndex -ge $OuterShardCount) {
     throw "OuterShardIndex must be smaller than OuterShardCount: $OuterShardIndex >= $OuterShardCount"
 }
 if ($SubshardA -ge $ShardCount -or $SubshardB -ge $ShardCount) {
-    throw "Subshard index must be smaller than ShardCount $ShardCount: $SubshardA,$SubshardB"
+    throw "Subshard index must be smaller than ShardCount ${ShardCount}: $SubshardA,$SubshardB"
 }
 if ($SubshardB -ne ($SubshardA + 1) -or $SubshardA -ne ($OuterShardIndex * 2)) {
     throw "Invalid outer/subshard mapping: outer=$OuterShardIndex pair=$SubshardA,$SubshardB"


### PR DESCRIPTION
## Summary

Keep the existing four hosted Windows test runners, but run two deterministic weighted native subshards concurrently inside each runner for both Debug and Release.

## Design

- keep exactly four hosted Windows test runners
- reuse the existing deterministic weighted planner with global `ShardCount=8`
- encode pair ownership explicitly in the Actions matrix:
  - 0 → 0+1
  - 1 → 2+3
  - 2 → 4+5
  - 3 → 6+7
- launch each `run_native_tests.ps1` invocation in its own `pwsh.exe` child process so the test runner's intentional `exit` stays local to that child
- centralize child process startup, mapping validation, stdout/stderr capture, ordered log replay, and exit-code auditing in `tests/native/run_paired_native_subshards.ps1`
- keep the candidate MQB and shared product library identical inputs for both children
- add no hosted runners, omit no tests, and change no individual test semantics

The 8-way weighted plan is `14/14/13/13/13/13/13/13`, covering all 67 native tests exactly once.

## Validation

Final head: `f788f85be03b3723091cceff6c027af5d894ac90`

- Native C++: full 67/67 + aggregate gate green
- Debug paired test steps: `1:25 / 1:18 / 1:34 / 1:33`; max `1:34` vs ~`2:39` after #65 (~41% lower)
- Native Release: full 67/67 green
- Release paired test steps: `1:25 / 1:34 / 1:33 / 1:49`; max `1:49` vs ~`2:34` after #65 (~29% lower)
- explicit pair/PID/exit-code audit green for all eight subshards
- Stage 1/2 self-host closure green
- exact runtime-only package validation green
- installer install/reinstall/uninstall/PATH lifecycle green
- validated artifact upload green
- release publication correctly skipped in PR context

Changed files are limited to the Debug workflow, Release workflow, and the shared paired-subshard helper.