### PR TITLE
feat: add performance timing baseline infrastructure

### DIFF
--- a/cpp/include/mqb/orchestration/MsvcIncrementalStaticTargetCoordinator.hpp
+++ b/cpp/include/mqb/orchestration/MsvcIncrementalStaticTargetCoordinator.hpp
@@ -12,6 +12,7 @@
 #include "mqb/orchestration/MsvcIncrementalArchiveCoordinator.hpp"
 #include "mqb/orchestration/MsvcIncrementalCompileCoordinator.hpp"
 #include "mqb/orchestration/MsvcIncrementalTargetCoordinator.hpp"
+#include "mqb/orchestration/TargetTimings.hpp"
 
 namespace mqb::orchestration {
 
@@ -46,6 +47,7 @@ struct IncrementalStaticTargetError {
 struct IncrementalStaticTargetResult {
     std::vector<TargetCompileResult> compiles;
     IncrementalArchiveResult archive;
+    TargetTimings timings;
     bool any_compiled{false};
 };
 

--- a/cpp/include/mqb/orchestration/MsvcIncrementalTargetCoordinator.hpp
+++ b/cpp/include/mqb/orchestration/MsvcIncrementalTargetCoordinator.hpp
@@ -12,6 +12,7 @@
 #include "mqb/core/ProjectArtifactLayout.hpp"
 #include "mqb/orchestration/MsvcIncrementalCompileCoordinator.hpp"
 #include "mqb/orchestration/MsvcIncrementalLinkCoordinator.hpp"
+#include "mqb/orchestration/TargetTimings.hpp"
 
 namespace mqb::orchestration {
 
@@ -57,6 +58,7 @@ struct IncrementalTargetError {
 struct IncrementalTargetResult {
     std::vector<TargetCompileResult> compiles;
     IncrementalLinkResult link;
+    TargetTimings timings;
     bool any_compiled{false};
 };
 

--- a/cpp/include/mqb/orchestration/MsvcModuleTargetCoordinator.hpp
+++ b/cpp/include/mqb/orchestration/MsvcModuleTargetCoordinator.hpp
@@ -14,6 +14,7 @@
 #include "mqb/msvc/MsvcModuleDependencyScanner.hpp"
 #include "mqb/orchestration/MsvcIncrementalLinkCoordinator.hpp"
 #include "mqb/orchestration/MsvcModuleCompileCoordinator.hpp"
+#include "mqb/orchestration/TargetTimings.hpp"
 
 namespace mqb::orchestration {
 
@@ -76,6 +77,7 @@ struct IncrementalModuleTargetResult {
     modules::ModuleDependencyPlan plan;
     ModuleCompileWaveResult compiles;
     IncrementalLinkResult link;
+    TargetTimings timings;
 };
 
 class MsvcModuleTargetCoordinator {

--- a/cpp/include/mqb/orchestration/MsvcTargetRouter.hpp
+++ b/cpp/include/mqb/orchestration/MsvcTargetRouter.hpp
@@ -60,6 +60,9 @@ struct RoutedTargetResult {
     MsvcTargetPipeline pipeline{MsvcTargetPipeline::ordinary};
     std::vector<TargetCompileResult> compiles;
     IncrementalLinkResult link;
+    TargetTimings timings;
+    std::size_t compile_hits{};
+    std::size_t compile_misses{};
     bool any_compiled{false};
 };
 

--- a/cpp/include/mqb/orchestration/TargetTimings.hpp
+++ b/cpp/include/mqb/orchestration/TargetTimings.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <chrono>
+
+namespace mqb::orchestration {
+
+struct TargetTimings {
+    std::chrono::nanoseconds dependency_scan{};
+    std::chrono::nanoseconds compile_queue{};
+    std::chrono::nanoseconds compile{};
+    std::chrono::nanoseconds link{};
+    std::chrono::nanoseconds archive{};
+};
+
+} // namespace mqb::orchestration

--- a/cpp/include/mqb/process/Process.hpp
+++ b/cpp/include/mqb/process/Process.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <chrono>
 #include <cstdint>
 #include <expected>
 #include <filesystem>
@@ -28,6 +29,7 @@ struct ProcessResult {
     int exit_code{};
     std::string stdout_text;
     std::string stderr_text;
+    std::chrono::nanoseconds launch_duration{};
 };
 
 enum class ProcessErrorCode {

--- a/cpp/mqb.json
+++ b/cpp/mqb.json
@@ -29,6 +29,7 @@
       "src/app/Application.cpp",
       "src/app/cli/Cli.cpp",
       "src/app/diagnostics/Diagnostics.cpp",
+      "src/app/diagnostics/PerformanceTimings.cpp",
       "src/app/cli/Invocation.cpp",
       "src/app/targets/ModuleCliTarget.cpp",
       "src/app/project/ProjectSetup.cpp",

--- a/cpp/src/app/Application.cpp
+++ b/cpp/src/app/Application.cpp
@@ -13,6 +13,7 @@
 #include "Diagnostics.hpp"
 #include "Invocation.hpp"
 #include "ModuleCliTarget.hpp"
+#include "PerformanceTimings.hpp"
 #include "ProjectSetup.hpp"
 #include "StaticCliTarget.hpp"
 #include "mqb/core/CompilerOptions.hpp"
@@ -83,6 +84,8 @@ void add_portable_root_if_missing(
 } // namespace
 
 int Application::run(const std::span<const std::string_view> arguments) {
+    const auto application_started = performance::Clock::now();
+
     auto parsed = mqb::cli::parse_arguments(arguments);
     if (!parsed) {
         std::cerr << "error: " << parsed.error().message << "\n\n" << mqb::cli::usage();
@@ -93,6 +96,8 @@ int Application::run(const std::span<const std::string_view> arguments) {
         std::cout << mqb::cli::usage();
         return 0;
     }
+
+    performance::Session timing_session{options.timings, application_started};
 
     auto invocation = resolve_invocation(options);
     if (!invocation) {
@@ -135,7 +140,9 @@ int Application::run(const std::span<const std::string_view> arguments) {
             discovery_request.extra_sources = effective.discovery_extra_sources;
             discovery_request.excluded_sources = effective.discovery_exclude_sources;
         }
+        const auto discovery_started = performance::Clock::now();
         auto discovered = mqb::discovery::SourceDiscovery::discover(discovery_request);
+        timing_session.add_discovery(performance::Clock::now() - discovery_started);
         if (!discovered) {
             diagnostics::print_error(message_with_path(
                 "source discovery failed: " + discovered.error().message,
@@ -262,6 +269,7 @@ int Application::run(const std::span<const std::string_view> arguments) {
                 .project_root = project_root,
                 .target_name = target_name,
                 .max_parallel_jobs = compile_jobs,
+                .timings = &timing_session,
                 .verbose = options.verbose,
             },
             *toolchain,
@@ -291,6 +299,7 @@ int Application::run(const std::span<const std::string_view> arguments) {
                     : std::nullopt,
                 .target_name = target_name,
                 .max_parallel_jobs = compile_jobs,
+                .timings = &timing_session,
                 .jobs_explicit = options.jobs.has_value(),
                 .force_named_modules = discovery_requires_module_pipeline
                     || has_external_module_providers,
@@ -361,6 +370,12 @@ int Application::run(const std::span<const std::string_view> arguments) {
         return result.error().code == mqb::orchestration::IncrementalTargetErrorCode::link_failed ? 5 : 4;
     }
 
+    timing_session.add_target(result->timings);
+    for (const auto& compile : result->compiles) {
+        timing_session.record_compile(compile.result.compiled);
+    }
+    timing_session.record_link(result->link.linked);
+
     for (const auto& compile : result->compiles) {
         diagnostics::print_compile_warnings(compile.result);
         const fs::path label = display_source(project_root, compile.source);
@@ -408,6 +423,7 @@ int Application::run(const std::span<const std::string_view> arguments) {
             "failed to run executable: " + run_result.error().message);
         return 6;
     }
+    timing_session.record_run_startup(run_result->launch_duration);
     diagnostics::print_process_output(*run_result);
     return run_result->exit_code;
 }

--- a/cpp/src/app/cli/Cli.cpp
+++ b/cpp/src/app/cli/Cli.cpp
@@ -189,6 +189,15 @@ long_equals_value(
     return value;
 }
 
+[[nodiscard]] std::expected<app::performance::Format, Error>
+parse_timings_format(const std::string_view value) {
+    if (value == "text") return app::performance::Format::text;
+    if (value == "json") return app::performance::Format::json;
+    return std::unexpected(error(
+        "unsupported timings format '" + std::string{value}
+        + "' (expected text or json)"));
+}
+
 } // namespace
 
 std::expected<Options, Error>
@@ -213,6 +222,18 @@ parse_arguments(const std::span<const std::string_view> arguments) {
         }
         if (argument == "--verbose" || argument == "-v") {
             options.verbose = true;
+            continue;
+        }
+        if (argument == "--timings") {
+            options.timings = app::performance::Format::text;
+            continue;
+        }
+        if (argument.starts_with("--timings=")) {
+            auto value = long_equals_value(argument, "--timings=");
+            if (!value) return std::unexpected(value.error());
+            auto format = parse_timings_format(*value);
+            if (!format) return std::unexpected(format.error());
+            options.timings = *format;
             continue;
         }
         if (argument == "--discover") {
@@ -527,6 +548,8 @@ Options:
   -j, --jobs <N>          Maximum concurrent TU scans/compiles (default: hardware concurrency)
   -o, --output <name>     Set target name under .mqb/bin/
   --run                   Run an executable after a successful build
+  --timings               Show phase timings and cache hit/miss counters
+  --timings=<text|json>   Select human-readable or JSON-line timing output
   --module-ifc <name=path>
                            Bind one external/prebuilt named module to a read-only IFC
   -I <dir>, -I<dir>       Add an include directory
@@ -558,6 +581,7 @@ MQB v5 intentionally does not accept the PowerShell-era command aliases. Use the
 shown above; unknown legacy spellings fail instead of silently entering a compatibility path.
 
 Job count is execution policy only; changing -j does not invalidate build caches.
+Timing output is observation-only and never participates in build/cache identity.
 Discovery is source selection only. Incremental header freshness uses MSVC
 /sourceDependencies metadata; /scanDependencies is module topology only.
 

--- a/cpp/src/app/cli/Cli.hpp
+++ b/cpp/src/app/cli/Cli.hpp
@@ -9,6 +9,7 @@
 #include <string_view>
 #include <vector>
 
+#include "PerformanceTimings.hpp"
 #include "mqb/core/BuildRequest.hpp"
 #include "mqb/core/CompilerOptions.hpp"
 #include "mqb/core/LinkOptions.hpp"
@@ -36,6 +37,7 @@ struct Options {
     std::vector<std::filesystem::path> portable_roots;
     std::optional<bool> discovery_override;
     std::optional<std::size_t> jobs;
+    app::performance::Format timings{app::performance::Format::disabled};
     bool discover_sources{true};
     bool verbose{false};
     bool show_help{false};

--- a/cpp/src/app/diagnostics/PerformanceTimings.cpp
+++ b/cpp/src/app/diagnostics/PerformanceTimings.cpp
@@ -1,0 +1,130 @@
+#include "PerformanceTimings.hpp"
+
+#include <iomanip>
+#include <iostream>
+#include <locale>
+#include <sstream>
+
+namespace mqb::app::performance {
+namespace {
+
+[[nodiscard]] double milliseconds(const std::chrono::nanoseconds duration) noexcept {
+    return std::chrono::duration<double, std::milli>{duration}.count();
+}
+
+void append_text_phase(
+    std::ostringstream& output,
+    const char* const label,
+    const std::chrono::nanoseconds duration) {
+    output << "  " << std::left << std::setw(17) << label
+           << std::right << std::fixed << std::setprecision(3)
+           << std::setw(12) << milliseconds(duration) << " ms\n";
+}
+
+} // namespace
+
+std::string render(const Snapshot& snapshot, const Format format) {
+    if (format == Format::disabled) {
+        return {};
+    }
+
+    std::ostringstream output;
+    output.imbue(std::locale::classic());
+
+    if (format == Format::json) {
+        output << std::fixed << std::setprecision(3)
+               << "{\"type\":\"mqb.timings\",\"schema_version\":1,\"unit\":\"ms\",\"phases\":{"
+               << "\"discovery\":" << milliseconds(snapshot.discovery) << ','
+               << "\"dependency_scan\":" << milliseconds(snapshot.target.dependency_scan) << ','
+               << "\"compile_queue\":" << milliseconds(snapshot.target.compile_queue) << ','
+               << "\"compile\":" << milliseconds(snapshot.target.compile) << ','
+               << "\"link\":" << milliseconds(snapshot.target.link) << ','
+               << "\"archive\":" << milliseconds(snapshot.target.archive) << ','
+               << "\"run_startup\":" << milliseconds(snapshot.run_startup) << ','
+               << "\"total\":" << milliseconds(snapshot.total)
+               << "},\"cache\":{"
+               << "\"compile\":{\"hits\":" << snapshot.cache.compile_hits
+               << ",\"misses\":" << snapshot.cache.compile_misses << "},"
+               << "\"link\":{\"hits\":" << snapshot.cache.link_hits
+               << ",\"misses\":" << snapshot.cache.link_misses << "},"
+               << "\"archive\":{\"hits\":" << snapshot.cache.archive_hits
+               << ",\"misses\":" << snapshot.cache.archive_misses << "}}}\n";
+        return output.str();
+    }
+
+    output << "[timings]\n";
+    append_text_phase(output, "discovery", snapshot.discovery);
+    append_text_phase(output, "dependency-scan", snapshot.target.dependency_scan);
+    append_text_phase(output, "compile-queue", snapshot.target.compile_queue);
+    append_text_phase(output, "compile", snapshot.target.compile);
+    append_text_phase(output, "link", snapshot.target.link);
+    append_text_phase(output, "archive", snapshot.target.archive);
+    append_text_phase(output, "run-startup", snapshot.run_startup);
+    append_text_phase(output, "total", snapshot.total);
+    output << "  cache             compile " << snapshot.cache.compile_hits << " hit / "
+           << snapshot.cache.compile_misses << " miss; link "
+           << snapshot.cache.link_hits << " hit / " << snapshot.cache.link_misses
+           << " miss; archive " << snapshot.cache.archive_hits << " hit / "
+           << snapshot.cache.archive_misses << " miss\n";
+    return output.str();
+}
+
+Session::~Session() noexcept {
+    if (format_ == Format::disabled) {
+        return;
+    }
+    try {
+        std::clog << render(snapshot(), format_) << std::flush;
+    } catch (...) {
+        // Timing diagnostics must never change build success or failure.
+    }
+}
+
+void Session::add_discovery(const Clock::duration duration) noexcept {
+    accumulated_.discovery += std::chrono::duration_cast<std::chrono::nanoseconds>(duration);
+}
+
+void Session::add_target(const orchestration::TargetTimings& timings) noexcept {
+    accumulated_.target.dependency_scan += timings.dependency_scan;
+    accumulated_.target.compile_queue += timings.compile_queue;
+    accumulated_.target.compile += timings.compile;
+    accumulated_.target.link += timings.link;
+    accumulated_.target.archive += timings.archive;
+}
+
+void Session::record_compile(const bool compiled) noexcept {
+    if (compiled) {
+        ++accumulated_.cache.compile_misses;
+    } else {
+        ++accumulated_.cache.compile_hits;
+    }
+}
+
+void Session::record_link(const bool linked) noexcept {
+    if (linked) {
+        ++accumulated_.cache.link_misses;
+    } else {
+        ++accumulated_.cache.link_hits;
+    }
+}
+
+void Session::record_archive(const bool archived) noexcept {
+    if (archived) {
+        ++accumulated_.cache.archive_misses;
+    } else {
+        ++accumulated_.cache.archive_hits;
+    }
+}
+
+void Session::record_run_startup(const std::chrono::nanoseconds duration) noexcept {
+    accumulated_.run_startup += duration;
+}
+
+Snapshot Session::snapshot(const Clock::time_point now) const noexcept {
+    Snapshot result = accumulated_;
+    result.total = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        now - application_started_);
+    return result;
+}
+
+} // namespace mqb::app::performance

--- a/cpp/src/app/diagnostics/PerformanceTimings.hpp
+++ b/cpp/src/app/diagnostics/PerformanceTimings.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <chrono>
+#include <cstddef>
+#include <string>
+
+#include "mqb/orchestration/TargetTimings.hpp"
+
+namespace mqb::app::performance {
+
+enum class Format {
+    disabled,
+    text,
+    json,
+};
+
+using Clock = std::chrono::steady_clock;
+
+struct CacheCounters {
+    std::size_t compile_hits{};
+    std::size_t compile_misses{};
+    std::size_t link_hits{};
+    std::size_t link_misses{};
+    std::size_t archive_hits{};
+    std::size_t archive_misses{};
+};
+
+struct Snapshot {
+    std::chrono::nanoseconds discovery{};
+    orchestration::TargetTimings target;
+    std::chrono::nanoseconds run_startup{};
+    std::chrono::nanoseconds total{};
+    CacheCounters cache;
+};
+
+[[nodiscard]] std::string render(const Snapshot& snapshot, Format format);
+
+class Session {
+public:
+    explicit Session(
+        Format format,
+        Clock::time_point application_started = Clock::now()) noexcept
+        : format_(format), application_started_(application_started) {}
+
+    ~Session() noexcept;
+
+    Session(const Session&) = delete;
+    Session& operator=(const Session&) = delete;
+
+    void add_discovery(Clock::duration duration) noexcept;
+    void add_target(const orchestration::TargetTimings& timings) noexcept;
+    void record_compile(bool compiled) noexcept;
+    void record_link(bool linked) noexcept;
+    void record_archive(bool archived) noexcept;
+    void record_run_startup(std::chrono::nanoseconds duration) noexcept;
+
+    [[nodiscard]] Snapshot snapshot(
+        Clock::time_point now = Clock::now()) const noexcept;
+
+private:
+    Format format_{Format::disabled};
+    Clock::time_point application_started_{};
+    Snapshot accumulated_;
+};
+
+} // namespace mqb::app::performance

--- a/cpp/src/app/targets/ModuleCliTarget.cpp
+++ b/cpp/src/app/targets/ModuleCliTarget.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "Diagnostics.hpp"
+#include "PerformanceTimings.hpp"
 #include "mqb/core/BuildTypes.hpp"
 #include "mqb/core/TranslationUnitClassifier.hpp"
 #include "mqb/msvc/MsvcCompileExecutor.hpp"
@@ -154,6 +155,17 @@ int run_module_target(
         return 4;
     }
 
+    if (request.timings) {
+        request.timings->add_target(result->timings);
+        for (std::size_t index = 0; index < result->compile_hits; ++index) {
+            request.timings->record_compile(false);
+        }
+        for (std::size_t index = 0; index < result->compile_misses; ++index) {
+            request.timings->record_compile(true);
+        }
+        request.timings->record_link(result->link.linked);
+    }
+
     for (const auto& compile : result->compiles) {
         diagnostics::print_compile_warnings(compile.result);
         const fs::path label = display_source(request.project_root, compile.source);
@@ -198,6 +210,9 @@ int run_module_target(
     if (!run_result) {
         diagnostics::print_error("failed to run executable: " + run_result.error().message);
         return 6;
+    }
+    if (request.timings) {
+        request.timings->record_run_startup(run_result->launch_duration);
     }
     diagnostics::print_process_output(*run_result);
     return run_result->exit_code;

--- a/cpp/src/app/targets/ModuleCliTarget.hpp
+++ b/cpp/src/app/targets/ModuleCliTarget.hpp
@@ -13,6 +13,10 @@
 #include "mqb/orchestration/MsvcIncrementalTargetCoordinator.hpp"
 #include "mqb/process/Process.hpp"
 
+namespace mqb::app::performance {
+class Session;
+}
+
 namespace mqb::cli {
 
 [[nodiscard]] bool is_module_interface_source(const std::filesystem::path& source);
@@ -26,6 +30,7 @@ struct ModuleCliTargetRequest {
     std::optional<std::filesystem::path> config_file;
     std::string target_name;
     std::size_t max_parallel_jobs{1};
+    app::performance::Session* timings{};
     bool jobs_explicit{false};
     bool force_named_modules{false};
     bool verbose{false};

--- a/cpp/src/app/targets/StaticCliTarget.cpp
+++ b/cpp/src/app/targets/StaticCliTarget.cpp
@@ -4,6 +4,7 @@
 #include <utility>
 
 #include "Diagnostics.hpp"
+#include "PerformanceTimings.hpp"
 #include "mqb/core/BuildTypes.hpp"
 #include "mqb/msvc/MsvcCompileExecutor.hpp"
 #include "mqb/msvc/MsvcLibrarian.hpp"
@@ -52,6 +53,14 @@ int run_static_target(
         return result.error().code == orchestration::IncrementalStaticTargetErrorCode::archive_failed
             ? 5
             : 4;
+    }
+
+    if (request.timings) {
+        request.timings->add_target(result->timings);
+        for (const auto& compile : result->compiles) {
+            request.timings->record_compile(compile.result.compiled);
+        }
+        request.timings->record_archive(result->archive.archived);
     }
 
     for (const auto& compile : result->compiles) {

--- a/cpp/src/app/targets/StaticCliTarget.hpp
+++ b/cpp/src/app/targets/StaticCliTarget.hpp
@@ -11,6 +11,10 @@
 #include "mqb/orchestration/MsvcIncrementalTargetCoordinator.hpp"
 #include "mqb/process/Process.hpp"
 
+namespace mqb::app::performance {
+class Session;
+}
+
 namespace mqb::cli {
 
 struct StaticCliTargetRequest {
@@ -20,6 +24,7 @@ struct StaticCliTargetRequest {
     std::filesystem::path project_root;
     std::string target_name;
     std::size_t max_parallel_jobs{1};
+    app::performance::Session* timings{};
     bool verbose{false};
 };
 

--- a/cpp/src/orchestration/incremental/MsvcIncrementalStaticTargetCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalStaticTargetCoordinator.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <chrono>
 #include <expected>
 #include <filesystem>
 #include <optional>
@@ -17,6 +18,7 @@ namespace mqb::orchestration {
 namespace {
 
 namespace fs = std::filesystem;
+using Clock = std::chrono::steady_clock;
 
 [[nodiscard]] std::string windows_path_key(const fs::path& path) {
     std::string value = path.lexically_normal().generic_string();
@@ -74,6 +76,9 @@ MsvcIncrementalStaticTargetCoordinator::run(const IncrementalStaticTargetRequest
             "static target compile parallelism must be at least one"));
     }
 
+    TargetTimings timings;
+    const auto queue_started = Clock::now();
+
     std::vector<std::string> seen_sources;
     std::vector<std::string> seen_objects;
     std::vector<std::string> seen_dependencies;
@@ -107,6 +112,10 @@ MsvcIncrementalStaticTargetCoordinator::run(const IncrementalStaticTargetRequest
 
     using CompileAttempt = std::expected<IncrementalCompileResult, IncrementalCompileError>;
     std::vector<std::optional<CompileAttempt>> attempts(request.sources.size());
+    timings.compile_queue = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        Clock::now() - queue_started);
+
+    const auto compile_started = Clock::now();
     const auto scheduled = BoundedWorkScheduler::run(
         request.sources.size(), request.max_parallel_compiles,
         [&](const std::size_t index) {
@@ -114,6 +123,8 @@ MsvcIncrementalStaticTargetCoordinator::run(const IncrementalStaticTargetRequest
             attempts[index].emplace(compile_coordinator_.run(compile_request));
             return attempts[index]->has_value();
         });
+    timings.compile = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        Clock::now() - compile_started);
     if (!scheduled) {
         return std::unexpected(failure(
             IncrementalStaticTargetErrorCode::scheduling_failed,
@@ -151,6 +162,7 @@ MsvcIncrementalStaticTargetCoordinator::run(const IncrementalStaticTargetRequest
         objects.push_back(request.sources[index].artifacts.object);
     }
 
+    const auto archive_started = Clock::now();
     auto archived = archive_coordinator_.run(IncrementalArchiveRequest{
         .objects = std::move(objects),
         .output = request.target.executable,
@@ -159,6 +171,8 @@ MsvcIncrementalStaticTargetCoordinator::run(const IncrementalStaticTargetRequest
         .link_time_code_generation = request.compiler_options.link_time_code_generation,
         .force_archive = result.any_compiled,
     });
+    timings.archive = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        Clock::now() - archive_started);
     if (!archived) {
         auto error = failure(
             IncrementalStaticTargetErrorCode::archive_failed,
@@ -167,6 +181,7 @@ MsvcIncrementalStaticTargetCoordinator::run(const IncrementalStaticTargetRequest
         return std::unexpected(std::move(error));
     }
     result.archive = std::move(*archived);
+    result.timings = timings;
     return result;
 }
 

--- a/cpp/src/orchestration/incremental/MsvcIncrementalTargetCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalTargetCoordinator.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <chrono>
 #include <expected>
 #include <filesystem>
 #include <optional>
@@ -17,6 +18,7 @@ namespace mqb::orchestration {
 namespace {
 
 namespace fs = std::filesystem;
+using Clock = std::chrono::steady_clock;
 
 [[nodiscard]] std::string windows_path_key(const fs::path& path) {
     std::string value = path.lexically_normal().generic_string();
@@ -85,6 +87,9 @@ MsvcIncrementalTargetCoordinator::run(const IncrementalTargetRequest& request) c
             "target compile parallelism must be at least one"));
     }
 
+    TargetTimings timings;
+    const auto queue_started = Clock::now();
+
     std::vector<std::string> seen_sources;
     std::vector<std::string> seen_objects;
     std::vector<std::string> seen_dependencies;
@@ -123,7 +128,10 @@ MsvcIncrementalTargetCoordinator::run(const IncrementalTargetRequest& request) c
 
     using CompileAttempt = std::expected<IncrementalCompileResult, IncrementalCompileError>;
     std::vector<std::optional<CompileAttempt>> attempts(request.sources.size());
+    timings.compile_queue = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        Clock::now() - queue_started);
 
+    const auto compile_started = Clock::now();
     const auto scheduled = BoundedWorkScheduler::run(
         request.sources.size(),
         request.max_parallel_compiles,
@@ -133,6 +141,8 @@ MsvcIncrementalTargetCoordinator::run(const IncrementalTargetRequest& request) c
             attempts[index].emplace(compile_coordinator_.run(compile_request));
             return attempts[index]->has_value();
         });
+    timings.compile = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        Clock::now() - compile_started);
     if (!scheduled) {
         return std::unexpected(failure(
             IncrementalTargetErrorCode::scheduling_failed,
@@ -186,7 +196,10 @@ MsvcIncrementalTargetCoordinator::run(const IncrementalTargetRequest& request) c
         .working_directory = request.working_directory,
         .force_relink = result.any_compiled,
     };
+    const auto link_started = Clock::now();
     auto linked = link_coordinator_.run(link_request);
+    timings.link = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        Clock::now() - link_started);
     if (!linked) {
         IncrementalTargetError error = failure(
             IncrementalTargetErrorCode::link_failed,
@@ -195,6 +208,7 @@ MsvcIncrementalTargetCoordinator::run(const IncrementalTargetRequest& request) c
         return std::unexpected(std::move(error));
     }
     result.link = std::move(*linked);
+    result.timings = timings;
     return result;
 }
 

--- a/cpp/src/orchestration/modules/ModuleTargetPreparation.cpp
+++ b/cpp/src/orchestration/modules/ModuleTargetPreparation.cpp
@@ -1,5 +1,6 @@
 #include "ModuleTargetPreparation.hpp"
 
+#include <chrono>
 #include <expected>
 #include <filesystem>
 #include <optional>
@@ -16,6 +17,7 @@ namespace mqb::orchestration::detail {
 namespace {
 
 namespace fs = std::filesystem;
+using Clock = std::chrono::steady_clock;
 
 [[nodiscard]] IncrementalModuleTargetError failure(
     const IncrementalModuleTargetErrorCode code,
@@ -58,6 +60,8 @@ prepare_module_target(
             "module target scan and compile parallelism must both be at least one"));
     }
 
+    const auto preparation_started = Clock::now();
+
     ModuleTargetArtifactRegistry artifacts{request.sources.size()};
     for (const auto& source : request.sources) {
         if (auto registered = artifacts.add_requested_source(source); !registered) {
@@ -68,6 +72,7 @@ prepare_module_target(
         return std::unexpected(std::move(registered.error()));
     }
 
+    const auto scan_started = Clock::now();
     auto scanned = scan_requested_module_sources(request, scanner);
     if (!scanned) {
         return std::unexpected(std::move(scanned.error()));
@@ -87,6 +92,8 @@ prepare_module_target(
             compile_sources); !injected) {
         return std::unexpected(std::move(injected.error()));
     }
+    prepared.timings.dependency_scan = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        Clock::now() - scan_started);
 
     auto plan = modules::ModuleDependencyGraphBuilder::build(
         scanned_units,
@@ -150,6 +157,10 @@ prepare_module_target(
         .working_directory = request.working_directory,
         .max_parallel_compiles = request.max_parallel_compiles,
     };
+
+    const auto preparation_total = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        Clock::now() - preparation_started);
+    prepared.timings.compile_queue = preparation_total - prepared.timings.dependency_scan;
     return prepared;
 }
 

--- a/cpp/src/orchestration/modules/ModuleTargetPreparation.hpp
+++ b/cpp/src/orchestration/modules/ModuleTargetPreparation.hpp
@@ -11,6 +11,7 @@ struct ModuleTargetPreparation {
     std::vector<ModuleTargetScanResult> scans;
     modules::ModuleDependencyPlan plan;
     ModuleCompileWaveRequest compile_request;
+    TargetTimings timings;
 };
 
 [[nodiscard]] std::expected<ModuleTargetPreparation, IncrementalModuleTargetError>

--- a/cpp/src/orchestration/modules/MsvcModuleTargetCoordinator.cpp
+++ b/cpp/src/orchestration/modules/MsvcModuleTargetCoordinator.cpp
@@ -1,5 +1,6 @@
 #include "mqb/orchestration/MsvcModuleTargetCoordinator.hpp"
 
+#include <chrono>
 #include <expected>
 #include <string>
 #include <utility>
@@ -9,6 +10,8 @@
 
 namespace mqb::orchestration {
 namespace {
+
+using Clock = std::chrono::steady_clock;
 
 [[nodiscard]] IncrementalModuleTargetError failure(
     const IncrementalModuleTargetErrorCode code,
@@ -31,10 +34,14 @@ MsvcModuleTargetCoordinator::run(const IncrementalModuleTargetRequest& request) 
     }
 
     IncrementalModuleTargetResult result;
+    result.timings = prepared->timings;
     result.scans = std::move(prepared->scans);
     result.plan = std::move(prepared->plan);
 
+    const auto compile_started = Clock::now();
     auto compiled = compile_coordinator_.run(prepared->compile_request);
+    result.timings.compile = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        Clock::now() - compile_started);
     if (!compiled) {
         IncrementalModuleTargetError error = failure(
             IncrementalModuleTargetErrorCode::compile_failed,
@@ -45,10 +52,13 @@ MsvcModuleTargetCoordinator::run(const IncrementalModuleTargetRequest& request) 
     }
     result.compiles = std::move(*compiled);
 
+    const auto link_started = Clock::now();
     auto linked = link_coordinator_.run(detail::make_module_target_link_request(
         request,
         prepared->compile_request,
         result.compiles.any_compiled));
+    result.timings.link = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        Clock::now() - link_started);
     if (!linked) {
         IncrementalModuleTargetError error = failure(
             IncrementalModuleTargetErrorCode::link_failed,

--- a/cpp/src/orchestration/routing/MsvcTargetRouter.cpp
+++ b/cpp/src/orchestration/routing/MsvcTargetRouter.cpp
@@ -58,12 +58,21 @@ MsvcTargetRouter::run(const RoutedTargetRequest& request) const {
             });
         }
 
-        return RoutedTargetResult{
+        RoutedTargetResult routed{
             .pipeline = MsvcTargetPipeline::ordinary,
             .compiles = std::move(result->compiles),
             .link = std::move(result->link),
+            .timings = result->timings,
             .any_compiled = result->any_compiled,
         };
+        for (const auto& compile : routed.compiles) {
+            if (compile.result.compiled) {
+                ++routed.compile_misses;
+            } else {
+                ++routed.compile_hits;
+            }
+        }
+        return routed;
     }
 
     std::vector<ModuleCompileSourceRequest> sources;
@@ -99,11 +108,19 @@ MsvcTargetRouter::run(const RoutedTargetRequest& request) const {
     routed.pipeline = MsvcTargetPipeline::named_modules;
     routed.any_compiled = result->compiles.any_compiled;
     routed.link = std::move(result->link);
+    routed.timings = result->timings;
+    for (const auto& compile : result->compiles.compiles) {
+        if (compile.result.compiled) {
+            ++routed.compile_misses;
+        } else {
+            ++routed.compile_hits;
+        }
+    }
 
     // Module-target execution may append toolchain-owned std/std.compat sources
     // after the caller's source prefix. Keep public compile ordering scoped to
     // the original target while still letting provider rebuilds affect
-    // any_compiled and downstream link freshness.
+    // any_compiled, cache counters, and downstream link freshness.
     const std::size_t public_source_count = std::min(
         request.sources.size(),
         result->compiles.compiles.size());

--- a/cpp/src/orchestration/routing/MsvcTargetRouter.cpp
+++ b/cpp/src/orchestration/routing/MsvcTargetRouter.cpp
@@ -116,11 +116,18 @@ MsvcTargetRouter::run(const RoutedTargetRequest& request) const {
             ++routed.compile_hits;
         }
     }
+    for (const auto& compile : result->compiles.header_unit_compiles) {
+        if (compile.result.compiled) {
+            ++routed.compile_misses;
+        } else {
+            ++routed.compile_hits;
+        }
+    }
 
     // Module-target execution may append toolchain-owned std/std.compat sources
     // after the caller's source prefix. Keep public compile ordering scoped to
-    // the original target while still letting provider rebuilds affect
-    // any_compiled, cache counters, and downstream link freshness.
+    // the original target while still letting generated providers and header
+    // units affect any_compiled, cache counters, and downstream link freshness.
     const std::size_t public_source_count = std::min(
         request.sources.size(),
         result->compiles.compiles.size());

--- a/cpp/src/platform/windows/WindowsProcessRunner.cpp
+++ b/cpp/src/platform/windows/WindowsProcessRunner.cpp
@@ -6,6 +6,7 @@
 #include <windows.h>
 
 #include <algorithm>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <expected>
@@ -598,6 +599,7 @@ WindowsProcessRunner::run(const process::ProcessSpec& spec) {
     }
 
     PROCESS_INFORMATION process_info{};
+    const auto launch_started = std::chrono::steady_clock::now();
     const BOOL created = ::CreateProcessW(
         executable.c_str(),
         command_line.data(),
@@ -609,6 +611,8 @@ WindowsProcessRunner::run(const process::ProcessSpec& spec) {
         working_directory ? working_directory->c_str() : nullptr,
         startup,
         &process_info);
+    const auto launch_duration = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        std::chrono::steady_clock::now() - launch_started);
     if (!created) {
         return std::unexpected(error(
             ProcessErrorCode::launch_failed,
@@ -631,6 +635,7 @@ WindowsProcessRunner::run(const process::ProcessSpec& spec) {
     thread_handle.reset();
 
     process::ProcessResult result;
+    result.launch_duration = launch_duration;
     std::optional<DWORD> stdout_error;
     std::optional<DWORD> stderr_error;
     std::optional<std::thread> stdout_reader;

--- a/cpp/tests/app/cli/cli_argument_tests.cpp
+++ b/cpp/tests/app/cli/cli_argument_tests.cpp
@@ -60,7 +60,31 @@ int main() {
                    "default standard should be C++23");
             expect(parsed->toolchain_preference == mqb::msvc::ToolchainPreference::automatic,
                    "default toolchain preference should be automatic");
+            expect(parsed->timings == mqb::app::performance::Format::disabled,
+                   "timing output should remain disabled by default");
         }
+    }
+
+    {
+        const std::vector arguments{"main.cpp"sv, "--timings"sv};
+        auto parsed = mqb::cli::parse_arguments(arguments);
+        expect(parsed.has_value()
+                   && parsed->timings == mqb::app::performance::Format::text,
+               "--timings should enable human-readable timing output");
+    }
+
+    {
+        const std::vector arguments{"main.cpp"sv, "--timings=json"sv};
+        auto parsed = mqb::cli::parse_arguments(arguments);
+        expect(parsed.has_value()
+                   && parsed->timings == mqb::app::performance::Format::json,
+               "--timings=json should enable machine-readable timing output");
+    }
+
+    {
+        const std::vector arguments{"main.cpp"sv, "--timings=xml"sv};
+        auto parsed = mqb::cli::parse_arguments(arguments);
+        expect(!parsed, "unsupported timing output formats should be rejected");
     }
 
     {

--- a/tests/native/assert_cpp_layout.ps1
+++ b/tests/native/assert_cpp_layout.ps1
@@ -122,7 +122,7 @@ Assert-DirectDirectories -Root $appRoot -Allowed @('cli', 'diagnostics', 'projec
 Assert-ExactFiles -Root $appRoot -Expected @('Application.cpp', 'Application.hpp', 'main.cpp')
 $appLeafFiles = [ordered]@{
     'cli' = @('Cli.cpp', 'Cli.hpp', 'Invocation.cpp', 'Invocation.hpp')
-    'diagnostics' = @('Diagnostics.cpp', 'Diagnostics.hpp')
+    'diagnostics' = @('Diagnostics.cpp', 'Diagnostics.hpp', 'PerformanceTimings.cpp', 'PerformanceTimings.hpp')
     'project' = @('ProjectSetup.cpp', 'ProjectSetup.hpp')
     'targets' = @('ModuleCliTarget.cpp', 'ModuleCliTarget.hpp', 'StaticCliTarget.cpp', 'StaticCliTarget.hpp')
 }

--- a/tests/native/benchmark_mqb.ps1
+++ b/tests/native/benchmark_mqb.ps1
@@ -89,8 +89,9 @@ inline int shared_value() { return 40; }
 int helper_value() { return shared_value() + 2; }
 '@
         Set-Content -LiteralPath (Join-Path $ordinaryRoot 'main.cpp') -Encoding utf8 -Value @'
+#include "common.hpp"
 int helper_value();
-int main() { return helper_value() == 42 ? 0 : 1; }
+int main() { return helper_value() == shared_value() + 2 ? 0 : 1; }
 '@
 
         $ordinaryArgs = @('main.cpp', 'helper.cpp', '--output', 'bench')
@@ -133,10 +134,18 @@ $summary = @(
         Group-Object scenario |
         ForEach-Object {
             $group = @($_.Group)
+            $sortedTotals = @($group.total_ms | Sort-Object)
+            $middle = [int][Math]::Floor($sortedTotals.Count / 2)
+            $median = if (($sortedTotals.Count % 2) -eq 0) {
+                ($sortedTotals[$middle - 1] + $sortedTotals[$middle]) / 2.0
+            }
+            else {
+                $sortedTotals[$middle]
+            }
             [PSCustomObject]@{
                 scenario = $_.Name
                 samples = $group.Count
-                median_total_ms = [Math]::Round((($group.total_ms | Sort-Object)[[int][Math]::Floor(($group.Count - 1) / 2)]), 3)
+                median_total_ms = [Math]::Round($median, 3)
                 min_total_ms = [Math]::Round((($group.total_ms | Measure-Object -Minimum).Minimum), 3)
                 max_total_ms = [Math]::Round((($group.total_ms | Measure-Object -Maximum).Maximum), 3)
             }

--- a/tests/native/benchmark_mqb.ps1
+++ b/tests/native/benchmark_mqb.ps1
@@ -1,0 +1,164 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$MqbPath,
+    [ValidateRange(1, 20)][int]$Iterations = 3,
+    [string]$OutputPath
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+function Get-FullPath {
+    param([Parameter(Mandatory = $true)][string]$Path)
+    return [System.IO.Path]::GetFullPath($Path)
+}
+
+$MqbPath = Get-FullPath $MqbPath
+if (-not (Test-Path -LiteralPath $MqbPath -PathType Leaf)) {
+    throw "MQB executable not found: $MqbPath"
+}
+if (-not [string]::IsNullOrWhiteSpace($OutputPath)) {
+    $OutputPath = Get-FullPath $OutputPath
+}
+
+function Invoke-TimedMqb {
+    param(
+        [Parameter(Mandatory = $true)][string]$Scenario,
+        [Parameter(Mandatory = $true)][int]$Iteration,
+        [Parameter(Mandatory = $true)][string]$WorkingDirectory,
+        [Parameter(Mandatory = $true)][string[]]$Arguments
+    )
+
+    Push-Location $WorkingDirectory
+    try {
+        $output = @(& $MqbPath @Arguments '--timings=json' 2>&1)
+        $exitCode = $LASTEXITCODE
+    }
+    finally {
+        Pop-Location
+    }
+
+    if ($exitCode -ne 0) {
+        foreach ($line in $output) { Write-Host $line }
+        throw "Benchmark scenario '$Scenario' failed with exit code $exitCode"
+    }
+
+    $timingLine = @($output | ForEach-Object { [string]$_ } |
+        Where-Object { $_ -like '{"type":"mqb.timings"*' }) | Select-Object -Last 1
+    if ([string]::IsNullOrWhiteSpace($timingLine)) {
+        foreach ($line in $output) { Write-Host $line }
+        throw "Benchmark scenario '$Scenario' produced no MQB timing JSON record"
+    }
+
+    $timing = $timingLine | ConvertFrom-Json
+    return [PSCustomObject]@{
+        iteration = $Iteration
+        scenario = $Scenario
+        total_ms = [double]$timing.phases.total
+        discovery_ms = [double]$timing.phases.discovery
+        dependency_scan_ms = [double]$timing.phases.dependency_scan
+        compile_queue_ms = [double]$timing.phases.compile_queue
+        compile_ms = [double]$timing.phases.compile
+        link_ms = [double]$timing.phases.link
+        archive_ms = [double]$timing.phases.archive
+        run_startup_ms = [double]$timing.phases.run_startup
+        compile_hits = [int]$timing.cache.compile.hits
+        compile_misses = [int]$timing.cache.compile.misses
+        link_hits = [int]$timing.cache.link.hits
+        link_misses = [int]$timing.cache.link.misses
+        archive_hits = [int]$timing.cache.archive.hits
+        archive_misses = [int]$timing.cache.archive.misses
+    }
+}
+
+$results = [System.Collections.Generic.List[object]]::new()
+$benchmarkRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("mqb-benchmark-" + [Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $benchmarkRoot | Out-Null
+
+try {
+    for ($iteration = 1; $iteration -le $Iterations; ++$iteration) {
+        $ordinaryRoot = Join-Path $benchmarkRoot "ordinary-$iteration"
+        New-Item -ItemType Directory -Path $ordinaryRoot | Out-Null
+
+        Set-Content -LiteralPath (Join-Path $ordinaryRoot 'common.hpp') -Encoding utf8 -Value @'
+#pragma once
+inline int shared_value() { return 40; }
+'@
+        Set-Content -LiteralPath (Join-Path $ordinaryRoot 'helper.cpp') -Encoding utf8 -Value @'
+#include "common.hpp"
+int helper_value() { return shared_value() + 2; }
+'@
+        Set-Content -LiteralPath (Join-Path $ordinaryRoot 'main.cpp') -Encoding utf8 -Value @'
+int helper_value();
+int main() { return helper_value() == 42 ? 0 : 1; }
+'@
+
+        $ordinaryArgs = @('main.cpp', 'helper.cpp', '--output', 'bench')
+        $results.Add((Invoke-TimedMqb -Scenario 'cold' -Iteration $iteration -WorkingDirectory $ordinaryRoot -Arguments $ordinaryArgs))
+        $results.Add((Invoke-TimedMqb -Scenario 'no-op' -Iteration $iteration -WorkingDirectory $ordinaryRoot -Arguments $ordinaryArgs))
+
+        Add-Content -LiteralPath (Join-Path $ordinaryRoot 'helper.cpp') -Encoding utf8 -Value "// single-tu mutation $iteration"
+        $results.Add((Invoke-TimedMqb -Scenario 'single-tu' -Iteration $iteration -WorkingDirectory $ordinaryRoot -Arguments $ordinaryArgs))
+
+        Add-Content -LiteralPath (Join-Path $ordinaryRoot 'common.hpp') -Encoding utf8 -Value "// public-header mutation $iteration"
+        $results.Add((Invoke-TimedMqb -Scenario 'public-header' -Iteration $iteration -WorkingDirectory $ordinaryRoot -Arguments $ordinaryArgs))
+
+        $results.Add((Invoke-TimedMqb -Scenario 'build-run' -Iteration $iteration -WorkingDirectory $ordinaryRoot -Arguments ($ordinaryArgs + @('--run'))))
+        $results.Add((Invoke-TimedMqb -Scenario 'link-only' -Iteration $iteration -WorkingDirectory $ordinaryRoot -Arguments ($ordinaryArgs + @('--linker-arg', '/MAP'))))
+
+        $moduleRoot = Join-Path $benchmarkRoot "modules-$iteration"
+        New-Item -ItemType Directory -Path $moduleRoot | Out-Null
+        Set-Content -LiteralPath (Join-Path $moduleRoot 'bench_math.ixx') -Encoding utf8 -Value @'
+export module bench_math;
+export int bench_value() { return 42; }
+'@
+        Set-Content -LiteralPath (Join-Path $moduleRoot 'main.cpp') -Encoding utf8 -Value @'
+import bench_math;
+int main() { return bench_value() == 42 ? 0 : 1; }
+'@
+        $moduleArgs = @('bench_math.ixx', 'main.cpp', '--std', 'latest', '--output', 'module_bench')
+        $results.Add((Invoke-TimedMqb -Scenario 'modules-cold' -Iteration $iteration -WorkingDirectory $moduleRoot -Arguments $moduleArgs))
+        $results.Add((Invoke-TimedMqb -Scenario 'modules-no-op' -Iteration $iteration -WorkingDirectory $moduleRoot -Arguments $moduleArgs))
+    }
+}
+finally {
+    Remove-Item -LiteralPath $benchmarkRoot -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+$ordered = @($results | Sort-Object iteration, scenario)
+$ordered | Format-Table -AutoSize
+
+$summary = @(
+    $ordered |
+        Group-Object scenario |
+        ForEach-Object {
+            $group = @($_.Group)
+            [PSCustomObject]@{
+                scenario = $_.Name
+                samples = $group.Count
+                median_total_ms = [Math]::Round((($group.total_ms | Sort-Object)[[int][Math]::Floor(($group.Count - 1) / 2)]), 3)
+                min_total_ms = [Math]::Round((($group.total_ms | Measure-Object -Minimum).Minimum), 3)
+                max_total_ms = [Math]::Round((($group.total_ms | Measure-Object -Maximum).Maximum), 3)
+            }
+        } |
+        Sort-Object scenario
+)
+
+Write-Host "`nMedian wall-clock summary:"
+$summary | Format-Table -AutoSize
+
+if (-not [string]::IsNullOrWhiteSpace($OutputPath)) {
+    $parent = Split-Path -Parent $OutputPath
+    if (-not [string]::IsNullOrWhiteSpace($parent)) {
+        New-Item -ItemType Directory -Path $parent -Force | Out-Null
+    }
+    [PSCustomObject]@{
+        schema_version = 1
+        generated_utc = [DateTime]::UtcNow.ToString('o')
+        mqb = $MqbPath
+        iterations = $Iterations
+        samples = $ordered
+        summary = $summary
+    } | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $OutputPath -Encoding utf8
+    Write-Host "Benchmark JSON: $OutputPath"
+}


### PR DESCRIPTION
## Summary

Starts the next MQB productization track with measurement infrastructure before optimization.

- add `--timings`, `--timings=text`, and `--timings=json`
- report wall-clock discovery, module dependency scan, compile queue/preparation, compile, link/archive, process startup, and total invocation time
- report compile/link/archive cache hit/miss counters without changing build identity
- preserve parallel-build semantics by measuring phase wall time rather than summing per-TU CPU time
- carry timing data through ordinary, static-library, named-module, header-unit, and toolchain-owned `std`/`std.compat` module paths
- measure executable launch latency at the `CreateProcessW` boundary instead of treating full program runtime as startup time
- add a repeatable Windows benchmark harness for cold, no-op, single-TU edit, public-header edit, build+run, link-only, modules-cold, and modules-no-op scenarios

## CLI

```powershell
mqb main.cpp --timings
mqb main.cpp --timings=json
```

JSON output is a single `mqb.timings` record with schema version 1, millisecond phase timings, and cache counters so benchmark automation can consume it directly.

## Design constraints

Timing is observation-only: it is not part of compiler/linker/archive signatures or cache identity, and this PR intentionally does not alter scheduler policy or add `/MP`.

Phase durations are wall-clock intervals, so parallel builds remain comparable instead of summing overlapping per-TU CPU time. `run_startup` is measured directly around `CreateProcessW`; full child runtime is not mislabeled as startup latency.

## Validation

Exact head validated: `b323582e6a409c40d85d4e7700229d0cecf3895c`.

- Native C++ #153: **success** — Debug self-build, shared native-test product library, all 4 Debug shards, final gate; existing 68-test matrix remains green.
- Native Release #125: **success** — Stage 0 Release self-build, shared product library, all 4 Release shards, Stage 1 self-host, runtime-only package, checksum/manifest validation, installer lifecycle, artifact upload.
- CLI parser coverage includes disabled/text/json/invalid timing modes.
- Production source manifest and strict responsibility-layout contract include the timing implementation.
- Static review additionally corrected module cache counters to include header-unit compiles and made the public-header benchmark invalidate both fixture TUs.

## Benchmark harness

```powershell
./tests/native/benchmark_mqb.ps1 -MqbPath ./path/to/mqb.exe -Iterations 3
./tests/native/benchmark_mqb.ps1 -MqbPath ./path/to/mqb.exe -Iterations 5 -OutputPath ./benchmark.json
```

The harness emits per-sample phase/cache data plus median/min/max total wall-clock summaries. It is intentionally a measurement harness rather than a hardware-independent absolute-time gate; future performance PRs can compare cold/incremental/no-op behavior against this baseline without baking hosted-runner timing noise into correctness CI.