### PR TITLE
feat: add build and run project commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **简体中文 | [English](README_EN.md)**
 
-MQB 是面向 **Windows + MSVC** 的原生 C/C++ 构建工具。给它一个或多个源文件，它负责源码发现、增量编译、Modules/Header Units 依赖排序、链接/归档，以及可选的构建后运行。
+MQB 是面向 **Windows + MSVC** 的原生 C/C++ 构建工具。给它一个项目入口或源文件，它负责源码发现、增量编译、Modules/Header Units 依赖排序、链接/归档，以及可选的构建后运行。
 
 最新稳定版与下载：[GitHub Releases](https://github.com/Iviesever/msvc-quick-build/releases/latest)
 
@@ -26,9 +26,39 @@ mqb --help
 
 ## 快速开始
 
-### 单文件
+### 构建 / 运行项目
+
+对于根目录或 `src/` 下只有一个 conventional `main.{c,cpp,cc,cxx}` 的简单项目：
 
 ```powershell
+mqb build
+mqb run
+mqb run -- input.txt "hello world" 42
+```
+
+正式项目可在 `mqb.json` 中设置稳定的默认入口：
+
+```json
+{
+  "version": 1,
+  "build": {
+    "entry": "src/main.cpp"
+  }
+}
+```
+
+显式 source 永远优先于 `build.entry`：
+
+```powershell
+mqb run tools/tool.cpp
+```
+
+### Source-first 兼容形式
+
+原有直接构建形式继续支持：
+
+```powershell
+mqb main.cpp
 mqb main.cpp --run
 ```
 
@@ -37,7 +67,7 @@ mqb main.cpp --run
 ### 精确多源文件
 
 ```powershell
-mqb main.cpp src/math.cpp src/io.cpp --release -j 8 -o app
+mqb build main.cpp src/math.cpp src/io.cpp --release -j 8 -o app
 ```
 
 多个 positional sources 表示精确 source set，不再自动扩展源码集合。
@@ -45,23 +75,16 @@ mqb main.cpp src/math.cpp src/io.cpp --release -j 8 -o app
 ### Target kinds
 
 ```powershell
-mqb main.cpp -o app
-mqb api.cpp --type dll -o codec
-mqb math.cpp vector.cpp --type static -o math
+mqb build main.cpp -o app
+mqb build api.cpp --type dll -o codec
+mqb build math.cpp vector.cpp --type static -o math
 ```
 
-支持 `exe`、`dll`、`static`。
-
-### 把参数传给程序
-
-```powershell
-mqb main.cpp --run -- input.txt "hello world" 42
-```
-
-`--` 后的内容只属于目标程序，不参与构建参数解析。
+支持 `exe`、`dll`、`static`。`mqb run` 只适用于 executable target。
 
 ## 核心能力
 
+- `mqb build` / `mqb run` 项目命令与 fail-closed 默认入口解析。
 - `.c` / `.cpp` / `.cc` / `.cxx` 原生 MSVC 构建。
 - Visual Studio 与 portable MSVC toolchain discovery。
 - 基于 `/sourceDependencies` 的 header freshness 与增量编译。
@@ -69,6 +92,7 @@ mqb main.cpp --run -- input.txt "hello world" 42
 - `-j / --jobs` 有界并行 scan/compile。
 - `exe` / `dll` / `static` typed targets。
 - typed runtime、LTCG、subsystem policy。
+- 原生 MSVC compiler/linker 参数与 `/link` 分界。
 - project-local named modules 与 header units。
 - external/prebuilt named-module IFC providers。
 - MSVC toolchain-owned `import std` / `import std.compat`。
@@ -96,6 +120,7 @@ MQB 从执行目录向上查找最近的 `mqb.json`。该文件所在目录成�
 {
   "version": 1,
   "build": {
+    "entry": "src/main.cpp",
     "configuration": "release",
     "standard": "latest",
     "type": "exe",
@@ -104,6 +129,8 @@ MQB 从执行目录向上查找最近的 `mqb.json`。该文件所在目录成�
   }
 }
 ```
+
+`build.entry` 相对 `mqb.json` 解析，仅在 `mqb build` / `mqb run` 没有显式 positional source 时使用。若未设置，MQB 只在 project root 与 `src/` 中寻找 conventional `main.{c,cpp,cc,cxx}`；必须恰好命中一个，否则明确报错。
 
 External/prebuilt module IFC 也可在配置中声明：
 
@@ -123,6 +150,8 @@ External/prebuilt module IFC 也可在配置中声明：
 ## 常用 CLI
 
 ```text
+mqb build [source...] [options]
+mqb run [source...] [options] [-- program-args...]
 mqb <source...> [options]
 ```
 
@@ -143,13 +172,15 @@ mqb <source...> [options]
 | `-D <value>` | preprocessor definition |
 | `-L <dir>` / `--lib-path <dir>` | library search directory |
 | `-l <name>` / `--lib <name>` | library |
+| `/option` / `-option` | 原生 MSVC compiler 参数 |
+| `/link <...>` | 后续 build 参数路由到 linker |
 | `--compiler-arg <arg>` | 原样 compiler argv element |
 | `--linker-arg <arg>` | 原样 linker argv element |
 | `--env <auto|vs|portable>` | toolchain selection |
-| `--run` | 构建后运行 executable |
+| `--run` | source-first 兼容形式：构建后运行 executable |
 | `-v, --verbose` | 详细输出 |
 | `-h, --help` | 完整 CLI 帮助 |
-| `--` | 后续参数传给目标程序 |
+| `--` | `mqb run` / `--run` 后续参数传给目标程序 |
 
 完整参数列表以当前 binary 的 `mqb --help` 为准。
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -2,7 +2,7 @@
 
 **[简体中文](README.md) | English**
 
-MQB is a native C/C++ build tool for **Windows + MSVC**. Give it one or more source files and it handles source discovery, incremental compilation, Modules/Header Units ordering, linking/archiving, and optional execution after a successful build.
+MQB is a native C/C++ build tool for **Windows + MSVC**. Give it a project entry or source files and it handles source discovery, incremental compilation, Modules/Header Units ordering, linking/archiving, and optional execution after a successful build.
 
 Latest stable release and downloads: [GitHub Releases](https://github.com/Iviesever/msvc-quick-build/releases/latest)
 
@@ -26,9 +26,39 @@ See [`docs/INSTALLATION_EN.md`](docs/INSTALLATION_EN.md) for install, PATH, and 
 
 ## Quick start
 
-### Single file
+### Build / run a project
+
+For a simple project with exactly one conventional `main.{c,cpp,cc,cxx}` under the project root or `src/`:
 
 ```powershell
+mqb build
+mqb run
+mqb run -- input.txt "hello world" 42
+```
+
+A real project can declare a stable default entry in `mqb.json`:
+
+```json
+{
+  "version": 1,
+  "build": {
+    "entry": "src/main.cpp"
+  }
+}
+```
+
+An explicit source always wins over `build.entry`:
+
+```powershell
+mqb run tools/tool.cpp
+```
+
+### Source-first compatibility form
+
+The existing direct form remains supported:
+
+```powershell
+mqb main.cpp
 mqb main.cpp --run
 ```
 
@@ -37,7 +67,7 @@ A single entry source enables smart discovery by default; writable build state s
 ### Exact multi-source build
 
 ```powershell
-mqb main.cpp src/math.cpp src/io.cpp --release -j 8 -o app
+mqb build main.cpp src/math.cpp src/io.cpp --release -j 8 -o app
 ```
 
 Multiple positional sources form an exact source set; MQB does not expand it through automatic source discovery.
@@ -45,23 +75,16 @@ Multiple positional sources form an exact source set; MQB does not expand it thr
 ### Target kinds
 
 ```powershell
-mqb main.cpp -o app
-mqb api.cpp --type dll -o codec
-mqb math.cpp vector.cpp --type static -o math
+mqb build main.cpp -o app
+mqb build api.cpp --type dll -o codec
+mqb build math.cpp vector.cpp --type static -o math
 ```
 
-Supported target kinds are `exe`, `dll`, and `static`.
-
-### Pass arguments to the program
-
-```powershell
-mqb main.cpp --run -- input.txt "hello world" 42
-```
-
-Everything after `--` belongs to the target program and is not parsed as a build option.
+Supported target kinds are `exe`, `dll`, and `static`. `mqb run` applies only to executable targets.
 
 ## Core capabilities
 
+- `mqb build` / `mqb run` project commands with fail-closed default-entry resolution.
 - Native MSVC builds for `.c` / `.cpp` / `.cc` / `.cxx`.
 - Visual Studio and portable MSVC toolchain discovery.
 - Header freshness and incremental compilation from `/sourceDependencies`.
@@ -69,6 +92,7 @@ Everything after `--` belongs to the target program and is not parsed as a build
 - Bounded parallel scan/compile with `-j / --jobs`.
 - Typed `exe` / `dll` / `static` targets.
 - Typed runtime, LTCG, and subsystem policy.
+- Native MSVC compiler/linker arguments with a `/link` boundary.
 - Project-local named modules and header units.
 - External/prebuilt named-module IFC providers.
 - MSVC toolchain-owned `import std` / `import std.compat`.
@@ -96,6 +120,7 @@ A common configuration:
 {
   "version": 1,
   "build": {
+    "entry": "src/main.cpp",
     "configuration": "release",
     "standard": "latest",
     "type": "exe",
@@ -104,6 +129,8 @@ A common configuration:
   }
 }
 ```
+
+`build.entry` is resolved relative to `mqb.json` and is used only when `mqb build` / `mqb run` has no explicit positional source. Without it, MQB checks only conventional `main.{c,cpp,cc,cxx}` files in the project root and `src/`; exactly one candidate must exist or MQB fails with a diagnostic.
 
 External/prebuilt module IFCs can also be declared in configuration:
 
@@ -123,6 +150,8 @@ See [`docs/MQB_CONFIG_EN.md`](docs/MQB_CONFIG_EN.md) for the complete schema, pa
 ## Common CLI
 
 ```text
+mqb build [source...] [options]
+mqb run [source...] [options] [-- program-args...]
 mqb <source...> [options]
 ```
 
@@ -143,13 +172,15 @@ mqb <source...> [options]
 | `-D <value>` | Preprocessor definition |
 | `-L <dir>` / `--lib-path <dir>` | Library search directory |
 | `-l <name>` / `--lib <name>` | Library |
+| `/option` / `-option` | Native MSVC compiler argument |
+| `/link <...>` | Route following build arguments to the linker |
 | `--compiler-arg <arg>` | Raw compiler argv element |
 | `--linker-arg <arg>` | Raw linker argv element |
 | `--env <auto|vs|portable>` | Toolchain selection |
-| `--run` | Run executable after build |
+| `--run` | Source-first compatibility form: run executable after build |
 | `-v, --verbose` | Verbose output |
 | `-h, --help` | Complete CLI help |
-| `--` | Pass remaining arguments to the target program |
+| `--` | Pass remaining arguments to the target program under `mqb run` / `--run` |
 
 Use the current binary's `mqb --help` as the complete CLI reference.
 

--- a/cpp/include/mqb/config/ProjectConfig.hpp
+++ b/cpp/include/mqb/config/ProjectConfig.hpp
@@ -19,6 +19,7 @@ struct BuildOverrides {
     std::optional<bool> link_time_code_generation;
     std::optional<LinkSubsystem> subsystem;
     std::optional<TargetKind> target_kind;
+    std::optional<std::filesystem::path> entry;
     std::optional<std::string> output_name;
     std::vector<std::string> defines;
     std::vector<std::filesystem::path> include_directories;

--- a/cpp/src/app/Application.cpp
+++ b/cpp/src/app/Application.cpp
@@ -118,8 +118,25 @@ int Application::run(const std::span<const std::string_view> arguments) {
     auto& project_config = project->config;
     auto& effective = project->effective;
     const fs::path& project_root = project->project_root;
-    const auto& requested_sources = invocation->requested_sources;
 
+    if (invocation->requested_sources.empty()) {
+        auto entry = resolve_default_entry(
+            project_root,
+            project_config ? project_config->build.entry : std::nullopt);
+        if (!entry) {
+            diagnostics::print_error(entry.error());
+            return 2;
+        }
+        invocation->requested_sources.push_back(std::move(*entry));
+        if (options.verbose) {
+            std::cout << "[entry] "
+                      << diagnostics::path_text(
+                             display_source(project_root, invocation->requested_sources.front()))
+                      << '\n';
+        }
+    }
+
+    const auto& requested_sources = invocation->requested_sources;
     std::vector<fs::path> sources = requested_sources;
     bool discovery_requires_module_pipeline = false;
     if (options.discover_sources

--- a/cpp/src/app/cli/Cli.cpp
+++ b/cpp/src/app/cli/Cli.cpp
@@ -203,10 +203,22 @@ parse_timings_format(const std::string_view value) {
 std::expected<Options, Error>
 parse_arguments(const std::span<const std::string_view> arguments) {
     Options options;
+    std::size_t first_argument = 0;
+    if (!arguments.empty()) {
+        if (arguments.front() == "build") {
+            options.command = Command::build;
+            first_argument = 1;
+        } else if (arguments.front() == "run") {
+            options.command = Command::run;
+            options.build.run_after_build = true;
+            first_argument = 1;
+        }
+    }
+
     bool native_linker_tail = false;
     bool native_linker_tail_has_argument = false;
 
-    for (std::size_t index = 0; index < arguments.size(); ++index) {
+    for (std::size_t index = first_argument; index < arguments.size(); ++index) {
         const std::string_view argument = arguments[index];
 
         if (argument == "--") {
@@ -229,7 +241,7 @@ parse_arguments(const std::span<const std::string_view> arguments) {
             continue;
         }
         if (argument == "/link" || argument == "-link") {
-            if (options.build.sources.empty()) {
+            if (options.build.sources.empty() && options.command == Command::direct) {
                 return std::unexpected(error(
                     "native MSVC /link must appear after at least one source file"));
             }
@@ -270,6 +282,10 @@ parse_arguments(const std::span<const std::string_view> arguments) {
             continue;
         }
         if (argument == "--run") {
+            if (options.command == Command::build) {
+                return std::unexpected(error(
+                    "mqb build does not accept --run; use 'mqb run' instead"));
+            }
             options.build.run_after_build = true;
             continue;
         }
@@ -541,13 +557,15 @@ parse_arguments(const std::span<const std::string_view> arguments) {
     if (native_linker_tail && !native_linker_tail_has_argument) {
         return std::unexpected(error("native MSVC /link requires at least one linker option"));
     }
-    if (!options.show_help && options.build.sources.empty()) {
+    if (!options.show_help
+        && options.build.sources.empty()
+        && options.command == Command::direct) {
         return std::unexpected(error("missing source file"));
     }
     if (!options.show_help
         && !options.build.run_after_build
         && !options.build.run_arguments.empty()) {
-        return std::unexpected(error("arguments after -- require --run"));
+        return std::unexpected(error("arguments after -- require 'mqb run' or --run"));
     }
     return options;
 }
@@ -555,13 +573,26 @@ parse_arguments(const std::span<const std::string_view> arguments) {
 std::string_view usage() noexcept {
     return "MQB " MQB_VERSION " - MSVC Quick Build (C++ refactor)\n\n"
 R"(Usage:
+  mqb build [entry.cpp] [options] [MSVC-compiler-options] [/link linker-options...]
+  mqb run [entry.cpp] [options] [MSVC-compiler-options] [/link linker-options...] [-- program-args...]
   mqb <entry.cpp> [options] [MSVC-compiler-options] [/link linker-options...] [-- program-args...]
   mqb <source.cpp> <more-sources...|module.ixx...> [options] [MSVC-compiler-options] [/link linker-options...] [-- program-args...]
+
+Commands:
+  build                     Build without running; source may be omitted when a default entry resolves
+  run                       Build an executable and run it; source may be omitted when a default entry resolves
+
+Default entry resolution for `mqb build` / `mqb run` with no positional source:
+  1. build.entry from the nearest mqb.json (config-relative)
+  2. exactly one conventional main source under project root or project root/src
+     using main.c, main.cpp, main.cc, or main.cxx
+  Zero or multiple conventional candidates fail closed; pass a source or set build.entry.
 
 Project configuration:
   MQB searches upward from the invocation directory for the nearest mqb.json.
   Scalar precedence is: explicit CLI > mqb.json > built-in defaults.
   Config paths are relative to mqb.json; CLI paths are relative to the invocation directory.
+  Explicit positional sources always take precedence over build.entry.
   External named-module IFCs may be declared under modules.external as logical-name -> IFC path.
 
 Source selection:
@@ -597,7 +628,7 @@ Options:
   --x86 | --x64           Explicitly select target architecture
   -j, --jobs <N>          Maximum concurrent TU scans/compiles (default: hardware concurrency)
   -o, --output <name>     Set target name under .mqb/bin/
-  --run                   Run an executable after a successful build
+  --run                   Legacy source-first alias for build-then-run; prefer `mqb run`
   --timings               Show phase timings and cache hit/miss counters
   --timings=<text|json>   Select human-readable or JSON-line timing output
   --module-ifc <name=path>
@@ -623,11 +654,12 @@ Options:
 Native MSVC compiler switches may use '/' or a single '-' prefix. MQB '--long' options remain
 in the MQB namespace. `/link` (or `-link`) is a one-way compiler-to-linker boundary for build
 arguments; MQB options must appear before it. The outer `--` delimiter still ends build parsing
-and starts executable argv, so `--run ... /link ... -- child-args` remains supported. Native
-switches and @response syntax are not semantically reimplemented by the CLI: they flow through
-the same ownership, normalization, conflict, and cache-identity rules as
---compiler-arg/--linker-arg. Bare `/I` and `/D` are the only native compiler forms that consume
-a following argv element in the CLI; attached forms remain opaque native tokens.
+and starts executable argv. `mqb run ... /link ... -- child-args` and the legacy source-first
+`--run` form remain supported. Native switches and @response syntax are not semantically
+reimplemented by the CLI: they flow through the same ownership, normalization, conflict, and
+cache-identity rules as --compiler-arg/--linker-arg. Bare `/I` and `/D` are the only native
+compiler forms that consume a following argv element in the CLI; attached forms remain opaque
+native tokens.
 
 Static libraries are produced by MSVC lib.exe from the compiled object set. Linker-only policy
 (libraries, library search paths, subsystem, and raw linker arguments) is rejected for static
@@ -639,8 +671,9 @@ quoted string into multiple switches. Project config entries are applied first a
 append afterward. Typed runtime/LTCG and structured artifact routing are emitted after raw
 arguments so the BuildPlan remains authoritative.
 
-MQB v5 intentionally does not accept the PowerShell-era command aliases. Use the native options
-shown above; unknown legacy spellings fail instead of silently entering a compatibility path.
+MQB v5 intentionally does not accept the PowerShell-era single-dash command aliases. Use the
+native options shown above; unknown legacy spellings fail instead of silently entering a
+compatibility path.
 
 Job count is execution policy only; changing -j does not invalidate build caches.
 Timing output is observation-only and never participates in build/cache identity.

--- a/cpp/src/app/cli/Cli.hpp
+++ b/cpp/src/app/cli/Cli.hpp
@@ -17,8 +17,15 @@
 
 namespace mqb::cli {
 
+enum class Command {
+    direct,
+    build,
+    run,
+};
+
 struct Options {
     BuildRequest build;
+    Command command{Command::direct};
     std::optional<BuildConfiguration> configuration_override;
     std::optional<Architecture> architecture_override;
     std::optional<CppStandard> standard_override;

--- a/cpp/src/app/cli/Invocation.cpp
+++ b/cpp/src/app/cli/Invocation.cpp
@@ -77,6 +77,15 @@ conventional_entry_candidates(const fs::path& project_root) {
         for (const auto name : names) {
             const fs::path candidate = (directory / name).lexically_normal();
             std::error_code error_code;
+            const bool exists = fs::exists(candidate, error_code);
+            if (error_code) {
+                return std::unexpected(
+                    "failed to inspect default entry candidate "
+                    + diagnostics::path_text(candidate) + ": " + error_code.message());
+            }
+            if (!exists) {
+                continue;
+            }
             const bool regular = fs::is_regular_file(candidate, error_code);
             if (error_code) {
                 return std::unexpected(
@@ -176,7 +185,7 @@ resolve_default_entry(
     if (candidates->empty()) {
         return std::unexpected(
             "no default entry found; pass a source file or set build.entry in mqb.json "
-            "(conventional fallback checks main.{c,cpp,cc,cxx} in the project root and src/)" );
+            "(conventional fallback checks main.{c,cpp,cc,cxx} in the project root and src/)");
     }
 
     std::string message =

--- a/cpp/src/app/cli/Invocation.cpp
+++ b/cpp/src/app/cli/Invocation.cpp
@@ -1,11 +1,13 @@
 #include "Invocation.hpp"
 
+#include <array>
 #include <expected>
 #include <filesystem>
 #include <string>
 #include <string_view>
 #include <system_error>
 #include <utility>
+#include <vector>
 
 #include "Diagnostics.hpp"
 #include "mqb/core/TranslationUnitClassifier.hpp"
@@ -30,6 +32,22 @@ absolute_path_from(
     return absolute.lexically_normal();
 }
 
+[[nodiscard]] std::expected<fs::path, std::string>
+validate_source(fs::path source, const std::string_view description) {
+    std::error_code error_code;
+    if (!fs::is_regular_file(source, error_code) || error_code) {
+        return std::unexpected(
+            std::string{description} + " does not exist: " + diagnostics::path_text(source));
+    }
+    if (!mqb::is_translation_unit_path(source)) {
+        return std::unexpected(
+            std::string{description}
+            + " must use .c, .cpp, .cc, .cxx, .ixx, .cppm, or .mpp: "
+            + diagnostics::path_text(source));
+    }
+    return source.lexically_normal();
+}
+
 [[nodiscard]] std::expected<void, std::string>
 resolve_directory_list(
     const fs::path& base,
@@ -43,6 +61,34 @@ resolve_directory_list(
         path = std::move(*resolved);
     }
     return {};
+}
+
+[[nodiscard]] std::expected<std::vector<fs::path>, std::string>
+conventional_entry_candidates(const fs::path& project_root) {
+    static constexpr std::array<std::string_view, 4> names{
+        "main.c",
+        "main.cpp",
+        "main.cc",
+        "main.cxx",
+    };
+
+    std::vector<fs::path> result;
+    for (const auto& directory : std::array<fs::path, 2>{project_root, project_root / "src"}) {
+        for (const auto name : names) {
+            const fs::path candidate = (directory / name).lexically_normal();
+            std::error_code error_code;
+            const bool regular = fs::is_regular_file(candidate, error_code);
+            if (error_code) {
+                return std::unexpected(
+                    "failed to inspect default entry candidate "
+                    + diagnostics::path_text(candidate) + ": " + error_code.message());
+            }
+            if (regular) {
+                result.push_back(candidate);
+            }
+        }
+    }
+    return result;
 }
 
 } // namespace
@@ -64,24 +110,19 @@ resolve_invocation(mqb::cli::Options& options) {
         if (!source) {
             return std::unexpected(source.error());
         }
-        if (!fs::is_regular_file(*source, error_code) || error_code) {
-            return std::unexpected(
-                "source file does not exist: " + diagnostics::path_text(*source));
-        }
-        if (!mqb::is_translation_unit_path(*source)) {
-            return std::unexpected(
-                "only .c, .cpp, .cc, .cxx, .ixx, .cppm, and .mpp sources are supported: "
-                + diagnostics::path_text(*source));
+        auto validated = validate_source(std::move(*source), "source file");
+        if (!validated) {
+            return std::unexpected(validated.error());
         }
         for (const auto& previous : requested_sources) {
             error_code.clear();
-            if (fs::equivalent(previous, *source, error_code) && !error_code) {
+            if (fs::equivalent(previous, *validated, error_code) && !error_code) {
                 return std::unexpected(
                     "source file was provided more than once: "
-                    + diagnostics::path_text(*source));
+                    + diagnostics::path_text(*validated));
             }
         }
-        requested_sources.push_back(std::move(*source));
+        requested_sources.push_back(std::move(*validated));
     }
 
     if (auto resolved = resolve_directory_list(
@@ -107,6 +148,44 @@ resolve_invocation(mqb::cli::Options& options) {
         .directory = std::move(invocation_directory),
         .requested_sources = std::move(requested_sources),
     };
+}
+
+std::expected<fs::path, std::string>
+resolve_default_entry(
+    const fs::path& project_root,
+    const std::optional<fs::path>& configured_entry) {
+    if (configured_entry) {
+        auto resolved = absolute_path_from(project_root, *configured_entry, "build.entry");
+        if (!resolved) {
+            return std::unexpected(resolved.error());
+        }
+        auto validated = validate_source(std::move(*resolved), "configured build.entry");
+        if (!validated) {
+            return std::unexpected(validated.error());
+        }
+        return validated;
+    }
+
+    auto candidates = conventional_entry_candidates(project_root);
+    if (!candidates) {
+        return std::unexpected(candidates.error());
+    }
+    if (candidates->size() == 1) {
+        return candidates->front();
+    }
+    if (candidates->empty()) {
+        return std::unexpected(
+            "no default entry found; pass a source file or set build.entry in mqb.json "
+            "(conventional fallback checks main.{c,cpp,cc,cxx} in the project root and src/)" );
+    }
+
+    std::string message =
+        "multiple conventional default entries found; pass a source file or set build.entry in mqb.json:";
+    for (const auto& candidate : *candidates) {
+        message += " ";
+        message += diagnostics::path_text(candidate);
+    }
+    return std::unexpected(std::move(message));
 }
 
 } // namespace mqb::app

--- a/cpp/src/app/cli/Invocation.hpp
+++ b/cpp/src/app/cli/Invocation.hpp
@@ -2,6 +2,7 @@
 
 #include <expected>
 #include <filesystem>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -16,5 +17,10 @@ struct Invocation {
 
 [[nodiscard]] std::expected<Invocation, std::string>
 resolve_invocation(mqb::cli::Options& options);
+
+[[nodiscard]] std::expected<std::filesystem::path, std::string>
+resolve_default_entry(
+    const std::filesystem::path& project_root,
+    const std::optional<std::filesystem::path>& configured_entry);
 
 } // namespace mqb::app

--- a/cpp/src/app/project/ProjectSetup.cpp
+++ b/cpp/src/app/project/ProjectSetup.cpp
@@ -199,7 +199,7 @@ prepare_project(
     if (options.build.run_after_build
         && options.build.target_kind != mqb::TargetKind::executable) {
         return std::unexpected(ProjectSetupError{
-            .message = "--run is only valid for executable targets",
+            .message = "run mode is only valid for executable targets",
             .config_error = std::nullopt,
         });
     }

--- a/cpp/src/app/project/ProjectSetup.cpp
+++ b/cpp/src/app/project/ProjectSetup.cpp
@@ -199,7 +199,7 @@ prepare_project(
     if (options.build.run_after_build
         && options.build.target_kind != mqb::TargetKind::executable) {
         return std::unexpected(ProjectSetupError{
-            .message = "run mode is only valid for executable targets",
+            .message = "--run is only valid for executable targets; `mqb run` also requires an executable target",
             .config_error = std::nullopt,
         });
     }

--- a/cpp/src/config/schema/ProjectConfigSchema.cpp
+++ b/cpp/src/config/schema/ProjectConfigSchema.cpp
@@ -215,7 +215,7 @@ using JsonValue = json::Value;
         **object,
         {
             "configuration", "architecture", "standard", "runtime", "ltcg",
-            "subsystem", "type", "output", "defines", "include_dirs",
+            "subsystem", "type", "entry", "output", "defines", "include_dirs",
             "library_dirs", "libraries", "compiler_args", "linker_args",
         },
         "build");
@@ -303,6 +303,12 @@ using JsonValue = json::Value;
                 "build.type must be 'exe', 'dll', or 'static'"));
         }
         out.target_kind = *parsed;
+    }
+
+    if (auto it = (**object).find("entry"); it != (**object).end()) {
+        auto text = require_string(file, it->second, "build.entry");
+        if (!text) return std::unexpected(text.error());
+        out.entry = resolve_path(root, *text);
     }
 
     if (auto it = (**object).find("output"); it != (**object).end()) {

--- a/cpp/tests/app/cli/mqb_native_msvc_cli_e2e_tests.cpp
+++ b/cpp/tests/app/cli/mqb_native_msvc_cli_e2e_tests.cpp
@@ -73,6 +73,83 @@ void verify_parser_contract() {
     using namespace std::string_view_literals;
 
     {
+        const std::vector arguments{"build"sv};
+        auto parsed = mqb::cli::parse_arguments(arguments);
+        expect(parsed.has_value(), "mqb build should parse without an explicit source");
+        if (parsed) {
+            expect(parsed->command == mqb::cli::Command::build,
+                   "build should record command intent");
+            expect(parsed->build.sources.empty(),
+                   "build should defer omitted source resolution until project setup");
+            expect(!parsed->build.run_after_build,
+                   "build command should not request execution");
+        }
+    }
+
+    {
+        const std::vector arguments{"run"sv, "--"sv, "child"sv};
+        auto parsed = mqb::cli::parse_arguments(arguments);
+        expect(parsed.has_value(), "mqb run should parse without an explicit source");
+        if (parsed) {
+            expect(parsed->command == mqb::cli::Command::run,
+                   "run should record command intent");
+            expect(parsed->build.run_after_build,
+                   "run command should reuse build-after-run execution policy");
+            expect(parsed->build.sources.empty(),
+                   "run should defer omitted source resolution until project setup");
+            expect(parsed->build.run_arguments.size() == 1
+                       && parsed->build.run_arguments.front() == "child",
+                   "run command should make the outer -- delimiter immediately useful");
+        }
+    }
+
+    {
+        const std::vector arguments{"build"sv, "main.cpp"sv, "/O2"sv};
+        auto parsed = mqb::cli::parse_arguments(arguments);
+        expect(parsed.has_value(), "build with an explicit source should parse");
+        if (parsed) {
+            expect(parsed->build.sources.size() == 1
+                       && parsed->build.sources.front() == "main.cpp",
+                   "explicit source should remain authoritative under build command");
+            expect(parsed->compiler_arguments.size() == 1
+                       && parsed->compiler_arguments.front() == "/O2",
+                   "build command should preserve native compiler syntax");
+        }
+    }
+
+    {
+        const std::vector arguments{
+            "build"sv, "/O2"sv, "/link"sv, "/DEBUG:FULL"sv};
+        auto parsed = mqb::cli::parse_arguments(arguments);
+        expect(parsed.has_value(),
+               "build command should allow native compiler/linker policy before default entry resolves");
+        if (parsed) {
+            expect(parsed->compiler_arguments.size() == 1
+                       && parsed->compiler_arguments.front() == "/O2",
+                   "source-less build command should preserve compiler policy");
+            expect(parsed->linker_arguments.size() == 1
+                       && parsed->linker_arguments.front() == "/DEBUG:FULL",
+                   "source-less build command should preserve /link tail");
+        }
+    }
+
+    {
+        const std::vector arguments{"build"sv, "--run"sv};
+        auto parsed = mqb::cli::parse_arguments(arguments);
+        expect(!parsed, "mqb build --run should fail instead of creating two command spellings");
+    }
+
+    {
+        const std::vector arguments{"main.cpp"sv};
+        auto parsed = mqb::cli::parse_arguments(arguments);
+        expect(parsed.has_value(), "source-first compatibility syntax should remain valid");
+        if (parsed) {
+            expect(parsed->command == mqb::cli::Command::direct,
+                   "source-first syntax should remain direct mode");
+        }
+    }
+
+    {
         const std::vector arguments{"main.cpp"sv, "/W4"sv, "/O2"sv, "/fp:fast"sv};
         auto parsed = mqb::cli::parse_arguments(arguments);
         expect(parsed.has_value(), "slash-prefixed native compiler switches should parse");
@@ -233,7 +310,7 @@ void verify_parser_contract() {
     }
 }
 
-void verify_candidate_e2e(const fs::path& mqb_executable) {
+void verify_native_candidate_e2e(const fs::path& mqb_executable) {
     const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
     TempTree tree{.root = fs::temp_directory_path() / ("mqb_native_msvc_cli_" + std::to_string(unique))};
     fs::create_directories(tree.root);
@@ -335,6 +412,144 @@ void verify_candidate_e2e(const fs::path& mqb_executable) {
     }
 }
 
+void verify_command_candidate_e2e(const fs::path& mqb_executable) {
+    const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
+    TempTree tree{.root = fs::temp_directory_path() / ("mqb_command_cli_" + std::to_string(unique))};
+    fs::create_directories(tree.root);
+    mqb::platform::windows::WindowsProcessRunner runner;
+
+    const fs::path conventional = tree.root / "conventional";
+    write_text(
+        conventional / "main.cpp",
+        "#include <cstdio>\n"
+        "int main(int argc, char** argv) {\n"
+        "  std::printf(\"conventional:%s\\n\", argc > 1 ? argv[1] : \"none\");\n"
+        "  return 0;\n"
+        "}\n");
+
+    auto build = run_process(
+        runner,
+        mqb_executable,
+        conventional,
+        {"build", "--env", "vs", "--no-discover", "-o", "command_build", "/W4"});
+    expect(build.has_value(), "source-less mqb build should launch");
+    if (build) {
+        if (build->exit_code != 0) dump_failure(*build);
+        expect(build->exit_code == 0,
+               "mqb build should resolve the unique conventional main.cpp and build it");
+    }
+    expect(fs::is_regular_file(conventional / ".mqb/bin/command_build.exe"),
+           "mqb build should produce the conventional-entry target");
+
+    auto run = run_process(
+        runner,
+        mqb_executable,
+        conventional,
+        {"run", "--env", "vs", "--no-discover", "-o", "command_run", "--", "hello"});
+    expect(run.has_value(), "source-less mqb run should launch");
+    if (run) {
+        if (run->exit_code != 0) dump_failure(*run);
+        expect(run->exit_code == 0, "mqb run should build and run the conventional entry");
+        expect(run->stdout_text.find("conventional:hello") != std::string::npos,
+               "mqb run should preserve child argv after --");
+    }
+
+    const fs::path configured = tree.root / "configured";
+    write_text(
+        configured / "main.cpp",
+        "#include <cstdio>\nint main() { std::puts(\"wrong-conventional\"); return 0; }\n");
+    write_text(
+        configured / "app/start.cpp",
+        "#include <cstdio>\n"
+        "int main(int argc, char** argv) {\n"
+        "  std::printf(\"configured:%s\\n\", argc > 1 ? argv[1] : \"none\");\n"
+        "  return 0;\n"
+        "}\n");
+    write_text(
+        configured / "explicit.cpp",
+        "#include <cstdio>\n"
+        "int main(int argc, char** argv) {\n"
+        "  std::printf(\"explicit:%s\\n\", argc > 1 ? argv[1] : \"none\");\n"
+        "  return 0;\n"
+        "}\n");
+    write_text(
+        configured / "mqb.json",
+        R"json({
+  "version": 1,
+  "build": {
+    "entry": "app/start.cpp",
+    "output": "configured_target"
+  }
+})json");
+
+    auto configured_run = run_process(
+        runner,
+        mqb_executable,
+        configured,
+        {"run", "--env", "vs", "--no-discover", "--", "cfg"});
+    expect(configured_run.has_value(), "configured-entry mqb run should launch");
+    if (configured_run) {
+        if (configured_run->exit_code != 0) dump_failure(*configured_run);
+        expect(configured_run->exit_code == 0,
+               "mqb run should build and execute build.entry from mqb.json");
+        expect(configured_run->stdout_text.find("configured:cfg") != std::string::npos,
+               "build.entry should take precedence over a conventional main.cpp");
+        expect(configured_run->stdout_text.find("wrong-conventional") == std::string::npos,
+               "configured build.entry should prevent conventional fallback selection");
+    }
+
+    auto explicit_run = run_process(
+        runner,
+        mqb_executable,
+        configured,
+        {"run", "explicit.cpp", "--env", "vs", "--no-discover", "-o", "explicit_target",
+         "--", "chosen"});
+    expect(explicit_run.has_value(), "explicit-source mqb run should launch");
+    if (explicit_run) {
+        if (explicit_run->exit_code != 0) dump_failure(*explicit_run);
+        expect(explicit_run->exit_code == 0,
+               "explicit source should remain valid when build.entry is configured");
+        expect(explicit_run->stdout_text.find("explicit:chosen") != std::string::npos,
+               "explicit source should take precedence over build.entry");
+    }
+
+    const fs::path ambiguous = tree.root / "ambiguous";
+    write_text(ambiguous / "main.cpp", "int main() { return 0; }\n");
+    write_text(ambiguous / "src/main.cpp", "int main() { return 0; }\n");
+    auto ambiguity = run_process(
+        runner,
+        mqb_executable,
+        ambiguous,
+        {"build", "--env", "vs", "--no-discover"});
+    expect(ambiguity.has_value(), "ambiguous default-entry build should launch");
+    if (ambiguity) {
+        expect(ambiguity->exit_code == 2,
+               "multiple conventional default entries should fail before toolchain execution");
+        expect(ambiguity->stderr_text.find("multiple conventional default entries")
+                   != std::string::npos,
+               "ambiguous default-entry failure should explain how to disambiguate");
+    }
+
+    const fs::path missing_configured = tree.root / "missing-configured";
+    write_text(missing_configured / "main.cpp", "int main() { return 0; }\n");
+    write_text(
+        missing_configured / "mqb.json",
+        R"json({"version":1,"build":{"entry":"missing.cpp"}})json");
+    auto missing = run_process(
+        runner,
+        mqb_executable,
+        missing_configured,
+        {"build", "--env", "vs", "--no-discover"});
+    expect(missing.has_value(), "missing configured-entry build should launch");
+    if (missing) {
+        expect(missing->exit_code == 2,
+               "invalid configured build.entry should fail instead of falling back to main.cpp");
+        expect(missing->stderr_text.find("configured build.entry does not exist")
+                   != std::string::npos,
+               "missing configured entry should retain a dedicated path diagnostic");
+    }
+}
+
 } // namespace
 
 int main(const int argc, char* argv[]) {
@@ -344,7 +559,8 @@ int main(const int argc, char* argv[]) {
     }
 
     verify_parser_contract();
-    verify_candidate_e2e(fs::path{argv[1]});
+    verify_native_candidate_e2e(fs::path{argv[1]});
+    verify_command_candidate_e2e(fs::path{argv[1]});
 
     if (failures != 0) {
         std::cerr << failures << " test(s) failed\n";

--- a/cpp/tests/app/cli/mqb_native_msvc_cli_e2e_tests.cpp
+++ b/cpp/tests/app/cli/mqb_native_msvc_cli_e2e_tests.cpp
@@ -530,6 +530,21 @@ void verify_command_candidate_e2e(const fs::path& mqb_executable) {
                "ambiguous default-entry failure should explain how to disambiguate");
     }
 
+    const fs::path absent = tree.root / "absent";
+    fs::create_directories(absent);
+    auto no_entry = run_process(
+        runner,
+        mqb_executable,
+        absent,
+        {"build", "--env", "vs", "--no-discover"});
+    expect(no_entry.has_value(), "missing default-entry build should launch");
+    if (no_entry) {
+        expect(no_entry->exit_code == 2,
+               "zero conventional default entries should fail before toolchain execution");
+        expect(no_entry->stderr_text.find("no default entry found") != std::string::npos,
+               "zero-candidate failure should explain how to provide an entry");
+    }
+
     const fs::path missing_configured = tree.root / "missing-configured";
     write_text(missing_configured / "main.cpp", "int main() { return 0; }\n");
     write_text(

--- a/cpp/tests/config/integration/project_config_tests.cpp
+++ b/cpp/tests/config/integration/project_config_tests.cpp
@@ -52,6 +52,7 @@ int main() {
     "architecture": "x86",
     "standard": "latest",
     "type": "static",
+    "entry": "src/main.cpp",
     "output": "demo",
     "defines": ["ONE=1", "TEXT=\u6d4b\u8bd5"],
     "include_dirs": ["include", "unicode/\u6d4b\u8bd5"],
@@ -94,6 +95,9 @@ int main() {
                "latest standard override should decode");
         expect(loaded->build.target_kind == mqb::TargetKind::static_library,
                "static target kind should decode");
+        expect(loaded->build.entry
+                   && *loaded->build.entry == (tree.root / "src/main.cpp").lexically_normal(),
+               "build.entry should resolve relative to mqb.json");
         expect(loaded->build.output_name && *loaded->build.output_name == "demo",
                "output override should decode");
         expect(loaded->build.defines.size() == 2,
@@ -162,8 +166,8 @@ int main() {
     if (minimal) {
         expect(!minimal->build.configuration && !minimal->build.architecture
                    && !minimal->build.standard && !minimal->build.target_kind
-                   && !minimal->build.output_name,
-               "missing build scalar fields must remain unset rather than receiving defaults");
+                   && !minimal->build.entry && !minimal->build.output_name,
+               "missing build scalar/path fields must remain unset rather than receiving defaults");
         expect(minimal->build.defines.empty() && minimal->build.include_directories.empty()
                    && minimal->build.library_directories.empty() && minimal->build.libraries.empty(),
                "missing build list fields must remain empty overrides");
@@ -172,6 +176,11 @@ int main() {
         expect(minimal->modules.external_providers.empty(),
                "missing modules policy must remain an empty override");
     }
+
+    write_text(config_file, R"json({"version":1,"build":{"entry":""}})json");
+    auto empty_entry = mqb::config::ProjectConfigLoader::load(config_file);
+    expect(!empty_entry && empty_entry.error().code == mqb::config::ErrorCode::schema_error,
+           "build.entry must be a non-empty string");
 
     write_text(config_file, R"json({"version":1,"modules":{"external":{"vendor.math":7}}})json");
     auto bad_provider_type = mqb::config::ProjectConfigLoader::load(config_file);

--- a/docs/MQB_CONFIG.md
+++ b/docs/MQB_CONFIG.md
@@ -33,6 +33,7 @@ modules
 {
   "version": 1,
   "build": {
+    "entry": "src/main.cpp",
     "configuration": "release",
     "architecture": "x64",
     "standard": "23",
@@ -66,6 +67,7 @@ modules
 
 | 字段 | 类型 | 含义 |
 |---|---|---|
+| `entry` | string | `mqb build` / `mqb run` 未提供 positional source 时使用的默认入口；路径相对 `mqb.json` |
 | `configuration` | string | `debug` / `release` |
 | `architecture` | string | `x86` / `x64` |
 | `standard` | string | `14`、`17`、`20`、`23`、`latest`；也接受 `c++...` 拼写 |
@@ -80,6 +82,46 @@ modules
 | `libraries` | string[] | link libraries；static target 不接受 |
 | `compiler_args` | string[] | 按顺序传给 `cl.exe` 的原始 argv element |
 | `linker_args` | string[] | 按顺序传给 linker 的原始 argv element；static target 不接受 |
+
+### 默认入口
+
+`build.entry` 是项目级默认入口，不是 source list。它只在下列形式没有显式 positional source 时参与解析：
+
+```powershell
+mqb build
+mqb run
+```
+
+优先级固定为：
+
+```text
+显式 positional source(s)
+    > build.entry
+    > conventional fallback
+```
+
+conventional fallback **不会递归扫描项目**。它只检查：
+
+```text
+<project-root>/main.c
+<project-root>/main.cpp
+<project-root>/main.cc
+<project-root>/main.cxx
+<project-root>/src/main.c
+<project-root>/src/main.cpp
+<project-root>/src/main.cc
+<project-root>/src/main.cxx
+```
+
+只有恰好一个候选存在时才会采用；0 个候选要求显式 source 或 `build.entry`，多个候选要求用户消歧。若已经配置 `build.entry` 但对应文件缺失或扩展名不受支持，MQB 会直接报错，不会悄悄回退到 conventional main。
+
+显式 source 始终优先，例如：
+
+```powershell
+mqb run tools/tool.cpp
+```
+
+即使项目设置了 `build.entry`，这里仍构建并运行 `tools/tool.cpp`。
 
 ### Typed policy
 
@@ -112,6 +154,7 @@ module interface:   .ixx .cppm .mpp
 
 规则：
 
+- `build.entry` 或唯一 conventional fallback 解析出的入口，与显式单入口一样进入 smart discovery；
 - 多个 positional source 本身就是精确 source set，不依赖 smart discovery；
 - v1 使用精确路径，不支持 glob；
 - entry TU 不能被排除；
@@ -188,6 +231,12 @@ subsystem
 output
 ```
 
+入口选择是独立的 source-selection policy：
+
+```text
+显式 positional source(s) > build.entry > 唯一 conventional main
+```
+
 普通 list-like 输入按顺序追加：
 
 ```text
@@ -207,27 +256,49 @@ CLI relative path      -> invocation directory
 mqb.json relative path -> directory containing mqb.json
 ```
 
+`build.entry` 属于后者。
+
 例如：
 
 ```text
 project/
 ├─ mqb.json
-├─ main.cpp
+├─ src/main.cpp
 ├─ include/
 └─ nested/work/
+```
+
+配置：
+
+```json
+{
+  "version": 1,
+  "build": {
+    "entry": "src/main.cpp",
+    "include_dirs": ["include"]
+  }
+}
 ```
 
 从 `project/nested/work` 运行：
 
 ```powershell
-mqb ../../main.cpp
+mqb run
 ```
 
-仍会加载 `project/mqb.json`，把 `"include_dirs": ["include"]` 解析为 `project/include`，并把 writable artifacts 放到 `project/.mqb/`。
+仍会加载 `project/mqb.json`，把 entry 解析为 `project/src/main.cpp`、include dir 解析为 `project/include`，并把 writable artifacts 放到 `project/.mqb/`。
+
+显式形式仍按 invocation directory 解析：
+
+```powershell
+mqb ../../src/main.cpp
+```
 
 ## 8. Cache 语义
 
 MQB 不以“配置文件时间戳变化”作为全量 rebuild 信号；它根据**生效后的构建语义**计算 identity。
+
+`build.entry` 自身不额外进入 compile/link identity；它只决定本次 source-selection 的入口。解析出的实际 source、discovery 结果与既有 compiler/linker semantics 继续决定 cache identity。
 
 典型影响：
 
@@ -246,10 +317,11 @@ MQB 不以“配置文件时间戳变化”作为全量 rebuild 信号；它根�
 ## 9. 当前明确边界
 
 - `exe`、`dll`、`static` 均受支持；
-- `--run` 仅适用于 executable；
+- `mqb run` 与 source-first `--run` 仅适用于 executable；
 - static target 不接受 subsystem、library paths/libraries、linker args；
 - **需要 Modules/Header Units pipeline 的 static-library target 当前仍 fail closed**；
 - discovery correction 使用精确路径，不支持 glob；
+- default-entry conventional fallback 不递归、不使用 glob；
 - 间接 `/DEFAULTLIB` 传递依赖不承诺完全的新鲜度跟踪。
 
 更底层的 provider graph、artifact identity 与职责边界见 [`ARCHITECTURE.md`](ARCHITECTURE.md)。

--- a/docs/MQB_CONFIG_EN.md
+++ b/docs/MQB_CONFIG_EN.md
@@ -33,6 +33,7 @@ modules
 {
   "version": 1,
   "build": {
+    "entry": "src/main.cpp",
     "configuration": "release",
     "architecture": "x64",
     "standard": "23",
@@ -66,6 +67,7 @@ modules
 
 | Field | Type | Meaning |
 |---|---|---|
+| `entry` | string | default entry used by `mqb build` / `mqb run` when no positional source is provided; relative to `mqb.json` |
 | `configuration` | string | `debug` / `release` |
 | `architecture` | string | `x86` / `x64` |
 | `standard` | string | `14`, `17`, `20`, `23`, `latest`; `c++...` spellings are also accepted |
@@ -80,6 +82,46 @@ modules
 | `libraries` | string[] | link libraries; not accepted for static targets |
 | `compiler_args` | string[] | ordered raw argv elements passed to `cl.exe` |
 | `linker_args` | string[] | ordered raw linker argv elements; not accepted for static targets |
+
+### Default entry
+
+`build.entry` is a project-level default entry, not a source list. It participates only when these command forms omit every positional source:
+
+```powershell
+mqb build
+mqb run
+```
+
+Entry selection is fixed as:
+
+```text
+explicit positional source(s)
+    > build.entry
+    > conventional fallback
+```
+
+The conventional fallback **does not recursively scan the project**. It checks only:
+
+```text
+<project-root>/main.c
+<project-root>/main.cpp
+<project-root>/main.cc
+<project-root>/main.cxx
+<project-root>/src/main.c
+<project-root>/src/main.cpp
+<project-root>/src/main.cc
+<project-root>/src/main.cxx
+```
+
+Exactly one candidate is required. Zero candidates require an explicit source or `build.entry`; multiple candidates require explicit disambiguation. If `build.entry` is configured but missing or has an unsupported translation-unit extension, MQB fails on that configured entry instead of silently falling back to a conventional main.
+
+Explicit sources always win, for example:
+
+```powershell
+mqb run tools/tool.cpp
+```
+
+Even when `build.entry` exists, this builds and runs `tools/tool.cpp`.
 
 ### Typed policy
 
@@ -112,6 +154,7 @@ module interface:   .ixx .cppm .mpp
 
 Rules:
 
+- an entry selected through `build.entry` or the unique conventional fallback enters the same smart-discovery path as an explicit single entry;
 - multiple positional sources already form an exact source set and do not depend on smart discovery;
 - v1 uses exact paths, not globs;
 - the entry TU cannot be excluded;
@@ -188,6 +231,12 @@ subsystem
 output
 ```
 
+Entry selection is a separate source-selection policy:
+
+```text
+explicit positional source(s) > build.entry > unique conventional main
+```
+
 Ordinary list-like inputs append deterministically:
 
 ```text
@@ -207,27 +256,49 @@ CLI relative path      -> invocation directory
 mqb.json relative path -> directory containing mqb.json
 ```
 
+`build.entry` uses the second base.
+
 Example:
 
 ```text
 project/
 ├─ mqb.json
-├─ main.cpp
+├─ src/main.cpp
 ├─ include/
 └─ nested/work/
+```
+
+Configuration:
+
+```json
+{
+  "version": 1,
+  "build": {
+    "entry": "src/main.cpp",
+    "include_dirs": ["include"]
+  }
+}
 ```
 
 From `project/nested/work`:
 
 ```powershell
-mqb ../../main.cpp
+mqb run
 ```
 
-MQB still loads `project/mqb.json`, resolves `"include_dirs": ["include"]` as `project/include`, and places writable artifacts under `project/.mqb/`.
+MQB still loads `project/mqb.json`, resolves the entry as `project/src/main.cpp`, resolves the include dir as `project/include`, and places writable artifacts under `project/.mqb/`.
+
+An explicit source remains invocation-relative:
+
+```powershell
+mqb ../../src/main.cpp
+```
 
 ## 8. Cache semantics
 
 MQB does not treat "the config file timestamp changed" as a global rebuild signal. Identity is derived from the **effective build semantics**.
+
+`build.entry` does not add a separate compile/link identity field; it selects the source-discovery entry for this invocation. The resolved source set and existing compiler/linker semantics continue to determine cache identity.
 
 Typical effects:
 
@@ -246,10 +317,11 @@ Missing recorded outputs also invalidate the corresponding compile/link/archive 
 ## 9. Explicit current boundaries
 
 - `exe`, `dll`, and `static` are supported;
-- `--run` applies only to executables;
+- `mqb run` and source-first `--run` apply only to executables;
 - static targets do not accept subsystem, library paths/libraries, or linker args;
-- **static-library targets that require the Modules/Header Units pipeline currently fail closed**;
-- discovery corrections use exact paths, not globs;
-- transitive `/DEFAULTLIB` dependencies are not promised to have complete freshness tracking.
+- **static-library targets that require the Modules/Header Units pipeline still fail closed**;
+- discovery corrections use exact paths and do not support globs;
+- conventional default-entry fallback is non-recursive and does not use globs;
+- freshness through indirect `/DEFAULTLIB`-style library propagation is not guaranteed to be complete.
 
-See [`ARCHITECTURE_EN.md`](ARCHITECTURE_EN.md) for the lower-level provider graph, artifact identity, and responsibility boundaries.
+See [`ARCHITECTURE_EN.md`](ARCHITECTURE_EN.md) for deeper provider-graph, artifact-identity, and responsibility boundaries.


### PR DESCRIPTION
## Summary

Implements PR 4 of the MQB productization track: first-class project commands and fail-closed default-entry resolution.

- add `mqb build [source...]`
- add `mqb run [source...] [-- program-args...]`
- preserve the existing source-first CLI, including `mqb main.cpp --run`
- add version-1 `mqb.json` field `build.entry`
- resolve omitted command sources only after project configuration is loaded
- keep explicit positional sources authoritative over `build.entry`
- use a deliberately narrow conventional fallback when `build.entry` is absent
- keep native MSVC compiler/linker routing and Parameter Engine behavior unchanged

## Default entry contract

When `mqb build` / `mqb run` has no positional source, entry selection is:

1. explicit positional source(s), when present
2. `build.entry` from the nearest `mqb.json`
3. exactly one conventional source among project-root or `src/` `main.c`, `main.cpp`, `main.cc`, `main.cxx`

The conventional fallback is non-recursive and uses no globbing. Zero candidates fail with guidance to pass a source or set `build.entry`; multiple candidates fail as ambiguous. A configured but missing/invalid `build.entry` fails directly and never silently falls back.

## Command contract

```powershell
mqb build
mqb build main.cpp /W4 /O2
mqb run
mqb run -- input.txt "hello world"
mqb run tools/tool.cpp /O2 /link /DEBUG:FULL -- child-arg
```

`mqb run` reuses the existing executable run pipeline and outer `--` delimiter. `mqb build --run` is rejected so the new command spelling has one clear owner; the old source-first `mqb main.cpp --run` form remains supported.

## Architecture

- `Cli` owns command intent and token parsing only.
- `ProjectConfigSchema` owns strict `build.entry` decoding and config-relative path normalization.
- `Invocation` owns source/default-entry filesystem validation.
- `Application` asks for a default entry only after `prepare_project()` and only when the explicit source list is empty.
- the resolved entry then enters the existing single-entry smart-discovery/module/compile/link pipeline unchanged.

No production translation unit or responsibility-directory change is introduced.

## Validation scope

The native graph remains exactly 70 tests. Existing `mqb_native_msvc_cli_e2e_tests.cpp` is extended rather than adding a new test node. It covers command parser intent plus candidate-MQB end-to-end cases for:

- source-less conventional `mqb build`
- source-less `mqb run -- child-arg`
- `build.entry` taking priority over a conventional main
- explicit source taking priority over `build.entry`
- zero conventional candidates failing before toolchain execution
- ambiguous conventional fallback rejection
- missing configured `build.entry` rejection
- source-less build command with native compiler + `/link` policy
- source-first compatibility

The final regression pass also preserved the existing `--run is only valid for executable targets` diagnostic substring while documenting that `mqb run` has the same executable-only target requirement.

## Exact final validation

Final head: `4c79897f258219f6cfb3582f61009edc357bf92f`

- Native C++ #183: success
  - Debug MQB self-build: success
  - shared Debug native-test product: success
  - 4/4 Debug shards: success
  - final Native C++ gate: success
- Native Release #152: success
  - Stage 0 Release MQB self-build: success
  - shared Release native-test product: success
  - 4/4 Release shards: success
  - Stage 1 self-host stable release: success
  - runtime-only release package staging: success
  - exact packaged-artifact validation: success
  - validated package upload: success
  - `publish-release`: skipped as expected for a pull request

No unresolved review threads or review blockers were present at final validation.