### PR TITLE
feat: add named build profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,43 @@ mqb run -- input.txt "hello world" 42
 mqb run tools/tool.cpp
 ```
 
+### Named profiles
+
+常用构建策略可以声明成显式命名 profile，而不用重复一长串 CLI 参数：
+
+```json
+{
+  "version": 1,
+  "build": {
+    "entry": "src/main.cpp",
+    "standard": "23"
+  },
+  "profiles": {
+    "dev": {
+      "build": {
+        "configuration": "debug",
+        "runtime": "MDd",
+        "compiler_args": ["/W4"]
+      }
+    },
+    "release": {
+      "build": {
+        "configuration": "release",
+        "ltcg": true,
+        "compiler_args": ["/O2"]
+      }
+    }
+  }
+}
+```
+
+```powershell
+mqb build --profile release
+mqb run --profile dev -- input.txt
+```
+
+第一版 profile 是**单个显式 overlay**：一次只能选择一个，没有继承、没有多 profile 叠加，也没有隐式默认 profile。优先级为 `CLI > selected profile > base mqb.json > built-in`；list 输入按 base → profile → CLI 追加。Profile 不能设置 `build.entry`，因此切换构建策略不会悄悄切换项目入口。
+
 ### Source-first 兼容形式
 
 原有直接构建形式继续支持：
@@ -85,6 +122,7 @@ mqb build math.cpp vector.cpp --type static -o math
 ## 核心能力
 
 - `mqb build` / `mqb run` 项目命令与 fail-closed 默认入口解析。
+- `mqb.json` named profiles 与 `base < profile < CLI` 分层解析。
 - `.c` / `.cpp` / `.cc` / `.cxx` 原生 MSVC 构建。
 - Visual Studio 与 portable MSVC toolchain discovery。
 - 基于 `/sourceDependencies` 的 header freshness 与增量编译。
@@ -132,6 +170,8 @@ MQB 从执行目录向上查找最近的 `mqb.json`。该文件所在目录成�
 
 `build.entry` 相对 `mqb.json` 解析，仅在 `mqb build` / `mqb run` 没有显式 positional source 时使用。若未设置，MQB 只在 project root 与 `src/` 中寻找 conventional `main.{c,cpp,cc,cxx}`；必须恰好命中一个，否则明确报错。
 
+Named profile 也声明在同一配置文件中，并用 `--profile <name>` 显式选择。Profile 内路径同样相对 `mqb.json`，native compiler/linker arguments 仍经过统一的 MSVC Parameter Engine；profile 名本身不是额外 cache 维度，最终生效的构建语义才决定 cache identity。
+
 External/prebuilt module IFC 也可在配置中声明：
 
 ```json
@@ -145,7 +185,7 @@ External/prebuilt module IFC 也可在配置中声明：
 }
 ```
 
-完整字段、路径基准、CLI/config precedence 和 module provider 规则见 [`docs/MQB_CONFIG.md`](docs/MQB_CONFIG.md)。
+完整字段、profiles、路径基准、CLI/config precedence 和 module provider 规则见 [`docs/MQB_CONFIG.md`](docs/MQB_CONFIG.md)。
 
 ## 常用 CLI
 
@@ -157,6 +197,7 @@ mqb <source...> [options]
 
 | 选项 | 作用 |
 |---|---|
+| `--profile <name>` | 选择 `mqb.json` 中一个 named profile |
 | `--debug` / `--release` | 构建配置 |
 | `--std <14|17|20|23|latest>` | C++ 标准 |
 | `--type <exe|dll|static>` | target kind |
@@ -188,7 +229,7 @@ mqb <source...> [options]
 
 | 主题 | 文档 |
 |---|---|
-| `mqb.json` 配置与 precedence | [`docs/MQB_CONFIG.md`](docs/MQB_CONFIG.md) |
+| `mqb.json` 配置、profiles 与 precedence | [`docs/MQB_CONFIG.md`](docs/MQB_CONFIG.md) |
 | 安装、PATH、卸载 | [`docs/INSTALLATION.md`](docs/INSTALLATION.md) |
 | 架构与 Modules/cache 模型 | [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) |
 | 开发 MQB | [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md) |

--- a/README_EN.md
+++ b/README_EN.md
@@ -53,6 +53,43 @@ An explicit source always wins over `build.entry`:
 mqb run tools/tool.cpp
 ```
 
+### Named profiles
+
+Frequently repeated build policy can be declared as an explicit named profile instead of repeating a long CLI sequence:
+
+```json
+{
+  "version": 1,
+  "build": {
+    "entry": "src/main.cpp",
+    "standard": "23"
+  },
+  "profiles": {
+    "dev": {
+      "build": {
+        "configuration": "debug",
+        "runtime": "MDd",
+        "compiler_args": ["/W4"]
+      }
+    },
+    "release": {
+      "build": {
+        "configuration": "release",
+        "ltcg": true,
+        "compiler_args": ["/O2"]
+      }
+    }
+  }
+}
+```
+
+```powershell
+mqb build --profile release
+mqb run --profile dev -- input.txt
+```
+
+The first profile version is a **single explicit overlay**: one profile per invocation, no inheritance, no multi-profile stacking, and no implicit default profile. Precedence is `CLI > selected profile > base mqb.json > built-in`; list inputs append in base → profile → CLI order. Profiles cannot set `build.entry`, so selecting build policy never silently changes project entry identity.
+
 ### Source-first compatibility form
 
 The existing direct form remains supported:
@@ -85,6 +122,7 @@ Supported target kinds are `exe`, `dll`, and `static`. `mqb run` applies only to
 ## Core capabilities
 
 - `mqb build` / `mqb run` project commands with fail-closed default-entry resolution.
+- Named `mqb.json` profiles with layered base < profile < CLI resolution.
 - Native MSVC builds for `.c` / `.cpp` / `.cc` / `.cxx`.
 - Visual Studio and portable MSVC toolchain discovery.
 - Header freshness and incremental compilation from `/sourceDependencies`.
@@ -132,6 +170,8 @@ A common configuration:
 
 `build.entry` is resolved relative to `mqb.json` and is used only when `mqb build` / `mqb run` has no explicit positional source. Without it, MQB checks only conventional `main.{c,cpp,cc,cxx}` files in the project root and `src/`; exactly one candidate must exist or MQB fails with a diagnostic.
 
+Named profiles live in the same configuration file and are selected explicitly with `--profile <name>`. Profile paths are also resolved relative to `mqb.json`, and native compiler/linker arguments still pass through the shared MSVC Parameter Engine. The profile name itself is not an extra cache dimension; final effective build semantics determine cache identity.
+
 External/prebuilt module IFCs can also be declared in configuration:
 
 ```json
@@ -145,7 +185,7 @@ External/prebuilt module IFCs can also be declared in configuration:
 }
 ```
 
-See [`docs/MQB_CONFIG_EN.md`](docs/MQB_CONFIG_EN.md) for the complete schema, path bases, CLI/config precedence, and module-provider rules.
+See [`docs/MQB_CONFIG_EN.md`](docs/MQB_CONFIG_EN.md) for the complete schema, profiles, path bases, CLI/config precedence, and module-provider rules.
 
 ## Common CLI
 
@@ -157,6 +197,7 @@ mqb <source...> [options]
 
 | Option | Purpose |
 |---|---|
+| `--profile <name>` | Select one named profile from `mqb.json` |
 | `--debug` / `--release` | Build configuration |
 | `--std <14|17|20|23|latest>` | C++ standard |
 | `--type <exe|dll|static>` | Target kind |
@@ -188,7 +229,7 @@ Use the current binary's `mqb --help` as the complete CLI reference.
 
 | Topic | Document |
 |---|---|
-| `mqb.json` configuration and precedence | [`docs/MQB_CONFIG_EN.md`](docs/MQB_CONFIG_EN.md) |
+| `mqb.json` configuration, profiles, and precedence | [`docs/MQB_CONFIG_EN.md`](docs/MQB_CONFIG_EN.md) |
 | Installation, PATH, and uninstall | [`docs/INSTALLATION_EN.md`](docs/INSTALLATION_EN.md) |
 | Architecture and Modules/cache model | [`docs/ARCHITECTURE_EN.md`](docs/ARCHITECTURE_EN.md) |
 | Developing MQB | [`docs/DEVELOPMENT_EN.md`](docs/DEVELOPMENT_EN.md) |

