### PR TITLE
refactor: decompose module target orchestration

### DIFF
--- a/cpp/mqb.json
+++ b/cpp/mqb.json
@@ -69,6 +69,8 @@
       "src/orchestration/incremental/MsvcIncrementalTargetCoordinator.cpp",
       "src/orchestration/modules/ModuleCompilePlan.cpp",
       "src/orchestration/modules/ModuleCompileRequestFactory.cpp",
+      "src/orchestration/modules/ModuleTargetLinkRequestFactory.cpp",
+      "src/orchestration/modules/ModuleTargetPreparation.cpp",
       "src/orchestration/modules/MsvcModuleCompileCoordinator.cpp",
       "src/orchestration/modules/MsvcModuleTargetCoordinator.cpp",
       "src/orchestration/routing/MsvcTargetRouter.cpp",

--- a/cpp/src/orchestration/modules/ModuleTargetLinkRequestFactory.cpp
+++ b/cpp/src/orchestration/modules/ModuleTargetLinkRequestFactory.cpp
@@ -1,0 +1,34 @@
+#include "ModuleTargetLinkRequestFactory.hpp"
+
+#include <filesystem>
+#include <optional>
+#include <utility>
+#include <vector>
+
+namespace mqb::orchestration::detail {
+
+namespace fs = std::filesystem;
+
+IncrementalLinkRequest make_module_target_link_request(
+    const IncrementalModuleTargetRequest& request,
+    const ModuleCompileWaveRequest& compile_request,
+    const bool force_relink) {
+    std::vector<fs::path> objects;
+    objects.reserve(compile_request.sources.size());
+    for (const auto& source : compile_request.sources) {
+        objects.push_back(source.artifacts.object);
+    }
+
+    return IncrementalLinkRequest{
+        .objects = std::move(objects),
+        .output = request.target.executable,
+        .options = request.link_options,
+        .cache_file = request.target.link_cache,
+        .working_directory = request.working_directory.empty()
+            ? std::nullopt
+            : std::optional<fs::path>{request.working_directory},
+        .force_relink = force_relink,
+    };
+}
+
+} // namespace mqb::orchestration::detail

--- a/cpp/src/orchestration/modules/ModuleTargetLinkRequestFactory.hpp
+++ b/cpp/src/orchestration/modules/ModuleTargetLinkRequestFactory.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "mqb/orchestration/MsvcModuleTargetCoordinator.hpp"
+
+namespace mqb::orchestration::detail {
+
+[[nodiscard]] IncrementalLinkRequest make_module_target_link_request(
+    const IncrementalModuleTargetRequest& request,
+    const ModuleCompileWaveRequest& compile_request,
+    bool force_relink);
+
+} // namespace mqb::orchestration::detail

