### PR TITLE
feat: add first-class precompiled headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,29 @@ mqb run --profile dev -- input.txt
 
 第一版 profile 是**单个显式 overlay**：一次只能选择一个，没有继承、没有多 profile 叠加，也没有隐式默认 profile。优先级为 `CLI > selected profile > base mqb.json > built-in`；list 输入按 base → profile → CLI 追加。Profile 不能设置 `build.entry`，因此切换构建策略不会悄悄切换项目入口。
 
+### First-class PCH
+
+普通 C++ target 可以把 MSVC 预编译头交给 MQB 作为一等构建产物管理：
+
+```json
+{
+  "version": 1,
+  "build": {
+    "entry": "src/main.cpp",
+    "pch": "include/pch.hpp"
+  }
+}
+```
+
+也可以直接从 CLI 启用或覆盖：
+
+```powershell
+mqb build --pch include/pch.hpp
+mqb build --profile dev --no-pch
+```
+
+PCH 是 scalar policy，遵循 `CLI > selected profile > base mqb.json > disabled default`。MQB 自己拥有 synthetic creator、`.pch`、配对 creator `.obj`、`/FI`、`/Yc` / `/Yu` 与 `/Fp`，并把 `.pch` 纳入 consumer cache dependency；raw PCH structural switches 不与这套模型竞争。当前 first-class PCH 支持普通 C++ 的 `exe` / `dll` / `static` target，C TU 和需要 Modules/Header Units pipeline 的 target 会 fail closed。详见 [`docs/PRECOMPILED_HEADERS.md`](docs/PRECOMPILED_HEADERS.md)。
+
 ### Source-first 兼容形式
 
 原有直接构建形式继续支持：
@@ -123,6 +146,7 @@ mqb build math.cpp vector.cpp --type static -o math
 
 - `mqb build` / `mqb run` 项目命令与 fail-closed 默认入口解析。
 - `mqb.json` named profiles 与 `base < profile < CLI` 分层解析。
+- 普通 C++ target 的 first-class MSVC PCH、独立 PCH cache 与自动 consumer invalidation。
 - `.c` / `.cpp` / `.cc` / `.cxx` 原生 MSVC 构建。
 - Visual Studio 与 portable MSVC toolchain discovery。
 - 基于 `/sourceDependencies` 的 header freshness 与增量编译。
@@ -138,7 +162,7 @@ mqb build math.cpp vector.cpp --type static -o math
 - Windows Unicode-safe artifact/path identity。
 - 所有 writable build state 收敛到项目 `.mqb/`。
 
-> 当前边界：需要 Modules/Header Units pipeline 的 `static` target 仍会显式拒绝；普通静态库构建不受影响。
+> 当前边界：first-class PCH 暂不与 C TU 或 Modules/Header Units pipeline 混用；需要 Modules/Header Units pipeline 的 `static` target 仍会显式拒绝。普通 C++ PCH 与普通静态库构建不受影响。
 
 ## `mqb.json`
 
@@ -162,6 +186,7 @@ MQB 从执行目录向上查找最近的 `mqb.json`。该文件所在目录成�
     "configuration": "release",
     "standard": "latest",
     "type": "exe",
+    "pch": "include/pch.hpp",
     "output": "app",
     "include_dirs": ["include"]
   }
@@ -169,6 +194,8 @@ MQB 从执行目录向上查找最近的 `mqb.json`。该文件所在目录成�
 ```
 
 `build.entry` 相对 `mqb.json` 解析，仅在 `mqb build` / `mqb run` 没有显式 positional source 时使用。若未设置，MQB 只在 project root 与 `src/` 中寻找 conventional `main.{c,cpp,cc,cxx}`；必须恰好命中一个，否则明确报错。
+
+`build.pch` 可为非空 header 路径或 `false`。配置/profile 中的 PCH 路径相对 `mqb.json`；CLI `--pch` 路径相对 invocation directory。Profile 可覆盖或用 `pch: false` 关闭 base PCH，CLI `--pch` / `--no-pch` 再覆盖 profile。
 
 Named profile 也声明在同一配置文件中，并用 `--profile <name>` 显式选择。Profile 内路径同样相对 `mqb.json`，native compiler/linker arguments 仍经过统一的 MSVC Parameter Engine；profile 名本身不是额外 cache 维度，最终生效的构建语义才决定 cache identity。
 
@@ -185,7 +212,7 @@ External/prebuilt module IFC 也可在配置中声明：
 }
 ```
 
-完整字段、profiles、路径基准、CLI/config precedence 和 module provider 规则见 [`docs/MQB_CONFIG.md`](docs/MQB_CONFIG.md)。
+完整字段、profiles、路径基准、CLI/config precedence 和 module provider 规则见 [`docs/MQB_CONFIG.md`](docs/MQB_CONFIG.md)。PCH artifact、ownership 与 invalidation 模型见 [`docs/PRECOMPILED_HEADERS.md`](docs/PRECOMPILED_HEADERS.md)。
 
 ## 常用 CLI
 
@@ -198,6 +225,7 @@ mqb <source...> [options]
 | 选项 | 作用 |
 |---|---|
 | `--profile <name>` | 选择 `mqb.json` 中一个 named profile |
+| `--pch <header>` / `--no-pch` | 启用/覆盖 first-class PCH，或关闭继承的 PCH policy |
 | `--debug` / `--release` | 构建配置 |
 | `--std <14|17|20|23|latest>` | C++ 标准 |
 | `--type <exe|dll|static>` | target kind |
@@ -230,6 +258,7 @@ mqb <source...> [options]
 | 主题 | 文档 |
 |---|---|
 | `mqb.json` 配置、profiles 与 precedence | [`docs/MQB_CONFIG.md`](docs/MQB_CONFIG.md) |
+| First-class PCH ownership、cache 与 invalidation | [`docs/PRECOMPILED_HEADERS.md`](docs/PRECOMPILED_HEADERS.md) |
 | 安装、PATH、卸载 | [`docs/INSTALLATION.md`](docs/INSTALLATION.md) |
 | 架构与 Modules/cache 模型 | [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) |
 | 开发 MQB | [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md) |

--- a/README_EN.md
+++ b/README_EN.md
@@ -90,6 +90,29 @@ mqb run --profile dev -- input.txt
 
 The first profile version is a **single explicit overlay**: one profile per invocation, no inheritance, no multi-profile stacking, and no implicit default profile. Precedence is `CLI > selected profile > base mqb.json > built-in`; list inputs append in base → profile → CLI order. Profiles cannot set `build.entry`, so selecting build policy never silently changes project entry identity.
 
+### First-class PCH
+
+Ordinary C++ targets can hand MSVC precompiled headers to MQB as first-class build artifacts:
+
+```json
+{
+  "version": 1,
+  "build": {
+    "entry": "src/main.cpp",
+    "pch": "include/pch.hpp"
+  }
+}
+```
+
+The CLI can enable/override or disable inherited PCH policy:
+
+```powershell
+mqb build --pch include/pch.hpp
+mqb build --profile dev --no-pch
+```
+
+PCH is scalar policy with `CLI > selected profile > base mqb.json > disabled default` precedence. MQB owns the synthetic creator, `.pch`, paired creator `.obj`, `/FI`, `/Yc` / `/Yu`, and `/Fp`, and records the `.pch` as a consumer cache dependency. Raw PCH structural switches do not compete with this model. First-class PCH currently supports ordinary C++ `exe` / `dll` / `static` targets; C translation units and targets that require the Modules/Header Unit pipeline fail closed. See [`docs/PRECOMPILED_HEADERS_EN.md`](docs/PRECOMPILED_HEADERS_EN.md).
+
 ### Source-first compatibility form
 
 The existing direct form remains supported:
@@ -123,6 +146,7 @@ Supported target kinds are `exe`, `dll`, and `static`. `mqb run` applies only to
 
 - `mqb build` / `mqb run` project commands with fail-closed default-entry resolution.
 - Named `mqb.json` profiles with layered base < profile < CLI resolution.
+- First-class MSVC PCH for ordinary C++ targets, with dedicated PCH cache and automatic consumer invalidation.
 - Native MSVC builds for `.c` / `.cpp` / `.cc` / `.cxx`.
 - Visual Studio and portable MSVC toolchain discovery.
 - Header freshness and incremental compilation from `/sourceDependencies`.
@@ -138,7 +162,7 @@ Supported target kinds are `exe`, `dll`, and `static`. `mqb run` applies only to
 - Windows Unicode-safe artifact/path identity.
 - All writable build state kept under project `.mqb/`.
 
-> Current boundary: `static` targets that require the Modules/Header Units pipeline are still rejected explicitly. Ordinary static-library builds are unaffected.
+> Current boundary: first-class PCH does not yet mix with C translation units or the Modules/Header Unit pipeline; `static` targets that require the Modules/Header Unit pipeline are still rejected explicitly. Ordinary C++ PCH and ordinary static-library builds are unaffected.
 
 ## `mqb.json`
 
@@ -162,6 +186,7 @@ A common configuration:
     "configuration": "release",
     "standard": "latest",
     "type": "exe",
+    "pch": "include/pch.hpp",
     "output": "app",
     "include_dirs": ["include"]
   }
@@ -169,6 +194,8 @@ A common configuration:
 ```
 
 `build.entry` is resolved relative to `mqb.json` and is used only when `mqb build` / `mqb run` has no explicit positional source. Without it, MQB checks only conventional `main.{c,cpp,cc,cxx}` files in the project root and `src/`; exactly one candidate must exist or MQB fails with a diagnostic.
+
+`build.pch` may be a non-empty header path or `false`. PCH paths from config/profiles resolve relative to `mqb.json`; CLI `--pch` paths resolve relative to the invocation directory. A profile may replace base PCH or disable it with `pch: false`, and CLI `--pch` / `--no-pch` overrides the selected profile.
 
 Named profiles live in the same configuration file and are selected explicitly with `--profile <name>`. Profile paths are also resolved relative to `mqb.json`, and native compiler/linker arguments still pass through the shared MSVC Parameter Engine. The profile name itself is not an extra cache dimension; final effective build semantics determine cache identity.
 
@@ -185,7 +212,7 @@ External/prebuilt module IFCs can also be declared in configuration:
 }
 ```
 
-See [`docs/MQB_CONFIG_EN.md`](docs/MQB_CONFIG_EN.md) for the complete schema, profiles, path bases, CLI/config precedence, and module-provider rules.
+See [`docs/MQB_CONFIG_EN.md`](docs/MQB_CONFIG_EN.md) for the complete schema, profiles, path bases, CLI/config precedence, and module-provider rules. See [`docs/PRECOMPILED_HEADERS_EN.md`](docs/PRECOMPILED_HEADERS_EN.md) for PCH ownership, artifacts, and invalidation behavior.
 
 ## Common CLI
 
@@ -198,6 +225,7 @@ mqb <source...> [options]
 | Option | Purpose |
 |---|---|
 | `--profile <name>` | Select one named profile from `mqb.json` |
+| `--pch <header>` / `--no-pch` | Enable/override first-class PCH or disable inherited PCH policy |
 | `--debug` / `--release` | Build configuration |
 | `--std <14|17|20|23|latest>` | C++ standard |
 | `--type <exe|dll|static>` | Target kind |
@@ -230,6 +258,7 @@ Use the current binary's `mqb --help` as the complete CLI reference.
 | Topic | Document |
 |---|---|
 | `mqb.json` configuration, profiles, and precedence | [`docs/MQB_CONFIG_EN.md`](docs/MQB_CONFIG_EN.md) |
+| First-class PCH ownership, cache, and invalidation | [`docs/PRECOMPILED_HEADERS_EN.md`](docs/PRECOMPILED_HEADERS_EN.md) |
 | Installation, PATH, and uninstall | [`docs/INSTALLATION_EN.md`](docs/INSTALLATION_EN.md) |
 | Architecture and Modules/cache model | [`docs/ARCHITECTURE_EN.md`](docs/ARCHITECTURE_EN.md) |
 | Developing MQB | [`docs/DEVELOPMENT_EN.md`](docs/DEVELOPMENT_EN.md) |