--- a/cpp/include/mqb/config/ProjectConfig.hpp
+++ b/cpp/include/mqb/config/ProjectConfig.hpp
@@ -2,6 +2,7 @@
 
 #include <expected>
 #include <filesystem>
+#include <map>
 #include <optional>
 #include <string>
 #include <vector>
@@ -40,6 +41,12 @@ struct ModuleOverrides {
     std::vector<ExternalModuleProvider> external_providers;
 };
 
+struct ProjectProfile {
+    BuildOverrides build;
+    DiscoveryOverrides discovery;
+    ModuleOverrides modules;
+};
+
 struct ProjectConfig {
     int version{1};
     std::filesystem::path file;
@@ -47,6 +54,7 @@ struct ProjectConfig {
     BuildOverrides build;
     DiscoveryOverrides discovery;
     ModuleOverrides modules;
+    std::map<std::string, ProjectProfile, std::less<>> profiles;
 };
 
 enum class ErrorCode {

--- a/cpp/include/mqb/config/ProjectOptions.hpp
+++ b/cpp/include/mqb/config/ProjectOptions.hpp
@@ -41,6 +41,7 @@ struct EffectiveProjectOptions {
 
 [[nodiscard]] EffectiveProjectOptions resolve_project_options(
     const ProjectConfig* project_config,
+    const ProjectProfile* profile,
     const ProjectOverrides& cli_overrides);
 
 } // namespace mqb::config

--- a/cpp/src/app/cli/Cli.cpp
+++ b/cpp/src/app/cli/Cli.cpp
@@ -198,6 +198,15 @@ parse_timings_format(const std::string_view value) {
         + "' (expected text or json)"));
 }
 
+[[nodiscard]] std::expected<void, Error>
+select_profile(Options& options, const std::string_view value) {
+    if (options.profile) {
+        return std::unexpected(error("--profile may be specified only once"));
+    }
+    options.profile = std::string{value};
+    return {};
+}
+
 } // namespace
 
 std::expected<Options, Error>
@@ -269,6 +278,20 @@ parse_arguments(const std::span<const std::string_view> arguments) {
             auto format = parse_timings_format(*value);
             if (!format) return std::unexpected(format.error());
             options.timings = *format;
+            continue;
+        }
+        if (argument == "--profile") {
+            auto value = require_value(arguments, index, argument);
+            if (!value) return std::unexpected(value.error());
+            auto selected = select_profile(options, *value);
+            if (!selected) return std::unexpected(selected.error());
+            continue;
+        }
+        if (argument.starts_with("--profile=")) {
+            auto value = long_equals_value(argument, "--profile=");
+            if (!value) return std::unexpected(value.error());
+            auto selected = select_profile(options, *value);
+            if (!selected) return std::unexpected(selected.error());
             continue;
         }
         if (argument == "--discover") {
@@ -590,9 +613,11 @@ Default entry resolution for `mqb build` / `mqb run` with no positional source:
 
 Project configuration:
   MQB searches upward from the invocation directory for the nearest mqb.json.
-  Scalar precedence is: explicit CLI > mqb.json > built-in defaults.
-  Config paths are relative to mqb.json; CLI paths are relative to the invocation directory.
+  Scalar precedence is: explicit CLI > selected profile > mqb.json > built-in defaults.
+  List-valued settings append in the same base -> profile -> CLI order.
+  Config/profile paths are relative to mqb.json; CLI paths are relative to the invocation directory.
   Explicit positional sources always take precedence over build.entry.
+  Profiles are selected explicitly with --profile and may not override build.entry.
   External named-module IFCs may be declared under modules.external as logical-name -> IFC path.
 
 Source selection:
@@ -614,6 +639,7 @@ other generated module provider. MSVC standard-library named modules require --s
 missing toolchain capability fails closed with a dedicated diagnostic.
 
 Options:
+  --profile <name>         Select one named profile from mqb.json
   --debug                  Explicitly select Debug compile/link preset
   --release                Explicitly select Release compile/link preset
   --config <debug|release> Select compile/link preset
@@ -667,9 +693,9 @@ targets. Typed LTCG remains valid for static targets and couples /GL compilation
 /LTCG archive policy.
 
 Raw compiler/linker arguments are one argv element per option occurrence; MQB does not split a
-quoted string into multiple switches. Project config entries are applied first and CLI raw args
-append afterward. Typed runtime/LTCG and structured artifact routing are emitted after raw
-arguments so the BuildPlan remains authoritative.
+quoted string into multiple switches. Project config entries are applied first, selected profile
+entries append/override next, and CLI entries apply last. Typed runtime/LTCG and structured
+artifact routing are emitted after raw arguments so the BuildPlan remains authoritative.
 
 MQB v5 intentionally does not accept the PowerShell-era single-dash command aliases. Use the
 native options shown above; unknown legacy spellings fail instead of silently entering a

--- a/cpp/src/app/cli/Cli.hpp
+++ b/cpp/src/app/cli/Cli.hpp
@@ -26,6 +26,7 @@ enum class Command {
 struct Options {
     BuildRequest build;
     Command command{Command::direct};
+    std::optional<std::string> profile;
     std::optional<BuildConfiguration> configuration_override;
     std::optional<Architecture> architecture_override;
     std::optional<CppStandard> standard_override;

--- a/cpp/src/app/project/ProjectSetup.cpp
+++ b/cpp/src/app/project/ProjectSetup.cpp
@@ -97,6 +97,24 @@ template <typename T>
     return {};
 }
 
+[[nodiscard]] std::string unknown_profile_message(
+    const std::string_view requested,
+    const mqb::config::ProjectConfig& config) {
+    std::string message = "unknown profile '" + std::string{requested} + "'";
+    if (config.profiles.empty()) {
+        message += "; mqb.json defines no profiles";
+        return message;
+    }
+    message += "; available profiles:";
+    for (const auto& [name, profile] : config.profiles) {
+        (void)profile;
+        message += " '";
+        message += name;
+        message += "'";
+    }
+    return message;
+}
+
 } // namespace
 
 std::expected<ProjectSetup, ProjectSetupError>
@@ -125,6 +143,24 @@ prepare_project(
     const std::filesystem::path project_root = project_config
         ? project_config->project_root
         : invocation_directory;
+
+    mqb::config::ProjectProfile* selected_profile = nullptr;
+    if (options.profile) {
+        if (!project_config) {
+            return std::unexpected(ProjectSetupError{
+                .message = "--profile requires an mqb.json project configuration",
+                .config_error = std::nullopt,
+            });
+        }
+        const auto profile = project_config->profiles.find(*options.profile);
+        if (profile == project_config->profiles.end()) {
+            return std::unexpected(ProjectSetupError{
+                .message = unknown_profile_message(*options.profile, *project_config),
+                .config_error = std::nullopt,
+            });
+        }
+        selected_profile = &profile->second;
+    }
 
     for (auto& provider : options.external_module_providers) {
         if (provider.interface_file.is_relative()) {
@@ -164,6 +200,16 @@ prepare_project(
             });
         }
     }
+    if (selected_profile) {
+        const std::string layer = "profile '" + *options.profile + "'";
+        auto normalized = normalize_native_parameters(selected_profile->build, layer);
+        if (!normalized) {
+            return std::unexpected(ProjectSetupError{
+                .message = normalized.error(),
+                .config_error = std::nullopt,
+            });
+        }
+    }
     if (auto normalized = normalize_native_parameters(
             cli_overrides.build,
             "CLI"); !normalized) {
@@ -174,10 +220,12 @@ prepare_project(
     }
 
     const bool subsystem_explicit = cli_overrides.build.subsystem.has_value()
+        || (selected_profile && selected_profile->build.subsystem.has_value())
         || (project_config && project_config->build.subsystem.has_value());
 
     auto effective = mqb::config::resolve_project_options(
         project_config ? &*project_config : nullptr,
+        selected_profile,
         cli_overrides);
     options.build.configuration = effective.configuration;
     options.build.architecture = effective.architecture;

--- a/cpp/src/config/resolution/ProjectOptions.cpp
+++ b/cpp/src/config/resolution/ProjectOptions.cpp
@@ -59,16 +59,28 @@ void apply_modules(
     }
 }
 
+void apply_profile(
+    EffectiveProjectOptions& effective,
+    const ProjectProfile& profile) {
+    apply_build(effective, profile.build);
+    apply_discovery(effective, profile.discovery);
+    apply_modules(effective, profile.modules);
+}
+
 } // namespace
 
 EffectiveProjectOptions resolve_project_options(
     const ProjectConfig* project_config,
+    const ProjectProfile* profile,
     const ProjectOverrides& cli_overrides) {
     EffectiveProjectOptions effective;
     if (project_config != nullptr) {
         apply_build(effective, project_config->build);
         apply_discovery(effective, project_config->discovery);
         apply_modules(effective, project_config->modules);
+    }
+    if (profile != nullptr) {
+        apply_profile(effective, *profile);
     }
     apply_build(effective, cli_overrides.build);
     apply_discovery(effective, cli_overrides.discovery);

--- a/cpp/src/config/schema/ProjectConfigSchema.cpp
+++ b/cpp/src/config/schema/ProjectConfigSchema.cpp
@@ -453,6 +453,72 @@ using JsonValue = json::Value;
     return {};
 }
 
