### PR TITLE
refactor: decompose module target preparation

### DIFF
--- a/cpp/mqb.json
+++ b/cpp/mqb.json
@@ -79,10 +79,13 @@
       "src/orchestration/incremental/MsvcIncrementalTargetCoordinator.cpp",
       "src/orchestration/modules/ModuleCompilePlan.cpp",
       "src/orchestration/modules/ModuleCompileRequestFactory.cpp",
+      "src/orchestration/modules/ModuleTargetArtifactRegistry.cpp",
       "src/orchestration/modules/ModuleTargetLinkRequestFactory.cpp",
       "src/orchestration/modules/ModuleTargetPreparation.cpp",
+      "src/orchestration/modules/ModuleTargetScanner.cpp",
       "src/orchestration/modules/MsvcModuleCompileCoordinator.cpp",
       "src/orchestration/modules/MsvcModuleTargetCoordinator.cpp",
+      "src/orchestration/modules/StandardLibraryModuleProvider.cpp",
       "src/orchestration/routing/MsvcTargetRouter.cpp",
       "src/platform/windows/CommandLine.cpp",
       "src/platform/windows/WindowsProcessRunner.cpp"

--- a/cpp/src/orchestration/modules/ModuleTargetArtifactRegistry.cpp
+++ b/cpp/src/orchestration/modules/ModuleTargetArtifactRegistry.cpp
@@ -1,0 +1,194 @@
+#include "ModuleTargetArtifactRegistry.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <string>
+#include <utility>
+
+namespace mqb::orchestration::detail {
+namespace {
+
+namespace fs = std::filesystem;
+
+[[nodiscard]] std::string windows_path_key(const fs::path& path) {
+    std::string value = path.lexically_normal().generic_string();
+    std::transform(
+        value.begin(), value.end(), value.begin(),
+        [](const unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+    return value;
+}
+
+[[nodiscard]] IncrementalModuleTargetError failure(
+    const IncrementalModuleTargetErrorCode code,
+    std::string message,
+    fs::path source = {}) {
+    return IncrementalModuleTargetError{
+        .code = code,
+        .message = std::move(message),
+        .source = std::move(source),
+    };
+}
+
+[[nodiscard]] IncrementalModuleTargetError artifact_failure(
+    const IncrementalModuleTargetErrorCode code,
+    std::string message,
+    const fs::path& source,
+    const fs::path& artifact) {
+    return IncrementalModuleTargetError{
+        .code = code,
+        .message = std::move(message),
+        .source = source,
+        .artifact = artifact,
+    };
+}
+
+} // namespace
+
+ModuleTargetArtifactRegistry::ModuleTargetArtifactRegistry(
+    const std::size_t expected_source_count) {
+    seen_sources_.reserve(expected_source_count + 2u);
+    claimed_artifacts_.reserve(expected_source_count * 5u + 18u);
+}
+
+std::expected<void, IncrementalModuleTargetError>
+ModuleTargetArtifactRegistry::claim(
+    const fs::path& source,
+    const fs::path& artifact,
+    const std::string_view role) {
+    if (artifact.empty()) {
+        return std::unexpected(artifact_failure(
+            IncrementalModuleTargetErrorCode::invalid_artifact,
+            "module target " + std::string{role} + " artifact path is empty",
+            source,
+            artifact));
+    }
+    if (!claimed_artifacts_.emplace(windows_path_key(artifact)).second) {
+        return std::unexpected(artifact_failure(
+            IncrementalModuleTargetErrorCode::artifact_collision,
+            "module target " + std::string{role}
+                + " artifact collides with another planned writable artifact",
+            source,
+            artifact));
+    }
+    return {};
+}
+
+std::expected<void, IncrementalModuleTargetError>
+ModuleTargetArtifactRegistry::add_requested_source(
+    const ModuleCompileSourceRequest& source) {
+    if (source.source.empty()) {
+        return std::unexpected(failure(
+            IncrementalModuleTargetErrorCode::duplicate_source,
+            "module target source path is empty",
+            source.source));
+    }
+    if (!seen_sources_.emplace(windows_path_key(source.source)).second) {
+        return std::unexpected(failure(
+            IncrementalModuleTargetErrorCode::duplicate_source,
+            "module target contains the same source more than once",
+            source.source));
+    }
+
+    if (auto result = claim(source.source, source.artifacts.object, "object"); !result) {
+        return result;
+    }
+    if (auto result = claim(
+            source.source,
+            source.artifacts.dependencies,
+            "source-dependency metadata"); !result) {
+        return result;
+    }
+    if (auto result = claim(
+            source.source,
+            source.artifacts.module_dependencies,
+            "module-scan metadata"); !result) {
+        return result;
+    }
+    if (auto result = claim(
+            source.source,
+            source.artifacts.compile_cache,
+            "compile-cache metadata"); !result) {
+        return result;
+    }
+    if (source.kind == TranslationUnitKind::module_interface) {
+        if (auto result = claim(
+                source.source,
+                source.artifacts.module_interface,
+                "IFC"); !result) {
+            return result;
+        }
+    }
+    return {};
+}
+
+std::expected<void, IncrementalModuleTargetError>
+ModuleTargetArtifactRegistry::add_target(const TargetArtifacts& target) {
+    if (auto result = claim({}, target.executable, "executable"); !result) {
+        return result;
+    }
+    return claim({}, target.link_cache, "link-cache metadata");
+}
+
+std::expected<void, IncrementalModuleTargetError>
+ModuleTargetArtifactRegistry::add_standard_library_source_identity(
+    const fs::path& source) {
+    if (!seen_sources_.emplace(windows_path_key(source)).second) {
+        return std::unexpected(failure(
+            IncrementalModuleTargetErrorCode::duplicate_source,
+            "toolchain standard-library module source collides with another target source",
+            source));
+    }
+    return {};
+}
+
+std::expected<void, IncrementalModuleTargetError>
+ModuleTargetArtifactRegistry::add_standard_library_artifacts(
+    const fs::path& source,
+    const SourceArtifacts& artifacts) {
+    if (auto result = claim(source, artifacts.object, "standard-library module object"); !result) {
+        return result;
+    }
+    if (auto result = claim(
+            source,
+            artifacts.dependencies,
+            "standard-library source-dependency metadata"); !result) {
+        return result;
+    }
+    if (auto result = claim(
+            source,
+            artifacts.module_dependencies,
+            "standard-library module-scan metadata"); !result) {
+        return result;
+    }
+    if (auto result = claim(
+            source,
+            artifacts.compile_cache,
+            "standard-library compile-cache metadata"); !result) {
+        return result;
+    }
+    return claim(source, artifacts.module_interface, "standard-library IFC");
+}
+
+std::expected<void, IncrementalModuleTargetError>
+ModuleTargetArtifactRegistry::add_header_unit_source(
+    const fs::path& source,
+    const SourceArtifacts& artifacts) {
+    // Header units are IFC-only producers. Object and module-scan paths from
+    // SourceArtifacts remain reserved layout slots but are not writable inputs
+    // to this target, so register only the artifacts this producer writes.
+    if (auto result = claim(
+            source,
+            artifacts.dependencies,
+            "header-unit source-dependency metadata"); !result) {
+        return result;
+    }
+    if (auto result = claim(
+            source,
+            artifacts.compile_cache,
+            "header-unit compile-cache metadata"); !result) {
+        return result;
+    }
+    return claim(source, artifacts.module_interface, "header-unit IFC");
+}
+
+} // namespace mqb::orchestration::detail

--- a/cpp/src/orchestration/modules/ModuleTargetArtifactRegistry.hpp
+++ b/cpp/src/orchestration/modules/ModuleTargetArtifactRegistry.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <cstddef>
+#include <expected>
+#include <filesystem>
+#include <string>
+#include <string_view>
+#include <unordered_set>
+
+#include "mqb/orchestration/MsvcModuleTargetCoordinator.hpp"
+
+namespace mqb::orchestration::detail {
+
+class ModuleTargetArtifactRegistry {
+public:
+    explicit ModuleTargetArtifactRegistry(std::size_t expected_source_count);
+
+    [[nodiscard]] std::expected<void, IncrementalModuleTargetError>
+    add_requested_source(const ModuleCompileSourceRequest& source);
+
+    [[nodiscard]] std::expected<void, IncrementalModuleTargetError>
+    add_target(const TargetArtifacts& target);
+
+    [[nodiscard]] std::expected<void, IncrementalModuleTargetError>
+    add_standard_library_source_identity(const std::filesystem::path& source);
+
+    [[nodiscard]] std::expected<void, IncrementalModuleTargetError>
+    add_standard_library_artifacts(
+        const std::filesystem::path& source,
+        const SourceArtifacts& artifacts);
+
+    [[nodiscard]] std::expected<void, IncrementalModuleTargetError>
+    add_header_unit_source(
+        const std::filesystem::path& source,
+        const SourceArtifacts& artifacts);
+
+private:
+    [[nodiscard]] std::expected<void, IncrementalModuleTargetError>
+    claim(
+        const std::filesystem::path& source,
+        const std::filesystem::path& artifact,
+        std::string_view role);
+
+    std::unordered_set<std::string> seen_sources_;
+    std::unordered_set<std::string> claimed_artifacts_;
+};
+
+} // namespace mqb::orchestration::detail

--- a/cpp/src/orchestration/modules/ModuleTargetPreparation.cpp
+++ b/cpp/src/orchestration/modules/ModuleTargetPreparation.cpp
@@ -1,33 +1,21 @@
 #include "ModuleTargetPreparation.hpp"
 
-#include <algorithm>
-#include <cctype>
 #include <expected>
 #include <filesystem>
 #include <optional>
 #include <string>
-#include <string_view>
-#include <system_error>
-#include <unordered_set>
 #include <utility>
 #include <vector>
 
+#include "ModuleTargetArtifactRegistry.hpp"
+#include "ModuleTargetScanner.hpp"
+#include "StandardLibraryModuleProvider.hpp"
 #include "mqb/modules/ModuleDependencyGraph.hpp"
-#include "mqb/msvc/MsvcModuleDependencyScanner.hpp"
-#include "mqb/orchestration/BoundedWorkScheduler.hpp"
 
 namespace mqb::orchestration::detail {
 namespace {
 
 namespace fs = std::filesystem;
-
-[[nodiscard]] std::string windows_path_key(const fs::path& path) {
-    std::string value = path.lexically_normal().generic_string();
-    std::transform(
-        value.begin(), value.end(), value.begin(),
-        [](const unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
-    return value;
-}
 
 [[nodiscard]] IncrementalModuleTargetError failure(
     const IncrementalModuleTargetErrorCode code,
@@ -38,50 +26,6 @@ namespace fs = std::filesystem;
         .message = std::move(message),
         .source = std::move(source),
     };
-}
-
-[[nodiscard]] IncrementalModuleTargetError artifact_failure(
-    const IncrementalModuleTargetErrorCode code,
-    std::string message,
-    const fs::path& source,
-    const fs::path& artifact) {
-    return IncrementalModuleTargetError{
-        .code = code,
-        .message = std::move(message),
-        .source = source,
-        .artifact = artifact,
-    };
-}
-
-[[nodiscard]] std::optional<IncrementalModuleTargetError> claim_artifact(
-    std::unordered_set<std::string>& claimed,
-    const fs::path& source,
-    const fs::path& artifact,
-    const std::string_view role) {
-    if (artifact.empty()) {
-        return artifact_failure(
-            IncrementalModuleTargetErrorCode::invalid_artifact,
-            "module target " + std::string{role} + " artifact path is empty",
-            source,
-            artifact);
-    }
-    if (!claimed.emplace(windows_path_key(artifact)).second) {
-        return artifact_failure(
-            IncrementalModuleTargetErrorCode::artifact_collision,
-            "module target " + std::string{role}
-                + " artifact collides with another planned writable artifact",
-            source,
-            artifact);
-    }
-    return std::nullopt;
-}
-
-[[nodiscard]] std::optional<fs::path> working_directory_for(
-    const fs::path& requested,
-    const fs::path& source) {
-    if (!requested.empty()) return requested;
-    if (!source.parent_path().empty()) return source.parent_path();
-    return std::nullopt;
 }
 
 [[nodiscard]] std::optional<HeaderUnitLookupMethod> core_lookup_method(
@@ -95,66 +39,6 @@ namespace fs = std::filesystem;
         return std::nullopt;
     }
     return std::nullopt;
-}
-
-[[nodiscard]] bool standard_library_module_name(const std::string_view logical_name) noexcept {
-    return logical_name == "std" || logical_name == "std.compat";
-}
-
-[[nodiscard]] std::optional<fs::path> standard_library_module_source(
-    const msvc::MsvcToolchain& toolchain,
-    const std::string_view logical_name) {
-    if (logical_name == "std") return toolchain.standard_library_modules.std;
-    if (logical_name == "std.compat") return toolchain.standard_library_modules.std_compat;
-    return std::nullopt;
-}
-
-[[nodiscard]] bool named_requirement(const modules::RequiredModule& requirement) noexcept {
-    return !requirement.unique_on_source_path
-        && requirement.lookup_method == modules::LookupMethod::by_name;
-}
-
-struct PendingStandardLibraryRequirement {
-    fs::path consumer;
-    std::string logical_name;
-};
-
-[[nodiscard]] std::optional<PendingStandardLibraryRequirement>
-next_standard_library_requirement(
-    const std::vector<modules::ScannedModuleUnit>& units,
-    const std::unordered_set<std::string>& injected) {
-    for (const auto& unit : units) {
-        for (const auto& requirement : unit.rule.required_modules) {
-            if (!named_requirement(requirement)
-                || !standard_library_module_name(requirement.logical_name)
-                || injected.contains(requirement.logical_name)) {
-                continue;
-            }
-            return PendingStandardLibraryRequirement{
-                .consumer = unit.source,
-                .logical_name = requirement.logical_name,
-            };
-        }
-    }
-    return std::nullopt;
-}
-
-[[nodiscard]] bool provides_named_interface(
-    const modules::P1689Rule& rule,
-    const std::string_view logical_name) {
-    return std::any_of(
-        rule.provided_modules.begin(),
-        rule.provided_modules.end(),
-        [&](const modules::ProvidedModule& provided) {
-            return !provided.unique_on_source_path
-                && provided.is_interface
-                && provided.logical_name == logical_name;
-        });
-}
-
-[[nodiscard]] bool regular_file(const fs::path& path) {
-    std::error_code error_code;
-    return fs::is_regular_file(path, error_code) && !error_code;
 }
 
 } // namespace
@@ -174,264 +58,34 @@ prepare_module_target(
             "module target scan and compile parallelism must both be at least one"));
     }
 
-    std::unordered_set<std::string> seen_sources;
-    std::unordered_set<std::string> claimed_artifacts;
-    seen_sources.reserve(request.sources.size() + 2u);
-    claimed_artifacts.reserve(request.sources.size() * 5u + 18u);
-
+    ModuleTargetArtifactRegistry artifacts{request.sources.size()};
     for (const auto& source : request.sources) {
-        if (source.source.empty()) {
-            return std::unexpected(failure(
-                IncrementalModuleTargetErrorCode::duplicate_source,
-                "module target source path is empty",
-                source.source));
-        }
-        if (!seen_sources.emplace(windows_path_key(source.source)).second) {
-            return std::unexpected(failure(
-                IncrementalModuleTargetErrorCode::duplicate_source,
-                "module target contains the same source more than once",
-                source.source));
-        }
-
-        if (auto error = claim_artifact(
-                claimed_artifacts, source.source, source.artifacts.object, "object")) {
-            return std::unexpected(std::move(*error));
-        }
-        if (auto error = claim_artifact(
-                claimed_artifacts,
-                source.source,
-                source.artifacts.dependencies,
-                "source-dependency metadata")) {
-            return std::unexpected(std::move(*error));
-        }
-        if (auto error = claim_artifact(
-                claimed_artifacts,
-                source.source,
-                source.artifacts.module_dependencies,
-                "module-scan metadata")) {
-            return std::unexpected(std::move(*error));
-        }
-        if (auto error = claim_artifact(
-                claimed_artifacts,
-                source.source,
-                source.artifacts.compile_cache,
-                "compile-cache metadata")) {
-            return std::unexpected(std::move(*error));
-        }
-        if (source.kind == TranslationUnitKind::module_interface) {
-            if (auto error = claim_artifact(
-                    claimed_artifacts,
-                    source.source,
-                    source.artifacts.module_interface,
-                    "IFC")) {
-                return std::unexpected(std::move(*error));
-            }
+        if (auto registered = artifacts.add_requested_source(source); !registered) {
+            return std::unexpected(std::move(registered.error()));
         }
     }
-
-    if (auto error = claim_artifact(
-            claimed_artifacts, {}, request.target.executable, "executable")) {
-        return std::unexpected(std::move(*error));
-    }
-    if (auto error = claim_artifact(
-            claimed_artifacts, {}, request.target.link_cache, "link-cache metadata")) {
-        return std::unexpected(std::move(*error));
+    if (auto registered = artifacts.add_target(request.target); !registered) {
+        return std::unexpected(std::move(registered.error()));
     }
 
-    using ScanAttempt = std::expected<msvc::ModuleScanResult, msvc::ModuleScanError>;
-    std::vector<std::optional<ScanAttempt>> attempts(request.sources.size());
-
-    const auto scheduled = BoundedWorkScheduler::run(
-        request.sources.size(), request.max_parallel_scans,
-        [&](const std::size_t index) {
-            const auto& source = request.sources[index];
-            msvc::ModuleScanInvocation invocation{
-                .source = source.source,
-                .output_file = source.artifacts.module_dependencies,
-                .options = request.compiler_options,
-                .kind = source.kind,
-                .working_directory = working_directory_for(
-                    request.working_directory,
-                    source.source),
-            };
-            attempts[index].emplace(scanner.scan(invocation));
-            return attempts[index]->has_value();
-        });
-    if (!scheduled) {
-        return std::unexpected(failure(
-            IncrementalModuleTargetErrorCode::scheduling_failed,
-            "module scan scheduler failed: " + scheduled.error().message));
-    }
-
-    for (std::size_t index = 0; index < attempts.size(); ++index) {
-        if (attempts[index] && !attempts[index]->has_value()) {
-            IncrementalModuleTargetError error = failure(
-                IncrementalModuleTargetErrorCode::scan_failed,
-                "module dependency scan failed",
-                request.sources[index].source);
-            error.scan_error = attempts[index]->error();
-            return std::unexpected(std::move(error));
-        }
+    auto scanned = scan_requested_module_sources(request, scanner);
+    if (!scanned) {
+        return std::unexpected(std::move(scanned.error()));
     }
 
     ModuleTargetPreparation prepared;
-    prepared.scans.reserve(request.sources.size());
-    std::vector<modules::ScannedModuleUnit> scanned_units;
-    scanned_units.reserve(request.sources.size() + 2u);
+    prepared.scans = std::move(scanned->scans);
+    std::vector<modules::ScannedModuleUnit> scanned_units = std::move(scanned->units);
     std::vector<ModuleCompileSourceRequest> compile_sources = request.sources;
     compile_sources.reserve(request.sources.size() + 2u);
 
-    for (std::size_t index = 0; index < request.sources.size(); ++index) {
-        if (!attempts[index]) {
-            return std::unexpected(failure(
-                IncrementalModuleTargetErrorCode::scheduling_failed,
-                "module scan scheduler stopped without a recorded scan failure",
-                request.sources[index].source));
-        }
-        auto scan = std::move(attempts[index]->value());
-        if (scan.dependencies.rules.size() != 1) {
-            return std::unexpected(failure(
-                IncrementalModuleTargetErrorCode::invalid_scan_result,
-                "one-source module scan must produce exactly one P1689 rule",
-                request.sources[index].source));
-        }
-        scanned_units.push_back(modules::ScannedModuleUnit{
-            .source = request.sources[index].source,
-            .rule = scan.dependencies.rules.front(),
-        });
-        prepared.scans.push_back(ModuleTargetScanResult{
-            .source = request.sources[index].source,
-            .result = std::move(scan),
-        });
-    }
-
-    // P1689 from the user's selected TUs is the only trigger for standard-library
-    // provider injection. Newly scanned toolchain providers may in turn require
-    // another toolchain-owned standard module (std.compat -> std), so repeat to
-    // a fixed point before handing the complete topology to the graph owner.
-    std::unordered_set<std::string> injected_standard_modules;
-    while (auto pending = next_standard_library_requirement(
-               scanned_units,
-               injected_standard_modules)) {
-        if (request.compiler_options.standard != CppStandard::latest) {
-            return std::unexpected(failure(
-                IncrementalModuleTargetErrorCode::standard_library_module_standard_unsupported,
-                "MSVC standard-library module '" + pending->logical_name
-                    + "' requires --std latest",
-                pending->consumer));
-        }
-        if (!request.artifact_layout) {
-            return std::unexpected(failure(
-                IncrementalModuleTargetErrorCode::artifact_layout_missing,
-                "standard-library module provider requires an artifact layout",
-                pending->consumer));
-        }
-
-        auto source = standard_library_module_source(
-            scanner.toolchain(),
-            pending->logical_name);
-        if (!source || source->empty() || !regular_file(*source)) {
-            return std::unexpected(failure(
-                IncrementalModuleTargetErrorCode::standard_library_module_unavailable,
-                "selected MSVC toolchain " + scanner.toolchain().identity.version
-                    + " does not provide standard-library module source '"
-                    + pending->logical_name + "'",
-                pending->consumer));
-        }
-
-        if (!seen_sources.emplace(windows_path_key(*source)).second) {
-            return std::unexpected(failure(
-                IncrementalModuleTargetErrorCode::duplicate_source,
-                "toolchain standard-library module source collides with another target source",
-                *source));
-        }
-
-        auto artifacts = request.artifact_layout->for_source(*source);
-        if (!artifacts) {
-            IncrementalModuleTargetError error = failure(
-                IncrementalModuleTargetErrorCode::artifact_layout_failed,
-                "failed to assign artifacts to standard-library module provider",
-                *source);
-            error.artifact_layout_error = artifacts.error();
-            return std::unexpected(std::move(error));
-        }
-
-        if (auto error = claim_artifact(
-                claimed_artifacts,
-                *source,
-                artifacts->object,
-                "standard-library module object")) {
-            return std::unexpected(std::move(*error));
-        }
-        if (auto error = claim_artifact(
-                claimed_artifacts,
-                *source,
-                artifacts->dependencies,
-                "standard-library source-dependency metadata")) {
-            return std::unexpected(std::move(*error));
-        }
-        if (auto error = claim_artifact(
-                claimed_artifacts,
-                *source,
-                artifacts->module_dependencies,
-                "standard-library module-scan metadata")) {
-            return std::unexpected(std::move(*error));
-        }
-        if (auto error = claim_artifact(
-                claimed_artifacts,
-                *source,
-                artifacts->compile_cache,
-                "standard-library compile-cache metadata")) {
-            return std::unexpected(std::move(*error));
-        }
-        if (auto error = claim_artifact(
-                claimed_artifacts,
-                *source,
-                artifacts->module_interface,
-                "standard-library IFC")) {
-            return std::unexpected(std::move(*error));
-        }
-
-        msvc::ModuleScanInvocation invocation{
-            .source = *source,
-            .output_file = artifacts->module_dependencies,
-            .options = request.compiler_options,
-            .kind = TranslationUnitKind::module_interface,
-            .working_directory = working_directory_for(
-                request.working_directory,
-                *source),
-        };
-        auto scan = scanner.scan(invocation);
-        if (!scan) {
-            IncrementalModuleTargetError error = failure(
-                IncrementalModuleTargetErrorCode::scan_failed,
-                "standard-library module dependency scan failed",
-                *source);
-            error.scan_error = scan.error();
-            return std::unexpected(std::move(error));
-        }
-        if (scan->dependencies.rules.size() != 1
-            || !provides_named_interface(
-                scan->dependencies.rules.front(),
-                pending->logical_name)) {
-            return std::unexpected(failure(
-                IncrementalModuleTargetErrorCode::invalid_scan_result,
-                "selected MSVC standard-library module source did not provide expected interface '"
-                    + pending->logical_name + "'",
-                *source));
-        }
-
-        scanned_units.push_back(modules::ScannedModuleUnit{
-            .source = *source,
-            .rule = scan->dependencies.rules.front(),
-            .toolchain_owned = true,
-        });
-        compile_sources.push_back(ModuleCompileSourceRequest{
-            .source = *source,
-            .artifacts = std::move(*artifacts),
-            .kind = TranslationUnitKind::module_interface,
-        });
-        injected_standard_modules.emplace(std::move(pending->logical_name));
+    if (auto injected = inject_standard_library_module_providers(
+            request,
+            scanner,
+            artifacts,
+            scanned_units,
+            compile_sources); !injected) {
+        return std::unexpected(std::move(injected.error()));
     }
 
     auto plan = modules::ModuleDependencyGraphBuilder::build(
@@ -463,46 +117,28 @@ prepare_module_target(
                 "resolved header-unit provider has a non-header lookup method",
                 header.source));
         }
-        auto artifacts = request.artifact_layout->for_source(header.source);
-        if (!artifacts) {
+
+        auto header_artifacts = request.artifact_layout->for_source(header.source);
+        if (!header_artifacts) {
             IncrementalModuleTargetError error = failure(
                 IncrementalModuleTargetErrorCode::artifact_layout_failed,
                 "failed to assign artifacts to discovered header-unit provider",
                 header.source);
-            error.artifact_layout_error = artifacts.error();
+            error.artifact_layout_error = header_artifacts.error();
             return std::unexpected(std::move(error));
         }
 
-        // Header units are IFC-only producers: object and module-scan paths from
-        // SourceArtifacts are reserved layout slots but are not writable inputs
-        // to this target. Claim only what the producer actually writes.
-        if (auto error = claim_artifact(
-                claimed_artifacts,
+        if (auto registered = artifacts.add_header_unit_source(
                 header.source,
-                artifacts->dependencies,
-                "header-unit source-dependency metadata")) {
-            return std::unexpected(std::move(*error));
-        }
-        if (auto error = claim_artifact(
-                claimed_artifacts,
-                header.source,
-                artifacts->compile_cache,
-                "header-unit compile-cache metadata")) {
-            return std::unexpected(std::move(*error));
-        }
-        if (auto error = claim_artifact(
-                claimed_artifacts,
-                header.source,
-                artifacts->module_interface,
-                "header-unit IFC")) {
-            return std::unexpected(std::move(*error));
+                *header_artifacts); !registered) {
+            return std::unexpected(std::move(registered.error()));
         }
 
         header_units.push_back(ModuleCompileHeaderUnitRequest{
             .source = header.source,
             .header_name = header.header_name,
             .lookup_method = *lookup,
-            .artifacts = std::move(*artifacts),
+            .artifacts = std::move(*header_artifacts),
         });
     }
 

--- a/cpp/src/orchestration/modules/ModuleTargetScanner.cpp
+++ b/cpp/src/orchestration/modules/ModuleTargetScanner.cpp
@@ -1,0 +1,109 @@
+#include "ModuleTargetScanner.hpp"
+
+#include <expected>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "mqb/orchestration/BoundedWorkScheduler.hpp"
+
+namespace mqb::orchestration::detail {
+namespace {
+
+namespace fs = std::filesystem;
+
+[[nodiscard]] IncrementalModuleTargetError failure(
+    const IncrementalModuleTargetErrorCode code,
+    std::string message,
+    fs::path source = {}) {
+    return IncrementalModuleTargetError{
+        .code = code,
+        .message = std::move(message),
+        .source = std::move(source),
+    };
+}
+
+[[nodiscard]] std::optional<fs::path> working_directory_for(
+    const fs::path& requested,
+    const fs::path& source) {
+    if (!requested.empty()) return requested;
+    if (!source.parent_path().empty()) return source.parent_path();
+    return std::nullopt;
+}
+
+} // namespace
+
+std::expected<ModuleTargetScanBatch, IncrementalModuleTargetError>
+scan_requested_module_sources(
+    const IncrementalModuleTargetRequest& request,
+    msvc::MsvcModuleDependencyScanner& scanner) {
+    using ScanAttempt = std::expected<msvc::ModuleScanResult, msvc::ModuleScanError>;
+    std::vector<std::optional<ScanAttempt>> attempts(request.sources.size());
+
+    const auto scheduled = BoundedWorkScheduler::run(
+        request.sources.size(), request.max_parallel_scans,
+        [&](const std::size_t index) {
+            const auto& source = request.sources[index];
+            msvc::ModuleScanInvocation invocation{
+                .source = source.source,
+                .output_file = source.artifacts.module_dependencies,
+                .options = request.compiler_options,
+                .kind = source.kind,
+                .working_directory = working_directory_for(
+                    request.working_directory,
+                    source.source),
+            };
+            attempts[index].emplace(scanner.scan(invocation));
+            return attempts[index]->has_value();
+        });
+    if (!scheduled) {
+        return std::unexpected(failure(
+            IncrementalModuleTargetErrorCode::scheduling_failed,
+            "module scan scheduler failed: " + scheduled.error().message));
+    }
+
+    for (std::size_t index = 0; index < attempts.size(); ++index) {
+        if (attempts[index] && !attempts[index]->has_value()) {
+            IncrementalModuleTargetError error = failure(
+                IncrementalModuleTargetErrorCode::scan_failed,
+                "module dependency scan failed",
+                request.sources[index].source);
+            error.scan_error = attempts[index]->error();
+            return std::unexpected(std::move(error));
+        }
+    }
+
+    ModuleTargetScanBatch batch;
+    batch.scans.reserve(request.sources.size());
+    batch.units.reserve(request.sources.size() + 2u);
+
+    for (std::size_t index = 0; index < request.sources.size(); ++index) {
+        if (!attempts[index]) {
+            return std::unexpected(failure(
+                IncrementalModuleTargetErrorCode::scheduling_failed,
+                "module scan scheduler stopped without a recorded scan failure",
+                request.sources[index].source));
+        }
+        auto scan = std::move(attempts[index]->value());
+        if (scan.dependencies.rules.size() != 1) {
+            return std::unexpected(failure(
+                IncrementalModuleTargetErrorCode::invalid_scan_result,
+                "one-source module scan must produce exactly one P1689 rule",
+                request.sources[index].source));
+        }
+        batch.units.push_back(modules::ScannedModuleUnit{
+            .source = request.sources[index].source,
+            .rule = scan.dependencies.rules.front(),
+        });
+        batch.scans.push_back(ModuleTargetScanResult{
+            .source = request.sources[index].source,
+            .result = std::move(scan),
+        });
+    }
+
+    return batch;
+}
+
+} // namespace mqb::orchestration::detail

--- a/cpp/src/orchestration/modules/ModuleTargetScanner.hpp
+++ b/cpp/src/orchestration/modules/ModuleTargetScanner.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <expected>
+#include <vector>
+
+#include "mqb/orchestration/MsvcModuleTargetCoordinator.hpp"
+
+namespace mqb::orchestration::detail {
+
+struct ModuleTargetScanBatch {
+    std::vector<ModuleTargetScanResult> scans;
+    std::vector<modules::ScannedModuleUnit> units;
+};
+
+[[nodiscard]] std::expected<ModuleTargetScanBatch, IncrementalModuleTargetError>
+scan_requested_module_sources(
+    const IncrementalModuleTargetRequest& request,
+    msvc::MsvcModuleDependencyScanner& scanner);
+
+} // namespace mqb::orchestration::detail

--- a/cpp/src/orchestration/modules/StandardLibraryModuleProvider.cpp
+++ b/cpp/src/orchestration/modules/StandardLibraryModuleProvider.cpp
@@ -1,0 +1,208 @@
+#include "StandardLibraryModuleProvider.hpp"
+
+#include <algorithm>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace mqb::orchestration::detail {
+namespace {
+
+namespace fs = std::filesystem;
+
+[[nodiscard]] IncrementalModuleTargetError failure(
+    const IncrementalModuleTargetErrorCode code,
+    std::string message,
+    fs::path source = {}) {
+    return IncrementalModuleTargetError{
+        .code = code,
+        .message = std::move(message),
+        .source = std::move(source),
+    };
+}
+
+[[nodiscard]] std::optional<fs::path> working_directory_for(
+    const fs::path& requested,
+    const fs::path& source) {
+    if (!requested.empty()) return requested;
+    if (!source.parent_path().empty()) return source.parent_path();
+    return std::nullopt;
+}
+
+[[nodiscard]] bool standard_library_module_name(
+    const std::string_view logical_name) noexcept {
+    return logical_name == "std" || logical_name == "std.compat";
+}
+
+[[nodiscard]] std::optional<fs::path> standard_library_module_source(
+    const msvc::MsvcToolchain& toolchain,
+    const std::string_view logical_name) {
+    if (logical_name == "std") return toolchain.standard_library_modules.std;
+    if (logical_name == "std.compat") return toolchain.standard_library_modules.std_compat;
+    return std::nullopt;
+}
+
+[[nodiscard]] bool named_requirement(
+    const modules::RequiredModule& requirement) noexcept {
+    return !requirement.unique_on_source_path
+        && requirement.lookup_method == modules::LookupMethod::by_name;
+}
+
+struct PendingStandardLibraryRequirement {
+    fs::path consumer;
+    std::string logical_name;
+};
+
+[[nodiscard]] std::optional<PendingStandardLibraryRequirement>
+next_standard_library_requirement(
+    const std::vector<modules::ScannedModuleUnit>& units,
+    const std::unordered_set<std::string>& injected) {
+    for (const auto& unit : units) {
+        for (const auto& requirement : unit.rule.required_modules) {
+            if (!named_requirement(requirement)
+                || !standard_library_module_name(requirement.logical_name)
+                || injected.contains(requirement.logical_name)) {
+                continue;
+            }
+            return PendingStandardLibraryRequirement{
+                .consumer = unit.source,
+                .logical_name = requirement.logical_name,
+            };
+        }
+    }
+    return std::nullopt;
+}
+
+[[nodiscard]] bool provides_named_interface(
+    const modules::P1689Rule& rule,
+    const std::string_view logical_name) {
+    return std::any_of(
+        rule.provided_modules.begin(),
+        rule.provided_modules.end(),
+        [&](const modules::ProvidedModule& provided) {
+            return !provided.unique_on_source_path
+                && provided.is_interface
+                && provided.logical_name == logical_name;
+        });
+}
+
+[[nodiscard]] bool regular_file(const fs::path& path) {
+    std::error_code error_code;
+    return fs::is_regular_file(path, error_code) && !error_code;
+}
+
+} // namespace
+
+std::expected<void, IncrementalModuleTargetError>
+inject_standard_library_module_providers(
+    const IncrementalModuleTargetRequest& request,
+    msvc::MsvcModuleDependencyScanner& scanner,
+    ModuleTargetArtifactRegistry& artifacts,
+    std::vector<modules::ScannedModuleUnit>& scanned_units,
+    std::vector<ModuleCompileSourceRequest>& compile_sources) {
+    // P1689 from the user's selected TUs is the only trigger for standard-library
+    // provider injection. Newly scanned toolchain providers may in turn require
+    // another toolchain-owned standard module (std.compat -> std), so repeat to
+    // a fixed point before handing the complete topology to the graph owner.
+    std::unordered_set<std::string> injected_standard_modules;
+    while (auto pending = next_standard_library_requirement(
+               scanned_units,
+               injected_standard_modules)) {
+        if (request.compiler_options.standard != CppStandard::latest) {
+            return std::unexpected(failure(
+                IncrementalModuleTargetErrorCode::standard_library_module_standard_unsupported,
+                "MSVC standard-library module '" + pending->logical_name
+                    + "' requires --std latest",
+                pending->consumer));
+        }
+        if (!request.artifact_layout) {
+            return std::unexpected(failure(
+                IncrementalModuleTargetErrorCode::artifact_layout_missing,
+                "standard-library module provider requires an artifact layout",
+                pending->consumer));
+        }
+
+        auto source = standard_library_module_source(
+            scanner.toolchain(),
+            pending->logical_name);
+        if (!source || source->empty() || !regular_file(*source)) {
+            return std::unexpected(failure(
+                IncrementalModuleTargetErrorCode::standard_library_module_unavailable,
+                "selected MSVC toolchain " + scanner.toolchain().identity.version
+                    + " does not provide standard-library module source '"
+                    + pending->logical_name + "'",
+                pending->consumer));
+        }
+
+        if (auto registered = artifacts.add_standard_library_source_identity(*source);
+            !registered) {
+            return std::unexpected(std::move(registered.error()));
+        }
+
+        auto source_artifacts = request.artifact_layout->for_source(*source);
+        if (!source_artifacts) {
+            IncrementalModuleTargetError error = failure(
+                IncrementalModuleTargetErrorCode::artifact_layout_failed,
+                "failed to assign artifacts to standard-library module provider",
+                *source);
+            error.artifact_layout_error = source_artifacts.error();
+            return std::unexpected(std::move(error));
+        }
+
+        if (auto registered = artifacts.add_standard_library_artifacts(
+                *source,
+                *source_artifacts); !registered) {
+            return std::unexpected(std::move(registered.error()));
+        }
+
+        msvc::ModuleScanInvocation invocation{
+            .source = *source,
+            .output_file = source_artifacts->module_dependencies,
+            .options = request.compiler_options,
+            .kind = TranslationUnitKind::module_interface,
+            .working_directory = working_directory_for(
+                request.working_directory,
+                *source),
+        };
+        auto scan = scanner.scan(invocation);
+        if (!scan) {
+            IncrementalModuleTargetError error = failure(
+                IncrementalModuleTargetErrorCode::scan_failed,
+                "standard-library module dependency scan failed",
+                *source);
+            error.scan_error = scan.error();
+            return std::unexpected(std::move(error));
+        }
+        if (scan->dependencies.rules.size() != 1
+            || !provides_named_interface(
+                scan->dependencies.rules.front(),
+                pending->logical_name)) {
+            return std::unexpected(failure(
+                IncrementalModuleTargetErrorCode::invalid_scan_result,
+                "selected MSVC standard-library module source did not provide expected interface '"
+                    + pending->logical_name + "'",
+                *source));
+        }
+
+        scanned_units.push_back(modules::ScannedModuleUnit{
+            .source = *source,
+            .rule = scan->dependencies.rules.front(),
+            .toolchain_owned = true,
+        });
+        compile_sources.push_back(ModuleCompileSourceRequest{
+            .source = *source,
+            .artifacts = std::move(*source_artifacts),
+            .kind = TranslationUnitKind::module_interface,
+        });
+        injected_standard_modules.emplace(std::move(pending->logical_name));
+    }
+
+    return {};
+}
+
+} // namespace mqb::orchestration::detail

--- a/cpp/src/orchestration/modules/StandardLibraryModuleProvider.hpp
+++ b/cpp/src/orchestration/modules/StandardLibraryModuleProvider.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <expected>
+#include <vector>
+
+#include "ModuleTargetArtifactRegistry.hpp"
+#include "mqb/orchestration/MsvcModuleTargetCoordinator.hpp"
+
+namespace mqb::orchestration::detail {
+
+[[nodiscard]] std::expected<void, IncrementalModuleTargetError>
+inject_standard_library_module_providers(
+    const IncrementalModuleTargetRequest& request,
+    msvc::MsvcModuleDependencyScanner& scanner,
+    ModuleTargetArtifactRegistry& artifacts,
+    std::vector<modules::ScannedModuleUnit>& scanned_units,
+    std::vector<ModuleCompileSourceRequest>& compile_sources);
+
+} // namespace mqb::orchestration::detail

--- a/tests/native/assert_cpp_layout.ps1
+++ b/tests/native/assert_cpp_layout.ps1
@@ -257,9 +257,12 @@ $orchestrationLeafFiles = [ordered]@{
     'modules' = @(
         'ModuleCompilePlan.cpp', 'ModuleCompilePlan.hpp',
         'ModuleCompileRequestFactory.cpp', 'ModuleCompileRequestFactory.hpp',
+        'ModuleTargetArtifactRegistry.cpp', 'ModuleTargetArtifactRegistry.hpp',
         'ModuleTargetLinkRequestFactory.cpp', 'ModuleTargetLinkRequestFactory.hpp',
         'ModuleTargetPreparation.cpp', 'ModuleTargetPreparation.hpp',
-        'MsvcModuleCompileCoordinator.cpp', 'MsvcModuleTargetCoordinator.cpp'
+        'ModuleTargetScanner.cpp', 'ModuleTargetScanner.hpp',
+        'MsvcModuleCompileCoordinator.cpp', 'MsvcModuleTargetCoordinator.cpp',
+        'StandardLibraryModuleProvider.cpp', 'StandardLibraryModuleProvider.hpp'
     )
     'routing' = @('MsvcTargetRouter.cpp')
     'scheduling' = @('BoundedWorkScheduler.cpp')


### PR DESCRIPTION
Decompose module-target preparation by reason to change while keeping the public orchestration API and observable failure ordering stable.

Key changes:
- add private `ModuleTargetArtifactRegistry` as the sole owner of source identity and writable-artifact collision rules
- add private `ModuleTargetScanner` for requested-source parallel P1689 scheduling, scan failure mapping, result cardinality, and scan-order preservation
- add private `StandardLibraryModuleProvider` for MSVC `std` / `std.compat` capability checks, fixed-point provider injection, provider scans, and generated artifact registration
- reduce `ModuleTargetPreparation.cpp` to composition: validate -> register artifacts -> scan -> inject toolchain providers -> build graph -> materialize header units -> build compile request
- preserve existing target-preparation path identity semantics and standard-library-provider error precedence rather than mixing behavior changes into this refactor
- keep all public headers unchanged
- update the exact responsibility layout contract and production source manifest
- intentionally grow the production graph from 60 to 63 non-main translation units
- keep the native test graph unchanged at 68 tests

Validation is pending on exact head `88fe745fa1823654002f703a54c538b9bd203c1a`.