--- a/cpp/include/mqb/config/ProjectConfig.hpp
+++ b/cpp/include/mqb/config/ProjectConfig.hpp
@@ -21,6 +21,7 @@ struct BuildOverrides {
     std::optional<LinkSubsystem> subsystem;
     std::optional<TargetKind> target_kind;
     std::optional<std::filesystem::path> entry;
+    std::optional<PrecompiledHeaderPolicy> precompiled_header;
     std::optional<std::string> output_name;
     std::vector<std::string> defines;
     std::vector<std::filesystem::path> include_directories;

--- a/cpp/include/mqb/config/ProjectOptions.hpp
+++ b/cpp/include/mqb/config/ProjectOptions.hpp
@@ -23,6 +23,7 @@ struct EffectiveProjectOptions {
     bool link_time_code_generation{false};
     LinkSubsystem subsystem{LinkSubsystem::console};
     TargetKind target_kind{TargetKind::executable};
+    std::optional<std::filesystem::path> precompiled_header;
     std::optional<std::string> output_name;
     std::vector<std::string> defines;
     std::vector<std::filesystem::path> include_directories;

--- a/cpp/include/mqb/core/Artifact.hpp
+++ b/cpp/include/mqb/core/Artifact.hpp
@@ -7,6 +7,7 @@ namespace mqb {
 enum class ArtifactKind {
     object,
     module_interface,
+    precompiled_header,
     executable,
     dynamic_library,
     static_library,

--- a/cpp/include/mqb/core/CompilerOptions.hpp
+++ b/cpp/include/mqb/core/CompilerOptions.hpp
@@ -16,6 +16,22 @@ enum class RuntimeLibrary {
     mtd,
 };
 
+struct PrecompiledHeaderPolicy {
+    bool enabled{false};
+    std::filesystem::path header;
+};
+
+enum class PrecompiledHeaderRole {
+    create,
+    use,
+};
+
+struct PrecompiledHeaderBinding {
+    std::filesystem::path header;
+    std::filesystem::path artifact;
+    PrecompiledHeaderRole role{PrecompiledHeaderRole::use};
+};
+
 // Project/toolchain-independent identity for a read-only named-module IFC
 // supplied outside the current source graph. Provider selection remains owned
 // by the P1689 module graph; this registry only carries explicit policy into
@@ -40,6 +56,9 @@ struct CompilerOptions {
     std::vector<std::string> defines;
     std::vector<std::filesystem::path> include_directories;
     std::vector<std::string> additional_arguments;
+    // Per-compile binding emitted by MQB after raw arguments. A create binding
+    // owns the .pch output; a use binding consumes exactly that artifact.
+    std::optional<PrecompiledHeaderBinding> precompiled_header;
     // Explicit read-only provider registry. These entries are intentionally not
     // hashed wholesale into every compile signature: after P1689 resolution,
     // only the ModuleReference entries actually consumed by a TU participate in

--- a/cpp/include/mqb/core/ProjectArtifactLayout.hpp
+++ b/cpp/include/mqb/core/ProjectArtifactLayout.hpp
@@ -17,6 +17,14 @@ struct SourceArtifacts {
     std::filesystem::path compile_cache;
 };
 
+struct PrecompiledHeaderArtifacts {
+    std::filesystem::path source;
+    std::filesystem::path object;
+    std::filesystem::path dependencies;
+    std::filesystem::path precompiled_header;
+    std::filesystem::path compile_cache;
+};
+
 struct TargetArtifacts {
     // Existing field name is retained through the executable/DLL slice to keep
     // the incremental target API stable. Static-library work will generalize the
@@ -45,6 +53,12 @@ public:
 
     [[nodiscard]] std::expected<SourceArtifacts, ArtifactLayoutError>
     for_source(const std::filesystem::path& source) const;
+
+    [[nodiscard]] std::expected<PrecompiledHeaderArtifacts, ArtifactLayoutError>
+    for_precompiled_header(
+        std::string_view target_name,
+        BuildConfiguration configuration,
+        Architecture architecture) const;
 
     [[nodiscard]] std::expected<TargetArtifacts, ArtifactLayoutError>
     for_target(

--- a/cpp/include/mqb/orchestration/MsvcIncrementalPchCoordinator.hpp
+++ b/cpp/include/mqb/orchestration/MsvcIncrementalPchCoordinator.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <expected>
+#include <filesystem>
+#include <optional>
+#include <string>
+
+#include "mqb/core/CompilerOptions.hpp"
+#include "mqb/core/ProjectArtifactLayout.hpp"
+#include "mqb/orchestration/MsvcIncrementalCompileCoordinator.hpp"
+
+namespace mqb::orchestration {
+
+enum class IncrementalPchErrorCode {
+    invalid_request,
+    header_missing,
+    synthetic_source_failed,
+    compile_failed,
+};
+
+struct IncrementalPchError {
+    IncrementalPchErrorCode code{IncrementalPchErrorCode::invalid_request};
+    std::string message;
+    std::optional<IncrementalCompileError> compile_error;
+};
+
+struct IncrementalPchRequest {
+    std::filesystem::path header;
+    PrecompiledHeaderArtifacts artifacts;
+    CompilerOptions compiler_options;
+    std::filesystem::path working_directory;
+};
+
+struct IncrementalPchResult {
+    IncrementalCompileResult compile;
+};
+
+class MsvcIncrementalPchCoordinator {
+public:
+    explicit MsvcIncrementalPchCoordinator(
+        MsvcIncrementalCompileCoordinator& compile_coordinator)
+        : compile_coordinator_(compile_coordinator) {}
+
+    [[nodiscard]] std::expected<IncrementalPchResult, IncrementalPchError>
+    run(const IncrementalPchRequest& request) const;
+
+private:
+    MsvcIncrementalCompileCoordinator& compile_coordinator_;
+};
+
+} // namespace mqb::orchestration

--- a/cpp/include/mqb/orchestration/MsvcIncrementalStaticTargetCoordinator.hpp
+++ b/cpp/include/mqb/orchestration/MsvcIncrementalStaticTargetCoordinator.hpp
@@ -18,10 +18,12 @@ namespace mqb::orchestration {
 
 struct IncrementalStaticTargetRequest {
     std::vector<TargetSourceRequest> sources;
+    std::vector<std::filesystem::path> additional_objects;
     TargetArtifacts target;
     CompilerOptions compiler_options;
     std::filesystem::path working_directory;
     std::size_t max_parallel_compiles{1};
+    bool force_downstream_rebuild{false};
 };
 
 enum class IncrementalStaticTargetErrorCode {

--- a/cpp/include/mqb/orchestration/MsvcIncrementalTargetCoordinator.hpp
+++ b/cpp/include/mqb/orchestration/MsvcIncrementalTargetCoordinator.hpp
@@ -23,11 +23,16 @@ struct TargetSourceRequest {
 
 struct IncrementalTargetRequest {
     std::vector<TargetSourceRequest> sources;
+    // MQB-owned objects created outside the ordinary source scheduler (for
+    // example the object paired with a first-class PCH creator). They enter the
+    // final link signature/order but are never compiled as consumer sources.
+    std::vector<std::filesystem::path> additional_objects;
     TargetArtifacts target;
     CompilerOptions compiler_options;
     LinkOptions link_options;
     std::filesystem::path working_directory;
     std::size_t max_parallel_compiles{1};
+    bool force_downstream_rebuild{false};
 };
 
 struct TargetCompileResult {

--- a/cpp/mqb.json
+++ b/cpp/mqb.json
@@ -78,6 +78,7 @@
       "src/orchestration/incremental/MsvcIncrementalArchiveCoordinator.cpp",
       "src/orchestration/incremental/MsvcIncrementalCompileCoordinator.cpp",
       "src/orchestration/incremental/MsvcIncrementalLinkCoordinator.cpp",
+      "src/orchestration/incremental/MsvcIncrementalPchCoordinator.cpp",
       "src/orchestration/incremental/MsvcIncrementalStaticTargetCoordinator.cpp",
       "src/orchestration/incremental/MsvcIncrementalTargetCoordinator.cpp",
       "src/orchestration/modules/ModuleCompilePlan.cpp",

--- a/cpp/src/app/Application.cpp
+++ b/cpp/src/app/Application.cpp
@@ -1,6 +1,7 @@
 #include "Application.hpp"
 
 #include <algorithm>
+#include <chrono>
 #include <filesystem>
 #include <iostream>
 #include <optional>
@@ -293,6 +294,7 @@ int Application::run(const std::span<const std::string_view> arguments) {
         compile_executor};
 
     std::optional<mqb::PrecompiledHeaderArtifacts> pch_artifacts;
+    bool pch_compiled = false;
     if (effective.precompiled_header) {
         if (module_target) {
             diagnostics::print_error(
@@ -331,16 +333,18 @@ int Application::run(const std::span<const std::string_view> arguments) {
             .working_directory = project_root,
         });
         mqb::orchestration::TargetTimings pch_timings;
-        pch_timings.compile = performance::Clock::now() - pch_started;
+        pch_timings.compile = std::chrono::duration_cast<std::chrono::nanoseconds>(
+            performance::Clock::now() - pch_started);
         timing_session.add_target(pch_timings);
         if (!pch) {
             print_pch_failure(pch.error());
             return 4;
         }
 
-        timing_session.record_compile(pch->compile.compiled);
+        pch_compiled = pch->compile.compiled;
+        timing_session.record_compile(pch_compiled);
         diagnostics::print_compile_warnings(pch->compile);
-        if (pch->compile.compiled) {
+        if (pch_compiled) {
             std::cout << "[pch] "
                       << diagnostics::path_text(display_source(project_root, *effective.precompiled_header));
             diagnostics::print_reasons(pch->compile.validation.reasons);
@@ -379,12 +383,16 @@ int Application::run(const std::span<const std::string_view> arguments) {
         return mqb::cli::run_static_target(
             mqb::cli::StaticCliTargetRequest{
                 .sources = std::move(target_sources),
+                .additional_objects = pch_artifacts
+                    ? std::vector<fs::path>{pch_artifacts->object}
+                    : std::vector<fs::path>{},
                 .target = std::move(*target_artifacts),
                 .compiler_options = std::move(compiler_options),
                 .project_root = project_root,
                 .target_name = target_name,
                 .max_parallel_jobs = compile_jobs,
                 .timings = &timing_session,
+                .force_downstream_rebuild = pch_compiled,
                 .verbose = options.verbose,
             },
             *toolchain,
@@ -441,6 +449,7 @@ int Application::run(const std::span<const std::string_view> arguments) {
         if (pch_artifacts && effective.precompiled_header) {
             std::cout << "  pch:     " << diagnostics::path_text(*effective.precompiled_header) << '\n'
                       << "    file:  " << diagnostics::path_text(pch_artifacts->precompiled_header) << '\n'
+                      << "    obj:   " << diagnostics::path_text(pch_artifacts->object) << '\n'
                       << "    cache: " << diagnostics::path_text(pch_artifacts->compile_cache) << '\n';
         }
         for (const auto& source : target_sources) {
@@ -473,11 +482,15 @@ int Application::run(const std::span<const std::string_view> arguments) {
 
     const mqb::orchestration::IncrementalTargetRequest request{
         .sources = std::move(target_sources),
+        .additional_objects = pch_artifacts
+            ? std::vector<fs::path>{pch_artifacts->object}
+            : std::vector<fs::path>{},
         .target = std::move(*target_artifacts),
         .compiler_options = std::move(compiler_options),
         .link_options = std::move(link_options),
         .working_directory = project_root,
         .max_parallel_compiles = compile_jobs,
+        .force_downstream_rebuild = pch_compiled,
     };
 
     auto result = target_coordinator.run(request);

--- a/cpp/src/app/Application.cpp
+++ b/cpp/src/app/Application.cpp
@@ -19,12 +19,14 @@
 #include "mqb/core/CompilerOptions.hpp"
 #include "mqb/core/LinkOptions.hpp"
 #include "mqb/core/ProjectArtifactLayout.hpp"
+#include "mqb/core/TranslationUnitClassifier.hpp"
 #include "mqb/discovery/SourceDiscovery.hpp"
 #include "mqb/msvc/MsvcCompileExecutor.hpp"
 #include "mqb/msvc/MsvcLinker.hpp"
 #include "mqb/msvc/MsvcToolchainLocator.hpp"
 #include "mqb/orchestration/MsvcIncrementalCompileCoordinator.hpp"
 #include "mqb/orchestration/MsvcIncrementalLinkCoordinator.hpp"
+#include "mqb/orchestration/MsvcIncrementalPchCoordinator.hpp"
 #include "mqb/orchestration/MsvcIncrementalTargetCoordinator.hpp"
 #include "mqb/platform/windows/WindowsProcessRunner.hpp"
 #include "mqb/process/Process.hpp"
@@ -79,6 +81,28 @@ void add_portable_root_if_missing(
         message += diagnostics::path_text(path);
     }
     return message;
+}
+
+void print_pch_failure(const mqb::orchestration::IncrementalPchError& error) {
+    diagnostics::print_error(error.message);
+    if (!error.compile_error) return;
+    const auto& compile_error = *error.compile_error;
+    if (!compile_error.message.empty()) {
+        diagnostics::print_error("PCH compile: " + compile_error.message);
+    }
+    if (!compile_error.compile_error) return;
+    const auto& executor_error = *compile_error.compile_error;
+    if (!executor_error.message.empty()) {
+        diagnostics::print_error("PCH executor: " + executor_error.message);
+    }
+    if (!executor_error.compiler_error) return;
+    const auto& compiler_error = *executor_error.compiler_error;
+    if (!compiler_error.message.empty()) {
+        diagnostics::print_error("PCH compiler: " + compiler_error.message);
+    }
+    if (compiler_error.process_result) {
+        diagnostics::print_process_output(*compiler_error.process_result);
+    }
 }
 
 } // namespace
@@ -263,6 +287,80 @@ int Application::run(const std::span<const std::string_view> arguments) {
                 return mqb::cli::is_module_interface_source(source.source);
             });
 
+    mqb::msvc::MsvcCompileExecutor compile_executor{*toolchain, runner};
+    mqb::orchestration::MsvcIncrementalCompileCoordinator compile_coordinator{
+        *toolchain,
+        compile_executor};
+
+    std::optional<mqb::PrecompiledHeaderArtifacts> pch_artifacts;
+    if (effective.precompiled_header) {
+        if (module_target) {
+            diagnostics::print_error(
+                "first-class PCH is not yet supported with the Modules/Header Unit pipeline");
+            return 2;
+        }
+        const auto c_source = std::find_if(
+            target_sources.begin(),
+            target_sources.end(),
+            [](const mqb::orchestration::TargetSourceRequest& source) {
+                return mqb::is_c_translation_unit_path(source.source);
+            });
+        if (c_source != target_sources.end()) {
+            diagnostics::print_error(
+                "first-class PCH currently requires an ordinary C++ source set; C translation unit found: "
+                + diagnostics::path_text(display_source(project_root, c_source->source)));
+            return 2;
+        }
+
+        auto allocated = layout->for_precompiled_header(
+            target_name,
+            options.build.configuration,
+            options.build.architecture);
+        if (!allocated) {
+            diagnostics::print_error(allocated.error().message);
+            return 2;
+        }
+        pch_artifacts = std::move(*allocated);
+
+        mqb::orchestration::MsvcIncrementalPchCoordinator pch_coordinator{compile_coordinator};
+        const auto pch_started = performance::Clock::now();
+        auto pch = pch_coordinator.run(mqb::orchestration::IncrementalPchRequest{
+            .header = *effective.precompiled_header,
+            .artifacts = *pch_artifacts,
+            .compiler_options = compiler_options,
+            .working_directory = project_root,
+        });
+        mqb::orchestration::TargetTimings pch_timings;
+        pch_timings.compile = performance::Clock::now() - pch_started;
+        timing_session.add_target(pch_timings);
+        if (!pch) {
+            print_pch_failure(pch.error());
+            return 4;
+        }
+
+        timing_session.record_compile(pch->compile.compiled);
+        diagnostics::print_compile_warnings(pch->compile);
+        if (pch->compile.compiled) {
+            std::cout << "[pch] "
+                      << diagnostics::path_text(display_source(project_root, *effective.precompiled_header));
+            diagnostics::print_reasons(pch->compile.validation.reasons);
+            std::cout << '\n';
+            if (pch->compile.process) {
+                diagnostics::print_process_output(*pch->compile.process);
+            }
+        } else {
+            std::cout << "[up-to-date] pch "
+                      << diagnostics::path_text(display_source(project_root, *effective.precompiled_header))
+                      << '\n';
+        }
+
+        compiler_options.precompiled_header = mqb::PrecompiledHeaderBinding{
+            .header = effective.precompiled_header->lexically_normal(),
+            .artifact = pch_artifacts->precompiled_header.lexically_normal(),
+            .role = mqb::PrecompiledHeaderRole::use,
+        };
+    }
+
     if (options.build.target_kind == mqb::TargetKind::static_library) {
         if (module_target) {
             diagnostics::print_error(
@@ -340,6 +438,11 @@ int Application::run(const std::span<const std::string_view> arguments) {
                   << (options.jobs ? "" : " (auto)") << '\n'
                   << "  cl:      " << diagnostics::path_text(toolchain->identity.compiler) << '\n'
                   << "  link:    " << diagnostics::path_text(toolchain->linker) << '\n';
+        if (pch_artifacts && effective.precompiled_header) {
+            std::cout << "  pch:     " << diagnostics::path_text(*effective.precompiled_header) << '\n'
+                      << "    file:  " << diagnostics::path_text(pch_artifacts->precompiled_header) << '\n'
+                      << "    cache: " << diagnostics::path_text(pch_artifacts->compile_cache) << '\n';
+        }
         for (const auto& source : target_sources) {
             std::cout << "  source:  " << diagnostics::path_text(display_source(project_root, source.source)) << '\n'
                       << "    obj:   " << diagnostics::path_text(source.artifacts.object) << '\n'
@@ -362,10 +465,6 @@ int Application::run(const std::span<const std::string_view> arguments) {
                   << "  cache:   " << diagnostics::path_text(target_artifacts->link_cache) << '\n';
     }
 
-    mqb::msvc::MsvcCompileExecutor compile_executor{*toolchain, runner};
-    mqb::orchestration::MsvcIncrementalCompileCoordinator compile_coordinator{
-        *toolchain,
-        compile_executor};
     mqb::msvc::MsvcLinker linker{*toolchain, runner};
     mqb::orchestration::MsvcIncrementalLinkCoordinator link_coordinator{*toolchain, linker};
     mqb::orchestration::MsvcIncrementalTargetCoordinator target_coordinator{

--- a/cpp/src/app/cli/Cli.cpp
+++ b/cpp/src/app/cli/Cli.cpp
@@ -207,6 +207,15 @@ select_profile(Options& options, const std::string_view value) {
     return {};
 }
 
+[[nodiscard]] std::expected<void, Error>
+select_pch(Options& options, PrecompiledHeaderPolicy policy) {
+    if (options.pch_override) {
+        return std::unexpected(error("--pch/--no-pch may be specified only once"));
+    }
+    options.pch_override = std::move(policy);
+    return {};
+}
+
 } // namespace
 
 std::expected<Options, Error>
@@ -291,6 +300,31 @@ parse_arguments(const std::span<const std::string_view> arguments) {
             auto value = long_equals_value(argument, "--profile=");
             if (!value) return std::unexpected(value.error());
             auto selected = select_profile(options, *value);
+            if (!selected) return std::unexpected(selected.error());
+            continue;
+        }
+        if (argument == "--pch") {
+            auto value = require_value(arguments, index, argument);
+            if (!value) return std::unexpected(value.error());
+            auto selected = select_pch(options, PrecompiledHeaderPolicy{
+                .enabled = true,
+                .header = std::filesystem::u8path(*value),
+            });
+            if (!selected) return std::unexpected(selected.error());
+            continue;
+        }
+        if (argument.starts_with("--pch=")) {
+            auto value = long_equals_value(argument, "--pch=");
+            if (!value) return std::unexpected(value.error());
+            auto selected = select_pch(options, PrecompiledHeaderPolicy{
+                .enabled = true,
+                .header = std::filesystem::u8path(*value),
+            });
+            if (!selected) return std::unexpected(selected.error());
+            continue;
+        }
+        if (argument == "--no-pch") {
+            auto selected = select_pch(options, PrecompiledHeaderPolicy{.enabled = false});
             if (!selected) return std::unexpected(selected.error());
             continue;
         }
@@ -618,6 +652,7 @@ Project configuration:
   Config/profile paths are relative to mqb.json; CLI paths are relative to the invocation directory.
   Explicit positional sources always take precedence over build.entry.
   Profiles are selected explicitly with --profile and may not override build.entry.
+  PCH policy is scalar: --pch/--no-pch overrides selected profile and base config.
   External named-module IFCs may be declared under modules.external as logical-name -> IFC path.
 
 Source selection:
@@ -640,6 +675,8 @@ missing toolchain capability fails closed with a dedicated diagnostic.
 
 Options:
   --profile <name>         Select one named profile from mqb.json
+  --pch <header>           Enable MQB-owned PCH for an ordinary C++ target
+  --no-pch                 Disable PCH inherited from mqb.json/profile
   --debug                  Explicitly select Debug compile/link preset
   --release                Explicitly select Release compile/link preset
   --config <debug|release> Select compile/link preset
@@ -677,6 +714,11 @@ Options:
   -h, --help              Show this help and the embedded build version
   --                      Pass all remaining argv elements to an executable program
 
+First-class PCH is currently limited to ordinary C++ source sets. It fails closed for C
+translation units and targets that require the Modules/Header Unit pipeline. MQB owns the
+synthetic creator TU, .pch path, paired creator object, /FI, /Yc|/Yu, and /Fp arguments; raw
+PCH structural switches remain in the parameter engine's MQB-owned/unsupported domain.
+
 Native MSVC compiler switches may use '/' or a single '-' prefix. MQB '--long' options remain
 in the MQB namespace. `/link` (or `-link`) is a one-way compiler-to-linker boundary for build
 arguments; MQB options must appear before it. The outer `--` delimiter still ends build parsing
@@ -694,8 +736,8 @@ targets. Typed LTCG remains valid for static targets and couples /GL compilation
 
 Raw compiler/linker arguments are one argv element per option occurrence; MQB does not split a
 quoted string into multiple switches. Project config entries are applied first, selected profile
-entries append/override next, and CLI entries apply last. Typed runtime/LTCG and structured
-artifact routing are emitted after raw arguments so the BuildPlan remains authoritative.
+entries append/override next, and CLI entries apply last. Typed runtime/LTCG/PCH policy and
+structured artifact routing are emitted after raw arguments so the BuildPlan remains authoritative.
 
 MQB v5 intentionally does not accept the PowerShell-era single-dash command aliases. Use the
 native options shown above; unknown legacy spellings fail instead of silently entering a
@@ -707,11 +749,12 @@ Discovery is source selection only. Incremental header freshness uses MSVC
 /sourceDependencies metadata; /scanDependencies is module topology only.
 
 Generated state:
-  .mqb/obj/    collision-free object files (including generated std/std.compat providers)
+  .mqb/obj/    collision-free ordinary object files
+  .mqb/pch/    MQB-owned synthetic PCH creator source/object/.pch state
   .mqb/deps/   compiler dependency metadata
   .mqb/scan/   module dependency scan metadata
   .mqb/ifc/    module/header-unit interface artifacts
-  .mqb/cache/  compile, link, and archive cache metadata
+  .mqb/cache/  compile, PCH, link, and archive cache metadata
   .mqb/bin/    executable, DLL/import-library, or static-library target artifacts
 )";
 }

--- a/cpp/src/app/cli/Cli.hpp
+++ b/cpp/src/app/cli/Cli.hpp
@@ -34,6 +34,7 @@ struct Options {
     std::optional<RuntimeLibrary> runtime_override;
     std::optional<bool> ltcg_override;
     std::optional<LinkSubsystem> subsystem_override;
+    std::optional<PrecompiledHeaderPolicy> pch_override;
     std::vector<std::string> defines;
     std::vector<std::filesystem::path> include_directories;
     std::vector<std::filesystem::path> library_directories;

--- a/cpp/src/app/project/ProjectSetup.cpp
+++ b/cpp/src/app/project/ProjectSetup.cpp
@@ -170,6 +170,14 @@ prepare_project(
             provider.interface_file = provider.interface_file.lexically_normal();
         }
     }
+    if (options.pch_override && options.pch_override->enabled) {
+        if (options.pch_override->header.is_relative()) {
+            options.pch_override->header = (
+                invocation_directory / options.pch_override->header).lexically_normal();
+        } else {
+            options.pch_override->header = options.pch_override->header.lexically_normal();
+        }
+    }
 
     mqb::config::ProjectOverrides cli_overrides;
     cli_overrides.build.configuration = options.configuration_override;
@@ -179,6 +187,7 @@ prepare_project(
     cli_overrides.build.runtime_library = options.runtime_override;
     cli_overrides.build.link_time_code_generation = options.ltcg_override;
     cli_overrides.build.subsystem = options.subsystem_override;
+    cli_overrides.build.precompiled_header = options.pch_override;
     cli_overrides.build.output_name = options.build.output_name;
     cli_overrides.build.defines = options.defines;
     cli_overrides.build.include_directories = options.include_directories;

--- a/cpp/src/app/targets/StaticCliTarget.cpp
+++ b/cpp/src/app/targets/StaticCliTarget.cpp
@@ -28,8 +28,11 @@ int run_static_target(
                   << "  project: " << diagnostics::path_text(request.project_root) << '\n'
                   << "  type:    static\n"
                   << "  cl:      " << diagnostics::path_text(toolchain.identity.compiler) << '\n'
-                  << "  lib:     " << diagnostics::path_text(toolchain.librarian) << '\n'
-                  << "  output:  " << diagnostics::path_text(request.target.executable) << '\n'
+                  << "  lib:     " << diagnostics::path_text(toolchain.librarian) << '\n';
+        for (const auto& object : request.additional_objects) {
+            std::cout << "  object:  " << diagnostics::path_text(object) << " (MQB-owned)\n";
+        }
+        std::cout << "  output:  " << diagnostics::path_text(request.target.executable) << '\n'
                   << "  cache:   " << diagnostics::path_text(request.target.link_cache) << '\n';
     }
 
@@ -43,10 +46,12 @@ int run_static_target(
 
     auto result = target_coordinator.run(orchestration::IncrementalStaticTargetRequest{
         .sources = std::move(request.sources),
+        .additional_objects = std::move(request.additional_objects),
         .target = request.target,
         .compiler_options = std::move(request.compiler_options),
         .working_directory = request.project_root,
         .max_parallel_compiles = request.max_parallel_jobs,
+        .force_downstream_rebuild = request.force_downstream_rebuild,
     });
     if (!result) {
         diagnostics::print_static_target_failure(result.error());

--- a/cpp/src/app/targets/StaticCliTarget.hpp
+++ b/cpp/src/app/targets/StaticCliTarget.hpp
@@ -19,12 +19,14 @@ namespace mqb::cli {
 
 struct StaticCliTargetRequest {
     std::vector<orchestration::TargetSourceRequest> sources;
+    std::vector<std::filesystem::path> additional_objects;
     TargetArtifacts target;
     CompilerOptions compiler_options;
     std::filesystem::path project_root;
     std::string target_name;
     std::size_t max_parallel_jobs{1};
     app::performance::Session* timings{};
+    bool force_downstream_rebuild{false};
     bool verbose{false};
 };
 

--- a/cpp/src/config/resolution/ProjectOptions.cpp
+++ b/cpp/src/config/resolution/ProjectOptions.cpp
@@ -23,6 +23,13 @@ void apply_build(
     }
     if (overrides.subsystem) effective.subsystem = *overrides.subsystem;
     if (overrides.target_kind) effective.target_kind = *overrides.target_kind;
+    if (overrides.precompiled_header) {
+        if (overrides.precompiled_header->enabled) {
+            effective.precompiled_header = overrides.precompiled_header->header;
+        } else {
+            effective.precompiled_header.reset();
+        }
+    }
     if (overrides.output_name) effective.output_name = overrides.output_name;
     append_all(effective.defines, overrides.defines);
     append_all(effective.include_directories, overrides.include_directories);

--- a/cpp/src/config/schema/ProjectConfigSchema.cpp
+++ b/cpp/src/config/schema/ProjectConfigSchema.cpp
@@ -202,6 +202,31 @@ using JsonValue = json::Value;
     return std::nullopt;
 }
 
+[[nodiscard]] std::expected<PrecompiledHeaderPolicy, Error> decode_pch(
+    const fs::path& file,
+    const fs::path& root,
+    const JsonValue& value) {
+    if (value.kind == json::Kind::boolean) {
+        if (value.boolean) {
+            return std::unexpected(schema_error(
+                file,
+                value,
+                "build.pch boolean form only accepts false; enable PCH with a header path string"));
+        }
+        return PrecompiledHeaderPolicy{.enabled = false};
+    }
+    if (value.kind != json::Kind::string || value.scalar.empty()) {
+        return std::unexpected(schema_error(
+            file,
+            value,
+            "build.pch must be a non-empty header path string or false"));
+    }
+    return PrecompiledHeaderPolicy{
+        .enabled = true,
+        .header = resolve_path(root, value.scalar),
+    };
+}
+
 [[nodiscard]] std::expected<void, Error> decode_build(
     const fs::path& file,
     const fs::path& root,
@@ -215,7 +240,7 @@ using JsonValue = json::Value;
         **object,
         {
             "configuration", "architecture", "standard", "runtime", "ltcg",
-            "subsystem", "type", "entry", "output", "defines", "include_dirs",
+            "subsystem", "type", "entry", "pch", "output", "defines", "include_dirs",
             "library_dirs", "libraries", "compiler_args", "linker_args",
         },
         "build");
@@ -309,6 +334,12 @@ using JsonValue = json::Value;
         auto text = require_string(file, it->second, "build.entry");
         if (!text) return std::unexpected(text.error());
         out.entry = resolve_path(root, *text);
+    }
+
+    if (auto it = (**object).find("pch"); it != (**object).end()) {
+        auto policy = decode_pch(file, root, it->second);
+        if (!policy) return std::unexpected(policy.error());
+        out.precompiled_header = std::move(*policy);
     }
 
     if (auto it = (**object).find("output"); it != (**object).end()) {

--- a/cpp/src/core/model/BuildSignature.cpp
+++ b/cpp/src/core/model/BuildSignature.cpp
@@ -182,6 +182,12 @@ BuildSignature BuildSignature::for_compile(
         // Preserve the historical signature byte stream when typed LTCG is off.
         hasher.add_string("mqb.ltcg.compile.v1");
     }
+    if (options.precompiled_header) {
+        hasher.add_string("mqb.precompiled-header.compile.v1");
+        hasher.add_path(options.precompiled_header->header);
+        hasher.add_path(options.precompiled_header->artifact);
+        hasher.add_enum(options.precompiled_header->role);
+    }
 
     return BuildSignature{hasher.finish()};
 }

--- a/cpp/src/core/planning/ProjectArtifactLayout.cpp
+++ b/cpp/src/core/planning/ProjectArtifactLayout.cpp
@@ -155,6 +155,22 @@ namespace fs = std::filesystem;
     return ".exe";
 }
 
+[[nodiscard]] std::string_view configuration_name(const BuildConfiguration configuration) {
+    switch (configuration) {
+    case BuildConfiguration::debug: return "debug";
+    case BuildConfiguration::release: return "release";
+    }
+    return "debug";
+}
+
+[[nodiscard]] std::string_view architecture_name(const Architecture architecture) {
+    switch (architecture) {
+    case Architecture::x86: return "x86";
+    case Architecture::x64: return "x64";
+    }
+    return "x64";
+}
+
 } // namespace
 
 std::expected<ProjectArtifactLayout, ArtifactLayoutError>
@@ -196,6 +212,31 @@ ProjectArtifactLayout::for_source(const fs::path& source) const {
         .compile_cache = append_suffix(
             artifact_root_ / "cache" / "compile" / key,
             ".mqbcache"),
+    };
+}
+
+std::expected<PrecompiledHeaderArtifacts, ArtifactLayoutError>
+ProjectArtifactLayout::for_precompiled_header(
+    const std::string_view target_name,
+    const BuildConfiguration configuration,
+    const Architecture architecture) const {
+    if (!valid_target_name(target_name)) {
+        return std::unexpected(failure(
+            ArtifactLayoutErrorCode::invalid_target_name,
+            fs::path{std::string{target_name}},
+            "target name must be one filename component"));
+    }
+
+    const fs::path key = fs::path{std::string{target_name}}
+        / std::string{configuration_name(configuration)}
+        / std::string{architecture_name(architecture)};
+    const fs::path root = artifact_root_ / "pch" / key;
+    return PrecompiledHeaderArtifacts{
+        .source = root / "creator.cpp",
+        .object = root / "creator.obj",
+        .dependencies = root / "creator.deps.json",
+        .precompiled_header = root / "project.pch",
+        .compile_cache = artifact_root_ / "cache" / "pch" / key / "creator.mqbcache",
     };
 }
 

--- a/cpp/src/msvc/compiler/CompilerArgumentBuilder.cpp
+++ b/cpp/src/msvc/compiler/CompilerArgumentBuilder.cpp
@@ -84,6 +84,16 @@ void append_common_compile_arguments(
     if (options.link_time_code_generation) arguments.emplace_back("/GL");
 }
 
+void append_precompiled_header_arguments(
+    std::vector<std::string>& arguments,
+    const PrecompiledHeaderBinding& binding) {
+    const std::string header = path_to_utf8(binding.header);
+    arguments.push_back("/FI" + header);
+    arguments.push_back(
+        std::string{binding.role == PrecompiledHeaderRole::create ? "/Yc" : "/Yu"} + header);
+    arguments.push_back("/Fp" + path_to_utf8(binding.artifact));
+}
+
 [[nodiscard]] std::string header_name_argument(const HeaderUnitLookupMethod lookup_method) {
     return lookup_method == HeaderUnitLookupMethod::angle ? "/headerName:angle" : "/headerName:quote";
 }
@@ -102,7 +112,7 @@ build_compile_arguments(const CompileInvocation& invocation) {
     const bool c_translation_unit = is_c_translation_unit_path(invocation.source);
     std::vector<std::string> arguments;
     arguments.reserve(
-        23 + invocation.options.defines.size()
+        26 + invocation.options.defines.size()
         + invocation.options.include_directories.size()
         + invocation.options.additional_arguments.size()
         + (invocation.module_references.size() * 2)
@@ -129,6 +139,9 @@ build_compile_arguments(const CompileInvocation& invocation) {
     if (invocation.source_dependencies) {
         arguments.emplace_back("/sourceDependencies");
         arguments.push_back(path_to_utf8(*invocation.source_dependencies));
+    }
+    if (invocation.options.precompiled_header) {
+        append_precompiled_header_arguments(arguments, *invocation.options.precompiled_header);
     }
     arguments.push_back("/Fo" + path_to_utf8(invocation.object));
     arguments.push_back(path_to_utf8(invocation.source));

--- a/cpp/src/msvc/compiler/CompilerInvocationValidation.cpp
+++ b/cpp/src/msvc/compiler/CompilerInvocationValidation.cpp
@@ -43,6 +43,16 @@ validate_compiler_options(const CompilerOptions& options) {
             return std::unexpected(invalid_request("additional compiler argument must not be empty"));
         }
     }
+    if (options.precompiled_header) {
+        if (options.precompiled_header->header.empty()) {
+            return std::unexpected(invalid_request(
+                "precompiled header binding must have a non-empty header path"));
+        }
+        if (options.precompiled_header->artifact.empty()) {
+            return std::unexpected(invalid_request(
+                "precompiled header binding must have a non-empty .pch artifact path"));
+        }
+    }
     return {};
 }
 
@@ -59,6 +69,14 @@ validate_module_contract(const CompileInvocation& invocation) {
     if (uses_module_contract && predates_cpp20(invocation.options.standard)) {
         return std::unexpected(invalid_request(
             "module and header-unit compilation requires C++20 or newer"));
+    }
+    if (uses_module_contract && invocation.options.precompiled_header) {
+        return std::unexpected(invalid_request(
+            "precompiled headers are not supported in the Modules/Header Unit compile pipeline"));
+    }
+    if (is_c_translation_unit_path(invocation.source) && invocation.options.precompiled_header) {
+        return std::unexpected(invalid_request(
+            "first-class precompiled headers currently require ordinary C++ translation units"));
     }
 
     if (invocation.kind == TranslationUnitKind::module_interface) {
@@ -146,6 +164,10 @@ validate_header_unit_compile_invocation(const HeaderUnitCompileInvocation& invoc
     if (predates_cpp20(invocation.options.standard)) {
         return std::unexpected(invalid_request(
             "header-unit compilation requires C++20 or newer"));
+    }
+    if (invocation.options.precompiled_header) {
+        return std::unexpected(invalid_request(
+            "precompiled headers are not supported for header-unit producer compilation"));
     }
     return validate_compiler_options(invocation.options);
 }

--- a/cpp/src/msvc/compiler/MsvcCompileExecutor.cpp
+++ b/cpp/src/msvc/compiler/MsvcCompileExecutor.cpp
@@ -100,8 +100,18 @@ MsvcCompileExecutor::execute(const CompileExecutionRequest& request) const {
         request.unit,
         ArtifactKind::module_interface,
         interface_count);
+    std::size_t pch_count = 0;
+    const Artifact* pch_output = find_single_artifact(
+        request.unit,
+        ArtifactKind::precompiled_header,
+        pch_count);
 
     const bool header_unit_producer = request.unit.header_unit.has_value();
+    const bool pch_creator = request.options.precompiled_header
+        && request.options.precompiled_header->role == PrecompiledHeaderRole::create;
+    const bool pch_consumer = request.options.precompiled_header
+        && request.options.precompiled_header->role == PrecompiledHeaderRole::use;
+
     if (header_unit_producer) {
         if (request.unit.kind != TranslationUnitKind::source) {
             return std::unexpected(invalid_request(
@@ -111,9 +121,9 @@ MsvcCompileExecutor::execute(const CompileExecutionRequest& request) const {
             return std::unexpected(invalid_request(
                 "header-unit producer identity must have a non-empty header name"));
         }
-        if (object_count != 0) {
+        if (object_count != 0 || pch_count != 0) {
             return std::unexpected(invalid_request(
-                "incremental header-unit producer must be IFC-only and must not expose an object artifact"));
+                "incremental header-unit producer must be IFC-only"));
         }
         if (module_interface == nullptr
             || interface_count != 1
@@ -137,6 +147,10 @@ MsvcCompileExecutor::execute(const CompileExecutionRequest& request) const {
             return std::unexpected(invalid_request(
                 "module interface translation unit must expose exactly one non-empty IFC artifact"));
         }
+        if (pch_count != 0) {
+            return std::unexpected(invalid_request(
+                "module interface translation unit must not expose a precompiled-header artifact"));
+        }
     } else {
         if (object == nullptr || object_count != 1 || object->path.empty()) {
             return std::unexpected(invalid_request(
@@ -146,11 +160,30 @@ MsvcCompileExecutor::execute(const CompileExecutionRequest& request) const {
             return std::unexpected(invalid_request(
                 "ordinary source translation unit must not expose an IFC output artifact"));
         }
+        if (pch_creator) {
+            if (pch_output == nullptr || pch_count != 1 || pch_output->path.empty()) {
+                return std::unexpected(invalid_request(
+                    "PCH creator must expose exactly one non-empty precompiled-header artifact"));
+            }
+            if (pch_output->path.lexically_normal()
+                != request.options.precompiled_header->artifact.lexically_normal()) {
+                return std::unexpected(invalid_request(
+                    "PCH creator output must match the typed precompiled-header artifact path"));
+            }
+        } else if (pch_count != 0) {
+            return std::unexpected(invalid_request(
+                "only a typed PCH creator may expose a precompiled-header artifact"));
+        }
+        if (pch_consumer && !regular_file(request.options.precompiled_header->artifact)) {
+            return std::unexpected(invalid_request(
+                "PCH consumer requires an existing MQB-owned precompiled-header artifact"));
+        }
     }
 
     for (const auto& output : request.unit.outputs) {
         if (output.kind != ArtifactKind::object
-            && output.kind != ArtifactKind::module_interface) {
+            && output.kind != ArtifactKind::module_interface
+            && output.kind != ArtifactKind::precompiled_header) {
             return std::unexpected(invalid_request(
                 "compile translation unit contains a non-compile output artifact"));
         }
@@ -223,6 +256,9 @@ MsvcCompileExecutor::execute(const CompileExecutionRequest& request) const {
     }
     for (const auto& reference : request.unit.header_unit_references) {
         add_interface_dependency(cache_dependencies, reference.interface_file);
+    }
+    if (pch_consumer) {
+        add_interface_dependency(cache_dependencies, request.options.precompiled_header->artifact);
     }
 
     CompileCacheEntry cache_entry{

--- a/cpp/src/orchestration/incremental/MsvcIncrementalPchCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalPchCoordinator.cpp
@@ -1,0 +1,162 @@
+#include "mqb/orchestration/MsvcIncrementalPchCoordinator.hpp"
+
+#include <expected>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <utility>
+
+#include "mqb/core/Artifact.hpp"
+#include "mqb/core/TranslationUnit.hpp"
+
+namespace mqb::orchestration {
+namespace {
+
+namespace fs = std::filesystem;
+constexpr std::string_view creator_source_text =
+    "// MQB synthetic precompiled-header creator. Header injection is owned by /FI.\n";
+
+[[nodiscard]] IncrementalPchError failure(
+    const IncrementalPchErrorCode code,
+    std::string message) {
+    return IncrementalPchError{
+        .code = code,
+        .message = std::move(message),
+    };
+}
+
+[[nodiscard]] bool regular_file(const fs::path& path) {
+    std::error_code error_code;
+    return fs::is_regular_file(path, error_code) && !error_code;
+}
+
+[[nodiscard]] std::expected<void, IncrementalPchError> ensure_parent(
+    const fs::path& path) {
+    if (path.parent_path().empty()) return {};
+    std::error_code error_code;
+    fs::create_directories(path.parent_path(), error_code);
+    if (error_code) {
+        return std::unexpected(failure(
+            IncrementalPchErrorCode::synthetic_source_failed,
+            "failed to create PCH artifact directory: " + error_code.message()));
+    }
+    return {};
+}
+
+[[nodiscard]] std::expected<void, IncrementalPchError> write_creator_if_needed(
+    const fs::path& source) {
+    auto parent = ensure_parent(source);
+    if (!parent) return std::unexpected(parent.error());
+
+    if (regular_file(source)) {
+        std::ifstream input{source, std::ios::binary};
+        if (input) {
+            const std::string existing{
+                std::istreambuf_iterator<char>{input},
+                std::istreambuf_iterator<char>{}};
+            if (existing == creator_source_text) {
+                return {};
+            }
+        }
+    }
+
+    std::ofstream output{source, std::ios::binary | std::ios::trunc};
+    if (!output) {
+        return std::unexpected(failure(
+            IncrementalPchErrorCode::synthetic_source_failed,
+            "failed to open synthetic PCH creator source for writing"));
+    }
+    output.write(creator_source_text.data(), static_cast<std::streamsize>(creator_source_text.size()));
+    output.close();
+    if (!output) {
+        return std::unexpected(failure(
+            IncrementalPchErrorCode::synthetic_source_failed,
+            "failed to write synthetic PCH creator source"));
+    }
+    return {};
+}
+
+} // namespace
+
+std::expected<IncrementalPchResult, IncrementalPchError>
+MsvcIncrementalPchCoordinator::run(const IncrementalPchRequest& request) const {
+    if (request.header.empty()) {
+        return std::unexpected(failure(
+            IncrementalPchErrorCode::invalid_request,
+            "PCH header path must not be empty"));
+    }
+    if (!regular_file(request.header)) {
+        return std::unexpected(failure(
+            IncrementalPchErrorCode::header_missing,
+            "PCH header does not exist or is not a regular file"));
+    }
+    if (request.artifacts.source.empty()
+        || request.artifacts.object.empty()
+        || request.artifacts.dependencies.empty()
+        || request.artifacts.precompiled_header.empty()
+        || request.artifacts.compile_cache.empty()) {
+        return std::unexpected(failure(
+            IncrementalPchErrorCode::invalid_request,
+            "PCH artifact layout contains an empty path"));
+    }
+
+    for (const fs::path* artifact : {
+             &request.artifacts.object,
+             &request.artifacts.dependencies,
+             &request.artifacts.precompiled_header,
+             &request.artifacts.compile_cache}) {
+        auto parent = ensure_parent(*artifact);
+        if (!parent) return std::unexpected(parent.error());
+    }
+    auto creator = write_creator_if_needed(request.artifacts.source);
+    if (!creator) return std::unexpected(creator.error());
+
+    CompilerOptions creator_options = request.compiler_options;
+    creator_options.precompiled_header = PrecompiledHeaderBinding{
+        .header = request.header.lexically_normal(),
+        .artifact = request.artifacts.precompiled_header.lexically_normal(),
+        .role = PrecompiledHeaderRole::create,
+    };
+
+    TranslationUnit unit;
+    unit.source = request.artifacts.source;
+    unit.kind = TranslationUnitKind::source;
+    unit.outputs = {
+        Artifact{
+            .path = request.artifacts.object,
+            .kind = ArtifactKind::object,
+        },
+        Artifact{
+            .path = request.artifacts.precompiled_header,
+            .kind = ArtifactKind::precompiled_header,
+        },
+    };
+
+    IncrementalCompileRequest compile_request{
+        .unit = std::move(unit),
+        .options = std::move(creator_options),
+        .cache_file = request.artifacts.compile_cache,
+        .source_dependencies_file = request.artifacts.dependencies,
+        .working_directory = request.working_directory,
+    };
+
+    auto compiled = compile_coordinator_.run(compile_request);
+    if (!compiled) {
+        IncrementalPchError error = failure(
+            IncrementalPchErrorCode::compile_failed,
+            "precompiled-header creator compilation failed");
+        error.compile_error = compiled.error();
+        return std::unexpected(std::move(error));
+    }
+    if (!regular_file(request.artifacts.precompiled_header)) {
+        return std::unexpected(failure(
+            IncrementalPchErrorCode::compile_failed,
+            "PCH creator completed without producing the owned .pch artifact"));
+    }
+    return IncrementalPchResult{.compile = std::move(*compiled)};
+}
+
+} // namespace mqb::orchestration

--- a/cpp/src/orchestration/incremental/MsvcIncrementalStaticTargetCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalStaticTargetCoordinator.cpp
@@ -83,6 +83,7 @@ MsvcIncrementalStaticTargetCoordinator::run(const IncrementalStaticTargetRequest
     std::vector<std::string> seen_objects;
     std::vector<std::string> seen_dependencies;
     std::vector<std::string> seen_caches;
+    seen_objects.reserve(request.sources.size() + request.additional_objects.size());
     for (const auto& source : request.sources) {
         if (!insert_unique(seen_sources, source.source)) {
             return std::unexpected(failure(
@@ -107,6 +108,16 @@ MsvcIncrementalStaticTargetCoordinator::run(const IncrementalStaticTargetRequest
                 IncrementalStaticTargetErrorCode::duplicate_compile_cache,
                 "two static target translation units map to the same compile cache",
                 source.source));
+        }
+    }
+    for (const auto& object : request.additional_objects) {
+        if (object.empty() || !insert_unique(seen_objects, object)) {
+            return std::unexpected(failure(
+                IncrementalStaticTargetErrorCode::duplicate_object,
+                object.empty()
+                    ? "MQB-owned additional object path must not be empty"
+                    : "MQB-owned additional object collides with another static target object",
+                object));
         }
     }
 
@@ -145,7 +156,8 @@ MsvcIncrementalStaticTargetCoordinator::run(const IncrementalStaticTargetRequest
     IncrementalStaticTargetResult result;
     result.compiles.reserve(request.sources.size());
     std::vector<fs::path> objects;
-    objects.reserve(request.sources.size());
+    objects.reserve(request.sources.size() + request.additional_objects.size());
+    objects.insert(objects.end(), request.additional_objects.begin(), request.additional_objects.end());
     for (std::size_t index = 0; index < request.sources.size(); ++index) {
         if (!attempts[index]) {
             return std::unexpected(failure(
@@ -169,7 +181,7 @@ MsvcIncrementalStaticTargetCoordinator::run(const IncrementalStaticTargetRequest
         .cache_file = request.target.link_cache,
         .working_directory = request.working_directory,
         .link_time_code_generation = request.compiler_options.link_time_code_generation,
-        .force_archive = result.any_compiled,
+        .force_archive = request.force_downstream_rebuild || result.any_compiled,
     });
     timings.archive = std::chrono::duration_cast<std::chrono::nanoseconds>(
         Clock::now() - archive_started);

--- a/cpp/src/orchestration/incremental/MsvcIncrementalTargetCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalTargetCoordinator.cpp
@@ -95,7 +95,7 @@ MsvcIncrementalTargetCoordinator::run(const IncrementalTargetRequest& request) c
     std::vector<std::string> seen_dependencies;
     std::vector<std::string> seen_compile_caches;
     seen_sources.reserve(request.sources.size());
-    seen_objects.reserve(request.sources.size());
+    seen_objects.reserve(request.sources.size() + request.additional_objects.size());
     seen_dependencies.reserve(request.sources.size());
     seen_compile_caches.reserve(request.sources.size());
 
@@ -125,6 +125,16 @@ MsvcIncrementalTargetCoordinator::run(const IncrementalTargetRequest& request) c
                 source.source));
         }
     }
+    for (const auto& object : request.additional_objects) {
+        if (object.empty() || !insert_unique(seen_objects, object)) {
+            return std::unexpected(failure(
+                IncrementalTargetErrorCode::duplicate_object,
+                object.empty()
+                    ? "MQB-owned additional object path must not be empty"
+                    : "MQB-owned additional object collides with another target object",
+                object));
+        }
+    }
 
     using CompileAttempt = std::expected<IncrementalCompileResult, IncrementalCompileError>;
     std::vector<std::optional<CompileAttempt>> attempts(request.sources.size());
@@ -149,9 +159,6 @@ MsvcIncrementalTargetCoordinator::run(const IncrementalTargetRequest& request) c
             "target compile scheduler failed: " + scheduled.error().message));
     }
 
-    // Work indices are assigned monotonically. After all workers join, scanning
-    // in source order therefore selects the lowest-index compile failure even if
-    // several in-flight compiles failed concurrently.
     for (std::size_t index = 0; index < attempts.size(); ++index) {
         if (!attempts[index]) {
             continue;
@@ -169,7 +176,8 @@ MsvcIncrementalTargetCoordinator::run(const IncrementalTargetRequest& request) c
     IncrementalTargetResult result;
     result.compiles.reserve(request.sources.size());
     std::vector<fs::path> objects;
-    objects.reserve(request.sources.size());
+    objects.reserve(request.sources.size() + request.additional_objects.size());
+    objects.insert(objects.end(), request.additional_objects.begin(), request.additional_objects.end());
 
     for (std::size_t index = 0; index < request.sources.size(); ++index) {
         if (!attempts[index]) {
@@ -194,7 +202,7 @@ MsvcIncrementalTargetCoordinator::run(const IncrementalTargetRequest& request) c
         .options = request.link_options,
         .cache_file = request.target.link_cache,
         .working_directory = request.working_directory,
-        .force_relink = result.any_compiled,
+        .force_relink = request.force_downstream_rebuild || result.any_compiled,
     };
     const auto link_started = Clock::now();
     auto linked = link_coordinator_.run(link_request);

--- a/cpp/tests/e2e/mqb_pch_e2e_tests.cpp
+++ b/cpp/tests/e2e/mqb_pch_e2e_tests.cpp
@@ -1,0 +1,250 @@
+#include <chrono>
+#include <expected>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "mqb/platform/windows/WindowsProcessRunner.hpp"
+#include "mqb/process/Process.hpp"
+
+namespace {
+
+namespace fs = std::filesystem;
+int failures = 0;
+
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+void write_text(const fs::path& path, const std::string_view text) {
+    fs::create_directories(path.parent_path());
+    std::ofstream stream{path, std::ios::binary | std::ios::trunc};
+    stream << text;
+}
+
+void rewrite_after_tick(const fs::path& path, const std::string_view text) {
+    std::this_thread::sleep_for(std::chrono::milliseconds{40});
+    write_text(path, text);
+}
+
+void dump_failure(const mqb::process::ProcessResult& result) {
+    std::cerr << "exit: " << result.exit_code << '\n'
+              << "stdout:\n" << result.stdout_text << '\n'
+              << "stderr:\n" << result.stderr_text << '\n';
+}
+
+[[nodiscard]] std::expected<mqb::process::ProcessResult, std::string>
+run_process(
+    mqb::platform::windows::WindowsProcessRunner& runner,
+    const fs::path& executable,
+    const fs::path& working_directory,
+    std::vector<std::string> arguments = {}) {
+    mqb::process::ProcessSpec spec;
+    spec.executable = executable;
+    spec.arguments = std::move(arguments);
+    spec.working_directory = working_directory;
+    spec.capture_stdout = true;
+    spec.capture_stderr = true;
+    auto result = runner.run(spec);
+    if (!result) {
+        return std::unexpected("failed to launch process: " + result.error().message);
+    }
+    return std::move(*result);
+}
+
+[[nodiscard]] bool contains(const mqb::process::ProcessResult& result, const std::string_view text) {
+    return result.stdout_text.find(text) != std::string::npos
+        || result.stderr_text.find(text) != std::string::npos;
+}
+
+struct TempTree {
+    fs::path root;
+    ~TempTree() {
+        std::error_code ignored;
+        fs::remove_all(root, ignored);
+    }
+};
+
+[[nodiscard]] std::vector<std::string> build_args() {
+    return {
+        "build", "main.cpp", "worker.cpp",
+        "--env", "vs", "--no-discover", "--debug",
+        "--pch", "include/pch.hpp",
+        "-o", "pch_app",
+    };
+}
+
+} // namespace
+
+int main(const int argc, char* argv[]) {
+    if (argc != 2) {
+        std::cerr << "usage: mqb_pch_e2e_tests <mqb-executable>\n";
+        return 2;
+    }
+
+    const fs::path mqb_executable{argv[1]};
+    const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
+    TempTree tree{
+        .root = fs::temp_directory_path() / ("mqb_pch_e2e_" + std::to_string(unique)),
+    };
+    fs::create_directories(tree.root);
+
+    const fs::path pch_header = tree.root / "include/pch.hpp";
+    write_text(
+        pch_header,
+        "#pragma once\n"
+        "struct PchValue { int value; };\n"
+        "inline constexpr int pch_bias = 10;\n");
+    write_text(
+        tree.root / "worker.cpp",
+        "int worker_value() { PchValue v{32}; return v.value + pch_bias; }\n");
+    write_text(
+        tree.root / "main.cpp",
+        "#include <cstdio>\n"
+        "int worker_value();\n"
+        "int main() { std::printf(\"pch=%d\\n\", worker_value()); return worker_value() == 42 ? 0 : 1; }\n");
+
+    mqb::platform::windows::WindowsProcessRunner runner;
+
+    auto cold = run_process(runner, mqb_executable, tree.root, build_args());
+    expect(cold.has_value(), "cold PCH build should launch");
+    if (cold) {
+        if (cold->exit_code != 0) dump_failure(*cold);
+        expect(cold->exit_code == 0, "cold PCH build should succeed");
+        expect(contains(*cold, "[pch]"), "cold build should report PCH creation");
+    }
+
+    const fs::path pch_root = tree.root / ".mqb/pch/pch_app/debug/x64";
+    const fs::path pch_file = pch_root / "project.pch";
+    const fs::path creator_object = pch_root / "creator.obj";
+    const fs::path executable = tree.root / ".mqb/bin/pch_app.exe";
+    expect(fs::is_regular_file(pch_file), "cold build should produce MQB-owned .pch");
+    expect(fs::is_regular_file(creator_object), "cold build should retain the paired PCH creator object");
+    expect(fs::is_regular_file(executable), "cold PCH build should link executable");
+
+    auto run = run_process(runner, executable, tree.root);
+    expect(run.has_value(), "PCH executable should launch");
+    if (run) {
+        if (run->exit_code != 0) dump_failure(*run);
+        expect(run->exit_code == 0, "PCH executable should succeed");
+        expect(run->stdout_text.find("pch=42") != std::string::npos,
+               "forced PCH include should provide declarations to ordinary sources");
+    }
+
+    auto warm = run_process(runner, mqb_executable, tree.root, build_args());
+    expect(warm.has_value(), "warm PCH build should launch");
+    if (warm) {
+        if (warm->exit_code != 0) dump_failure(*warm);
+        expect(warm->exit_code == 0, "warm PCH build should succeed");
+        expect(contains(*warm, "[up-to-date] pch"), "warm build should reuse PCH cache");
+        expect(contains(*warm, "[up-to-date] main.cpp"), "warm build should reuse main object");
+        expect(contains(*warm, "[up-to-date] worker.cpp"), "warm build should reuse worker object");
+        expect(contains(*warm, "[up-to-date] pch_app.exe"), "warm build should reuse linked target");
+    }
+
+    rewrite_after_tick(
+        tree.root / "main.cpp",
+        "#include <cstdio>\n"
+        "int worker_value();\n"
+        "int main() { const int value = worker_value(); std::printf(\"pch=%d\\n\", value); return value == 42 ? 0 : 1; }\n");
+    auto source_changed = run_process(runner, mqb_executable, tree.root, build_args());
+    expect(source_changed.has_value(), "source-only PCH build should launch");
+    if (source_changed) {
+        if (source_changed->exit_code != 0) dump_failure(*source_changed);
+        expect(source_changed->exit_code == 0, "source-only change should build successfully");
+        expect(contains(*source_changed, "[up-to-date] pch"),
+               "ordinary source change must not rebuild the PCH creator");
+        expect(contains(*source_changed, "[compile] main.cpp"),
+               "changed ordinary source should rebuild its object");
+    }
+
+    rewrite_after_tick(
+        pch_header,
+        "#pragma once\n"
+        "struct PchValue { int value; };\n"
+        "inline constexpr int pch_bias = 11;\n");
+    auto header_changed = run_process(runner, mqb_executable, tree.root, build_args());
+    expect(header_changed.has_value(), "header-changed PCH build should launch");
+    if (header_changed) {
+        if (header_changed->exit_code != 0) dump_failure(*header_changed);
+        expect(header_changed->exit_code == 0, "header change should rebuild PCH target successfully");
+        expect(contains(*header_changed, "[pch]"), "PCH header change should rebuild the creator");
+        expect(contains(*header_changed, "[compile] main.cpp")
+                   && contains(*header_changed, "[compile] worker.cpp"),
+               "PCH rebuild should invalidate all ordinary PCH consumers");
+        expect(contains(*header_changed, "[link] pch_app.exe"),
+               "PCH creator rebuild should force downstream relink");
+    }
+
+    std::error_code remove_error;
+    fs::remove(pch_file, remove_error);
+    expect(!remove_error, "test should be able to remove the PCH artifact");
+    auto repaired = run_process(runner, mqb_executable, tree.root, build_args());
+    expect(repaired.has_value(), "missing-PCH repair build should launch");
+    if (repaired) {
+        if (repaired->exit_code != 0) dump_failure(*repaired);
+        expect(repaired->exit_code == 0, "missing PCH artifact should be repairable");
+        expect(contains(*repaired, "[pch]"), "missing .pch should invalidate creator cache");
+        expect(fs::is_regular_file(pch_file), "repair should restore the owned .pch artifact");
+    }
+
+    write_text(tree.root / "plain.c", "int main(void) { return 0; }\n");
+    auto c_rejected = run_process(
+        runner,
+        mqb_executable,
+        tree.root,
+        {"build", "plain.c", "--env", "vs", "--no-discover", "--pch", "include/pch.hpp"});
+    expect(c_rejected.has_value(), "C + PCH rejection should launch candidate MQB");
+    if (c_rejected) {
+        expect(c_rejected->exit_code == 2, "C + first-class PCH should fail closed");
+        expect(contains(*c_rejected, "ordinary C++ source set"),
+               "C + PCH rejection should explain the current language boundary");
+    }
+
+    write_text(tree.root / "math.ixx", "export module math; export int answer() { return 42; }\n");
+    auto module_rejected = run_process(
+        runner,
+        mqb_executable,
+        tree.root,
+        {"build", "math.ixx", "--env", "vs", "--no-discover", "--std", "20", "--pch", "include/pch.hpp"});
+    expect(module_rejected.has_value(), "module + PCH rejection should launch candidate MQB");
+    if (module_rejected) {
+        expect(module_rejected->exit_code == 2,
+               "Modules/Header Unit pipeline + first-class PCH should fail closed");
+        expect(contains(*module_rejected, "Modules/Header Unit pipeline"),
+               "module + PCH rejection should explain the current pipeline boundary");
+    }
+
+    write_text(
+        tree.root / "static_source.cpp",
+        "int static_value() { PchValue v{1}; return v.value + pch_bias; }\n");
+    auto static_build = run_process(
+        runner,
+        mqb_executable,
+        tree.root,
+        {"build", "static_source.cpp", "--env", "vs", "--no-discover", "--debug",
+         "--type", "static", "--pch", "include/pch.hpp", "-o", "pch_static"});
+    expect(static_build.has_value(), "static PCH build should launch");
+    if (static_build) {
+        if (static_build->exit_code != 0) dump_failure(*static_build);
+        expect(static_build->exit_code == 0, "ordinary C++ static target should support first-class PCH");
+        expect(fs::is_regular_file(tree.root / ".mqb/bin/pch_static.lib"),
+               "static PCH build should produce archive containing the synthetic creator object");
+    }
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+    std::cout << "mqb_pch_e2e_tests passed\n";
+    return 0;
+}

--- a/cpp/tests/e2e/mqb_pch_e2e_tests.cpp
+++ b/cpp/tests/e2e/mqb_pch_e2e_tests.cpp
@@ -197,6 +197,110 @@ int main(const int argc, char* argv[]) {
         expect(fs::is_regular_file(pch_file), "repair should restore the owned .pch artifact");
     }
 
+    // Exercise the project/profile/CLI scalar precedence through the real
+    // candidate binary from a nested invocation directory. Config/profile PCH
+    // paths must remain config-relative while CLI PCH paths remain invocation-relative.
+    write_text(tree.root / "include/base.hpp", "#pragma once\ninline constexpr int base_marker = 1;\n");
+    write_text(tree.root / "include/profile.hpp", "#pragma once\ninline constexpr int profile_marker = 2;\n");
+    write_text(tree.root / "include/cli.hpp", "#pragma once\ninline constexpr int cli_marker = 3;\n");
+    write_text(
+        tree.root / "config_main.cpp",
+        "#include \"include/base.hpp\"\n"
+        "int main() { return base_marker == 1 ? 0 : 1; }\n");
+    write_text(
+        tree.root / "mqb.json",
+        R"json({
+  "version": 1,
+  "build": {
+    "pch": "include/base.hpp"
+  },
+  "profiles": {
+    "profile": {
+      "build": {
+        "pch": "include/profile.hpp"
+      }
+    },
+    "off": {
+      "build": {
+        "pch": false
+      }
+    }
+  }
+})json");
+    const fs::path nested = tree.root / "nested/work";
+    fs::create_directories(nested);
+
+    auto config_base = run_process(
+        runner,
+        mqb_executable,
+        nested,
+        {"build", "../../config_main.cpp", "--env", "vs", "--no-discover",
+         "-o", "pch_config_base"});
+    expect(config_base.has_value(), "base-config PCH build should launch from nested directory");
+    if (config_base) {
+        if (config_base->exit_code != 0) dump_failure(*config_base);
+        expect(config_base->exit_code == 0, "base-config PCH build should succeed");
+        expect(contains(*config_base, "[pch]") && contains(*config_base, "base.hpp"),
+               "base build.pch should resolve relative to mqb.json and create that PCH");
+    }
+
+    auto profile_override = run_process(
+        runner,
+        mqb_executable,
+        nested,
+        {"build", "../../config_main.cpp", "--env", "vs", "--no-discover",
+         "--profile", "profile", "-o", "pch_config_profile"});
+    expect(profile_override.has_value(), "profile PCH override build should launch");
+    if (profile_override) {
+        if (profile_override->exit_code != 0) dump_failure(*profile_override);
+        expect(profile_override->exit_code == 0, "profile PCH override should build successfully");
+        expect(contains(*profile_override, "[pch]") && contains(*profile_override, "profile.hpp"),
+               "selected profile PCH should override base PCH using config-relative path semantics");
+    }
+
+    auto profile_disable = run_process(
+        runner,
+        mqb_executable,
+        nested,
+        {"build", "../../config_main.cpp", "--env", "vs", "--no-discover",
+         "--profile", "off", "-o", "pch_config_profile_off"});
+    expect(profile_disable.has_value(), "profile PCH disable build should launch");
+    if (profile_disable) {
+        if (profile_disable->exit_code != 0) dump_failure(*profile_disable);
+        expect(profile_disable->exit_code == 0, "profile pch:false should disable base PCH and still build");
+        expect(!contains(*profile_disable, "[pch]") && !contains(*profile_disable, "[up-to-date] pch"),
+               "profile pch:false should suppress PCH orchestration inherited from base config");
+    }
+
+    auto cli_override = run_process(
+        runner,
+        mqb_executable,
+        nested,
+        {"build", "../../config_main.cpp", "--env", "vs", "--no-discover",
+         "--profile", "profile", "--pch", "../../include/cli.hpp",
+         "-o", "pch_config_cli"});
+    expect(cli_override.has_value(), "CLI PCH override build should launch");
+    if (cli_override) {
+        if (cli_override->exit_code != 0) dump_failure(*cli_override);
+        expect(cli_override->exit_code == 0, "CLI PCH override should build successfully");
+        expect(contains(*cli_override, "[pch]") && contains(*cli_override, "cli.hpp"),
+               "CLI --pch should override selected profile and resolve relative to invocation directory");
+    }
+
+    auto cli_disable = run_process(
+        runner,
+        mqb_executable,
+        nested,
+        {"build", "../../config_main.cpp", "--env", "vs", "--no-discover",
+         "--profile", "profile", "--no-pch", "-o", "pch_config_cli_off"});
+    expect(cli_disable.has_value(), "CLI PCH disable build should launch");
+    if (cli_disable) {
+        if (cli_disable->exit_code != 0) dump_failure(*cli_disable);
+        expect(cli_disable->exit_code == 0, "CLI --no-pch should override selected profile and build");
+        expect(!contains(*cli_disable, "[pch]") && !contains(*cli_disable, "[up-to-date] pch"),
+               "CLI --no-pch should suppress profile/base PCH orchestration");
+    }
+
     write_text(tree.root / "plain.c", "int main(void) { return 0; }\n");
     auto c_rejected = run_process(
         runner,

--- a/docs/MQB_CONFIG.md
+++ b/docs/MQB_CONFIG.md
@@ -42,6 +42,7 @@ profiles
     "runtime": "MT",
     "ltcg": true,
     "subsystem": "console",
+    "pch": "include/pch.hpp",
     "output": "game",
     "defines": ["GAME_BUILD=1"],
     "include_dirs": ["include", "third_party/include"],
@@ -66,6 +67,7 @@ profiles
       "build": {
         "configuration": "debug",
         "runtime": "MDd",
+        "pch": false,
         "compiler_args": ["/W4"]
       },
       "discovery": {
@@ -95,6 +97,7 @@ profiles
 | `runtime` | string | `MD`、`MDd`、`MT`、`MTd` |
 | `ltcg` | boolean | 联动编译 `/GL` 与下游 `/LTCG` |
 | `subsystem` | string | `console` / `windows`；static target 不接受 |
+| `pch` | string / `false` | 为普通 C++ target 启用 first-class PCH；路径相对 `mqb.json`；`false` 显式关闭前层 PCH policy |
 | `output` | string | `.mqb/bin/` 下的目标名，扩展名由 target kind 决定 |
 | `defines` | string[] | 不带 `/D` 的宏定义 |
 | `include_dirs` | string[] | include search path |
@@ -145,9 +148,59 @@ mqb run tools/tool.cpp
 
 `build.entry` **只能声明在根 `build` 层**。Profile 是构建策略 overlay，不能通过 `profiles.<name>.build.entry` 改变项目身份；该字段会被 strict schema 直接拒绝。
 
+### First-class PCH
+
+`build.pch` 是 scalar policy。启用时必须给出非空 header path：
+
+```json
+{
+  "version": 1,
+  "build": {
+    "pch": "include/pch.hpp"
+  }
+}
+```
+
+布尔 `true` 被拒绝，因为“启用但不指定 header”无法形成稳定 PCH identity。`false` 用于显式关闭更低层继承的 PCH：
+
+```json
+{
+  "version": 1,
+  "build": {
+    "pch": "include/pch.hpp"
+  },
+  "profiles": {
+    "clean": {
+      "build": {
+        "pch": false
+      }
+    }
+  }
+}
+```
+
+CLI 等价/覆盖形式：
+
+```powershell
+mqb build --pch include/pch.hpp
+mqb build --profile dev --no-pch
+```
+
+PCH policy 遵循：
+
+```text
+显式 CLI > selected profile > base mqb.json > disabled default
+```
+
+配置/profile PCH 路径相对 `mqb.json`；`--pch` 相对 invocation directory。
+
+MQB 自己拥有 synthetic creator、`.pch`、配对 creator `.obj`、`/FI`、`/Yc` / `/Yu`、`/Fp` 和 PCH cache/dependency tracking。Raw PCH structural switches 不能绕过这套 ownership。`.pch` 会成为普通 consumer compile cache 的显式 dependency；PCH creator 重建也会强制 downstream link/archive。完整 artifact/invalidation 契约见 [`PRECOMPILED_HEADERS.md`](PRECOMPILED_HEADERS.md)。
+
+当前 first-class PCH 只支持普通 C++ source set，可用于 `exe` / `dll` / `static`；与 C TU 或 Modules/Header Units pipeline 组合时 fail closed。
+
 ### Typed policy
 
-`type`、`runtime`、`ltcg`、`subsystem` 是 MQB 的强类型策略，不是字符串形式的 MSVC flag 别名。MQB 后端负责最终命令行拼写，冲突的 raw compiler/linker argument 不应被用来绕过 typed policy。
+`type`、`runtime`、`ltcg`、`subsystem`、`pch` 是 MQB 的强类型/结构化策略，不是字符串形式的 MSVC flag 别名。MQB 后端负责最终命令行拼写，冲突的 raw compiler/linker argument 不应被用来绕过 typed policy 或 MQB-owned artifact routing。
 
 `ltcg: true` 同时影响 compile 与 downstream target：
 
@@ -242,7 +295,7 @@ discovery
 modules
 ```
 
-它们复用根层完全相同的 typed policy、list、路径和 module-provider 解码规则，但 `build.entry` 除外：profile 内禁止设置入口。
+它们复用根层完全相同的 typed policy、list、路径和 module-provider 解码规则，但 `build.entry` 除外：profile 内禁止设置入口。`build.pch` 可以在 profile 中用另一条 header path 覆盖 base，也可以用 `false` 关闭 base PCH。
 
 示例：
 
@@ -252,6 +305,7 @@ modules
   "build": {
     "entry": "src/main.cpp",
     "standard": "23",
+    "pch": "include/pch.hpp",
     "defines": ["PROJECT=1"]
   },
   "profiles": {
@@ -259,6 +313,7 @@ modules
       "build": {
         "configuration": "debug",
         "runtime": "MDd",
+        "pch": false,
         "defines": ["DEV=1"],
         "compiler_args": ["/W4"]
       }
@@ -295,9 +350,9 @@ mqb build --profile=release
 - 没有隐式 default profile；未写 `--profile` 就只使用 base config + CLI；
 - `--profile` 需要项目存在 `mqb.json`；
 - 未找到 profile 时 fail closed，并列出可用 profile 名；
-- profile 中的 relative path 与 base config 一样，以 `mqb.json` 所在目录为基准；
+- profile 中的 relative path（包括 `pch`）与 base config 一样，以 `mqb.json` 所在目录为基准；
 - profile 中的 `compiler_args` / `linker_args` 仍进入同一 MSVC Parameter Engine，semantic option 会先在 profile 自身层归一化，然后再由更高优先级 CLI 覆盖；
-- profile 可以选择 `type` 等 typed policy，因此最终 target 仍受同一 executable/static/DLL 合法性门禁约束。
+- profile 可以选择 `type` / `pch` 等 policy，因此最终 target 仍受同一 executable/static/DLL/PCH 合法性门禁约束。
 
 ## 7. 优先级
 
@@ -317,10 +372,13 @@ type
 runtime
 ltcg
 subsystem
+pch
 output
 ```
 
-同一层内，typed policy 与等价 native MSVC semantic option 必须一致，否则在进入 toolchain 前 fail closed。例如 profile 同时写 `runtime: "MT"` 与 `/MD` 会被拒绝。
+其中 PCH 的 built-in default 是 disabled；`pch: false` 与 `--no-pch` 都是显式 scalar override。
+
+同一层内，typed policy 与等价 native MSVC semantic option 必须一致，否则在进入 toolchain 前 fail closed。例如 profile 同时写 `runtime: "MT"` 与 `/MD` 会被拒绝。PCH 的 `/Yc`、`/Yu`、`/Fp` 等 structural switches 由 MQB ownership model 直接保留，不属于可与 `pch` 并行配置的 raw semantic alias。
 
 入口选择是独立的 source-selection policy：
 
@@ -347,7 +405,7 @@ CLI relative path                 -> invocation directory
 mqb.json / profile relative path  -> directory containing mqb.json
 ```
 
-`build.entry` 属于后者，但只能出现在 root build 层。
+`build.entry` 与 `build.pch` 都属于 config-relative 路径；`entry` 只能出现在 root build 层，而 `pch` 可被 profile 覆盖。CLI `--pch` 始终使用 invocation-relative 路径。
 
 例如：
 
@@ -355,6 +413,7 @@ mqb.json / profile relative path  -> directory containing mqb.json
 project/
 ├─ mqb.json
 ├─ src/main.cpp
+├─ include/pch.hpp
 ├─ include/
 └─ nested/work/
 ```
@@ -366,6 +425,7 @@ project/
   "version": 1,
   "build": {
     "entry": "src/main.cpp",
+    "pch": "include/pch.hpp",
     "include_dirs": ["include"]
   },
   "profiles": {
@@ -384,12 +444,12 @@ project/
 mqb run --profile dev
 ```
 
-仍会加载 `project/mqb.json`，把 entry 解析为 `project/src/main.cpp`、base include dir 解析为 `project/include`、profile include dir 解析为 `project/third_party/dev/include`，并把 writable artifacts 放到 `project/.mqb/`。
+仍会加载 `project/mqb.json`，把 entry 解析为 `project/src/main.cpp`、PCH 解析为 `project/include/pch.hpp`、base include dir 解析为 `project/include`、profile include dir 解析为 `project/third_party/dev/include`，并把 writable artifacts 放到 `project/.mqb/`。
 
 显式 CLI source/path 仍按 invocation directory 解析：
 
 ```powershell
-mqb ../../src/main.cpp
+mqb ../../src/main.cpp --pch ../../include/pch.hpp
 ```
 
 ## 9. Cache 语义
@@ -398,9 +458,12 @@ MQB 不以“配置文件时间戳变化”或“profile 名变化”作为全�
 
 `build.entry` 自身不额外进入 compile/link identity；它只决定本次 source-selection 的入口。Profile name 也不是额外 cache 维度。两个 profile 如果解析成完全相同的 effective build policy/source graph，应复用同一套既有 cache identity。
 
+PCH 的 identity 由最终 effective PCH header/artifact/role 与正常 compiler/toolchain semantics 共同决定；profile 名本身不作为额外维度。PCH creator 使用独立 compile cache，`.pch` 同时是 consumer compile cache dependency。缺失 `.pch` 会触发 creator repair；PCH creator 重建会使 consumers 失效并强制 downstream link/archive。
+
 典型影响：
 
 - `runtime` / compiler args / typed module references 改变 compile identity；
+- `pch` 改变 PCH creator/consumer compile identity，并通过 `.pch` dependency 传播 freshness；
 - `ltcg` 同时改变 compile 与 link/archive identity；
 - `subsystem` 只影响 link identity；
 - libraries / library dirs / linker args 改变 link identity；
@@ -409,7 +472,7 @@ MQB 不以“配置文件时间戳变化”或“profile 名变化”作为全�
 - external/prebuilt IFC identity 改变会使依赖它的 consumer compile cache 失效；
 - selected MSVC toolchain identity 改变时，不会静默复用不兼容的 toolchain-owned standard-library IFC。
 
-缺失的已记录输出也会使相应 compile/link/archive cache 失效并触发修复。
+缺失的已记录输出也会使相应 compile/link/archive/PCH cache 失效并触发修复。
 
 `-j/--jobs` 是执行策略，不属于 build identity，也不是 v1 配置字段。
 
@@ -417,6 +480,8 @@ MQB 不以“配置文件时间戳变化”或“profile 名变化”作为全�
 
 - `exe`、`dll`、`static` 均受支持；
 - `mqb run` 与 source-first `--run` 仅适用于 executable；
+- ordinary C++ `exe` / `dll` / `static` 支持 first-class PCH；
+- first-class PCH 与 C TU 或 Modules/Header Units pipeline 组合时当前 fail closed；
 - static target 不接受 subsystem、library paths/libraries、linker args；
 - **需要 Modules/Header Units pipeline 的 static-library target 当前仍 fail closed**；
 - discovery correction 使用精确路径，不支持 glob；
@@ -425,4 +490,4 @@ MQB 不以“配置文件时间戳变化”或“profile 名变化”作为全�
 - profile 不能覆盖 `build.entry`；
 - 间接 `/DEFAULTLIB` 传递依赖不承诺完全的新鲜度跟踪。
 
-更底层的 provider graph、artifact identity 与职责边界见 [`ARCHITECTURE.md`](ARCHITECTURE.md)。
+PCH artifact/ownership 细节见 [`PRECOMPILED_HEADERS.md`](PRECOMPILED_HEADERS.md)；更底层的 provider graph、artifact identity 与职责边界见 [`ARCHITECTURE.md`](ARCHITECTURE.md)。

--- a/docs/MQB_CONFIG_EN.md
+++ b/docs/MQB_CONFIG_EN.md
@@ -42,6 +42,7 @@ profiles
     "runtime": "MT",
     "ltcg": true,
     "subsystem": "console",
+    "pch": "include/pch.hpp",
     "output": "game",
     "defines": ["GAME_BUILD=1"],
     "include_dirs": ["include", "third_party/include"],
@@ -66,6 +67,7 @@ profiles
       "build": {
         "configuration": "debug",
         "runtime": "MDd",
+        "pch": false,
         "compiler_args": ["/W4"]
       },
       "discovery": {
@@ -95,6 +97,7 @@ profiles
 | `runtime` | string | `MD`, `MDd`, `MT`, `MTd` |
 | `ltcg` | boolean | couples compile `/GL` with downstream `/LTCG` |
 | `subsystem` | string | `console` / `windows`; not accepted for static targets |
+| `pch` | string / `false` | enable first-class PCH for ordinary C++ targets; path is relative to `mqb.json`; `false` disables inherited PCH policy |
 | `output` | string | target name under `.mqb/bin/`; extension follows target kind |
 | `defines` | string[] | preprocessor definitions without `/D` |
 | `include_dirs` | string[] | include search paths |
@@ -145,9 +148,59 @@ Even when `build.entry` exists, this builds and runs `tools/tool.cpp`.
 
 `build.entry` may appear **only in the root `build` layer**. Profiles are build-policy overlays and cannot change project identity through `profiles.<name>.build.entry`; strict schema validation rejects that field.
 
+### First-class PCH
+
+`build.pch` is scalar policy. Enabling it requires a non-empty header path:
+
+```json
+{
+  "version": 1,
+  "build": {
+    "pch": "include/pch.hpp"
+  }
+}
+```
+
+Boolean `true` is rejected because "enabled without naming a header" cannot form stable PCH identity. `false` explicitly disables PCH inherited from a lower layer:
+
+```json
+{
+  "version": 1,
+  "build": {
+    "pch": "include/pch.hpp"
+  },
+  "profiles": {
+    "clean": {
+      "build": {
+        "pch": false
+      }
+    }
+  }
+}
+```
+
+CLI forms:
+
+```powershell
+mqb build --pch include/pch.hpp
+mqb build --profile dev --no-pch
+```
+
+PCH precedence is:
+
+```text
+explicit CLI > selected profile > base mqb.json > disabled default
+```
+
+Config/profile PCH paths are relative to `mqb.json`; a `--pch` path is relative to the invocation directory.
+
+MQB owns the synthetic creator, `.pch`, paired creator `.obj`, `/FI`, `/Yc` / `/Yu`, `/Fp`, and PCH cache/dependency tracking. Raw PCH structural switches cannot bypass this ownership. The `.pch` is an explicit consumer compile-cache dependency, and rebuilding the creator forces downstream link/archive work. See [`PRECOMPILED_HEADERS_EN.md`](PRECOMPILED_HEADERS_EN.md) for the complete artifact and invalidation contract.
+
+First-class PCH currently supports ordinary C++ source sets for `exe` / `dll` / `static`. Combining it with a C translation unit or the Modules/Header Unit pipeline fails closed.
+
 ### Typed policy
 
-`type`, `runtime`, `ltcg`, and `subsystem` are typed MQB policies, not string aliases for MSVC flags. The backend owns the final command-line spelling; raw compiler/linker arguments should not be used to bypass conflicting typed policy.
+`type`, `runtime`, `ltcg`, `subsystem`, and `pch` are structured MQB policies, not string aliases for MSVC flags. The backend owns final command-line spelling; raw compiler/linker arguments should not bypass typed policy or MQB-owned artifact routing.
 
 `ltcg: true` affects both compile and the downstream target:
 
@@ -242,7 +295,7 @@ discovery
 modules
 ```
 
-Those sections reuse the same typed-policy, list, path, and module-provider decoding rules as the root layers, except that profile-local `build.entry` is prohibited.
+Those sections reuse the same typed-policy, list, path, and module-provider decoding rules as the root layers, except that profile-local `build.entry` is prohibited. A profile may replace base `build.pch` with another header or disable it with `false`.
 
 Example:
 
@@ -252,6 +305,7 @@ Example:
   "build": {
     "entry": "src/main.cpp",
     "standard": "23",
+    "pch": "include/pch.hpp",
     "defines": ["PROJECT=1"]
   },
   "profiles": {
@@ -259,6 +313,7 @@ Example:
       "build": {
         "configuration": "debug",
         "runtime": "MDd",
+        "pch": false,
         "defines": ["DEV=1"],
         "compiler_args": ["/W4"]
       }
@@ -295,9 +350,9 @@ The current contract is deliberately small and deterministic:
 - there is no implicit default profile; omitting `--profile` means base config + CLI only;
 - `--profile` requires an `mqb.json` project configuration;
 - an unknown profile fails closed and reports the available profile names;
-- relative paths inside a profile use the `mqb.json` directory as their base, exactly like root config paths;
+- relative paths inside a profile, including `pch`, use the `mqb.json` directory as their base, exactly like root config paths;
 - profile `compiler_args` / `linker_args` still flow through the same MSVC Parameter Engine. Semantic native options are normalized within the profile layer before higher-precedence CLI policy is applied;
-- a profile may select typed policy such as `type`, so the final target still passes through the same executable/static/DLL validity gates.
+- a profile may select policy such as `type` and `pch`, so the final target still passes through the same executable/static/DLL/PCH validity gates.
 
 ## 7. Precedence
 
@@ -317,10 +372,13 @@ type
 runtime
 ltcg
 subsystem
+pch
 output
 ```
 
-Within one layer, typed policy and equivalent native MSVC semantic options must agree or MQB fails closed before toolchain execution. For example, a profile that declares `runtime: "MT"` and `/MD` is rejected.
+PCH's built-in default is disabled; `pch: false` and `--no-pch` are explicit scalar overrides.
+
+Within one layer, typed policy and equivalent native MSVC semantic options must agree or MQB fails closed before toolchain execution. For example, a profile that declares `runtime: "MT"` and `/MD` is rejected. PCH structural `/Yc`, `/Yu`, and `/Fp` switches are MQB-owned and are not raw aliases that can be configured alongside `pch`.
 
 Entry selection is a separate source-selection policy:
 
@@ -347,7 +405,7 @@ CLI relative path                 -> invocation directory
 mqb.json / profile relative path  -> directory containing mqb.json
 ```
 
-`build.entry` uses the second base but is valid only in the root build layer.
+Both `build.entry` and `build.pch` are config-relative paths. `entry` is valid only in the root build layer, while `pch` may be overridden by a profile. CLI `--pch` remains invocation-relative.
 
 Example:
 
@@ -355,6 +413,7 @@ Example:
 project/
 ├─ mqb.json
 ├─ src/main.cpp
+├─ include/pch.hpp
 ├─ include/
 └─ nested/work/
 ```
@@ -366,6 +425,7 @@ Configuration:
   "version": 1,
   "build": {
     "entry": "src/main.cpp",
+    "pch": "include/pch.hpp",
     "include_dirs": ["include"]
   },
   "profiles": {
@@ -384,12 +444,12 @@ From `project/nested/work`:
 mqb run --profile dev
 ```
 
-MQB still loads `project/mqb.json`, resolves the entry as `project/src/main.cpp`, the base include directory as `project/include`, the profile include directory as `project/third_party/dev/include`, and places writable artifacts under `project/.mqb/`.
+MQB still loads `project/mqb.json`, resolves the entry as `project/src/main.cpp`, PCH as `project/include/pch.hpp`, the base include directory as `project/include`, the profile include directory as `project/third_party/dev/include`, and places writable artifacts under `project/.mqb/`.
 
 Explicit CLI sources and paths remain invocation-relative:
 
 ```powershell
-mqb ../../src/main.cpp
+mqb ../../src/main.cpp --pch ../../include/pch.hpp
 ```
 
 ## 9. Cache semantics
@@ -398,9 +458,12 @@ MQB does not treat "the config file timestamp changed" or "the profile name chan
 
 `build.entry` does not add a separate compile/link identity field; it selects the source-discovery entry for this invocation. The profile name is likewise not a separate cache dimension. Two profiles that resolve to identical effective build policy/source graphs should reuse the same existing cache identity.
 
+PCH identity is derived from the final effective PCH header/artifact/role together with normal compiler/toolchain semantics; the profile name itself does not add another dimension. The creator has its own compile cache, and `.pch` is an explicit dependency of consumer compile caches. A missing `.pch` triggers creator repair; rebuilding the creator invalidates consumers and forces downstream link/archive work.
+
 Typical effects:
 
 - `runtime`, compiler args, and typed module references change compile identity;
+- `pch` changes creator/consumer compile identity and propagates freshness through the `.pch` dependency;
 - `ltcg` changes compile and link/archive identity;
 - `subsystem` changes link identity only;
 - libraries, library dirs, and linker args change link identity;
@@ -409,7 +472,7 @@ Typical effects:
 - changing an external/prebuilt IFC invalidates dependent consumer compile caches;
 - changing the selected MSVC toolchain identity does not silently reuse incompatible toolchain-owned standard-library IFCs.
 
-Missing recorded outputs also invalidate the corresponding compile/link/archive cache and trigger repair.
+Missing recorded outputs invalidate the corresponding compile/link/archive/PCH cache and trigger repair.
 
 `-j/--jobs` is execution policy. It is not part of build identity and is not a v1 configuration field.
 
@@ -417,6 +480,8 @@ Missing recorded outputs also invalidate the corresponding compile/link/archive 
 
 - `exe`, `dll`, and `static` are supported;
 - `mqb run` and source-first `--run` apply only to executables;
+- ordinary C++ `exe` / `dll` / `static` targets support first-class PCH;
+- first-class PCH combined with a C translation unit or Modules/Header Unit pipeline currently fails closed;
 - static targets do not accept subsystem, library paths/libraries, or linker args;
 - **static-library targets that require the Modules/Header Units pipeline still fail closed**;
 - discovery corrections use exact paths and do not support globs;
@@ -425,4 +490,4 @@ Missing recorded outputs also invalidate the corresponding compile/link/archive 
 - profiles cannot override `build.entry`;
 - freshness through indirect `/DEFAULTLIB`-style library propagation is not guaranteed to be complete.
 
-See [`ARCHITECTURE_EN.md`](ARCHITECTURE_EN.md) for deeper provider-graph, artifact-identity, and responsibility boundaries.
+See [`PRECOMPILED_HEADERS_EN.md`](PRECOMPILED_HEADERS_EN.md) for PCH artifact/ownership details and [`ARCHITECTURE_EN.md`](ARCHITECTURE_EN.md) for deeper provider-graph, artifact-identity, and responsibility boundaries.

--- a/docs/PRECOMPILED_HEADERS.md
+++ b/docs/PRECOMPILED_HEADERS.md
@@ -1,0 +1,165 @@
+# First-class PCH
+
+MQB treats MSVC precompiled headers as a first-class build artifact rather than as raw `/Yc`, `/Yu`, and `/Fp` escape hatches.
+
+## Quick start
+
+Project configuration:
+
+```json
+{
+  "version": 1,
+  "build": {
+    "entry": "src/main.cpp",
+    "pch": "include/pch.hpp"
+  }
+}
+```
+
+CLI:
+
+```powershell
+mqb build --pch include/pch.hpp
+mqb run --pch include/pch.hpp
+```
+
+Disable an inherited PCH policy:
+
+```powershell
+mqb build --profile dev --no-pch
+```
+
+`build.pch` accepts either a non-empty header path string or `false`. Boolean `true` is rejected because enabling PCH without naming its header would leave its identity ambiguous.
+
+## Precedence and path bases
+
+PCH policy is a scalar build policy and follows the same precedence as other scalar project settings:
+
+```text
+explicit CLI > selected profile > base mqb.json > disabled default
+```
+
+Examples:
+
+```json
+{
+  "version": 1,
+  "build": {
+    "pch": "include/base.hpp"
+  },
+  "profiles": {
+    "dev": {
+      "build": {
+        "pch": "include/dev.hpp"
+      }
+    },
+    "clean": {
+      "build": {
+        "pch": false
+      }
+    }
+  }
+}
+```
+
+```powershell
+mqb build                         # include/base.hpp
+mqb build --profile dev           # include/dev.hpp
+mqb build --profile dev --pch alt.hpp
+mqb build --profile dev --no-pch  # disabled
+mqb build --profile clean         # disabled
+```
+
+Paths in `mqb.json` and profiles are resolved relative to the directory containing `mqb.json`. A path supplied by `--pch` is resolved relative to the invocation directory.
+
+## Ownership model
+
+When PCH is enabled, MQB owns the entire structural contract:
+
+- the synthetic PCH creator translation unit;
+- the `.pch` artifact path;
+- the paired creator `.obj`;
+- `/FI<header>`;
+- `/Yc<header>` on the creator;
+- `/Yu<header>` on consumers;
+- `/Fp<artifact>`;
+- incremental PCH cache metadata and dependency tracking.
+
+The same normalized header identity is used for `/FI`, `/Yc`, and `/Yu`. Raw PCH structural switches remain rejected by the MSVC Parameter Engine so that user arguments cannot silently compete with MQB-owned artifact routing.
+
+The synthetic creator source is generated under `.mqb/pch/` and is written only when its fixed contents differ, so a normal warm invocation does not invalidate the PCH merely by touching the generated source.
+
+## Build graph and cache behavior
+
+A PCH creator is built before ordinary PCH consumers through the existing incremental compile coordinator. Its compile action produces two owned outputs atomically:
+
+```text
+creator.obj
+project.pch
+```
+
+The creator cache records the header/include dependencies reported by MSVC `/sourceDependencies`. The `.pch` is also an explicit dependency of every consumer compile cache entry.
+
+Consequences:
+
+- a fully warm build reuses the creator, every consumer object, and the downstream target;
+- changing only an ordinary source recompiles that source without rebuilding the PCH;
+- changing the PCH header or one of its tracked dependencies rebuilds the PCH and invalidates consumers;
+- deleting the `.pch` invalidates the creator cache and repairs the missing artifact;
+- changing typed/raw compile semantics that participate in the creator signature rebuilds the PCH;
+- changing the target name, configuration, or architecture selects separate PCH artifact state.
+
+The paired creator object is deliberately retained as a downstream target input. Executable/DLL links include it, and static-library targets archive it. This preserves the MSVC PCH object/debug-information contract instead of treating `.pch` as a standalone link-independent file.
+
+If the creator is rebuilt, MQB forces the downstream link/archive even before normal object freshness checks could otherwise decide that the target is warm.
+
+## Generated state
+
+For target `app`, Debug, x64, MQB uses:
+
+```text
+.mqb/
+├─ pch/
+│  └─ app/
+│     └─ debug/
+│        └─ x64/
+│           ├─ creator.cpp
+│           ├─ creator.obj
+│           ├─ creator.deps.json
+│           └─ project.pch
+└─ cache/
+   └─ pch/
+      └─ app/
+         └─ debug/
+            └─ x64/
+               └─ creator.mqbcache
+```
+
+All of these are writable MQB-owned state and remain under the project `.mqb/` root.
+
+## Current boundary
+
+The first-class PCH pipeline currently supports ordinary C++ source sets for executable, DLL, and static-library targets.
+
+MQB fails closed when PCH is combined with:
+
+- a C translation unit;
+- a target that requires the Modules/Header Unit pipeline.
+
+These combinations are rejected before trying to approximate incompatible graph semantics. They can be enabled later only when MQB can model and validate their artifact/dependency behavior explicitly.
+
+## Diagnostics and timing
+
+Cold/rebuilt PCH work is reported as:
+
+```text
+[pch] include/pch.hpp ...
+```
+
+A warm creator is reported as:
+
+```text
+[up-to-date] pch include/pch.hpp
+```
+
+PCH creator work contributes to compile timing/cache counters. It is not hidden as linker or generic setup time.

--- a/docs/PRECOMPILED_HEADERS_EN.md
+++ b/docs/PRECOMPILED_HEADERS_EN.md
@@ -1,0 +1,165 @@
+# First-class PCH
+
+MQB treats MSVC precompiled headers as a first-class build artifact instead of exposing raw `/Yc`, `/Yu`, and `/Fp` switches as an escape hatch.
+
+## Quick start
+
+Project configuration:
+
+```json
+{
+  "version": 1,
+  "build": {
+    "entry": "src/main.cpp",
+    "pch": "include/pch.hpp"
+  }
+}
+```
+
+CLI:
+
+```powershell
+mqb build --pch include/pch.hpp
+mqb run --pch include/pch.hpp
+```
+
+Disable PCH inherited from a project or profile:
+
+```powershell
+mqb build --profile dev --no-pch
+```
+
+`build.pch` accepts either a non-empty header path string or `false`. Boolean `true` is rejected because enabling PCH without naming the header would leave its identity ambiguous.
+
+## Precedence and path bases
+
+PCH is scalar build policy and follows the normal scalar precedence:
+
+```text
+explicit CLI > selected profile > base mqb.json > disabled default
+```
+
+Example:
+
+```json
+{
+  "version": 1,
+  "build": {
+    "pch": "include/base.hpp"
+  },
+  "profiles": {
+    "dev": {
+      "build": {
+        "pch": "include/dev.hpp"
+      }
+    },
+    "clean": {
+      "build": {
+        "pch": false
+      }
+    }
+  }
+}
+```
+
+```powershell
+mqb build                         # include/base.hpp
+mqb build --profile dev           # include/dev.hpp
+mqb build --profile dev --pch alt.hpp
+mqb build --profile dev --no-pch  # disabled
+mqb build --profile clean         # disabled
+```
+
+PCH paths from `mqb.json` and profiles resolve relative to the directory containing `mqb.json`. A `--pch` path resolves relative to the invocation directory.
+
+## Ownership model
+
+With first-class PCH enabled, MQB owns the complete structural contract:
+
+- the synthetic creator translation unit;
+- the `.pch` artifact path;
+- the paired creator `.obj`;
+- `/FI<header>`;
+- `/Yc<header>` on the creator;
+- `/Yu<header>` on consumers;
+- `/Fp<artifact>`;
+- incremental PCH cache metadata and dependency tracking.
+
+The same normalized header identity is used for `/FI`, `/Yc`, and `/Yu`. Raw PCH structural switches remain rejected by the MSVC Parameter Engine, so user arguments cannot silently compete with MQB-owned artifact routing.
+
+The synthetic creator is generated below `.mqb/pch/` and rewritten only when its fixed contents differ. A normal warm invocation therefore does not invalidate PCH by touching the generated source.
+
+## Build graph and cache behavior
+
+The creator is built before ordinary PCH consumers through the existing incremental compile coordinator. Its compile action owns two outputs:
+
+```text
+creator.obj
+project.pch
+```
+
+The creator cache records header/include dependencies emitted by MSVC `/sourceDependencies`. The `.pch` is also recorded as an explicit dependency of every consumer compile cache entry.
+
+This gives the following behavior:
+
+- a fully warm build reuses the creator, all consumer objects, and the downstream target;
+- changing only an ordinary source recompiles that source without rebuilding PCH;
+- changing the PCH header or a tracked dependency rebuilds PCH and invalidates consumers;
+- deleting the `.pch` invalidates creator cache and repairs the missing artifact;
+- changing compile semantics included in creator identity rebuilds PCH;
+- target name, build configuration, and architecture select separate PCH state.
+
+The creator object deliberately remains a downstream target input. Executable/DLL links include it, and static-library targets archive it. This preserves the MSVC PCH object/debug-information contract instead of pretending that `.pch` is link-independent.
+
+When the creator rebuilds, MQB forces the downstream link/archive even if normal object freshness would otherwise consider the target warm.
+
+## Generated state
+
+For target `app`, Debug, x64:
+
+```text
+.mqb/
+├─ pch/
+│  └─ app/
+│     └─ debug/
+│        └─ x64/
+│           ├─ creator.cpp
+│           ├─ creator.obj
+│           ├─ creator.deps.json
+│           └─ project.pch
+└─ cache/
+   └─ pch/
+      └─ app/
+         └─ debug/
+            └─ x64/
+               └─ creator.mqbcache
+```
+
+All paths are writable MQB-owned state under the project `.mqb/` root.
+
+## Current boundary
+
+First-class PCH currently supports ordinary C++ source sets for executable, DLL, and static-library targets.
+
+MQB fails closed when PCH is combined with:
+
+- a C translation unit;
+- a target that requires the Modules/Header Unit pipeline.
+
+These combinations are not approximated. They should only be enabled later when their artifact and dependency semantics can be modeled and validated explicitly.
+
+## Diagnostics and timing
+
+Cold or rebuilt PCH work is reported as:
+
+```text
+[pch] include/pch.hpp ...
+```
+
+A warm creator is reported as:
+
+```text
+[up-to-date] pch include/pch.hpp
+```
+
+PCH creator work contributes to compile timing and cache counters rather than being hidden as generic setup or link work.

--- a/tests/native/assert_cpp_layout.ps1
+++ b/tests/native/assert_cpp_layout.ps1
@@ -257,6 +257,7 @@ $orchestrationLeafFiles = [ordered]@{
         'MsvcIncrementalArchiveCoordinator.cpp',
         'MsvcIncrementalCompileCoordinator.cpp',
         'MsvcIncrementalLinkCoordinator.cpp',
+        'MsvcIncrementalPchCoordinator.cpp',
         'MsvcIncrementalStaticTargetCoordinator.cpp',
         'MsvcIncrementalTargetCoordinator.cpp'
     )

--- a/tests/native/run_native_tests.ps1
+++ b/tests/native/run_native_tests.ps1
@@ -84,8 +84,8 @@ if ($includeDirs.Count -eq 0) { throw 'Native test config has no include_dirs.' 
 $allTestFiles = @(Get-ChildItem -LiteralPath $cppRoot -Recurse -File -Filter '*_tests.cpp' |
     Where-Object { $_.FullName -notmatch '[\\/]\.mqb[\\/]' } |
     Sort-Object FullName)
-if ($allTestFiles.Count -ne 70) {
-    throw "Native test manifest drift: expected 70 *_tests.cpp files, found $($allTestFiles.Count)."
+if ($allTestFiles.Count -ne 71) {
+    throw "Native test manifest drift: expected 71 *_tests.cpp files, found $($allTestFiles.Count)."
 }
 
 function Get-TestRelativePath {
@@ -105,6 +105,7 @@ function Get-TestRelativePath {
 $testWeightOverrides = [ordered]@{
     'tests/e2e/mqb_module_cli_e2e_tests.cpp' = 10
     'tests/e2e/mqb_build_policy_e2e_tests.cpp' = 9
+    'tests/e2e/mqb_pch_e2e_tests.cpp' = 7
     'tests/e2e/mqb_static_library_e2e_tests.cpp' = 7
     'tests/e2e/mqb_cli_e2e_tests.cpp' = 4
     'tests/e2e/mqb_runtime_subsystem_config_e2e_tests.cpp' = 4
@@ -120,7 +121,7 @@ $testWeightOverrides = [ordered]@{
 $relativeTestPaths = @($allTestFiles | ForEach-Object { Get-TestRelativePath -File $_ })
 foreach ($weightedPath in $testWeightOverrides.Keys) {
     if ($weightedPath -notin $relativeTestPaths) {
-        throw "Native test weight override is stale or missing from the 70-test manifest: $weightedPath"
+        throw "Native test weight override is stale or missing from the 71-test manifest: $weightedPath"
     }
 }
 


### PR DESCRIPTION
## Summary

Implements PR 6 of the MQB productization track: first-class MSVC precompiled headers owned by MQB rather than exposed as raw `/Yc`/`/Yu`/`/Fp` escape hatches.

## Delivered

- `build.pch` config/profile policy plus `--pch <header>` / `--no-pch`
- scalar precedence: `base mqb.json < selected profile < CLI`, with config/profile paths config-relative and CLI paths invocation-relative
- target/config/architecture-specific PCH state under `.mqb/pch/`
- write-if-changed MQB-owned synthetic creator TU
- PCH creation through the existing incremental compile/cache coordinator
- one normalized header identity for `/FI`, `/Yc`/`/Yu`, and `/Fp`
- `.pch` as a compile output/cache artifact and explicit consumer dependency
- PCH binding role/header/artifact in compile signature identity
- creator build before ordinary consumers
- paired creator `.obj` retained as an MQB-owned synthetic target object in executable/DLL link or static archive
- downstream link/archive forced when the creator is rebuilt
- fail-closed boundary for C translation units and the Modules/Header Unit pipeline in this milestone
- dedicated Chinese/English PCH documentation and config/README coverage

## MSVC ownership contract

MQB owns the synthetic creator TU, `.pch`, paired creator object, `/FI`, `/Yc`/`/Yu`, and `/Fp`. Raw PCH structural options remain rejected by the MSVC Parameter Engine.

The paired creator object intentionally remains in the downstream object set because MSVC PCH consumers can depend on the object generated alongside `/Yc`, including the shared `/Z7` debug-type contract.

## Validation

Exact validated head: `0c31e76ddad6be412cbfa888a6d79d2be495328e`

Native C++ #201 / run `31799242168`:
- Debug candidate self-build: success
- 67-TU shared native-test product: success
- 71-test graph, 4/4 Debug shards: success
- final Native C++ gate: success

Native Release #168 / run `31799242182`:
- Stage 0 Release self-build + shared product: success
- 71-test graph, 4/4 Release shards: success
- Stage 1 stable self-host: success
- runtime-only package staging: success
- exact packaged-artifact validation: success
- validated artifact upload: success
- `publish-release`: skipped as expected for a PR

PCH E2E covers cold -> warm reuse, ordinary-source-only changes, header-triggered creator/consumer invalidation, missing `.pch` repair, executable/static targets, C/Modules fail-closed behavior, and real base-config/profile/CLI PCH precedence from a nested invocation directory.