+[[nodiscard]] std::expected<void, Error> decode_profile(
+    const fs::path& file,
+    const fs::path& root,
+    const std::string_view profile_name,
+    const JsonValue& value,
+    ProjectProfile& out) {
+    const std::string scope = "profiles." + std::string{profile_name};
+    auto object = require_object(file, value, scope);
+    if (!object) return std::unexpected(object.error());
+
+    auto known = reject_unknown(
+        file,
+        **object,
+        {"build", "discovery", "modules"},
+        scope);
+    if (!known) return std::unexpected(known.error());
+
+    if (auto it = (**object).find("build"); it != (**object).end()) {
+        auto build_object = require_object(file, it->second, scope + ".build");
+        if (!build_object) return std::unexpected(build_object.error());
+        if (auto entry = (**build_object).find("entry"); entry != (**build_object).end()) {
+            return std::unexpected(schema_error(
+                file,
+                entry->second,
+                scope + ".build.entry is not allowed; build.entry is project identity and must be declared at the root build layer"));
+        }
+        auto decoded = decode_build(file, root, it->second, out.build);
+        if (!decoded) return std::unexpected(decoded.error());
+    }
+
+    if (auto it = (**object).find("discovery"); it != (**object).end()) {
+        auto decoded = decode_discovery(file, root, it->second, out.discovery);
+        if (!decoded) return std::unexpected(decoded.error());
+    }
+
+    if (auto it = (**object).find("modules"); it != (**object).end()) {
+        auto decoded = decode_modules(file, root, it->second, out.modules);
+        if (!decoded) return std::unexpected(decoded.error());
+    }
+
+    return {};
+}
+
+[[nodiscard]] std::expected<void, Error> decode_profiles(
+    const fs::path& file,
+    const fs::path& root,
+    const JsonValue& value,
+    std::map<std::string, ProjectProfile, std::less<>>& out) {
+    auto object = require_object(file, value, "profiles");
+    if (!object) return std::unexpected(object.error());
+
+    for (const auto& [name, profile_value] : **object) {
+        if (name.empty()) {
+            return std::unexpected(schema_error(
+                file,
+                profile_value,
+                "profile name must not be empty"));
+        }
+        ProjectProfile profile;
+        auto decoded = decode_profile(file, root, name, profile_value, profile);
+        if (!decoded) return std::unexpected(decoded.error());
+        out.emplace(name, std::move(profile));
+    }
+    return {};
+}
+
 } // namespace
 
 std::expected<ProjectConfig, Error> decode_project_config(
@@ -464,7 +530,7 @@ std::expected<ProjectConfig, Error> decode_project_config(
     auto known = reject_unknown(
         file,
         **object,
-        {"version", "build", "discovery", "modules"},
+        {"version", "build", "discovery", "modules", "profiles"},
         "root");
     if (!known) return std::unexpected(known.error());
 
@@ -535,6 +601,15 @@ std::expected<ProjectConfig, Error> decode_project_config(
             config.project_root,
             it->second,
             config.modules);
+        if (!decoded) return std::unexpected(decoded.error());
+    }
+
+    if (auto it = (**object).find("profiles"); it != (**object).end()) {
+        auto decoded = decode_profiles(
+            file,
+            config.project_root,
+            it->second,
+            config.profiles);
         if (!decoded) return std::unexpected(decoded.error());
     }
 

--- a/cpp/tests/config/integration/build_policy_config_tests.cpp
+++ b/cpp/tests/config/integration/build_policy_config_tests.cpp
@@ -81,7 +81,7 @@ int main() {
         cli.build.subsystem = mqb::LinkSubsystem::console;
         cli.build.compiler_arguments = {"/WX"};
         cli.build.linker_arguments = {"/MAP:cli.map"};
-        const auto effective = mqb::config::resolve_project_options(&*loaded, cli);
+        const auto effective = mqb::config::resolve_project_options(&*loaded, nullptr, cli);
         expect(effective.standard == mqb::CppStandard::cpp14,
                "CLI scalar standard should override project config");
         expect(effective.target_kind == mqb::TargetKind::executable,

--- a/cpp/tests/config/integration/project_config_tests.cpp
+++ b/cpp/tests/config/integration/project_config_tests.cpp
@@ -70,6 +70,34 @@ int main() {
       "vendor.math": "prebuilt/vendor.math.ifc",
       "vendor.text": "prebuilt/vendor text.ifc"
     }
+  },
+  "profiles": {
+    "dev": {
+      "build": {
+        "configuration": "debug",
+        "standard": "20",
+        "runtime": "MDd",
+        "defines": ["PROFILE_DEV=1"],
+        "include_dirs": ["profiles/dev/include"],
+        "compiler_args": ["/W4"]
+      },
+      "discovery": {
+        "enabled": true,
+        "extra_sources": ["profiles/dev/extra.cpp"]
+      },
+      "modules": {
+        "external": {
+          "vendor.math": "profiles/dev/vendor.math.ifc"
+        }
+      }
+    },
+    "ship": {
+      "build": {
+        "configuration": "release",
+        "ltcg": true,
+        "compiler_args": ["/O2"]
+      }
+    }
   }
 })json");
 
@@ -82,7 +110,7 @@ int main() {
     }
 
     auto loaded = mqb::config::ProjectConfigLoader::load(config_file);
-    expect(loaded.has_value(), "full version-1 config should load");
+    expect(loaded.has_value(), "full version-1 config with profiles should load");
     if (loaded) {
         expect(loaded->version == 1, "config version should be retained");
         expect(loaded->project_root == tree.root.lexically_normal(),
@@ -152,6 +180,36 @@ int main() {
                            == (tree.root / "prebuilt/vendor text.ifc").lexically_normal(),
                    "external provider mapping should preserve names and spaces in config-relative paths");
         }
+
+        expect(loaded->profiles.size() == 2,
+               "profiles object should decode every named profile");
+        const auto dev = loaded->profiles.find("dev");
+        expect(dev != loaded->profiles.end(), "dev profile should be addressable by name");
+        if (dev != loaded->profiles.end()) {
+            expect(dev->second.build.configuration == mqb::BuildConfiguration::debug,
+                   "profile build scalar should decode");
+            expect(dev->second.build.standard == mqb::CppStandard::cpp20,
+                   "profile C++ standard should decode");
+            expect(dev->second.build.runtime_library == mqb::RuntimeLibrary::mdd,
+                   "profile runtime should decode");
+            expect(!dev->second.build.entry,
+                   "profile build layer should never acquire project entry identity");
+            expect(dev->second.build.include_directories.size() == 1
+                       && dev->second.build.include_directories[0]
+                           == (tree.root / "profiles/dev/include").lexically_normal(),
+                   "profile paths should resolve relative to mqb.json");
+            expect(dev->second.discovery.enabled && *dev->second.discovery.enabled,
+                   "profile discovery scalar should decode");
+            expect(dev->second.discovery.extra_sources.size() == 1
+                       && dev->second.discovery.extra_sources[0]
+                           == (tree.root / "profiles/dev/extra.cpp").lexically_normal(),
+                   "profile discovery paths should resolve relative to mqb.json");
+            expect(dev->second.modules.external_providers.size() == 1
+                       && dev->second.modules.external_providers[0].logical_name == "vendor.math"
+                       && dev->second.modules.external_providers[0].interface_file
+                           == (tree.root / "profiles/dev/vendor.math.ifc").lexically_normal(),
+                   "profile module providers should decode with config-relative IFC paths");
+        }
     }
 
     write_text(config_file, R"json({"version":1,"build":{"type":"lib"}})json");
