### PR TITLE
refactor: unify incremental file snapshot policy

### DIFF
--- a/cpp/src/orchestration/incremental/IncrementalFileSnapshot.hpp
+++ b/cpp/src/orchestration/incremental/IncrementalFileSnapshot.hpp
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <filesystem>
+#include <optional>
+#include <system_error>
+
+#include "mqb/core/FileSnapshot.hpp"
+
+namespace mqb::orchestration::detail {
+
+namespace fs = std::filesystem;
+
+enum class IncrementalFileSnapshotFailureKind {
+    status,
+    timestamp,
+};
+
+struct IncrementalFileSnapshotFailure {
+    IncrementalFileSnapshotFailureKind kind{IncrementalFileSnapshotFailureKind::status};
+    std::error_code error_code;
+};
+
+struct IncrementalFileSnapshotResult {
+    FileSnapshot snapshot;
+    std::optional<IncrementalFileSnapshotFailure> failure;
+};
+
+[[nodiscard]] inline IncrementalFileSnapshotResult missing_file_snapshot(const fs::path& path) {
+    return IncrementalFileSnapshotResult{
+        .snapshot = FileSnapshot{
+            .path = path,
+            .exists = false,
+        },
+        .failure = std::nullopt,
+    };
+}
+
+[[nodiscard]] inline IncrementalFileSnapshotResult snapshot_regular_file(const fs::path& path) {
+    if (path.empty()) {
+        return missing_file_snapshot(path);
+    }
+
+    std::error_code error_code;
+    const fs::file_status status = fs::status(path, error_code);
+    if (error_code) {
+        if (error_code == std::errc::no_such_file_or_directory) {
+            return missing_file_snapshot(path);
+        }
+        return IncrementalFileSnapshotResult{
+            .snapshot = FileSnapshot{
+                .path = path,
+                .exists = false,
+            },
+            .failure = IncrementalFileSnapshotFailure{
+                .kind = IncrementalFileSnapshotFailureKind::status,
+                .error_code = error_code,
+            },
+        };
+    }
+    if (!fs::is_regular_file(status)) {
+        return missing_file_snapshot(path);
+    }
+
+    const auto modified = fs::last_write_time(path, error_code);
+    if (error_code) {
+        if (error_code == std::errc::no_such_file_or_directory) {
+            return missing_file_snapshot(path);
+        }
+        return IncrementalFileSnapshotResult{
+            .snapshot = FileSnapshot{
+                .path = path,
+                .exists = false,
+            },
+            .failure = IncrementalFileSnapshotFailure{
+                .kind = IncrementalFileSnapshotFailureKind::timestamp,
+                .error_code = error_code,
+            },
+        };
+    }
+
+    return IncrementalFileSnapshotResult{
+        .snapshot = FileSnapshot{
+            .path = path,
+            .exists = true,
+            .modified = modified,
+        },
+        .failure = std::nullopt,
+    };
+}
+
+} // namespace mqb::orchestration::detail

--- a/cpp/src/orchestration/incremental/MsvcIncrementalArchiveCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalArchiveCoordinator.cpp
@@ -4,7 +4,6 @@
 #include <filesystem>
 #include <optional>
 #include <string>
-#include <system_error>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -15,19 +14,25 @@
 #include "mqb/core/BuildSignature.hpp"
 #include "mqb/core/FileSnapshot.hpp"
 
