### PR TITLE
refactor: unify Windows path identity

### DIFF
--- a/cpp/include/mqb/platform/windows/PathIdentity.hpp
+++ b/cpp/include/mqb/platform/windows/PathIdentity.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+
+namespace mqb::platform::windows {
+
+// MQB targets Windows/MSVC. Internal path identity must therefore be stable
+// across ordinary ASCII case differences without routing non-ASCII path bytes
+// through the active narrow-character locale. Preserve UTF-8 bytes verbatim
+// and fold only ASCII A-Z after lexical normalization.
+[[nodiscard]] inline std::string path_identity_key(const std::filesystem::path& path) {
+    const std::u8string utf8 = path.lexically_normal().generic_u8string();
+    std::string key;
+    key.reserve(utf8.size());
+    for (const char8_t ch : utf8) {
+        const unsigned char byte = static_cast<unsigned char>(ch);
+        if (byte >= static_cast<unsigned char>('A')
+            && byte <= static_cast<unsigned char>('Z')) {
+            key.push_back(static_cast<char>(byte + ('a' - 'A')));
+        } else {
+            key.push_back(static_cast<char>(byte));
+        }
+    }
+    return key;
+}
+
+} // namespace mqb::platform::windows

--- a/cpp/src/discovery/indexing/DiscoveryPath.hpp
+++ b/cpp/src/discovery/indexing/DiscoveryPath.hpp
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "mqb/core/TranslationUnitClassifier.hpp"
+#include "mqb/platform/windows/PathIdentity.hpp"
 
 namespace mqb::discovery::detail {
 
@@ -36,7 +37,7 @@ namespace fs = std::filesystem;
 }
 
 [[nodiscard]] inline std::string path_key(const fs::path& path) {
-    return ascii_lower(utf8_path_text(path.lexically_normal()));
+    return mqb::platform::windows::path_identity_key(path);
 }
 
 [[nodiscard]] inline bool inside_root(const fs::path& root, const fs::path& path) {

--- a/cpp/src/modules/ModuleDependencyGraph.cpp
+++ b/cpp/src/modules/ModuleDependencyGraph.cpp
@@ -8,16 +8,25 @@
 #include <utility>
 #include <vector>
 
+#include "mqb/platform/windows/PathIdentity.hpp"
+
 namespace mqb::modules {
 namespace {
 
 namespace fs = std::filesystem;
 
-[[nodiscard]] std::string path_key(const fs::path& path) {
-    const auto bytes = path.lexically_normal().generic_u8string();
-    return std::string{
-        reinterpret_cast<const char*>(bytes.data()),
-        bytes.size()};
+[[nodiscard]] std::string graph_node_key(const fs::path& path) {
+    const std::u8string utf8 = path.lexically_normal().generic_u8string();
+    std::string key;
+    key.reserve(utf8.size());
+    for (const char8_t ch : utf8) {
+        key.push_back(static_cast<char>(ch));
+    }
+    return key;
+}
+
+[[nodiscard]] std::string path_identity_key(const fs::path& path) {
+    return mqb::platform::windows::path_identity_key(path);
 }
 
 [[nodiscard]] ModuleGraphError graph_failure(
@@ -83,10 +92,10 @@ ModuleDependencyGraphBuilder::build(
     const std::vector<ScannedModuleUnit>& units,
     const std::span<const ExternalModuleProvider> external_providers) {
     DependencyGraph graph;
-    std::unordered_map<std::string, std::size_t> unit_by_key;
-    std::unordered_map<std::string, fs::path> source_by_key;
-    unit_by_key.reserve(units.size());
-    source_by_key.reserve(units.size());
+    std::unordered_map<std::string, std::size_t> unit_by_identity;
+    std::unordered_map<std::string, fs::path> source_by_graph_key;
+    unit_by_identity.reserve(units.size());
+    source_by_graph_key.reserve(units.size());
 
     for (std::size_t index = 0; index < units.size(); ++index) {
         if (units[index].source.empty()) {
@@ -94,16 +103,18 @@ ModuleDependencyGraphBuilder::build(
                 ModuleGraphErrorCode::empty_source,
                 "module graph unit source path is empty"));
         }
-        const std::string key = path_key(units[index].source);
-        if (unit_by_key.contains(key)) {
+        const std::string identity = path_identity_key(units[index].source);
+        if (unit_by_identity.contains(identity)) {
             return std::unexpected(graph_failure(
                 ModuleGraphErrorCode::duplicate_source,
                 "module graph contains the same source more than once",
                 units[index].source));
         }
-        unit_by_key.emplace(key, index);
-        source_by_key.emplace(key, units[index].source);
-        auto added = graph.add_node(key);
+        unit_by_identity.emplace(identity, index);
+
+        const std::string graph_key = graph_node_key(units[index].source);
+        source_by_graph_key.emplace(graph_key, units[index].source);
+        auto added = graph.add_node(graph_key);
         if (!added) {
             return std::unexpected(graph_failure(
                 ModuleGraphErrorCode::duplicate_source,
@@ -180,10 +191,10 @@ ModuleDependencyGraphBuilder::build(
     }
 
     ModuleDependencyPlan plan;
-    std::unordered_map<std::string, std::size_t> header_unit_by_key;
+    std::unordered_map<std::string, std::size_t> header_unit_by_identity;
 
     for (std::size_t consumer_index = 0; consumer_index < units.size(); ++consumer_index) {
-        const std::string consumer_key = path_key(units[consumer_index].source);
+        const std::string consumer_graph_key = graph_node_key(units[consumer_index].source);
         for (const auto& required : units[consumer_index].rule.required_modules) {
             const bool header_unit = required.unique_on_source_path
                 || required.lookup_method != LookupMethod::by_name;
@@ -198,8 +209,8 @@ ModuleDependencyGraphBuilder::build(
                 }
 
                 const fs::path header_source = required.source_path->lexically_normal();
-                const std::string header_key = path_key(header_source);
-                if (unit_by_key.contains(header_key)) {
+                const std::string header_identity = path_identity_key(header_source);
+                if (unit_by_identity.contains(header_identity)) {
                     return std::unexpected(graph_failure(
                         ModuleGraphErrorCode::header_unit_source_conflict,
                         "header-unit source path collides with a scanned translation unit",
@@ -207,9 +218,11 @@ ModuleDependencyGraphBuilder::build(
                         required.logical_name));
                 }
 
-                auto header = header_unit_by_key.find(header_key);
-                if (header == header_unit_by_key.end()) {
-                    auto added = graph.add_node(header_key);
+                auto header = header_unit_by_identity.find(header_identity);
+                std::string header_graph_key;
+                if (header == header_unit_by_identity.end()) {
+                    header_graph_key = graph_node_key(header_source);
+                    auto added = graph.add_node(header_graph_key);
                     if (!added) {
                         return std::unexpected(graph_failure(
                             ModuleGraphErrorCode::header_unit_source_conflict,
@@ -217,20 +230,23 @@ ModuleDependencyGraphBuilder::build(
                             header_source,
                             required.logical_name));
                     }
-                    source_by_key.emplace(header_key, header_source);
+                    source_by_graph_key.emplace(header_graph_key, header_source);
                     const std::size_t header_index = plan.header_units.size();
                     plan.header_units.push_back(PlannedHeaderUnit{
                         .source = header_source,
                         .header_name = required.logical_name,
                         .lookup_method = required.lookup_method,
                     });
-                    header = header_unit_by_key.emplace(header_key, header_index).first;
+                    header = header_unit_by_identity.emplace(header_identity, header_index).first;
                 } else if (!same_header_identity(plan.header_units[header->second], required)) {
                     return std::unexpected(graph_failure(
                         ModuleGraphErrorCode::conflicting_header_unit_identity,
                         "the same header-unit source path is required with conflicting import identity",
                         header_source,
                         required.logical_name));
+                }
+                if (header_graph_key.empty()) {
+                    header_graph_key = graph_node_key(plan.header_units[header->second].source);
                 }
 
                 plan.resolved_header_unit_dependencies.push_back(ResolvedHeaderUnitDependency{
@@ -240,7 +256,7 @@ ModuleDependencyGraphBuilder::build(
                     .lookup_method = required.lookup_method,
                 });
 
-                auto dependency = graph.add_dependency(consumer_key, header_key);
+                auto dependency = graph.add_dependency(consumer_graph_key, header_graph_key);
                 if (!dependency) {
                     ModuleGraphError error = graph_failure(
                         ModuleGraphErrorCode::dependency_cycle,
@@ -281,8 +297,8 @@ ModuleDependencyGraphBuilder::build(
             });
 
             auto dependency = graph.add_dependency(
-                consumer_key,
-                path_key(units[provider->second].source));
+                consumer_graph_key,
+                graph_node_key(units[provider->second].source));
             if (!dependency) {
                 ModuleGraphError error = graph_failure(
                     ModuleGraphErrorCode::dependency_cycle,
@@ -309,8 +325,8 @@ ModuleDependencyGraphBuilder::build(
         auto& output_level = plan.compile_levels.emplace_back();
         output_level.reserve(level.size());
         for (const auto& key : level) {
-            const auto source = source_by_key.find(key);
-            if (source != source_by_key.end()) output_level.push_back(source->second);
+            const auto source = source_by_graph_key.find(key);
+            if (source != source_by_graph_key.end()) output_level.push_back(source->second);
         }
     }
 

--- a/cpp/src/orchestration/modules/ModuleCompilePlan.cpp
+++ b/cpp/src/orchestration/modules/ModuleCompilePlan.cpp
@@ -10,25 +10,15 @@
 #include <unordered_set>
 #include <utility>
 
+#include "mqb/platform/windows/PathIdentity.hpp"
+
 namespace mqb::orchestration::detail {
 namespace {
 
 namespace fs = std::filesystem;
 
 [[nodiscard]] std::string windows_path_key(const fs::path& path) {
-    const std::u8string utf8 = path.lexically_normal().generic_u8string();
-    std::string value;
-    value.reserve(utf8.size());
-    for (const char8_t ch : utf8) {
-        const unsigned char byte = static_cast<unsigned char>(ch);
-        if (byte >= static_cast<unsigned char>('A')
-            && byte <= static_cast<unsigned char>('Z')) {
-            value.push_back(static_cast<char>(byte + ('a' - 'A')));
-        } else {
-            value.push_back(static_cast<char>(byte));
-        }
-    }
-    return value;
+    return mqb::platform::windows::path_identity_key(path);
 }
 
 [[nodiscard]] ModuleCompileError failure(

--- a/cpp/src/orchestration/modules/ModuleTargetArtifactRegistry.cpp
+++ b/cpp/src/orchestration/modules/ModuleTargetArtifactRegistry.cpp
@@ -1,22 +1,14 @@
 #include "ModuleTargetArtifactRegistry.hpp"
 
-#include <algorithm>
-#include <cctype>
 #include <string>
 #include <utility>
+
+#include "mqb/platform/windows/PathIdentity.hpp"
 
 namespace mqb::orchestration::detail {
 namespace {
 
 namespace fs = std::filesystem;
-
-[[nodiscard]] std::string windows_path_key(const fs::path& path) {
-    std::string value = path.lexically_normal().generic_string();
-    std::transform(
-        value.begin(), value.end(), value.begin(),
-        [](const unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
-    return value;
-}
 
 [[nodiscard]] IncrementalModuleTargetError failure(
     const IncrementalModuleTargetErrorCode code,
@@ -62,7 +54,8 @@ ModuleTargetArtifactRegistry::claim(
             source,
             artifact));
     }
-    if (!claimed_artifacts_.emplace(windows_path_key(artifact)).second) {
+    if (!claimed_artifacts_.emplace(
+            mqb::platform::windows::path_identity_key(artifact)).second) {
         return std::unexpected(artifact_failure(
             IncrementalModuleTargetErrorCode::artifact_collision,
             "module target " + std::string{role}
@@ -82,7 +75,8 @@ ModuleTargetArtifactRegistry::add_requested_source(
             "module target source path is empty",
             source.source));
     }
-    if (!seen_sources_.emplace(windows_path_key(source.source)).second) {
+    if (!seen_sources_.emplace(
+            mqb::platform::windows::path_identity_key(source.source)).second) {
         return std::unexpected(failure(
             IncrementalModuleTargetErrorCode::duplicate_source,
             "module target contains the same source more than once",
@@ -132,7 +126,8 @@ ModuleTargetArtifactRegistry::add_target(const TargetArtifacts& target) {
 std::expected<void, IncrementalModuleTargetError>
 ModuleTargetArtifactRegistry::add_standard_library_source_identity(
     const fs::path& source) {
-    if (!seen_sources_.emplace(windows_path_key(source)).second) {
+    if (!seen_sources_.emplace(
+            mqb::platform::windows::path_identity_key(source)).second) {
         return std::unexpected(failure(
             IncrementalModuleTargetErrorCode::duplicate_source,
             "toolchain standard-library module source collides with another target source",

--- a/cpp/tests/modules/module_dependency_graph_tests.cpp
+++ b/cpp/tests/modules/module_dependency_graph_tests.cpp
@@ -261,6 +261,16 @@ int main() {
 
     {
         const std::vector units{
+            unit(fs::path{u8"C:/项目/Modules/A.ixx"}, {provide("A")}),
+            unit(fs::path{u8"c:/项目/modules/a.IXX"}, {provide("B")}),
+        };
+        auto duplicate = ModuleDependencyGraphBuilder::build(units);
+        expect(!duplicate && duplicate.error().code == ModuleGraphErrorCode::duplicate_source,
+               "Windows source identity should reject ASCII case variants without narrowing Unicode paths");
+    }
+
+    {
+        const std::vector units{
             unit("A.ixx", {provide("A")}, {require_named("B")}),
             unit("B.ixx", {provide("B")}, {require_named("A")}),
         };

--- a/cpp/tests/orchestration/modules/module_target_validation_tests.cpp
+++ b/cpp/tests/orchestration/modules/module_target_validation_tests.cpp
@@ -187,6 +187,27 @@ int main() {
 
     {
         auto request = make_request();
+        const fs::path first = fs::path{u8"C:/项目/.MQB/OBJ/模块.OBJ"};
+        const fs::path second = fs::path{u8"c:/项目/.mqb/obj/模块.obj"};
+        request.sources[0].artifacts.object = first;
+        request.sources[1].artifacts.object = second;
+
+        const auto result = target.run(request);
+        expect(!result,
+               "Unicode artifact paths that differ only by ASCII case should collide on Windows");
+        if (!result) {
+            expect(result.error().code
+                       == mqb::orchestration::IncrementalModuleTargetErrorCode::artifact_collision,
+                   "case-variant Unicode artifact paths should report artifact_collision");
+            expect(result.error().artifact == second,
+                   "case-variant collision should identify the second conflicting path");
+        }
+        expect(runner.calls == 0,
+               "Unicode artifact identity validation must finish before external process execution");
+    }
+
+    {
+        auto request = make_request();
         request.sources[0].artifacts.dependencies.clear();
 
         const auto result = target.run(request);


### PR DESCRIPTION
Final C++ architecture/modernization closeout: make Windows path identity a single Unicode-safe platform primitive and remove the last locale-dependent path-key policy.

Key changes:
- add `mqb/platform/windows/PathIdentity.hpp` as the shared path-identity owner
- define identity as lexical normalization + UTF-8 byte preservation + ASCII-only case folding
- route discovery, module dependency graph, module compile planning, and module-target artifact ownership through that primitive
- keep module-graph deterministic scheduling/display order on the existing case-preserving normalized UTF-8 node key, explicitly separating equality from ordering
- remove `generic_string()` / `std::tolower` from module-target artifact identity
- fix module-graph source identity so ASCII case variants of the same Windows path fail as duplicates
- add module-graph and module-target regressions using non-ASCII paths plus ASCII case variants
- keep public build/CLI behavior unchanged
- keep production manifest unchanged at 63 non-main translation units
- keep the native test graph unchanged at 68 test files

The first candidate correctly exposed an ordering/identity coupling in the existing graph test; the final implementation preserves the prior deterministic order while applying the unified identity only to equality/collision decisions.

Exact head for validation: `4955728fa025769663cc9d0fe6d673b115eaecb8`.