@@ -175,12 +233,28 @@ int main() {
                "missing discovery enabled field must remain unset");
         expect(minimal->modules.external_providers.empty(),
                "missing modules policy must remain an empty override");
+        expect(minimal->profiles.empty(),
+               "missing profiles object should remain an empty named-profile registry");
     }
 
     write_text(config_file, R"json({"version":1,"build":{"entry":""}})json");
     auto empty_entry = mqb::config::ProjectConfigLoader::load(config_file);
     expect(!empty_entry && empty_entry.error().code == mqb::config::ErrorCode::schema_error,
            "build.entry must be a non-empty string");
+
+    write_text(config_file, R"json({"version":1,"profiles":{"bad":{"build":{"entry":"other.cpp"}}}})json");
+    auto profile_entry = mqb::config::ProjectConfigLoader::load(config_file);
+    expect(!profile_entry && profile_entry.error().code == mqb::config::ErrorCode::schema_error,
+           "profile build.entry should be rejected as project identity rather than build policy");
+    if (!profile_entry) {
+        expect(profile_entry.error().message.find("build.entry is not allowed") != std::string::npos,
+               "profile entry rejection should explain the project-identity boundary");
+    }
+
+    write_text(config_file, R"json({"version":1,"profiles":{"bad":{"surprise":true}}})json");
+    auto bad_profile_field = mqb::config::ProjectConfigLoader::load(config_file);
+    expect(!bad_profile_field && bad_profile_field.error().code == mqb::config::ErrorCode::schema_error,
+           "unknown profile fields should be rejected by strict schema");
 
     write_text(config_file, R"json({"version":1,"modules":{"external":{"vendor.math":7}}})json");
     auto bad_provider_type = mqb::config::ProjectConfigLoader::load(config_file);

--- a/cpp/tests/config/resolution/project_options_tests.cpp
+++ b/cpp/tests/config/resolution/project_options_tests.cpp
@@ -19,7 +19,7 @@ int main() {
 
     {
         const mqb::config::ProjectOverrides cli;
-        const auto effective = mqb::config::resolve_project_options(nullptr, cli);
+        const auto effective = mqb::config::resolve_project_options(nullptr, nullptr, cli);
         expect(effective.configuration == mqb::BuildConfiguration::debug,
                "built-in configuration default should be debug");
         expect(effective.architecture == mqb::Architecture::x64,
@@ -63,7 +63,7 @@ int main() {
 
     {
         const mqb::config::ProjectOverrides cli;
-        const auto effective = mqb::config::resolve_project_options(&project, cli);
+        const auto effective = mqb::config::resolve_project_options(&project, nullptr, cli);
         expect(effective.configuration == mqb::BuildConfiguration::release,
                "project config should override built-in configuration");
         expect(effective.architecture == mqb::Architecture::x86,
@@ -84,18 +84,80 @@ int main() {
                "project external module registry should populate effective provider policy");
     }
 
+    mqb::config::ProjectProfile profile;
+    profile.build.configuration = mqb::BuildConfiguration::debug;
+    profile.build.standard = mqb::CppStandard::cpp20;
+    profile.build.output_name = "from-profile";
+    profile.build.defines = {"PROFILE_B=2", "SHARED=profile"};
+    profile.build.include_directories = {fs::path{"profile/include"}};
+    profile.build.libraries = {"profilelib"};
+    profile.discovery.enabled = true;
+    profile.discovery.exclude_directories = {fs::path{"profile-tests"}};
+    profile.modules.external_providers = {
+        mqb::ExternalModuleProvider{
+            .logical_name = "vendor.math",
+            .interface_file = fs::path{"profile/vendor.math.ifc"},
+        },
+        mqb::ExternalModuleProvider{
+            .logical_name = "profile.only",
+            .interface_file = fs::path{"profile/profile.only.ifc"},
+        },
+    };
+
+    {
+        const mqb::config::ProjectOverrides cli;
+        const auto effective = mqb::config::resolve_project_options(&project, &profile, cli);
+        expect(effective.configuration == mqb::BuildConfiguration::debug,
+               "profile scalar should override base project config");
+        expect(effective.architecture == mqb::Architecture::x86,
+               "base scalar should remain when profile leaves it unset");
+        expect(effective.standard == mqb::CppStandard::cpp20,
+               "profile standard should override base standard");
+        expect(effective.target_kind == mqb::TargetKind::static_library,
+               "base target kind should remain when profile leaves it unset");
+        expect(effective.output_name && *effective.output_name == "from-profile",
+               "profile output should override base output");
+        expect(effective.discovery_enabled,
+               "profile discovery scalar should override base discovery scalar");
+        expect(effective.defines.size() == 4
+                   && effective.defines[0] == "CONFIG_A=1"
+                   && effective.defines[1] == "SHARED=config"
+                   && effective.defines[2] == "PROFILE_B=2"
+                   && effective.defines[3] == "SHARED=profile",
+               "profile list values should append after base config lists");
+        expect(effective.include_directories.size() == 2
+                   && effective.include_directories[1] == fs::path{"profile/include"},
+               "profile paths should append after base paths");
+        expect(effective.libraries.size() == 2
+                   && effective.libraries[0] == "configlib"
+                   && effective.libraries[1] == "profilelib",
+               "profile libraries should append after base libraries");
+        expect(effective.external_module_providers.size() == 3,
+               "profile modules should replace by logical name and append profile-only providers");
+        if (effective.external_module_providers.size() == 3) {
+            expect(effective.external_module_providers[0].logical_name == "vendor.math"
+                       && effective.external_module_providers[0].interface_file
+                           == fs::path{"profile/vendor.math.ifc"},
+                   "profile provider should replace matching base provider in place");
+            expect(effective.external_module_providers[1].logical_name == "config.only",
+                   "base-only provider should remain after profile overlay");
+            expect(effective.external_module_providers[2].logical_name == "profile.only",
+                   "profile-only provider should append deterministically");
+        }
+    }
+
     {
         mqb::config::ProjectOverrides cli;
-        cli.build.configuration = mqb::BuildConfiguration::debug;
+        cli.build.configuration = mqb::BuildConfiguration::release;
         cli.build.architecture = mqb::Architecture::x64;
-        cli.build.standard = mqb::CppStandard::cpp20;
+        cli.build.standard = mqb::CppStandard::cpp23;
         cli.build.target_kind = mqb::TargetKind::dynamic_library;
         cli.build.output_name = "from-cli";
-        cli.build.defines = {"CLI_B=2", "SHARED=cli"};
+        cli.build.defines = {"CLI_C=3", "SHARED=cli"};
         cli.build.include_directories = {fs::path{"cli/include"}};
         cli.build.library_directories = {fs::path{"cli/lib"}};
         cli.build.libraries = {"clilib"};
-        cli.discovery.enabled = true;
+        cli.discovery.enabled = false;
         cli.discovery.exclude_directories = {fs::path{"cli-tests"}};
         cli.discovery.extra_sources = {fs::path{"src/cli-extra.cpp"}};
         cli.discovery.exclude_sources = {fs::path{"src/cli-old.cpp"}};
@@ -110,58 +172,58 @@ int main() {
             },
         };
 
-        const auto effective = mqb::config::resolve_project_options(&project, cli);
-        expect(effective.configuration == mqb::BuildConfiguration::debug,
-               "CLI configuration should override project config");
+        const auto effective = mqb::config::resolve_project_options(&project, &profile, cli);
+        expect(effective.configuration == mqb::BuildConfiguration::release,
+               "CLI configuration should override selected profile");
         expect(effective.architecture == mqb::Architecture::x64,
-               "CLI architecture should override project config");
-        expect(effective.standard == mqb::CppStandard::cpp20,
-               "CLI standard should override project config");
+               "CLI architecture should override base config");
+        expect(effective.standard == mqb::CppStandard::cpp23,
+               "CLI standard should override selected profile");
         expect(effective.target_kind == mqb::TargetKind::dynamic_library,
-               "CLI target kind should override static project config");
+               "CLI target kind should override base project config");
         expect(effective.output_name && *effective.output_name == "from-cli",
-               "CLI output should override project config");
-        expect(effective.discovery_enabled,
-               "CLI discovery override should override project config");
-        expect(effective.defines.size() == 4
+               "CLI output should override selected profile");
+        expect(!effective.discovery_enabled,
+               "CLI discovery override should override selected profile");
+        expect(effective.defines.size() == 6
                    && effective.defines[0] == "CONFIG_A=1"
-                   && effective.defines[1] == "SHARED=config"
-                   && effective.defines[2] == "CLI_B=2"
-                   && effective.defines[3] == "SHARED=cli",
-               "CLI list values should append after config list values in stable order");
-        expect(effective.include_directories.size() == 2
+                   && effective.defines[2] == "PROFILE_B=2"
+                   && effective.defines[4] == "CLI_C=3"
+                   && effective.defines[5] == "SHARED=cli",
+               "list precedence should preserve base then profile then CLI order");
+        expect(effective.include_directories.size() == 3
                    && effective.include_directories[0] == fs::path{"config/include"}
-                   && effective.include_directories[1] == fs::path{"cli/include"},
-               "include path precedence should preserve config then CLI order");
+                   && effective.include_directories[1] == fs::path{"profile/include"}
+                   && effective.include_directories[2] == fs::path{"cli/include"},
+               "include path precedence should preserve base then profile then CLI order");
         expect(effective.library_directories.size() == 2
                    && effective.library_directories[0] == fs::path{"config/lib"}
                    && effective.library_directories[1] == fs::path{"cli/lib"},
-               "library path lists should append CLI after config");
-        expect(effective.libraries.size() == 2
+               "unset profile library paths should not disturb base plus CLI order");
+        expect(effective.libraries.size() == 3
                    && effective.libraries[0] == "configlib"
-                   && effective.libraries[1] == "clilib",
-               "libraries should append CLI after config");
-        expect(effective.discovery_exclude_directories.size() == 2,
-               "discovery exclude directories should be additive");
+                   && effective.libraries[1] == "profilelib"
+                   && effective.libraries[2] == "clilib",
+               "libraries should append through all three layers");
+        expect(effective.discovery_exclude_directories.size() == 3,
+               "discovery exclude directories should be additive across all layers");
         expect(effective.discovery_extra_sources.size() == 2,
-               "discovery extra sources should be additive");
+               "discovery extra sources should append base then CLI when profile is empty");
         expect(effective.discovery_exclude_sources.size() == 2,
-               "discovery excluded sources should be additive");
-        expect(effective.external_module_providers.size() == 3,
-               "CLI external module providers should override by logical name without dropping config-only providers");
-        if (effective.external_module_providers.size() == 3) {
+               "discovery excluded sources should append base then CLI when profile is empty");
+        expect(effective.external_module_providers.size() == 4,
+               "CLI providers should replace the selected profile provider and keep base/profile-only providers");
+        if (effective.external_module_providers.size() == 4) {
             expect(effective.external_module_providers[0].logical_name == "vendor.math"
                        && effective.external_module_providers[0].interface_file
                            == fs::path{"cli/vendor.math.ifc"},
-                   "CLI provider should replace the matching config provider in-place");
-            expect(effective.external_module_providers[1].logical_name == "config.only"
-                       && effective.external_module_providers[1].interface_file
-                           == fs::path{"config/config.only.ifc"},
-                   "config-only provider should remain available after CLI override resolution");
-            expect(effective.external_module_providers[2].logical_name == "cli.only"
-                       && effective.external_module_providers[2].interface_file
-                           == fs::path{"cli/cli.only.ifc"},
-                   "CLI-only provider should append deterministically after config registry entries");
+                   "CLI provider should replace the matching profile provider in-place");
+            expect(effective.external_module_providers[1].logical_name == "config.only",
+                   "config-only provider should remain after profile and CLI overlays");
+            expect(effective.external_module_providers[2].logical_name == "profile.only",
+                   "profile-only provider should remain after CLI overlay");
+            expect(effective.external_module_providers[3].logical_name == "cli.only",
+                   "CLI-only provider should append deterministically");
         }
     }
 