+#include "IncrementalFileSnapshot.hpp"
+
 namespace mqb::orchestration {
 namespace {
 
 namespace fs = std::filesystem;
 
-[[nodiscard]] std::expected<FileSnapshot, std::string> snapshot_file(const fs::path& path) {
-    std::error_code ec;
-    const bool exists = fs::exists(path, ec);
-    if (ec) return std::unexpected("failed to query file existence: " + ec.message());
-    if (!exists) return FileSnapshot{.path = path, .exists = false};
-    const auto modified = fs::last_write_time(path, ec);
-    if (ec) return std::unexpected("failed to query file timestamp: " + ec.message());
-    return FileSnapshot{.path = path, .exists = true, .modified = modified};
+[[nodiscard]] std::string snapshot_failure_message(
+    const detail::IncrementalFileSnapshotFailure& failure) {
+    const char* prefix = nullptr;
+    switch (failure.kind) {
+    case detail::IncrementalFileSnapshotFailureKind::status:
+        prefix = "failed to query file type: ";
+        break;
+    case detail::IncrementalFileSnapshotFailureKind::timestamp:
+        prefix = "failed to query file timestamp: ";
+        break;
+    }
+    return std::string{prefix} + failure.error_code.message();
 }
 
 void snapshot_inputs(
@@ -36,16 +41,15 @@ void snapshot_inputs(
     std::vector<IncrementalArchiveWarning>& warnings) {
     snapshots.reserve(paths.size());
     for (const auto& path : paths) {
-        if (auto snapshot = snapshot_file(path)) {
-            snapshots.push_back(std::move(*snapshot));
-        } else {
+        auto snapshot = detail::snapshot_regular_file(path);
+        if (snapshot.failure) {
             warnings.push_back(IncrementalArchiveWarning{
                 .code = IncrementalArchiveWarningCode::file_snapshot_failed,
                 .path = path,
-                .message = snapshot.error(),
+                .message = snapshot_failure_message(*snapshot.failure),
             });
-            snapshots.push_back(FileSnapshot{.path = path, .exists = false});
         }
+        snapshots.push_back(std::move(snapshot.snapshot));
     }
 }
 
@@ -76,16 +80,15 @@ MsvcIncrementalArchiveCoordinator::run(const IncrementalArchiveRequest& request)
         });
     }
 
-    FileSnapshot output_snapshot{.path = request.output, .exists = false};
-    if (auto snapshot = snapshot_file(request.output)) {
-        output_snapshot = std::move(*snapshot);
-    } else {
+    auto output_snapshot_result = detail::snapshot_regular_file(request.output);
+    if (output_snapshot_result.failure) {
         result.warnings.push_back(IncrementalArchiveWarning{
             .code = IncrementalArchiveWarningCode::file_snapshot_failed,
             .path = request.output,
-            .message = snapshot.error(),
+            .message = snapshot_failure_message(*output_snapshot_result.failure),
         });
     }
+    FileSnapshot output_snapshot = std::move(output_snapshot_result.snapshot);
 
     std::vector<FileSnapshot> object_snapshots;
     snapshot_inputs(request.objects, object_snapshots, result.warnings);

--- a/cpp/src/orchestration/incremental/MsvcIncrementalCompileCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalCompileCoordinator.cpp
@@ -6,7 +6,6 @@
 #include <filesystem>
 #include <optional>
 #include <string>
-#include <system_error>
 #include <utility>
 #include <vector>
 
@@ -15,85 +14,33 @@
 #include "mqb/core/CompileCacheFile.hpp"
 #include "mqb/msvc/MsvcCompileExecutor.hpp"
 
+#include "IncrementalFileSnapshot.hpp"
+
 namespace mqb::orchestration {
 namespace {
 
-namespace fs = std::filesystem;
-
-struct SnapshotResult {
-    FileSnapshot snapshot;
-    std::optional<IncrementalCompileWarning> warning;
-};
-
-[[nodiscard]] SnapshotResult missing_snapshot(const fs::path& path) {
-    return SnapshotResult{
-        .snapshot = FileSnapshot{
-            .path = path,
-            .exists = false,
-        },
-    };
-}
-
-[[nodiscard]] SnapshotResult snapshot_file(const fs::path& path) {
-    if (path.empty()) {
-        return missing_snapshot(path);
-    }
-
-    std::error_code error_code;
-    const fs::file_status status = fs::status(path, error_code);
-    if (error_code) {
-        if (error_code == std::errc::no_such_file_or_directory) {
-            return missing_snapshot(path);
-        }
-        return SnapshotResult{
-            .snapshot = FileSnapshot{
-                .path = path,
-                .exists = false,
-            },
-            .warning = IncrementalCompileWarning{
-                .code = IncrementalCompileWarningCode::file_snapshot_failed,
-                .path = path,
-                .message = "failed to query file type while validating compile cache",
-            },
-        };
-    }
-    if (!fs::is_regular_file(status)) {
-        return missing_snapshot(path);
-    }
-
-    const auto modified = fs::last_write_time(path, error_code);
-    if (error_code) {
-        if (error_code == std::errc::no_such_file_or_directory) {
-            return missing_snapshot(path);
-        }
-        return SnapshotResult{
-            .snapshot = FileSnapshot{
-                .path = path,
-                .exists = false,
-            },
-            .warning = IncrementalCompileWarning{
-                .code = IncrementalCompileWarningCode::file_snapshot_failed,
-                .path = path,
-                .message = "failed to read file timestamp while validating compile cache",
-            },
-        };
-    }
-
-    return SnapshotResult{
-        .snapshot = FileSnapshot{
-            .path = path,
-            .exists = true,
-            .modified = modified,
-        },
-    };
-}
-
-void append_warning(
+void append_snapshot_warning(
     std::vector<IncrementalCompileWarning>& warnings,
-    std::optional<IncrementalCompileWarning> warning) {
-    if (warning) {
-        warnings.push_back(std::move(*warning));
+    const std::filesystem::path& path,
+    std::optional<detail::IncrementalFileSnapshotFailure> failure) {
+    if (!failure) {
+        return;
     }
+
+    std::string message;
+    switch (failure->kind) {
+    case detail::IncrementalFileSnapshotFailureKind::status:
+        message = "failed to query file type while validating compile cache";
+        break;
+    case detail::IncrementalFileSnapshotFailureKind::timestamp:
+        message = "failed to read file timestamp while validating compile cache";
+        break;
+    }
+    warnings.push_back(IncrementalCompileWarning{
+        .code = IncrementalCompileWarningCode::file_snapshot_failed,
+        .path = path,
+        .message = std::move(message),
+    });
 }
 
 void add_reason_once(
@@ -122,14 +69,20 @@ MsvcIncrementalCompileCoordinator::run(const IncrementalCompileRequest& request)
         cached_entry = std::move(*loaded_cache);
     }
 
-    auto source_snapshot = snapshot_file(request.unit.source);
-    append_warning(result.warnings, std::move(source_snapshot.warning));
+    auto source_snapshot = detail::snapshot_regular_file(request.unit.source);
+    append_snapshot_warning(
+        result.warnings,
+        request.unit.source,
+        std::move(source_snapshot.failure));
 
     std::vector<FileSnapshot> output_snapshots;
     output_snapshots.reserve(request.unit.outputs.size());
     for (const auto& output : request.unit.outputs) {
-        auto output_snapshot = snapshot_file(output.path);
-        append_warning(result.warnings, std::move(output_snapshot.warning));
+        auto output_snapshot = detail::snapshot_regular_file(output.path);
+        append_snapshot_warning(
+            result.warnings,
+            output.path,
+            std::move(output_snapshot.failure));
         output_snapshots.push_back(std::move(output_snapshot.snapshot));
     }
 
@@ -137,8 +90,11 @@ MsvcIncrementalCompileCoordinator::run(const IncrementalCompileRequest& request)
     if (cached_entry) {
         dependency_snapshots.reserve(cached_entry->dependencies.size());
         for (const auto& dependency : cached_entry->dependencies) {
-            auto dependency_snapshot = snapshot_file(dependency);
-            append_warning(result.warnings, std::move(dependency_snapshot.warning));
+            auto dependency_snapshot = detail::snapshot_regular_file(dependency);
+            append_snapshot_warning(
+                result.warnings,
+                dependency,
+                std::move(dependency_snapshot.failure));
             dependency_snapshots.push_back(std::move(dependency_snapshot.snapshot));
         }
     }

--- a/cpp/src/orchestration/incremental/MsvcIncrementalLinkCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalLinkCoordinator.cpp
@@ -17,31 +17,25 @@
 #include "mqb/msvc/MsvcLibraryResolver.hpp"
 #include "mqb/msvc/MsvcLinker.hpp"
 
+#include "IncrementalFileSnapshot.hpp"
+
 namespace mqb::orchestration {
 namespace {
 
 namespace fs = std::filesystem;
 
-[[nodiscard]] std::expected<FileSnapshot, std::string>
-snapshot_file(const fs::path& path) {
-    std::error_code error_code;
-    const bool exists = fs::exists(path, error_code);
-    if (error_code) {
-        return std::unexpected("failed to query file existence: " + error_code.message());
+[[nodiscard]] std::string snapshot_failure_message(
+    const detail::IncrementalFileSnapshotFailure& failure) {
+    const char* prefix = nullptr;
+    switch (failure.kind) {
+    case detail::IncrementalFileSnapshotFailureKind::status:
+        prefix = "failed to query file type: ";
+        break;
+    case detail::IncrementalFileSnapshotFailureKind::timestamp:
+        prefix = "failed to query file timestamp: ";
+        break;
     }
-    if (!exists) {
-        return FileSnapshot{.path = path, .exists = false};
-    }
-
-    const auto modified = fs::last_write_time(path, error_code);
-    if (error_code) {
-        return std::unexpected("failed to query file timestamp: " + error_code.message());
-    }
-    return FileSnapshot{
-        .path = path,
-        .exists = true,
-        .modified = modified,
-    };
+    return std::string{prefix} + failure.error_code.message();
 }
 
 void snapshot_inputs(
@@ -50,16 +44,15 @@ void snapshot_inputs(
     std::vector<IncrementalLinkWarning>& warnings) {
     snapshots.reserve(paths.size());
     for (const auto& path : paths) {
-        if (auto snapshot = snapshot_file(path)) {
-            snapshots.push_back(std::move(*snapshot));
-        } else {
+        auto snapshot = detail::snapshot_regular_file(path);
+        if (snapshot.failure) {
             warnings.push_back(IncrementalLinkWarning{
                 .code = IncrementalLinkWarningCode::file_snapshot_failed,
                 .path = path,
-                .message = snapshot.error(),
+                .message = snapshot_failure_message(*snapshot.failure),
             });
-            snapshots.push_back(FileSnapshot{.path = path, .exists = false});
         }
+        snapshots.push_back(std::move(snapshot.snapshot));
     }
 }
 
@@ -133,16 +126,15 @@ MsvcIncrementalLinkCoordinator::run(const IncrementalLinkRequest& request) const
         });
     }
 
-    FileSnapshot output_snapshot{.path = request.output, .exists = false};
-    if (auto snapshot = snapshot_file(request.output)) {
-        output_snapshot = std::move(*snapshot);
-    } else {
+    auto output_snapshot_result = detail::snapshot_regular_file(request.output);
+    if (output_snapshot_result.failure) {
         result.warnings.push_back(IncrementalLinkWarning{
             .code = IncrementalLinkWarningCode::file_snapshot_failed,
             .path = request.output,
-            .message = snapshot.error(),
+            .message = snapshot_failure_message(*output_snapshot_result.failure),
         });
     }
+    FileSnapshot output_snapshot = std::move(output_snapshot_result.snapshot);
 
     std::vector<FileSnapshot> object_snapshots;
     snapshot_inputs(request.objects, object_snapshots, result.warnings);

--- a/cpp/tests/orchestration/incremental/incremental_archive_coordinator_tests.cpp
+++ b/cpp/tests/orchestration/incremental/incremental_archive_coordinator_tests.cpp
@@ -1,0 +1,207 @@
+#include <algorithm>
+#include <chrono>
+#include <expected>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <string_view>
+
+#include "mqb/core/BuildTypes.hpp"
+#include "mqb/msvc/MsvcLibrarian.hpp"
+#include "mqb/msvc/MsvcToolchainLocator.hpp"
+#include "mqb/orchestration/MsvcIncrementalArchiveCoordinator.hpp"
+#include "mqb/process/Process.hpp"
+
+namespace {
+
+namespace fs = std::filesystem;
+int failures = 0;
+
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+class TemporaryDirectory {
+public:
+    TemporaryDirectory() {
+        const auto tick = std::chrono::steady_clock::now().time_since_epoch().count();
+        path_ = fs::temp_directory_path()
+            / ("mqb-archive-orchestration-test-" + std::to_string(tick));
+        fs::create_directories(path_);
+    }
+
+    ~TemporaryDirectory() {
+        std::error_code ignored;
+        fs::remove_all(path_, ignored);
+    }
+
+    [[nodiscard]] const fs::path& path() const noexcept { return path_; }
+
+private:
+    fs::path path_;
+};
+
+void write_text(const fs::path& path, const std::string_view text) {
+    if (!path.parent_path().empty()) {
+        fs::create_directories(path.parent_path());
+    }
+    std::ofstream file{path, std::ios::binary | std::ios::trunc};
+    file.write(text.data(), static_cast<std::streamsize>(text.size()));
+}
+
+class LibrarianLikeRunner final : public mqb::process::ProcessRunner {
+public:
+    int calls{};
+
+    std::expected<mqb::process::ProcessResult, mqb::process::ProcessError>
+    run(const mqb::process::ProcessSpec& spec) override {
+        ++calls;
+        const auto output_argument = std::find_if(
+            spec.arguments.begin(),
+            spec.arguments.end(),
+            [](const std::string& argument) {
+                return argument.starts_with("/OUT:");
+            });
+        if (output_argument == spec.arguments.end()) {
+            return mqb::process::ProcessResult{
+                .exit_code = 1,
+                .stderr_text = "simulated lib.exe invocation had no /OUT argument",
+            };
+        }
+
+        write_text(fs::path{output_argument->substr(5)}, "fake archive produced by librarian runner");
+        return mqb::process::ProcessResult{
+            .exit_code = 0,
+            .stdout_text = "simulated lib.exe success",
+        };
+    }
+};
+
+[[nodiscard]] bool has_reason(
+    const mqb::ArchiveCacheValidation& validation,
+    const mqb::BuildReason reason) {
+    return std::find(validation.reasons.begin(), validation.reasons.end(), reason)
+        != validation.reasons.end();
+}
+
+[[nodiscard]] bool has_warning(
+    const mqb::orchestration::IncrementalArchiveResult& result,
+    const mqb::orchestration::IncrementalArchiveWarningCode code) {
+    return std::any_of(
+        result.warnings.begin(),
+        result.warnings.end(),
+        [code](const mqb::orchestration::IncrementalArchiveWarning& warning) {
+            return warning.code == code;
+        });
+}
+
+} // namespace
+
+int main() {
+    TemporaryDirectory fixture;
+    const fs::path fake_compiler = fixture.path() / "toolchain" / "cl.exe";
+    const fs::path fake_linker = fixture.path() / "toolchain" / "link.exe";
+    const fs::path fake_librarian = fixture.path() / "toolchain" / "lib.exe";
+    const fs::path object = fixture.path() / "obj" / "main.cpp.obj";
+    const fs::path output = fixture.path() / "lib" / "main.lib";
+    const fs::path cache_file = fixture.path() / "cache" / "main.archivecache";
+
+    write_text(fake_compiler, "fake compiler identity bytes");
+    write_text(fake_linker, "fake linker identity bytes");
+    write_text(fake_librarian, "fake librarian identity bytes");
+    write_text(object, "fake object input");
+
+    const mqb::msvc::MsvcToolchain toolchain{
+        .identity = mqb::ToolchainIdentity{
+            .compiler = fake_compiler,
+            .version = "19.51.test",
+            .binary_stamp = "compiler-stamp",
+        },
+        .linker = fake_linker,
+        .librarian = fake_librarian,
+        .vc_tools_root = fixture.path() / "toolchain",
+        .source = mqb::msvc::ToolchainSource::visual_studio,
+    };
+
+    LibrarianLikeRunner runner;
+    mqb::msvc::MsvcLibrarian librarian{toolchain, runner};
+    mqb::orchestration::MsvcIncrementalArchiveCoordinator coordinator{toolchain, librarian};
+
+    const mqb::orchestration::IncrementalArchiveRequest request{
+        .objects = {object},
+        .output = output,
+        .cache_file = cache_file,
+        .working_directory = fixture.path(),
+        .link_time_code_generation = false,
+        .force_archive = false,
+    };
+
+    const auto cold = coordinator.run(request);
+    expect(cold.has_value(), "cold incremental archive should succeed");
+    if (cold) {
+        expect(cold->archived, "cold archive should execute one librarian action");
+        expect(cold->plan.actions.size() == 1,
+               "cold archive should retain one planned ArchiveAction");
+        expect(has_reason(cold->validation, mqb::BuildReason::missing_cache_entry),
+               "cold archive should explain missing archive cache");
+        expect(has_reason(cold->validation, mqb::BuildReason::missing_output),
+               "cold archive should explain missing static library");
+    }
+    expect(runner.calls == 1, "cold archive should invoke lib.exe exactly once");
+    expect(fs::is_regular_file(output), "cold archive should create static library output");
+    expect(fs::is_regular_file(cache_file), "cold archive should persist archive cache metadata");
+
+    const auto warm = coordinator.run(request);
+    expect(warm.has_value(), "warm archive validation should succeed");
+    if (warm) {
+        expect(!warm->archived, "unchanged warm archive should skip lib.exe");
+        expect(warm->plan.empty(), "unchanged warm archive should produce an empty plan");
+        expect(warm->validation.reusable(), "unchanged warm archive cache should be reusable");
+    }
+    expect(runner.calls == 1, "warm archive cache hit should not invoke lib.exe again");
+
+    std::error_code snapshot_error;
+    const auto output_time = fs::last_write_time(output, snapshot_error);
+    expect(!snapshot_error, "directory regression should read archive output timestamp");
+    snapshot_error.clear();
+    fs::remove(object, snapshot_error);
+    expect(!snapshot_error, "directory regression should remove the regular object file");
+    snapshot_error.clear();
+    fs::create_directory(object, snapshot_error);
+    expect(!snapshot_error, "directory regression should create a directory at the object path");
+    snapshot_error.clear();
+    fs::last_write_time(object, output_time - std::chrono::hours{1}, snapshot_error);
+    expect(!snapshot_error,
+           "directory regression should make the directory older than the archive output");
+
+    const auto directory_input = coordinator.run(request);
+    expect(directory_input.has_value(),
+           "directory object recheck should remain an incremental validation operation");
+    if (directory_input) {
+        expect(directory_input->archived,
+               "a directory at an object path must not be accepted as a reusable archive input");
+        expect(has_reason(
+                   directory_input->validation,
+                   mqb::BuildReason::archive_inputs_changed),
+               "directory object should invalidate archive input freshness");
+        expect(!has_warning(
+                   *directory_input,
+                   mqb::orchestration::IncrementalArchiveWarningCode::file_snapshot_failed),
+               "non-regular object paths should be ordinary missing snapshots, not I/O warnings");
+    }
+    expect(runner.calls == 2,
+           "directory object should force exactly one conservative rearchive");
+    expect(fs::is_regular_file(output),
+           "directory object regression should still leave a valid archive output");
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+    std::cout << "mqb_orchestration_incremental_archive_tests passed\n";
+    return 0;
+}

--- a/cpp/tests/orchestration/incremental/incremental_link_coordinator_tests.cpp
+++ b/cpp/tests/orchestration/incremental/incremental_link_coordinator_tests.cpp
@@ -206,6 +206,72 @@ int main() {
     }
     expect(runner.calls == 4, "corrupt metadata should invoke link.exe exactly once more");
 
+    const fs::path directory_object = fixture.path() / "obj" / "directory-input.obj";
+    const fs::path directory_output = fixture.path() / "bin" / "directory-input.exe";
+    const fs::path directory_cache = fixture.path() / "cache" / "directory-input.linkcache";
+    write_text(directory_object, "regular object before directory regression");
+
+    LinkerLikeRunner directory_runner;
+    directory_runner.output = directory_output;
+    mqb::msvc::MsvcLinker directory_linker{toolchain, directory_runner};
+    mqb::orchestration::MsvcIncrementalLinkCoordinator directory_coordinator{
+        toolchain, directory_linker};
+    const mqb::orchestration::IncrementalLinkRequest directory_request{
+        .objects = {directory_object},
+        .output = directory_output,
+        .options = debug_options,
+        .cache_file = directory_cache,
+        .working_directory = fixture.path(),
+        .force_relink = false,
+    };
+
+    const auto directory_cold = directory_coordinator.run(directory_request);
+    expect(directory_cold.has_value() && directory_cold->linked,
+           "directory regression fixture should create a warm link cache");
+    const auto directory_warm = directory_coordinator.run(directory_request);
+    expect(directory_warm.has_value() && !directory_warm->linked,
+           "directory regression fixture should begin as a reusable warm link");
+    expect(directory_runner.calls == 1,
+           "directory regression warm-up should invoke link.exe only for the cold build");
+
+    std::error_code directory_error;
+    const auto directory_output_time = fs::last_write_time(directory_output, directory_error);
+    expect(!directory_error,
+           "directory regression should read the existing output timestamp");
+    directory_error.clear();
+    fs::remove(directory_object, directory_error);
+    expect(!directory_error,
+           "directory regression should replace the object file");
+    directory_error.clear();
+    fs::create_directory(directory_object, directory_error);
+    expect(!directory_error,
+           "directory regression should create a directory at the object path");
+    directory_error.clear();
+    fs::last_write_time(
+        directory_object,
+        directory_output_time - std::chrono::hours{1},
+        directory_error);
+    expect(!directory_error,
+           "directory regression should make the directory older than the linked output");
+
+    const auto directory_recheck = directory_coordinator.run(directory_request);
+    expect(directory_recheck.has_value(),
+           "directory object recheck should remain an incremental validation operation");
+    if (directory_recheck) {
+        expect(directory_recheck->linked,
+               "a directory at an object path must not be accepted as a reusable file input");
+        expect(has_reason(
+                   directory_recheck->validation,
+                   mqb::BuildReason::link_inputs_changed),
+               "directory object should invalidate link input freshness");
+        expect(!has_warning(
+                   *directory_recheck,
+                   mqb::orchestration::IncrementalLinkWarningCode::file_snapshot_failed),
+               "non-regular object paths should be ordinary missing snapshots, not I/O warnings");
+    }
+    expect(directory_runner.calls == 2,
+           "directory object should force exactly one conservative relink");
+
     std::error_code ignored;
     fs::remove(cache_file, ignored);
     fs::remove(output, ignored);

--- a/tests/native/assert_cpp_layout.ps1
+++ b/tests/native/assert_cpp_layout.ps1
@@ -247,6 +247,7 @@ Assert-LeafLayout -Root (Join-Path $testsRoot 'msvc') -LeafFiles ([ordered]@{
 # in include/mqb/orchestration for API stability.
 $orchestrationLeafFiles = [ordered]@{
     'incremental' = @(
+        'IncrementalFileSnapshot.hpp',
         'MsvcIncrementalArchiveCoordinator.cpp',
         'MsvcIncrementalCompileCoordinator.cpp',
         'MsvcIncrementalLinkCoordinator.cpp',
@@ -266,6 +267,7 @@ $orchestrationLeafFiles = [ordered]@{
 Assert-LeafLayout -Root (Join-Path $srcRoot 'orchestration') -LeafFiles $orchestrationLeafFiles
 Assert-LeafLayout -Root (Join-Path $testsRoot 'orchestration') -LeafFiles ([ordered]@{
     'incremental' = @(
+        'incremental_archive_coordinator_tests.cpp',
         'incremental_compile_coordinator_tests.cpp',
         'incremental_link_coordinator_tests.cpp',
         'incremental_target_coordinator_tests.cpp'

--- a/tests/native/run_native_tests.ps1
+++ b/tests/native/run_native_tests.ps1
@@ -84,8 +84,8 @@ if ($includeDirs.Count -eq 0) { throw 'Native test config has no include_dirs.' 
 $allTestFiles = @(Get-ChildItem -LiteralPath $cppRoot -Recurse -File -Filter '*_tests.cpp' |
     Where-Object { $_.FullName -notmatch '[\\/]\.mqb[\\/]' } |
     Sort-Object FullName)
-if ($allTestFiles.Count -ne 67) {
-    throw "Native test manifest drift: expected 67 *_tests.cpp files, found $($allTestFiles.Count)."
+if ($allTestFiles.Count -ne 68) {
+    throw "Native test manifest drift: expected 68 *_tests.cpp files, found $($allTestFiles.Count)."
 }
 
 function Get-TestRelativePath {
@@ -120,7 +120,7 @@ $testWeightOverrides = [ordered]@{
 $relativeTestPaths = @($allTestFiles | ForEach-Object { Get-TestRelativePath -File $_ })
 foreach ($weightedPath in $testWeightOverrides.Keys) {
     if ($weightedPath -notin $relativeTestPaths) {
-        throw "Native test weight override is stale or missing from the 67-test manifest: $weightedPath"
+        throw "Native test weight override is stale or missing from the 68-test manifest: $weightedPath"
     }
 }
 


### PR DESCRIPTION
Unify incremental compile, link, and archive cache filesystem snapshots behind one private policy while keeping all public orchestration APIs stable.

Key changes:
- add private `IncrementalFileSnapshot.hpp` shared by compile/link/archive coordinators
- treat only regular files as present snapshots; directories/special files and ENOENT races degrade to ordinary missing files
- preserve real status/timestamp I/O failures as coordinator-specific warnings
- add a link regression proving a directory substituted at an object path invalidates a warm link cache
- add the missing dedicated incremental archive coordinator test with the same directory-input regression
- extend the exact orchestration layout contract
- intentionally grow the native test graph from 67 to 68 tests
- keep the production manifest unchanged at 60 non-main translation units

Validation is pending on exact head `aa24cd8f37fdeafff3337d2775867101b40ad86c`.