--- a/cpp/src/orchestration/modules/ModuleTargetPreparation.cpp
+++ b/cpp/src/orchestration/modules/ModuleTargetPreparation.cpp
@@ -1,0 +1,520 @@
+#include "ModuleTargetPreparation.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <expected>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "mqb/modules/ModuleDependencyGraph.hpp"
+#include "mqb/msvc/MsvcModuleDependencyScanner.hpp"
+#include "mqb/orchestration/BoundedWorkScheduler.hpp"
+
+namespace mqb::orchestration::detail {
+namespace {
+
+namespace fs = std::filesystem;
+
+[[nodiscard]] std::string windows_path_key(const fs::path& path) {
+    std::string value = path.lexically_normal().generic_string();
+    std::transform(
+        value.begin(), value.end(), value.begin(),
+        [](const unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+    return value;
+}
+
+[[nodiscard]] IncrementalModuleTargetError failure(
+    const IncrementalModuleTargetErrorCode code,
+    std::string message,
+    fs::path source = {}) {
+    return IncrementalModuleTargetError{
+        .code = code,
+        .message = std::move(message),
+        .source = std::move(source),
+    };
+}
+
+[[nodiscard]] IncrementalModuleTargetError artifact_failure(
+    const IncrementalModuleTargetErrorCode code,
+    std::string message,
+    const fs::path& source,
+    const fs::path& artifact) {
+    return IncrementalModuleTargetError{
+        .code = code,
+        .message = std::move(message),
+        .source = source,
+        .artifact = artifact,
+    };
+}
+
+[[nodiscard]] std::optional<IncrementalModuleTargetError> claim_artifact(
+    std::unordered_set<std::string>& claimed,
+    const fs::path& source,
+    const fs::path& artifact,
+    const std::string_view role) {
+    if (artifact.empty()) {
+        return artifact_failure(
+            IncrementalModuleTargetErrorCode::invalid_artifact,
+            "module target " + std::string{role} + " artifact path is empty",
+            source,
+            artifact);
+    }
+    if (!claimed.emplace(windows_path_key(artifact)).second) {
+        return artifact_failure(
+            IncrementalModuleTargetErrorCode::artifact_collision,
+            "module target " + std::string{role}
+                + " artifact collides with another planned writable artifact",
+            source,
+            artifact);
+    }
+    return std::nullopt;
+}
+
+[[nodiscard]] std::optional<fs::path> working_directory_for(
+    const fs::path& requested,
+    const fs::path& source) {
+    if (!requested.empty()) return requested;
+    if (!source.parent_path().empty()) return source.parent_path();
+    return std::nullopt;
+}
+
+[[nodiscard]] std::optional<HeaderUnitLookupMethod> core_lookup_method(
+    const modules::LookupMethod lookup_method) {
+    switch (lookup_method) {
+    case modules::LookupMethod::include_angle:
+        return HeaderUnitLookupMethod::angle;
+    case modules::LookupMethod::include_quote:
+        return HeaderUnitLookupMethod::quote;
+    case modules::LookupMethod::by_name:
+        return std::nullopt;
+    }
+    return std::nullopt;
+}
+
+[[nodiscard]] bool standard_library_module_name(const std::string_view logical_name) noexcept {
+    return logical_name == "std" || logical_name == "std.compat";
+}
+
+[[nodiscard]] std::optional<fs::path> standard_library_module_source(
+    const msvc::MsvcToolchain& toolchain,
+    const std::string_view logical_name) {
+    if (logical_name == "std") return toolchain.standard_library_modules.std;
+    if (logical_name == "std.compat") return toolchain.standard_library_modules.std_compat;
+    return std::nullopt;
+}
+
+[[nodiscard]] bool named_requirement(const modules::RequiredModule& requirement) noexcept {
+    return !requirement.unique_on_source_path
+        && requirement.lookup_method == modules::LookupMethod::by_name;
+}
+
+struct PendingStandardLibraryRequirement {
+    fs::path consumer;
+    std::string logical_name;
+};
+
+[[nodiscard]] std::optional<PendingStandardLibraryRequirement>
+next_standard_library_requirement(
+    const std::vector<modules::ScannedModuleUnit>& units,
+    const std::unordered_set<std::string>& injected) {
+    for (const auto& unit : units) {
+        for (const auto& requirement : unit.rule.required_modules) {
+            if (!named_requirement(requirement)
+                || !standard_library_module_name(requirement.logical_name)
+                || injected.contains(requirement.logical_name)) {
+                continue;
+            }
+            return PendingStandardLibraryRequirement{
+                .consumer = unit.source,
+                .logical_name = requirement.logical_name,
+            };
+        }
+    }
+    return std::nullopt;
+}
+
+[[nodiscard]] bool provides_named_interface(
+    const modules::P1689Rule& rule,
+    const std::string_view logical_name) {
+    return std::any_of(
+        rule.provided_modules.begin(),
+        rule.provided_modules.end(),
+        [&](const modules::ProvidedModule& provided) {
+            return !provided.unique_on_source_path
+                && provided.is_interface
+                && provided.logical_name == logical_name;
+        });
+}
+
+[[nodiscard]] bool regular_file(const fs::path& path) {
+    std::error_code error_code;
+    return fs::is_regular_file(path, error_code) && !error_code;
+}
+
+} // namespace
+
+std::expected<ModuleTargetPreparation, IncrementalModuleTargetError>
+prepare_module_target(
+    const IncrementalModuleTargetRequest& request,
+    msvc::MsvcModuleDependencyScanner& scanner) {
+    if (request.sources.empty()) {
+        return std::unexpected(failure(
+            IncrementalModuleTargetErrorCode::no_sources,
+            "module target requires at least one source"));
+    }
+    if (request.max_parallel_scans == 0 || request.max_parallel_compiles == 0) {
+        return std::unexpected(failure(
+            IncrementalModuleTargetErrorCode::invalid_parallelism,
+            "module target scan and compile parallelism must both be at least one"));
+    }
+
+    std::unordered_set<std::string> seen_sources;
+    std::unordered_set<std::string> claimed_artifacts;
+    seen_sources.reserve(request.sources.size() + 2u);
+    claimed_artifacts.reserve(request.sources.size() * 5u + 18u);
+
+    for (const auto& source : request.sources) {
+        if (source.source.empty()) {
+            return std::unexpected(failure(
+                IncrementalModuleTargetErrorCode::duplicate_source,
+                "module target source path is empty",
+                source.source));
+        }
+        if (!seen_sources.emplace(windows_path_key(source.source)).second) {
+            return std::unexpected(failure(
+                IncrementalModuleTargetErrorCode::duplicate_source,
+                "module target contains the same source more than once",
+                source.source));
+        }
+
+        if (auto error = claim_artifact(
+                claimed_artifacts, source.source, source.artifacts.object, "object")) {
+            return std::unexpected(std::move(*error));
+        }
+        if (auto error = claim_artifact(
+                claimed_artifacts,
+                source.source,
+                source.artifacts.dependencies,
+                "source-dependency metadata")) {
+            return std::unexpected(std::move(*error));
+        }
+        if (auto error = claim_artifact(
+                claimed_artifacts,
+                source.source,
+                source.artifacts.module_dependencies,
+                "module-scan metadata")) {
+            return std::unexpected(std::move(*error));
+        }
+        if (auto error = claim_artifact(
+                claimed_artifacts,
+                source.source,
+                source.artifacts.compile_cache,
+                "compile-cache metadata")) {
+            return std::unexpected(std::move(*error));
+        }
+        if (source.kind == TranslationUnitKind::module_interface) {
+            if (auto error = claim_artifact(
+                    claimed_artifacts,
+                    source.source,
+                    source.artifacts.module_interface,
+                    "IFC")) {
+                return std::unexpected(std::move(*error));
+            }
+        }
+    }
+
+    if (auto error = claim_artifact(
+            claimed_artifacts, {}, request.target.executable, "executable")) {
+        return std::unexpected(std::move(*error));
+    }
+    if (auto error = claim_artifact(
+            claimed_artifacts, {}, request.target.link_cache, "link-cache metadata")) {
+        return std::unexpected(std::move(*error));
+    }
+
+    using ScanAttempt = std::expected<msvc::ModuleScanResult, msvc::ModuleScanError>;
+    std::vector<std::optional<ScanAttempt>> attempts(request.sources.size());
+
+    const auto scheduled = BoundedWorkScheduler::run(
+        request.sources.size(), request.max_parallel_scans,
+        [&](const std::size_t index) {
+            const auto& source = request.sources[index];
+            msvc::ModuleScanInvocation invocation{
+                .source = source.source,
+                .output_file = source.artifacts.module_dependencies,
+                .options = request.compiler_options,
+                .kind = source.kind,
+                .working_directory = working_directory_for(
+                    request.working_directory,
+                    source.source),
+            };
+            attempts[index].emplace(scanner.scan(invocation));
+            return attempts[index]->has_value();
+        });
+    if (!scheduled) {
+        return std::unexpected(failure(
+            IncrementalModuleTargetErrorCode::scheduling_failed,
+            "module scan scheduler failed: " + scheduled.error().message));
+    }
+
+    for (std::size_t index = 0; index < attempts.size(); ++index) {
+        if (attempts[index] && !attempts[index]->has_value()) {
+            IncrementalModuleTargetError error = failure(
+                IncrementalModuleTargetErrorCode::scan_failed,
+                "module dependency scan failed",
+                request.sources[index].source);
+            error.scan_error = attempts[index]->error();
+            return std::unexpected(std::move(error));
+        }
+    }
+
+    ModuleTargetPreparation prepared;
+    prepared.scans.reserve(request.sources.size());
+    std::vector<modules::ScannedModuleUnit> scanned_units;
+    scanned_units.reserve(request.sources.size() + 2u);
+    std::vector<ModuleCompileSourceRequest> compile_sources = request.sources;
+    compile_sources.reserve(request.sources.size() + 2u);
+
+    for (std::size_t index = 0; index < request.sources.size(); ++index) {
+        if (!attempts[index]) {
+            return std::unexpected(failure(
+                IncrementalModuleTargetErrorCode::scheduling_failed,
+                "module scan scheduler stopped without a recorded scan failure",
+                request.sources[index].source));
+        }
+        auto scan = std::move(attempts[index]->value());
+        if (scan.dependencies.rules.size() != 1) {
+            return std::unexpected(failure(
+                IncrementalModuleTargetErrorCode::invalid_scan_result,
+                "one-source module scan must produce exactly one P1689 rule",
+                request.sources[index].source));
+        }
+        scanned_units.push_back(modules::ScannedModuleUnit{
+            .source = request.sources[index].source,
+            .rule = scan.dependencies.rules.front(),
+        });
+        prepared.scans.push_back(ModuleTargetScanResult{
+            .source = request.sources[index].source,
+            .result = std::move(scan),
+        });
+    }
+
+    // P1689 from the user's selected TUs is the only trigger for standard-library
+    // provider injection. Newly scanned toolchain providers may in turn require
+    // another toolchain-owned standard module (std.compat -> std), so repeat to
+    // a fixed point before handing the complete topology to the graph owner.
+    std::unordered_set<std::string> injected_standard_modules;
+    while (auto pending = next_standard_library_requirement(
+               scanned_units,
+               injected_standard_modules)) {
+        if (request.compiler_options.standard != CppStandard::latest) {
+            return std::unexpected(failure(
+                IncrementalModuleTargetErrorCode::standard_library_module_standard_unsupported,
+                "MSVC standard-library module '" + pending->logical_name
+                    + "' requires --std latest",
+                pending->consumer));
+        }
+        if (!request.artifact_layout) {
+            return std::unexpected(failure(
+                IncrementalModuleTargetErrorCode::artifact_layout_missing,
+                "standard-library module provider requires an artifact layout",
+                pending->consumer));
+        }
+
+        auto source = standard_library_module_source(
+            scanner.toolchain(),
+            pending->logical_name);
+        if (!source || source->empty() || !regular_file(*source)) {
+            return std::unexpected(failure(
+                IncrementalModuleTargetErrorCode::standard_library_module_unavailable,
+                "selected MSVC toolchain " + scanner.toolchain().identity.version
+                    + " does not provide standard-library module source '"
+                    + pending->logical_name + "'",
+                pending->consumer));
+        }
+
+        if (!seen_sources.emplace(windows_path_key(*source)).second) {
+            return std::unexpected(failure(
+                IncrementalModuleTargetErrorCode::duplicate_source,
+                "toolchain standard-library module source collides with another target source",
+                *source));
+        }
+
+        auto artifacts = request.artifact_layout->for_source(*source);
+        if (!artifacts) {
+            IncrementalModuleTargetError error = failure(
+                IncrementalModuleTargetErrorCode::artifact_layout_failed,
+                "failed to assign artifacts to standard-library module provider",
+                *source);
+            error.artifact_layout_error = artifacts.error();
+            return std::unexpected(std::move(error));
+        }
+
+        if (auto error = claim_artifact(
+                claimed_artifacts,
+                *source,
+                artifacts->object,
+                "standard-library module object")) {
+            return std::unexpected(std::move(*error));
+        }
+        if (auto error = claim_artifact(
+                claimed_artifacts,
+                *source,
+                artifacts->dependencies,
+                "standard-library source-dependency metadata")) {
+            return std::unexpected(std::move(*error));
+        }
+        if (auto error = claim_artifact(
+                claimed_artifacts,
+                *source,
+                artifacts->module_dependencies,
+                "standard-library module-scan metadata")) {
+            return std::unexpected(std::move(*error));
+        }
+        if (auto error = claim_artifact(
+                claimed_artifacts,
+                *source,
+                artifacts->compile_cache,
+                "standard-library compile-cache metadata")) {
+            return std::unexpected(std::move(*error));
+        }
+        if (auto error = claim_artifact(
+                claimed_artifacts,
+                *source,
+                artifacts->module_interface,
+                "standard-library IFC")) {
+            return std::unexpected(std::move(*error));
+        }
+
+        msvc::ModuleScanInvocation invocation{
+            .source = *source,
+            .output_file = artifacts->module_dependencies,
+            .options = request.compiler_options,
+            .kind = TranslationUnitKind::module_interface,
+            .working_directory = working_directory_for(
+                request.working_directory,
+                *source),
+        };
+        auto scan = scanner.scan(invocation);
+        if (!scan) {
+            IncrementalModuleTargetError error = failure(
+                IncrementalModuleTargetErrorCode::scan_failed,
+                "standard-library module dependency scan failed",
+                *source);
+            error.scan_error = scan.error();
+            return std::unexpected(std::move(error));
+        }
+        if (scan->dependencies.rules.size() != 1
+            || !provides_named_interface(
+                scan->dependencies.rules.front(),
+                pending->logical_name)) {
+            return std::unexpected(failure(
+                IncrementalModuleTargetErrorCode::invalid_scan_result,
+                "selected MSVC standard-library module source did not provide expected interface '"
+                    + pending->logical_name + "'",
+                *source));
+        }
+
+        scanned_units.push_back(modules::ScannedModuleUnit{
+            .source = *source,
+            .rule = scan->dependencies.rules.front(),
+            .toolchain_owned = true,
+        });
+        compile_sources.push_back(ModuleCompileSourceRequest{
+            .source = *source,
+            .artifacts = std::move(*artifacts),
+            .kind = TranslationUnitKind::module_interface,
+        });
+        injected_standard_modules.emplace(std::move(pending->logical_name));
+    }
+
+    auto plan = modules::ModuleDependencyGraphBuilder::build(
+        scanned_units,
+        request.compiler_options.external_module_providers);
+    if (!plan) {
+        IncrementalModuleTargetError error = failure(
+            IncrementalModuleTargetErrorCode::graph_failed,
+            "failed to build module dependency graph");
+        error.graph_error = plan.error();
+        return std::unexpected(std::move(error));
+    }
+    prepared.plan = *plan;
+
+    std::vector<ModuleCompileHeaderUnitRequest> header_units;
+    header_units.reserve(prepared.plan.header_units.size());
+    if (!prepared.plan.header_units.empty() && !request.artifact_layout) {
+        return std::unexpected(failure(
+            IncrementalModuleTargetErrorCode::artifact_layout_missing,
+            "module target discovered project-local header units but no artifact layout was provided",
+            prepared.plan.header_units.front().source));
+    }
+
+    for (const auto& header : prepared.plan.header_units) {
+        const auto lookup = core_lookup_method(header.lookup_method);
+        if (!lookup) {
+            return std::unexpected(failure(
+                IncrementalModuleTargetErrorCode::invalid_header_unit,
+                "resolved header-unit provider has a non-header lookup method",
+                header.source));
+        }
+        auto artifacts = request.artifact_layout->for_source(header.source);
+        if (!artifacts) {
+            IncrementalModuleTargetError error = failure(
+                IncrementalModuleTargetErrorCode::artifact_layout_failed,
+                "failed to assign artifacts to discovered header-unit provider",
+                header.source);
+            error.artifact_layout_error = artifacts.error();
+            return std::unexpected(std::move(error));
+        }
+
+        // Header units are IFC-only producers: object and module-scan paths from
+        // SourceArtifacts are reserved layout slots but are not writable inputs
+        // to this target. Claim only what the producer actually writes.
+        if (auto error = claim_artifact(
+                claimed_artifacts,
+                header.source,
+                artifacts->dependencies,
+                "header-unit source-dependency metadata")) {
+            return std::unexpected(std::move(*error));
+        }
+        if (auto error = claim_artifact(
+                claimed_artifacts,
+                header.source,
+                artifacts->compile_cache,
+                "header-unit compile-cache metadata")) {
+            return std::unexpected(std::move(*error));
+        }
+        if (auto error = claim_artifact(
+                claimed_artifacts,
+                header.source,
+                artifacts->module_interface,
+                "header-unit IFC")) {
+            return std::unexpected(std::move(*error));
+        }
+
+        header_units.push_back(ModuleCompileHeaderUnitRequest{
+            .source = header.source,
+            .header_name = header.header_name,
+            .lookup_method = *lookup,
+            .artifacts = std::move(*artifacts),
+        });
+    }
+
+    prepared.compile_request = ModuleCompileWaveRequest{
+        .sources = std::move(compile_sources),
+        .header_units = std::move(header_units),
+        .plan = prepared.plan,
+        .compiler_options = request.compiler_options,
+        .working_directory = request.working_directory,
+        .max_parallel_compiles = request.max_parallel_compiles,
+    };
+    return prepared;
+}
+
+} // namespace mqb::orchestration::detail

--- a/cpp/src/orchestration/modules/ModuleTargetPreparation.hpp
+++ b/cpp/src/orchestration/modules/ModuleTargetPreparation.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <expected>
+#include <vector>
+
+#include "mqb/orchestration/MsvcModuleTargetCoordinator.hpp"
+
+namespace mqb::orchestration::detail {
+
+struct ModuleTargetPreparation {
+    std::vector<ModuleTargetScanResult> scans;
+    modules::ModuleDependencyPlan plan;
+    ModuleCompileWaveRequest compile_request;
+};
+
+[[nodiscard]] std::expected<ModuleTargetPreparation, IncrementalModuleTargetError>
+prepare_module_target(
+    const IncrementalModuleTargetRequest& request,
+    msvc::MsvcModuleDependencyScanner& scanner);
+
+} // namespace mqb::orchestration::detail

--- a/cpp/src/orchestration/modules/MsvcModuleTargetCoordinator.cpp
+++ b/cpp/src/orchestration/modules/MsvcModuleTargetCoordinator.cpp
@@ -1,49 +1,23 @@
 #include "mqb/orchestration/MsvcModuleTargetCoordinator.hpp"
 
 #include <expected>
-#include <filesystem>
-#include <optional>
 #include <string>
 #include <utility>
-#include <vector>
 
+#include "ModuleTargetLinkRequestFactory.hpp"
 #include "ModuleTargetPreparation.hpp"
 
 namespace mqb::orchestration {
 namespace {
 
-namespace fs = std::filesystem;
-
 [[nodiscard]] IncrementalModuleTargetError failure(
     const IncrementalModuleTargetErrorCode code,
     std::string message,
-    fs::path source = {}) {
+    std::filesystem::path source = {}) {
     return IncrementalModuleTargetError{
         .code = code,
         .message = std::move(message),
         .source = std::move(source),
-    };
-}
-
-[[nodiscard]] IncrementalLinkRequest make_link_request(
-    const IncrementalModuleTargetRequest& request,
-    const ModuleCompileWaveRequest& compile_request,
-    const bool force_relink) {
-    std::vector<fs::path> objects;
-    objects.reserve(compile_request.sources.size());
-    for (const auto& source : compile_request.sources) {
-        objects.push_back(source.artifacts.object);
-    }
-
-    return IncrementalLinkRequest{
-        .objects = std::move(objects),
-        .output = request.target.executable,
-        .options = request.link_options,
-        .cache_file = request.target.link_cache,
-        .working_directory = request.working_directory.empty()
-            ? std::nullopt
-            : std::optional<fs::path>{request.working_directory},
-        .force_relink = force_relink,
     };
 }
 
@@ -71,7 +45,7 @@ MsvcModuleTargetCoordinator::run(const IncrementalModuleTargetRequest& request) 
     }
     result.compiles = std::move(*compiled);
 
-    auto linked = link_coordinator_.run(make_link_request(
+    auto linked = link_coordinator_.run(detail::make_module_target_link_request(
         request,
         prepared->compile_request,
         result.compiles.any_compiled));

--- a/cpp/src/orchestration/modules/MsvcModuleTargetCoordinator.cpp
+++ b/cpp/src/orchestration/modules/MsvcModuleTargetCoordinator.cpp
@@ -1,32 +1,18 @@
 #include "mqb/orchestration/MsvcModuleTargetCoordinator.hpp"
 
-#include <algorithm>
-#include <cctype>
 #include <expected>
 #include <filesystem>
 #include <optional>
 #include <string>
-#include <string_view>
-#include <unordered_set>
 #include <utility>
 #include <vector>
 
-#include "mqb/modules/ModuleDependencyGraph.hpp"
-#include "mqb/msvc/MsvcModuleDependencyScanner.hpp"
-#include "mqb/orchestration/BoundedWorkScheduler.hpp"
+#include "ModuleTargetPreparation.hpp"
 
 namespace mqb::orchestration {
 namespace {
 
 namespace fs = std::filesystem;
-
-[[nodiscard]] std::string windows_path_key(const fs::path& path) {
-    std::string value = path.lexically_normal().generic_string();
-    std::transform(
-        value.begin(), value.end(), value.begin(),
-        [](const unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
-    return value;
-}
 
 [[nodiscard]] IncrementalModuleTargetError failure(
     const IncrementalModuleTargetErrorCode code,
@@ -39,438 +25,42 @@ namespace fs = std::filesystem;
     };
 }
 
-[[nodiscard]] IncrementalModuleTargetError artifact_failure(
-    const IncrementalModuleTargetErrorCode code,
-    std::string message,
-    const fs::path& source,
-    const fs::path& artifact) {
-    return IncrementalModuleTargetError{
-        .code = code,
-        .message = std::move(message),
-        .source = source,
-        .artifact = artifact,
+[[nodiscard]] IncrementalLinkRequest make_link_request(
+    const IncrementalModuleTargetRequest& request,
+    const ModuleCompileWaveRequest& compile_request,
+    const bool force_relink) {
+    std::vector<fs::path> objects;
+    objects.reserve(compile_request.sources.size());
+    for (const auto& source : compile_request.sources) {
+        objects.push_back(source.artifacts.object);
+    }
+
+    return IncrementalLinkRequest{
+        .objects = std::move(objects),
+        .output = request.target.executable,
+        .options = request.link_options,
+        .cache_file = request.target.link_cache,
+        .working_directory = request.working_directory.empty()
+            ? std::nullopt
+            : std::optional<fs::path>{request.working_directory},
+        .force_relink = force_relink,
     };
-}
-
-[[nodiscard]] std::optional<IncrementalModuleTargetError> claim_artifact(
-    std::unordered_set<std::string>& claimed,
-    const fs::path& source,
-    const fs::path& artifact,
-    const std::string_view role) {
-    if (artifact.empty()) {
-        return artifact_failure(
-            IncrementalModuleTargetErrorCode::invalid_artifact,
-            "module target " + std::string{role} + " artifact path is empty",
-            source,
-            artifact);
-    }
-    if (!claimed.emplace(windows_path_key(artifact)).second) {
-        return artifact_failure(
-            IncrementalModuleTargetErrorCode::artifact_collision,
-            "module target " + std::string{role}
-                + " artifact collides with another planned writable artifact",
-            source,
-            artifact);
-    }
-    return std::nullopt;
-}
-
-[[nodiscard]] std::optional<fs::path> working_directory_for(
-    const fs::path& requested,
-    const fs::path& source) {
-    if (!requested.empty()) return requested;
-    if (!source.parent_path().empty()) return source.parent_path();
-    return std::nullopt;
-}
-
-[[nodiscard]] std::optional<HeaderUnitLookupMethod> core_lookup_method(
-    const modules::LookupMethod lookup_method) {
-    switch (lookup_method) {
-    case modules::LookupMethod::include_angle:
-        return HeaderUnitLookupMethod::angle;
-    case modules::LookupMethod::include_quote:
-        return HeaderUnitLookupMethod::quote;
-    case modules::LookupMethod::by_name:
-        return std::nullopt;
-    }
-    return std::nullopt;
-}
-
-[[nodiscard]] bool standard_library_module_name(const std::string_view logical_name) noexcept {
-    return logical_name == "std" || logical_name == "std.compat";
-}
-
-[[nodiscard]] std::optional<fs::path> standard_library_module_source(
-    const msvc::MsvcToolchain& toolchain,
-    const std::string_view logical_name) {
-    if (logical_name == "std") return toolchain.standard_library_modules.std;
-    if (logical_name == "std.compat") return toolchain.standard_library_modules.std_compat;
-    return std::nullopt;
-}
-
-[[nodiscard]] bool named_requirement(const modules::RequiredModule& requirement) noexcept {
-    return !requirement.unique_on_source_path
-        && requirement.lookup_method == modules::LookupMethod::by_name;
-}
-
-struct PendingStandardLibraryRequirement {
-    std::filesystem::path consumer;
-    std::string logical_name;
-};
-
-[[nodiscard]] std::optional<PendingStandardLibraryRequirement>
-next_standard_library_requirement(
-    const std::vector<modules::ScannedModuleUnit>& units,
-    const std::unordered_set<std::string>& injected) {
-    for (const auto& unit : units) {
-        for (const auto& requirement : unit.rule.required_modules) {
-            if (!named_requirement(requirement)
-                || !standard_library_module_name(requirement.logical_name)
-                || injected.contains(requirement.logical_name)) {
-                continue;
-            }
-            return PendingStandardLibraryRequirement{
-                .consumer = unit.source,
-                .logical_name = requirement.logical_name,
-            };
-        }
-    }
-    return std::nullopt;
-}
-
-[[nodiscard]] bool provides_named_interface(
-    const modules::P1689Rule& rule,
-    const std::string_view logical_name) {
-    return std::any_of(
-        rule.provided_modules.begin(),
-        rule.provided_modules.end(),
-        [&](const modules::ProvidedModule& provided) {
-            return !provided.unique_on_source_path
-                && provided.is_interface
-                && provided.logical_name == logical_name;
-        });
-}
-
-[[nodiscard]] bool regular_file(const fs::path& path) {
-    std::error_code error_code;
-    return fs::is_regular_file(path, error_code) && !error_code;
 }
 
 } // namespace
 
 std::expected<IncrementalModuleTargetResult, IncrementalModuleTargetError>
 MsvcModuleTargetCoordinator::run(const IncrementalModuleTargetRequest& request) const {
-    if (request.sources.empty()) {
-        return std::unexpected(failure(
-            IncrementalModuleTargetErrorCode::no_sources,
-            "module target requires at least one source"));
-    }
-    if (request.max_parallel_scans == 0 || request.max_parallel_compiles == 0) {
-        return std::unexpected(failure(
-            IncrementalModuleTargetErrorCode::invalid_parallelism,
-            "module target scan and compile parallelism must both be at least one"));
-    }
-
-    std::unordered_set<std::string> seen_sources;
-    std::unordered_set<std::string> claimed_artifacts;
-    seen_sources.reserve(request.sources.size() + 2u);
-    claimed_artifacts.reserve(request.sources.size() * 5u + 18u);
-
-    for (const auto& source : request.sources) {
-        if (source.source.empty()) {
-            return std::unexpected(failure(
-                IncrementalModuleTargetErrorCode::duplicate_source,
-                "module target source path is empty",
-                source.source));
-        }
-        if (!seen_sources.emplace(windows_path_key(source.source)).second) {
-            return std::unexpected(failure(
-                IncrementalModuleTargetErrorCode::duplicate_source,
-                "module target contains the same source more than once",
-                source.source));
-        }
-
-        if (auto error = claim_artifact(claimed_artifacts, source.source, source.artifacts.object, "object")) {
-            return std::unexpected(std::move(*error));
-        }
-        if (auto error = claim_artifact(
-                claimed_artifacts, source.source, source.artifacts.dependencies, "source-dependency metadata")) {
-            return std::unexpected(std::move(*error));
-        }
-        if (auto error = claim_artifact(
-                claimed_artifacts, source.source, source.artifacts.module_dependencies, "module-scan metadata")) {
-            return std::unexpected(std::move(*error));
-        }
-        if (auto error = claim_artifact(
-                claimed_artifacts, source.source, source.artifacts.compile_cache, "compile-cache metadata")) {
-            return std::unexpected(std::move(*error));
-        }
-        if (source.kind == TranslationUnitKind::module_interface) {
-            if (auto error = claim_artifact(
-                    claimed_artifacts, source.source, source.artifacts.module_interface, "IFC")) {
-                return std::unexpected(std::move(*error));
-            }
-        }
-    }
-
-    if (auto error = claim_artifact(claimed_artifacts, {}, request.target.executable, "executable")) {
-        return std::unexpected(std::move(*error));
-    }
-    if (auto error = claim_artifact(
-            claimed_artifacts, {}, request.target.link_cache, "link-cache metadata")) {
-        return std::unexpected(std::move(*error));
-    }
-
-    using ScanAttempt = std::expected<msvc::ModuleScanResult, msvc::ModuleScanError>;
-    std::vector<std::optional<ScanAttempt>> attempts(request.sources.size());
-
-    const auto scheduled = BoundedWorkScheduler::run(
-        request.sources.size(), request.max_parallel_scans,
-        [&](const std::size_t index) {
-            const auto& source = request.sources[index];
-            msvc::ModuleScanInvocation invocation{
-                .source = source.source,
-                .output_file = source.artifacts.module_dependencies,
-                .options = request.compiler_options,
-                .kind = source.kind,
-                .working_directory = working_directory_for(request.working_directory, source.source),
-            };
-            attempts[index].emplace(scanner_.scan(invocation));
-            return attempts[index]->has_value();
-        });
-    if (!scheduled) {
-        return std::unexpected(failure(
-            IncrementalModuleTargetErrorCode::scheduling_failed,
-            "module scan scheduler failed: " + scheduled.error().message));
-    }
-
-    for (std::size_t index = 0; index < attempts.size(); ++index) {
-        if (attempts[index] && !attempts[index]->has_value()) {
-            IncrementalModuleTargetError error = failure(
-                IncrementalModuleTargetErrorCode::scan_failed,
-                "module dependency scan failed",
-                request.sources[index].source);
-            error.scan_error = attempts[index]->error();
-            return std::unexpected(std::move(error));
-        }
+    auto prepared = detail::prepare_module_target(request, scanner_);
+    if (!prepared) {
+        return std::unexpected(std::move(prepared.error()));
     }
 
     IncrementalModuleTargetResult result;
-    result.scans.reserve(request.sources.size());
-    std::vector<modules::ScannedModuleUnit> scanned_units;
-    scanned_units.reserve(request.sources.size() + 2u);
-    std::vector<ModuleCompileSourceRequest> compile_sources = request.sources;
-    compile_sources.reserve(request.sources.size() + 2u);
+    result.scans = std::move(prepared->scans);
+    result.plan = std::move(prepared->plan);
 
-    for (std::size_t index = 0; index < request.sources.size(); ++index) {
-        if (!attempts[index]) {
-            return std::unexpected(failure(
-                IncrementalModuleTargetErrorCode::scheduling_failed,
-                "module scan scheduler stopped without a recorded scan failure",
-                request.sources[index].source));
-        }
-        auto scan = std::move(attempts[index]->value());
-        if (scan.dependencies.rules.size() != 1) {
-            return std::unexpected(failure(
-                IncrementalModuleTargetErrorCode::invalid_scan_result,
-                "one-source module scan must produce exactly one P1689 rule",
-                request.sources[index].source));
-        }
-        scanned_units.push_back(modules::ScannedModuleUnit{
-            .source = request.sources[index].source,
-            .rule = scan.dependencies.rules.front(),
-        });
-        result.scans.push_back(ModuleTargetScanResult{
-            .source = request.sources[index].source,
-            .result = std::move(scan),
-        });
-    }
-
-    // P1689 from the user's selected TUs is the only trigger for standard-library
-    // provider injection. Newly scanned toolchain providers may in turn require
-    // another toolchain-owned standard module (std.compat -> std), so repeat to
-    // a fixed point before handing the complete topology to the graph owner.
-    std::unordered_set<std::string> injected_standard_modules;
-    while (auto pending = next_standard_library_requirement(
-               scanned_units,
-               injected_standard_modules)) {
-        if (request.compiler_options.standard != CppStandard::latest) {
-            return std::unexpected(failure(
-                IncrementalModuleTargetErrorCode::standard_library_module_standard_unsupported,
-                "MSVC standard-library module '" + pending->logical_name
-                    + "' requires --std latest",
-                pending->consumer));
-        }
-        if (!request.artifact_layout) {
-            return std::unexpected(failure(
-                IncrementalModuleTargetErrorCode::artifact_layout_missing,
-                "standard-library module provider requires an artifact layout",
-                pending->consumer));
-        }
-
-        auto source = standard_library_module_source(
-            scanner_.toolchain(),
-            pending->logical_name);
-        if (!source || source->empty() || !regular_file(*source)) {
-            return std::unexpected(failure(
-                IncrementalModuleTargetErrorCode::standard_library_module_unavailable,
-                "selected MSVC toolchain " + scanner_.toolchain().identity.version
-                    + " does not provide standard-library module source '"
-                    + pending->logical_name + "'",
-                pending->consumer));
-        }
-
-        const std::string source_key = windows_path_key(*source);
-        if (!seen_sources.emplace(source_key).second) {
-            return std::unexpected(failure(
-                IncrementalModuleTargetErrorCode::duplicate_source,
-                "toolchain standard-library module source collides with another target source",
-                *source));
-        }
-
-        auto artifacts = request.artifact_layout->for_source(*source);
-        if (!artifacts) {
-            IncrementalModuleTargetError error = failure(
-                IncrementalModuleTargetErrorCode::artifact_layout_failed,
-                "failed to assign artifacts to standard-library module provider",
-                *source);
-            error.artifact_layout_error = artifacts.error();
-            return std::unexpected(std::move(error));
-        }
-
-        if (auto error = claim_artifact(
-                claimed_artifacts, *source, artifacts->object, "standard-library module object")) {
-            return std::unexpected(std::move(*error));
-        }
-        if (auto error = claim_artifact(
-                claimed_artifacts, *source, artifacts->dependencies, "standard-library source-dependency metadata")) {
-            return std::unexpected(std::move(*error));
-        }
-        if (auto error = claim_artifact(
-                claimed_artifacts, *source, artifacts->module_dependencies, "standard-library module-scan metadata")) {
-            return std::unexpected(std::move(*error));
-        }
-        if (auto error = claim_artifact(
-                claimed_artifacts, *source, artifacts->compile_cache, "standard-library compile-cache metadata")) {
-            return std::unexpected(std::move(*error));
-        }
-        if (auto error = claim_artifact(
-                claimed_artifacts, *source, artifacts->module_interface, "standard-library IFC")) {
-            return std::unexpected(std::move(*error));
-        }
-
-        msvc::ModuleScanInvocation invocation{
-            .source = *source,
-            .output_file = artifacts->module_dependencies,
-            .options = request.compiler_options,
-            .kind = TranslationUnitKind::module_interface,
-            .working_directory = working_directory_for(request.working_directory, *source),
-        };
-        auto scan = scanner_.scan(invocation);
-        if (!scan) {
-            IncrementalModuleTargetError error = failure(
-                IncrementalModuleTargetErrorCode::scan_failed,
-                "standard-library module dependency scan failed",
-                *source);
-            error.scan_error = scan.error();
-            return std::unexpected(std::move(error));
-        }
-        if (scan->dependencies.rules.size() != 1
-            || !provides_named_interface(
-                scan->dependencies.rules.front(),
-                pending->logical_name)) {
-            return std::unexpected(failure(
-                IncrementalModuleTargetErrorCode::invalid_scan_result,
-                "selected MSVC standard-library module source did not provide expected interface '"
-                    + pending->logical_name + "'",
-                *source));
-        }
-
-        scanned_units.push_back(modules::ScannedModuleUnit{
-            .source = *source,
-            .rule = scan->dependencies.rules.front(),
-            .toolchain_owned = true,
-        });
-        compile_sources.push_back(ModuleCompileSourceRequest{
-            .source = *source,
-            .artifacts = std::move(*artifacts),
-            .kind = TranslationUnitKind::module_interface,
-        });
-        injected_standard_modules.emplace(std::move(pending->logical_name));
-    }
-
-    auto plan = modules::ModuleDependencyGraphBuilder::build(
-        scanned_units,
-        request.compiler_options.external_module_providers);
-    if (!plan) {
-        IncrementalModuleTargetError error = failure(
-            IncrementalModuleTargetErrorCode::graph_failed,
-            "failed to build module dependency graph");
-        error.graph_error = plan.error();
-        return std::unexpected(std::move(error));
-    }
-    result.plan = *plan;
-
-    std::vector<ModuleCompileHeaderUnitRequest> header_units;
-    header_units.reserve(result.plan.header_units.size());
-    if (!result.plan.header_units.empty() && !request.artifact_layout) {
-        return std::unexpected(failure(
-            IncrementalModuleTargetErrorCode::artifact_layout_missing,
-            "module target discovered project-local header units but no artifact layout was provided",
-            result.plan.header_units.front().source));
-    }
-
-    for (const auto& header : result.plan.header_units) {
-        const auto lookup = core_lookup_method(header.lookup_method);
-        if (!lookup) {
-            return std::unexpected(failure(
-                IncrementalModuleTargetErrorCode::invalid_header_unit,
-                "resolved header-unit provider has a non-header lookup method",
-                header.source));
-        }
-        auto artifacts = request.artifact_layout->for_source(header.source);
-        if (!artifacts) {
-            IncrementalModuleTargetError error = failure(
-                IncrementalModuleTargetErrorCode::artifact_layout_failed,
-                "failed to assign artifacts to discovered header-unit provider",
-                header.source);
-            error.artifact_layout_error = artifacts.error();
-            return std::unexpected(std::move(error));
-        }
-
-        // Header units are IFC-only producers: object and module-scan paths from
-        // SourceArtifacts are reserved layout slots but are not writable inputs
-        // to this target. Claim only what the producer actually writes.
-        if (auto error = claim_artifact(
-                claimed_artifacts, header.source, artifacts->dependencies, "header-unit source-dependency metadata")) {
-            return std::unexpected(std::move(*error));
-        }
-        if (auto error = claim_artifact(
-                claimed_artifacts, header.source, artifacts->compile_cache, "header-unit compile-cache metadata")) {
-            return std::unexpected(std::move(*error));
-        }
-        if (auto error = claim_artifact(
-                claimed_artifacts, header.source, artifacts->module_interface, "header-unit IFC")) {
-            return std::unexpected(std::move(*error));
-        }
-
-        header_units.push_back(ModuleCompileHeaderUnitRequest{
-            .source = header.source,
-            .header_name = header.header_name,
-            .lookup_method = *lookup,
-            .artifacts = std::move(*artifacts),
-        });
-    }
-
-    ModuleCompileWaveRequest compile_request{
-        .sources = std::move(compile_sources),
-        .header_units = std::move(header_units),
-        .plan = result.plan,
-        .compiler_options = request.compiler_options,
-        .working_directory = request.working_directory,
-        .max_parallel_compiles = request.max_parallel_compiles,
-    };
-    auto compiled = compile_coordinator_.run(compile_request);
+    auto compiled = compile_coordinator_.run(prepared->compile_request);
     if (!compiled) {
         IncrementalModuleTargetError error = failure(
             IncrementalModuleTargetErrorCode::compile_failed,
@@ -481,23 +71,10 @@ MsvcModuleTargetCoordinator::run(const IncrementalModuleTargetRequest& request) 
     }
     result.compiles = std::move(*compiled);
 
-    std::vector<fs::path> objects;
-    objects.reserve(compile_request.sources.size());
-    for (const auto& source : compile_request.sources) {
-        objects.push_back(source.artifacts.object);
-    }
-
-    IncrementalLinkRequest link_request{
-        .objects = std::move(objects),
-        .output = request.target.executable,
-        .options = request.link_options,
-        .cache_file = request.target.link_cache,
-        .working_directory = request.working_directory.empty()
-            ? std::nullopt
-            : std::optional<fs::path>{request.working_directory},
-        .force_relink = result.compiles.any_compiled,
-    };
-    auto linked = link_coordinator_.run(link_request);
+    auto linked = link_coordinator_.run(make_link_request(
+        request,
+        prepared->compile_request,
+        result.compiles.any_compiled));
     if (!linked) {
         IncrementalModuleTargetError error = failure(
             IncrementalModuleTargetErrorCode::link_failed,

--- a/tests/native/assert_cpp_layout.ps1
+++ b/tests/native/assert_cpp_layout.ps1
@@ -204,6 +204,8 @@ $orchestrationLeafFiles = [ordered]@{
     'modules' = @(
         'ModuleCompilePlan.cpp', 'ModuleCompilePlan.hpp',
         'ModuleCompileRequestFactory.cpp', 'ModuleCompileRequestFactory.hpp',
+        'ModuleTargetLinkRequestFactory.cpp', 'ModuleTargetLinkRequestFactory.hpp',
+        'ModuleTargetPreparation.cpp', 'ModuleTargetPreparation.hpp',
         'MsvcModuleCompileCoordinator.cpp', 'MsvcModuleTargetCoordinator.cpp'
     )
     'routing' = @('MsvcTargetRouter.cpp')


### PR DESCRIPTION
## What changed

- extract module-target preflight, P1689 scanning, standard-library module injection, dependency-graph construction, and header-unit materialization into private `ModuleTargetPreparation`
- extract final compile-source object collection and incremental-link request construction into private `ModuleTargetLinkRequestFactory`
- reduce `MsvcModuleTargetCoordinator` to a thin `prepare -> compile -> link` pipeline facade
- keep `include/mqb/orchestration/MsvcModuleTargetCoordinator.hpp` unchanged; no public API or error enum changes
- register the two new production translation units in `cpp/mqb.json`
- extend the exact orchestration/modules layout contract with the four new private component files

## Behavior preserved

- public scan results remain in `request.sources` order
- user P1689 requirements remain the trigger for toolchain-owned `std` / `std.compat` provider injection, including fixed-point `std.compat -> std` discovery
- target/source/artifact collision checks remain fail-closed before compile/link execution
- standard-library module availability and `--std latest` validation are unchanged
- header units remain IFC-only producers for target artifact ownership
- graph errors, scan errors, compile errors, and link errors retain the existing public mappings
- final link objects are still derived from the complete compile source set, including dynamically injected standard-library module providers
- `force_relink` still follows `result.compiles.any_compiled`

## Why

After #69 separated module compile planning/request materialization from wave execution, `MsvcModuleTargetCoordinator.cpp` remained the next semantic outlier: a single translation unit owned target validation, scanning, toolchain-provider injection, graph preparation, header-unit materialization, compile handoff, link request construction, and link handoff.

This split follows reasons-to-change rather than line count:

- `ModuleTargetPreparation` owns turning the public target request into a validated complete `ModuleCompileWaveRequest`
- `ModuleTargetLinkRequestFactory` owns translating the complete compile source set into `IncrementalLinkRequest`
- `MsvcModuleTargetCoordinator` owns only pipeline composition and public error/result mapping

## Validation

Final head `8824a16253429bf8e3e87093378b1fef832b33a4` is fully green for every workflow applicable to this change:

- **Native C++**: Debug self-build + shared native-test product + all 4 paired Debug shards + final gate succeeded
- **Native Release**: Stage 0 Release self-build + shared Release native-test product + all 4 paired Release shards + stable self-host + runtime-only package staging/validation/upload succeeded
- **Native Installer**: not triggered by design; this PR does not touch installer/VERSION/seed/build-driver paths covered by that workflow's pull-request filter

The successful self-builds validate the exact production manifest and updated orchestration/modules responsibility layout on real Windows/MSVC C++23 builds. Existing module-target, standard-library module, header-unit, graph, incremental compile/link, and integration tests all passed on both Debug and Release paths.