--- a/cpp/tests/e2e/mqb_project_config_e2e_tests.cpp
+++ b/cpp/tests/e2e/mqb_project_config_e2e_tests.cpp
@@ -161,6 +161,21 @@ struct TempTree {
     "exclude_dirs": ["tests"],
     "extra_sources": ["manual.cpp"],
     "exclude_sources": ["legacy.cpp"]
+  },
+  "profiles": {
+    "fast": {
+      "build": {
+        "configuration": "debug",
+        "output": "profile_product",
+        "compiler_args": ["/std:c++20", "/DPROFILE_VALUE=7", "/W4"],
+        "linker_args": ["/DEBUG:FULL"]
+      }
+    },
+    "static-check": {
+      "build": {
+        "type": "static"
+      }
+    }
   }
 })json";
 }
@@ -220,6 +235,9 @@ int main(int argc, char* argv[]) {
 #ifndef CONFIG_VALUE
 #error CONFIG_VALUE must come from mqb.json
 #endif
+#ifndef PROFILE_VALUE
+#define PROFILE_VALUE 0
+#endif
 #ifndef CLI_VALUE
 #define CLI_VALUE 0
 #endif
@@ -231,7 +249,8 @@ int main() {
 #else
     constexpr int debug_bonus = 0;
 #endif
-    std::printf("config-e2e=%d\n", value() + manual_value() + library_value() + CONFIG_VALUE + CLI_VALUE + debug_bonus);
+    std::printf("config-e2e=%d\n", value() + manual_value() + library_value()
+        + CONFIG_VALUE + PROFILE_VALUE + CLI_VALUE + debug_bonus);
     return 0;
 }
 )cpp");
@@ -306,6 +325,76 @@ int main() {
                "config-only define change should alter executable behavior");
     } else {
         expect(false, "config-changed executable should launch");
+    }
+
+    auto profile_build = run_mqb(
+        runner,
+        mqb_executable,
+        nested_working_directory,
+        {"--profile", "fast"});
+    expect(profile_build.has_value(), "selected-profile invocation should launch");
+    if (profile_build) {
+        if (profile_build->exit_code != 0) dump_failure(*profile_build);
+        expect(profile_build->exit_code == 0, "selected profile build should succeed");
+        expect(profile_build->stdout_text.find("[link] profile_product.exe") != std::string::npos,
+               "profile output scalar should override base config output");
+    }
+    const fs::path profile_exe = tree.root / ".mqb" / "bin" / "profile_product.exe";
+    auto profile_run = run_executable(runner, profile_exe, tree.root);
+    expect(profile_run.has_value() && profile_run->exit_code == 0,
+           "profile-built executable should launch");
+    if (profile_run) {
+        expect(profile_run->stdout_text.find("config-e2e=1117") != std::string::npos,
+               "profile debug configuration and native /D policy should overlay base config");
+    }
+
+    auto profile_cli_override = run_mqb(
+        runner,
+        mqb_executable,
+        nested_working_directory,
+        {"--profile=fast", "--release", "--std", "23", "-DCLI_VALUE=10", "-o", "profile_cli_product"});
+    expect(profile_cli_override.has_value(), "CLI-over-profile invocation should launch");
+    if (profile_cli_override) {
+        if (profile_cli_override->exit_code != 0) dump_failure(*profile_cli_override);
+        expect(profile_cli_override->exit_code == 0,
+               "CLI should override profile scalar semantics after profile native normalization");
+        expect(profile_cli_override->stdout_text.find("[link] profile_cli_product.exe") != std::string::npos,
+               "CLI output should override selected profile output");
+    }
+    const fs::path profile_cli_exe = tree.root / ".mqb" / "bin" / "profile_cli_product.exe";
+    auto profile_cli_run = run_executable(runner, profile_cli_exe, tree.root);
+    expect(profile_cli_run.has_value() && profile_cli_run->exit_code == 0,
+           "CLI-over-profile executable should launch");
+    if (profile_cli_run) {
+        expect(profile_cli_run->stdout_text.find("config-e2e=127") != std::string::npos,
+               "CLI release/define overrides should win while retaining profile and base list inputs");
+    }
+
+    auto unknown_profile = run_mqb(
+        runner,
+        mqb_executable,
+        nested_working_directory,
+        {"--profile", "missing"});
+    expect(unknown_profile.has_value(), "unknown profile invocation should launch candidate MQB");
+    if (unknown_profile) {
+        expect(unknown_profile->exit_code == 2,
+               "unknown profile should fail closed before build execution");
+        expect(unknown_profile->stderr_text.find("unknown profile 'missing'") != std::string::npos
+                   && unknown_profile->stderr_text.find("'fast'") != std::string::npos,
+               "unknown profile diagnostic should name the request and available profiles");
+    }
+
+    auto static_run = run_mqb(
+        runner,
+        mqb_executable,
+        nested_working_directory,
+        {"--profile", "static-check", "--run"});
+    expect(static_run.has_value(), "profile target-kind run validation should launch candidate MQB");
+    if (static_run) {
+        expect(static_run->exit_code == 2,
+               "profile selecting static target should be rejected by executable-only run contract");
+        expect(static_run->stderr_text.find("--run is only valid for executable targets") != std::string::npos,
+               "profile target-kind validation should preserve the established run diagnostic");
     }
 
     auto cli_override = run_mqb(

--- a/docs/MQB_CONFIG.md
+++ b/docs/MQB_CONFIG.md
@@ -5,7 +5,7 @@
 `mqb.json` 是 MQB 的版本化项目配置文件。MQB 从 invocation directory 向上查找最近的 `mqb.json`；找到后，该文件所在目录同时成为：
 
 - project root；
-- 配置相对路径的基准；
+- 配置与 profile 相对路径的基准；
 - `.mqb/` 构建状态的根目录。
 
 ## 1. 最小配置
@@ -25,6 +25,7 @@ version
 build
 discovery
 modules
+profiles
 ```
 
 ## 2. 完整示例
@@ -58,6 +59,25 @@ modules
   "modules": {
     "external": {
       "vendor.math": "third_party/ifc/vendor.math.ifc"
+    }
+  },
+  "profiles": {
+    "dev": {
+      "build": {
+        "configuration": "debug",
+        "runtime": "MDd",
+        "compiler_args": ["/W4"]
+      },
+      "discovery": {
+        "enabled": true
+      }
+    },
+    "release": {
+      "build": {
+        "configuration": "release",
+        "ltcg": true,
+        "compiler_args": ["/O2"]
+      }
     }
   }
 }
@@ -122,6 +142,8 @@ mqb run tools/tool.cpp
 ```
 
 即使项目设置了 `build.entry`，这里仍构建并运行 `tools/tool.cpp`。
+
+`build.entry` **只能声明在根 `build` 层**。Profile 是构建策略 overlay，不能通过 `profiles.<name>.build.entry` 改变项目身份；该字段会被 strict schema 直接拒绝。
 
 ### Typed policy
 
@@ -201,7 +223,7 @@ mqb main.cpp --module-ifc vendor.math=C:\sdk\vendor.math.ifc
 - MQB 不会把 external IFC 加入 source discovery 或 compile levels；
 - provider 缺失会在进入真正 consumer compile 前 fail closed；
 - provider identity 会进入 consumer compile/cache identity，替换 IFC 会使相关 cache 失效；
-- 同名 CLI provider 会覆盖同名 config provider；
+- base config、selected profile 与 CLI 按 logical module name 分层合并，后层同名 provider 定点覆盖前层；
 - CLI 内重复声明同一 logical module name 会报错。
 
 ### `std` / `std.compat`
@@ -210,12 +232,79 @@ mqb main.cpp --module-ifc vendor.math=C:\sdk\vendor.math.ifc
 
 当 P1689 requirement 实际出现 `std` / `std.compat` 时，MQB 才会查询当前 VC Tools 的标准库 module source，并把它作为 toolchain-owned provider 注入同一 module graph。当前 MSVC 标准库 named modules 要求满足 toolchain capability，并使用 `--std latest`。
 
-## 6. 优先级
+## 6. `profiles`
+
+`profiles` 是 profile name 到配置 overlay 的对象。每个 profile 只接受：
+
+```text
+build
+discovery
+modules
+```
+
+它们复用根层完全相同的 typed policy、list、路径和 module-provider 解码规则，但 `build.entry` 除外：profile 内禁止设置入口。
+
+示例：
+
+```json
+{
+  "version": 1,
+  "build": {
+    "entry": "src/main.cpp",
+    "standard": "23",
+    "defines": ["PROJECT=1"]
+  },
+  "profiles": {
+    "dev": {
+      "build": {
+        "configuration": "debug",
+        "runtime": "MDd",
+        "defines": ["DEV=1"],
+        "compiler_args": ["/W4"]
+      }
+    },
+    "release": {
+      "build": {
+        "configuration": "release",
+        "ltcg": true,
+        "compiler_args": ["/O2"]
+      }
+    }
+  }
+}
+```
+
+选择方式：
+
+```powershell
+mqb build --profile release
+mqb run --profile dev -- input.txt
+```
+
+也接受：
+
+```powershell
+mqb build --profile=release
+```
+
+当前契约刻意保持简单且确定：
+
+- 一次 invocation 最多选择一个 profile；重复 `--profile` 报错；
+- 不存在 profile inheritance；
+- 不支持多 profile stacking；
+- 没有隐式 default profile；未写 `--profile` 就只使用 base config + CLI；
+- `--profile` 需要项目存在 `mqb.json`；
+- 未找到 profile 时 fail closed，并列出可用 profile 名；
+- profile 中的 relative path 与 base config 一样，以 `mqb.json` 所在目录为基准；
+- profile 中的 `compiler_args` / `linker_args` 仍进入同一 MSVC Parameter Engine，semantic option 会先在 profile 自身层归一化，然后再由更高优先级 CLI 覆盖；
+- profile 可以选择 `type` 等 typed policy，因此最终 target 仍受同一 executable/static/DLL 合法性门禁约束。
+
+## 7. 优先级
 
 Scalar policy：
 
 ```text
-显式 CLI > mqb.json > built-in default
+显式 CLI > selected profile > base mqb.json > built-in default
 ```
 
 包括：
@@ -231,32 +320,34 @@ subsystem
 output
 ```
 
+同一层内，typed policy 与等价 native MSVC semantic option 必须一致，否则在进入 toolchain 前 fail closed。例如 profile 同时写 `runtime: "MT"` 与 `/MD` 会被拒绝。
+
 入口选择是独立的 source-selection policy：
 
 ```text
-显式 positional source(s) > build.entry > 唯一 conventional main
+显式 positional source(s) > root build.entry > 唯一 conventional main
 ```
 
 普通 list-like 输入按顺序追加：
 
 ```text
-mqb.json entries -> CLI entries
+base mqb.json entries -> selected profile entries -> CLI entries
 ```
 
-适用于 defines、include dirs、library dirs、libraries、compiler args、linker args。
+适用于 defines、include dirs、library dirs、libraries、compiler args、linker args，以及 discovery list corrections。
 
-External module provider registry 按 logical module name 合并；同名 CLI 项定点覆盖 config 项，而不是简单追加。
+External module provider registry 按 logical module name 合并；同名后层项定点覆盖前层项，而不是制造重复 provider。
 
-## 7. 路径基准
+## 8. 路径基准
 
 MQB 明确区分两种相对路径：
 
 ```text
-CLI relative path      -> invocation directory
-mqb.json relative path -> directory containing mqb.json
+CLI relative path                 -> invocation directory
+mqb.json / profile relative path  -> directory containing mqb.json
 ```
 
-`build.entry` 属于后者。
+`build.entry` 属于后者，但只能出现在 root build 层。
 
 例如：
 
@@ -276,6 +367,13 @@ project/
   "build": {
     "entry": "src/main.cpp",
     "include_dirs": ["include"]
+  },
+  "profiles": {
+    "dev": {
+      "build": {
+        "include_dirs": ["third_party/dev/include"]
+      }
+    }
   }
 }
 ```
@@ -283,22 +381,22 @@ project/
 从 `project/nested/work` 运行：
 
 ```powershell
-mqb run
+mqb run --profile dev
 ```
 
-仍会加载 `project/mqb.json`，把 entry 解析为 `project/src/main.cpp`、include dir 解析为 `project/include`，并把 writable artifacts 放到 `project/.mqb/`。
+仍会加载 `project/mqb.json`，把 entry 解析为 `project/src/main.cpp`、base include dir 解析为 `project/include`、profile include dir 解析为 `project/third_party/dev/include`，并把 writable artifacts 放到 `project/.mqb/`。
 
-显式形式仍按 invocation directory 解析：
+显式 CLI source/path 仍按 invocation directory 解析：
 
 ```powershell
 mqb ../../src/main.cpp
 ```
 
-## 8. Cache 语义
+## 9. Cache 语义
 
-MQB 不以“配置文件时间戳变化”作为全量 rebuild 信号；它根据**生效后的构建语义**计算 identity。
+MQB 不以“配置文件时间戳变化”或“profile 名变化”作为全量 rebuild 信号；它根据**最终生效的构建语义**计算 identity。
 
-`build.entry` 自身不额外进入 compile/link identity；它只决定本次 source-selection 的入口。解析出的实际 source、discovery 结果与既有 compiler/linker semantics 继续决定 cache identity。
+`build.entry` 自身不额外进入 compile/link identity；它只决定本次 source-selection 的入口。Profile name 也不是额外 cache 维度。两个 profile 如果解析成完全相同的 effective build policy/source graph，应复用同一套既有 cache identity。
 
 典型影响：
 
@@ -307,6 +405,7 @@ MQB 不以“配置文件时间戳变化”作为全量 rebuild 信号；它根�
 - `subsystem` 只影响 link identity；
 - libraries / library dirs / linker args 改变 link identity；
 - `type` 改变 downstream target ownership；
+- discovery/profile corrections 通过最终 source set 影响参与构建的 TUs；
 - external/prebuilt IFC identity 改变会使依赖它的 consumer compile cache 失效；
 - selected MSVC toolchain identity 改变时，不会静默复用不兼容的 toolchain-owned standard-library IFC。
 
@@ -314,7 +413,7 @@ MQB 不以“配置文件时间戳变化”作为全量 rebuild 信号；它根�
 
 `-j/--jobs` 是执行策略，不属于 build identity，也不是 v1 配置字段。
 
-## 9. 当前明确边界
+## 10. 当前明确边界
 
 - `exe`、`dll`、`static` 均受支持；
 - `mqb run` 与 source-first `--run` 仅适用于 executable；
@@ -322,6 +421,8 @@ MQB 不以“配置文件时间戳变化”作为全量 rebuild 信号；它根�
 - **需要 Modules/Header Units pipeline 的 static-library target 当前仍 fail closed**；
 - discovery correction 使用精确路径，不支持 glob；
 - default-entry conventional fallback 不递归、不使用 glob；
+- profile 当前仅支持单个显式选择，不支持继承、多 profile stacking 或 implicit default profile；
+- profile 不能覆盖 `build.entry`；
 - 间接 `/DEFAULTLIB` 传递依赖不承诺完全的新鲜度跟踪。
 
 更底层的 provider graph、artifact identity 与职责边界见 [`ARCHITECTURE.md`](ARCHITECTURE.md)。

--- a/docs/MQB_CONFIG_EN.md
+++ b/docs/MQB_CONFIG_EN.md
@@ -5,7 +5,7 @@
 `mqb.json` is MQB's versioned project configuration file. MQB searches upward from the invocation directory for the nearest `mqb.json`. Once found, its directory becomes:
 
 - the project root;
-- the base for configuration-relative paths;
+- the base for configuration- and profile-relative paths;
 - the root of writable `.mqb/` build state.
 
 ## 1. Minimal configuration
@@ -25,6 +25,7 @@ version
 build
 discovery
 modules
+profiles
 ```
 
 ## 2. Complete example
@@ -58,6 +59,25 @@ modules
   "modules": {
     "external": {
       "vendor.math": "third_party/ifc/vendor.math.ifc"
+    }
+  },
+  "profiles": {
+    "dev": {
+      "build": {
+        "configuration": "debug",
+        "runtime": "MDd",
+        "compiler_args": ["/W4"]
+      },
+      "discovery": {
+        "enabled": true
+      }
+    },
+    "release": {
+      "build": {
+        "configuration": "release",
+        "ltcg": true,
+        "compiler_args": ["/O2"]
+      }
     }
   }
 }
@@ -122,6 +142,8 @@ mqb run tools/tool.cpp
 ```
 
 Even when `build.entry` exists, this builds and runs `tools/tool.cpp`.
+
+`build.entry` may appear **only in the root `build` layer**. Profiles are build-policy overlays and cannot change project identity through `profiles.<name>.build.entry`; strict schema validation rejects that field.
 
 ### Typed policy
 
@@ -201,7 +223,7 @@ Behavior:
 - it is not added to source discovery or compile levels;
 - a missing provider fails closed before the real consumer compile begins;
 - provider identity participates in consumer compile/cache identity, so replacing the IFC invalidates affected consumers;
-- a CLI provider overrides a config provider with the same logical name;
+- base config, selected profile, and CLI merge providers by logical name; a later layer replaces the matching earlier provider in place;
 - declaring the same logical name more than once on the CLI is an error.
 
 ### `std` / `std.compat`
@@ -210,12 +232,79 @@ Behavior:
 
 Only when a P1689 requirement actually references `std` or `std.compat` does MQB query the current VC Tools standard-library module source and inject it as a toolchain-owned provider into the same module graph. Current MSVC standard-library named modules require a supporting toolchain and `--std latest`.
 
-## 6. Precedence
+## 6. `profiles`
+
+`profiles` maps profile names to configuration overlays. Each profile accepts only:
+
+```text
+build
+discovery
+modules
+```
+
+Those sections reuse the same typed-policy, list, path, and module-provider decoding rules as the root layers, except that profile-local `build.entry` is prohibited.
+
+Example:
+
+```json
+{
+  "version": 1,
+  "build": {
+    "entry": "src/main.cpp",
+    "standard": "23",
+    "defines": ["PROJECT=1"]
+  },
+  "profiles": {
+    "dev": {
+      "build": {
+        "configuration": "debug",
+        "runtime": "MDd",
+        "defines": ["DEV=1"],
+        "compiler_args": ["/W4"]
+      }
+    },
+    "release": {
+      "build": {
+        "configuration": "release",
+        "ltcg": true,
+        "compiler_args": ["/O2"]
+      }
+    }
+  }
+}
+```
+
+Select a profile explicitly:
+
+```powershell
+mqb build --profile release
+mqb run --profile dev -- input.txt
+```
+
+The equals form is also accepted:
+
+```powershell
+mqb build --profile=release
+```
+
+The current contract is deliberately small and deterministic:
+
+- at most one profile may be selected per invocation; duplicate `--profile` is an error;
+- there is no profile inheritance;
+- multi-profile stacking is not supported;
+- there is no implicit default profile; omitting `--profile` means base config + CLI only;
+- `--profile` requires an `mqb.json` project configuration;
+- an unknown profile fails closed and reports the available profile names;
+- relative paths inside a profile use the `mqb.json` directory as their base, exactly like root config paths;
+- profile `compiler_args` / `linker_args` still flow through the same MSVC Parameter Engine. Semantic native options are normalized within the profile layer before higher-precedence CLI policy is applied;
+- a profile may select typed policy such as `type`, so the final target still passes through the same executable/static/DLL validity gates.
+
+## 7. Precedence
 
 Scalar policy:
 
 ```text
-explicit CLI > mqb.json > built-in default
+explicit CLI > selected profile > base mqb.json > built-in default
 ```
 
 This covers:
@@ -231,32 +320,34 @@ subsystem
 output
 ```
 
+Within one layer, typed policy and equivalent native MSVC semantic options must agree or MQB fails closed before toolchain execution. For example, a profile that declares `runtime: "MT"` and `/MD` is rejected.
+
 Entry selection is a separate source-selection policy:
 
 ```text
-explicit positional source(s) > build.entry > unique conventional main
+explicit positional source(s) > root build.entry > unique conventional main
 ```
 
 Ordinary list-like inputs append deterministically:
 
 ```text
-mqb.json entries -> CLI entries
+base mqb.json entries -> selected profile entries -> CLI entries
 ```
 
-This applies to defines, include dirs, library dirs, libraries, compiler args, and linker args.
+This applies to defines, include dirs, library dirs, libraries, compiler args, linker args, and discovery list corrections.
 
-The external module provider registry merges by logical module name. A CLI entry replaces the config entry with the same name rather than merely appending another provider.
+The external module provider registry merges by logical module name. A matching entry in a later layer replaces the earlier provider rather than creating a duplicate.
 
-## 7. Path bases
+## 8. Path bases
 
 MQB distinguishes two relative-path bases:
 
 ```text
-CLI relative path      -> invocation directory
-mqb.json relative path -> directory containing mqb.json
+CLI relative path                 -> invocation directory
+mqb.json / profile relative path  -> directory containing mqb.json
 ```
 
-`build.entry` uses the second base.
+`build.entry` uses the second base but is valid only in the root build layer.
 
 Example:
 
@@ -276,6 +367,13 @@ Configuration:
   "build": {
     "entry": "src/main.cpp",
     "include_dirs": ["include"]
+  },
+  "profiles": {
+    "dev": {
+      "build": {
+        "include_dirs": ["third_party/dev/include"]
+      }
+    }
   }
 }
 ```
@@ -283,22 +381,22 @@ Configuration:
 From `project/nested/work`:
 
 ```powershell
-mqb run
+mqb run --profile dev
 ```
 
-MQB still loads `project/mqb.json`, resolves the entry as `project/src/main.cpp`, resolves the include dir as `project/include`, and places writable artifacts under `project/.mqb/`.
+MQB still loads `project/mqb.json`, resolves the entry as `project/src/main.cpp`, the base include directory as `project/include`, the profile include directory as `project/third_party/dev/include`, and places writable artifacts under `project/.mqb/`.
 
-An explicit source remains invocation-relative:
+Explicit CLI sources and paths remain invocation-relative:
 
 ```powershell
 mqb ../../src/main.cpp
 ```
 
-## 8. Cache semantics
+## 9. Cache semantics
 
-MQB does not treat "the config file timestamp changed" as a global rebuild signal. Identity is derived from the **effective build semantics**.
+MQB does not treat "the config file timestamp changed" or "the profile name changed" as a global rebuild signal. Identity is derived from the **final effective build semantics**.
 
-`build.entry` does not add a separate compile/link identity field; it selects the source-discovery entry for this invocation. The resolved source set and existing compiler/linker semantics continue to determine cache identity.
+`build.entry` does not add a separate compile/link identity field; it selects the source-discovery entry for this invocation. The profile name is likewise not a separate cache dimension. Two profiles that resolve to identical effective build policy/source graphs should reuse the same existing cache identity.
 
 Typical effects:
 
@@ -307,6 +405,7 @@ Typical effects:
 - `subsystem` changes link identity only;
 - libraries, library dirs, and linker args change link identity;
 - `type` changes downstream target ownership;
+- discovery/profile corrections affect participating TUs through the final source set;
 - changing an external/prebuilt IFC invalidates dependent consumer compile caches;
 - changing the selected MSVC toolchain identity does not silently reuse incompatible toolchain-owned standard-library IFCs.
 
@@ -314,7 +413,7 @@ Missing recorded outputs also invalidate the corresponding compile/link/archive 
 
 `-j/--jobs` is execution policy. It is not part of build identity and is not a v1 configuration field.
 
-## 9. Explicit current boundaries
+## 10. Explicit current boundaries
 
 - `exe`, `dll`, and `static` are supported;
 - `mqb run` and source-first `--run` apply only to executables;
@@ -322,6 +421,8 @@ Missing recorded outputs also invalidate the corresponding compile/link/archive 
 - **static-library targets that require the Modules/Header Units pipeline still fail closed**;
 - discovery corrections use exact paths and do not support globs;
 - conventional default-entry fallback is non-recursive and does not use globs;
+- profiles currently support one explicit selection only: no inheritance, multi-profile stacking, or implicit default profile;
+- profiles cannot override `build.entry`;
 - freshness through indirect `/DEFAULTLIB`-style library propagation is not guaranteed to be complete.
 
 See [`ARCHITECTURE_EN.md`](ARCHITECTURE_EN.md) for deeper provider-graph, artifact-identity, and responsibility boundaries.


### PR DESCRIPTION
## Summary

Implements PR 5 of the MQB productization track: explicit named build profiles layered into the existing strict project configuration and resolution engine.

- add `--profile <name>` / `--profile=<name>`
- add strict version-1 `mqb.json` `profiles` objects
- preserve one resolution model: built-ins < base `mqb.json` < selected profile < CLI
- keep scalar override, list append, and module-provider-by-logical-name replacement semantics unchanged
- normalize native MSVC compiler/linker arguments inside a profile through the same Parameter Engine before resolution
- fail closed for missing/unknown profiles
- allow exactly one explicitly selected profile per invocation
- deliberately omit profile inheritance, multi-profile stacking, and an implicit default profile in this milestone

## Profile boundary

Profiles are build-policy overlays, not alternate project identities. `profiles.<name>.build.entry` is rejected by the strict schema; the root `build.entry` and explicit positional sources remain authoritative for entry selection.

Config and profile paths are relative to `mqb.json`; CLI paths remain relative to the invocation directory.

## Resolution contract

Scalar precedence:

`explicit CLI > selected profile > base mqb.json > built-in defaults`

List-valued settings append in stable base -> profile -> CLI order. External named-module providers continue to replace an existing provider by logical name while preserving deterministic registry order.

Only the final effective build policy participates in the existing BuildPlan/cache identity; the profile name itself is not a separate cache dimension.

## Validation scope

The native graph remains exactly 70 tests; no production translation unit is added.

Coverage added to existing nodes includes:
- strict profile schema and config-relative paths
- rejection of profile-local `build.entry`
- base/profile/CLI scalar and list precedence
- module provider replacement across all three layers
- candidate-MQB `--profile fast` build
- profile native `/std:c++20` semantic normalization
- CLI `--release --std 23` overriding the selected profile
- unknown-profile diagnostics with available names
- profile-selected static target flowing into the established executable-only `--run` validation

## Documentation

Chinese and English README/config references document:
- explicit single-profile selection
- no inheritance, stacking, or implicit default profile
- `build.entry` project-identity boundary
- base/profile/CLI precedence and path bases
- same-layer native/typed semantic conflict behavior
- effective-semantics-only cache identity

## Exact final validation

Final head: `c56aae1dc012a35b1d2da9d0fad35271a919d28e`

- Native C++ #189: success
  - Debug MQB self-build: success
  - shared Debug native-test product: success
  - 4/4 Debug shards: success
  - final Native C++ gate: success
- Native Release #157: success
  - Stage 0 Release MQB self-build: success
  - shared Release native-test product: success
  - 4/4 Release shards: success
  - Stage 1 self-host stable release: success
  - runtime-only package staging: success
  - exact packaged-artifact validation: success
  - validated package upload: success
  - `publish-release`: skipped as expected for a pull request

At final validation, `main` remained at the PR base and there were no review submissions or unresolved review threads.