### PR TITLE
feat: add adaptive parallelism policy

### DIFF
--- a/cpp/include/mqb/orchestration/BoundedWorkScheduler.hpp
+++ b/cpp/include/mqb/orchestration/BoundedWorkScheduler.hpp
@@ -5,6 +5,8 @@
 #include <functional>
 #include <string>
 
+#include "mqb/orchestration/ParallelismPolicy.hpp"
+
 namespace mqb::orchestration {
 
 enum class BoundedWorkErrorCode {
@@ -33,6 +35,16 @@ public:
     run(
         std::size_t item_count,
         std::size_t max_workers,
+        const std::function<bool(std::size_t)>& work);
+
+    // Automatic policy is resolved against the current ready batch instead of
+    // being converted to a fixed integer earlier in application composition.
+    // Fixed policy remains a hard user ceiling. This overload deliberately owns
+    // the hardware-concurrency observation so callers can preserve policy intent.
+    [[nodiscard]] static std::expected<BoundedWorkSummary, BoundedWorkError>
+    run(
+        std::size_t item_count,
+        ParallelismPolicy policy,
         const std::function<bool(std::size_t)>& work);
 };
 

--- a/cpp/include/mqb/orchestration/MsvcIncrementalStaticTargetCoordinator.hpp
+++ b/cpp/include/mqb/orchestration/MsvcIncrementalStaticTargetCoordinator.hpp
@@ -12,6 +12,7 @@
 #include "mqb/orchestration/MsvcIncrementalArchiveCoordinator.hpp"
 #include "mqb/orchestration/MsvcIncrementalCompileCoordinator.hpp"
 #include "mqb/orchestration/MsvcIncrementalTargetCoordinator.hpp"
+#include "mqb/orchestration/ParallelismPolicy.hpp"
 #include "mqb/orchestration/TargetTimings.hpp"
 
 namespace mqb::orchestration {
@@ -22,7 +23,7 @@ struct IncrementalStaticTargetRequest {
     TargetArtifacts target;
     CompilerOptions compiler_options;
     std::filesystem::path working_directory;
-    std::size_t max_parallel_compiles{1};
+    ParallelismPolicy compile_parallelism{};
     bool force_downstream_rebuild{false};
 };
 

--- a/cpp/include/mqb/orchestration/MsvcIncrementalStaticTargetCoordinator.hpp
+++ b/cpp/include/mqb/orchestration/MsvcIncrementalStaticTargetCoordinator.hpp
@@ -23,7 +23,7 @@ struct IncrementalStaticTargetRequest {
     TargetArtifacts target;
     CompilerOptions compiler_options;
     std::filesystem::path working_directory;
-    ParallelismPolicy compile_parallelism{};
+    ParallelismPolicy max_parallel_compiles{};
     bool force_downstream_rebuild{false};
 };
 

--- a/cpp/include/mqb/orchestration/MsvcIncrementalTargetCoordinator.hpp
+++ b/cpp/include/mqb/orchestration/MsvcIncrementalTargetCoordinator.hpp
@@ -12,6 +12,7 @@
 #include "mqb/core/ProjectArtifactLayout.hpp"
 #include "mqb/orchestration/MsvcIncrementalCompileCoordinator.hpp"
 #include "mqb/orchestration/MsvcIncrementalLinkCoordinator.hpp"
+#include "mqb/orchestration/ParallelismPolicy.hpp"
 #include "mqb/orchestration/TargetTimings.hpp"
 
 namespace mqb::orchestration {
@@ -31,7 +32,7 @@ struct IncrementalTargetRequest {
     CompilerOptions compiler_options;
     LinkOptions link_options;
     std::filesystem::path working_directory;
-    std::size_t max_parallel_compiles{1};
+    ParallelismPolicy compile_parallelism{};
     bool force_downstream_rebuild{false};
 };
 

--- a/cpp/include/mqb/orchestration/MsvcIncrementalTargetCoordinator.hpp
+++ b/cpp/include/mqb/orchestration/MsvcIncrementalTargetCoordinator.hpp
@@ -32,7 +32,7 @@ struct IncrementalTargetRequest {
     CompilerOptions compiler_options;
     LinkOptions link_options;
     std::filesystem::path working_directory;
-    ParallelismPolicy compile_parallelism{};
+    ParallelismPolicy max_parallel_compiles{};
     bool force_downstream_rebuild{false};
 };
 

--- a/cpp/include/mqb/orchestration/MsvcModuleCompileCoordinator.hpp
+++ b/cpp/include/mqb/orchestration/MsvcModuleCompileCoordinator.hpp
@@ -35,7 +35,7 @@ struct ModuleCompileWaveRequest {
     modules::ModuleDependencyPlan plan;
     CompilerOptions compiler_options;
     std::filesystem::path working_directory;
-    ParallelismPolicy compile_parallelism{};
+    ParallelismPolicy max_parallel_compiles{};
 };
 
 struct ModuleCompileResult {

--- a/cpp/include/mqb/orchestration/MsvcModuleCompileCoordinator.hpp
+++ b/cpp/include/mqb/orchestration/MsvcModuleCompileCoordinator.hpp
@@ -12,6 +12,7 @@
 #include "mqb/core/TranslationUnit.hpp"
 #include "mqb/modules/ModuleDependencyGraph.hpp"
 #include "mqb/orchestration/MsvcIncrementalCompileCoordinator.hpp"
+#include "mqb/orchestration/ParallelismPolicy.hpp"
 
 namespace mqb::orchestration {
 
@@ -34,7 +35,7 @@ struct ModuleCompileWaveRequest {
     modules::ModuleDependencyPlan plan;
     CompilerOptions compiler_options;
     std::filesystem::path working_directory;
-    std::size_t max_parallel_compiles{1};
+    ParallelismPolicy compile_parallelism{};
 };
 
 struct ModuleCompileResult {

--- a/cpp/include/mqb/orchestration/MsvcModuleTargetCoordinator.hpp
+++ b/cpp/include/mqb/orchestration/MsvcModuleTargetCoordinator.hpp
@@ -29,8 +29,8 @@ struct IncrementalModuleTargetRequest {
     CompilerOptions compiler_options;
     LinkOptions link_options;
     std::filesystem::path working_directory;
-    ParallelismPolicy scan_parallelism{};
-    ParallelismPolicy compile_parallelism{};
+    ParallelismPolicy max_parallel_scans{};
+    ParallelismPolicy max_parallel_compiles{};
 };
 
 struct ModuleTargetScanResult {

--- a/cpp/include/mqb/orchestration/MsvcModuleTargetCoordinator.hpp
+++ b/cpp/include/mqb/orchestration/MsvcModuleTargetCoordinator.hpp
@@ -14,6 +14,7 @@
 #include "mqb/msvc/MsvcModuleDependencyScanner.hpp"
 #include "mqb/orchestration/MsvcIncrementalLinkCoordinator.hpp"
 #include "mqb/orchestration/MsvcModuleCompileCoordinator.hpp"
+#include "mqb/orchestration/ParallelismPolicy.hpp"
 #include "mqb/orchestration/TargetTimings.hpp"
 
 namespace mqb::orchestration {
@@ -28,8 +29,8 @@ struct IncrementalModuleTargetRequest {
     CompilerOptions compiler_options;
     LinkOptions link_options;
     std::filesystem::path working_directory;
-    std::size_t max_parallel_scans{1};
-    std::size_t max_parallel_compiles{1};
+    ParallelismPolicy scan_parallelism{};
+    ParallelismPolicy compile_parallelism{};
 };
 
 struct ModuleTargetScanResult {

--- a/cpp/include/mqb/orchestration/MsvcTargetRouter.hpp
+++ b/cpp/include/mqb/orchestration/MsvcTargetRouter.hpp
@@ -14,6 +14,7 @@
 #include "mqb/core/TranslationUnit.hpp"
 #include "mqb/orchestration/MsvcIncrementalTargetCoordinator.hpp"
 #include "mqb/orchestration/MsvcModuleTargetCoordinator.hpp"
+#include "mqb/orchestration/ParallelismPolicy.hpp"
 
 namespace mqb::orchestration {
 
@@ -37,7 +38,7 @@ struct RoutedTargetRequest {
     CompilerOptions compiler_options;
     LinkOptions link_options;
     std::filesystem::path working_directory;
-    std::size_t max_parallel_jobs{1};
+    ParallelismPolicy parallelism{};
     // Execution-routing state only. This is used when discovery observed module
     // syntax but found no local named-module interface provider, including a
     // header-unit-only entry. It must not affect compile/link cache identity.

--- a/cpp/include/mqb/orchestration/MsvcTargetRouter.hpp
+++ b/cpp/include/mqb/orchestration/MsvcTargetRouter.hpp
@@ -38,7 +38,7 @@ struct RoutedTargetRequest {
     CompilerOptions compiler_options;
     LinkOptions link_options;
     std::filesystem::path working_directory;
-    ParallelismPolicy parallelism{};
+    ParallelismPolicy max_parallel_jobs{};
     // Execution-routing state only. This is used when discovery observed module
     // syntax but found no local named-module interface provider, including a
     // header-unit-only entry. It must not affect compile/link cache identity.

--- a/cpp/include/mqb/orchestration/ParallelismPolicy.hpp
+++ b/cpp/include/mqb/orchestration/ParallelismPolicy.hpp
@@ -14,15 +14,21 @@ struct ParallelismPolicy {
     ParallelismMode mode{ParallelismMode::automatic};
     std::size_t fixed_jobs{1};
 
+    constexpr ParallelismPolicy() noexcept = default;
+
+    // Preserve source compatibility for existing request initializers such as
+    // `.max_parallel_compiles = 4` while upgrading the field type from a raw
+    // integer to an explicit scheduling policy. Zero becomes an invalid fixed
+    // policy and therefore keeps the existing fail-closed validation behavior.
+    constexpr ParallelismPolicy(const std::size_t jobs) noexcept
+        : mode(ParallelismMode::fixed), fixed_jobs(jobs) {}
+
     [[nodiscard]] static constexpr ParallelismPolicy automatic() noexcept {
         return ParallelismPolicy{};
     }
 
     [[nodiscard]] static constexpr ParallelismPolicy fixed(const std::size_t jobs) noexcept {
-        return ParallelismPolicy{
-            .mode = ParallelismMode::fixed,
-            .fixed_jobs = jobs,
-        };
+        return ParallelismPolicy{jobs};
     }
 
     [[nodiscard]] constexpr bool valid() const noexcept {
@@ -31,6 +37,18 @@ struct ParallelismPolicy {
 
     [[nodiscard]] constexpr bool is_automatic() const noexcept {
         return mode == ParallelismMode::automatic;
+    }
+
+    friend constexpr bool operator==(
+        const ParallelismPolicy policy,
+        const std::size_t jobs) noexcept {
+        return policy.mode == ParallelismMode::fixed && policy.fixed_jobs == jobs;
+    }
+
+    friend constexpr bool operator==(
+        const std::size_t jobs,
+        const ParallelismPolicy policy) noexcept {
+        return policy == jobs;
     }
 };
 

--- a/cpp/include/mqb/orchestration/ParallelismPolicy.hpp
+++ b/cpp/include/mqb/orchestration/ParallelismPolicy.hpp
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+
+namespace mqb::orchestration {
+
+enum class ParallelismMode {
+    automatic,
+    fixed,
+};
+
+struct ParallelismPolicy {
+    ParallelismMode mode{ParallelismMode::automatic};
+    std::size_t fixed_jobs{1};
+
+    [[nodiscard]] static constexpr ParallelismPolicy automatic() noexcept {
+        return ParallelismPolicy{};
+    }
+
+    [[nodiscard]] static constexpr ParallelismPolicy fixed(const std::size_t jobs) noexcept {
+        return ParallelismPolicy{
+            .mode = ParallelismMode::fixed,
+            .fixed_jobs = jobs,
+        };
+    }
+
+    [[nodiscard]] constexpr bool valid() const noexcept {
+        return mode == ParallelismMode::automatic || fixed_jobs != 0;
+    }
+
+    [[nodiscard]] constexpr bool is_automatic() const noexcept {
+        return mode == ParallelismMode::automatic;
+    }
+};
+
+struct ParallelismDecision {
+    std::size_t workers{};
+    std::size_t work_items{};
+    std::size_t hardware_threads{};
+    ParallelismMode mode{ParallelismMode::automatic};
+};
+
+class ParallelismResolver {
+public:
+    [[nodiscard]] static constexpr ParallelismDecision resolve(
+        const ParallelismPolicy policy,
+        const std::size_t work_items,
+        const unsigned int hardware_threads) noexcept {
+        if (work_items == 0 || !policy.valid()) {
+            return ParallelismDecision{
+                .workers = 0,
+                .work_items = work_items,
+                .hardware_threads = static_cast<std::size_t>(hardware_threads),
+                .mode = policy.mode,
+            };
+        }
+
+        const std::size_t budget = policy.is_automatic()
+            ? (hardware_threads == 0
+                ? std::size_t{1}
+                : static_cast<std::size_t>(hardware_threads))
+            : policy.fixed_jobs;
+        return ParallelismDecision{
+            .workers = std::max<std::size_t>(1, std::min(budget, work_items)),
+            .work_items = work_items,
+            .hardware_threads = static_cast<std::size_t>(hardware_threads),
+            .mode = policy.mode,
+        };
+    }
+};
+
+} // namespace mqb::orchestration

--- a/cpp/src/app/Application.cpp
+++ b/cpp/src/app/Application.cpp
@@ -6,7 +6,6 @@
 #include <iostream>
 #include <optional>
 #include <string>
-#include <thread>
 #include <utility>
 #include <vector>
 
@@ -29,6 +28,7 @@
 #include "mqb/orchestration/MsvcIncrementalLinkCoordinator.hpp"
 #include "mqb/orchestration/MsvcIncrementalPchCoordinator.hpp"
 #include "mqb/orchestration/MsvcIncrementalTargetCoordinator.hpp"
+#include "mqb/orchestration/ParallelismPolicy.hpp"
 #include "mqb/platform/windows/WindowsProcessRunner.hpp"
 #include "mqb/process/Process.hpp"
 
@@ -82,6 +82,15 @@ void add_portable_root_if_missing(
         message += diagnostics::path_text(path);
     }
     return message;
+}
+
+void print_jobs(const mqb::orchestration::ParallelismPolicy policy) {
+    std::cout << "  jobs:    ";
+    if (policy.is_automatic()) {
+        std::cout << "auto\n";
+    } else {
+        std::cout << policy.fixed_jobs << '\n';
+    }
 }
 
 void print_pch_failure(const mqb::orchestration::IncrementalPchError& error) {
@@ -208,14 +217,8 @@ int Application::run(const std::span<const std::string_view> arguments) {
     }
     options.build.sources = sources;
 
-    const unsigned int hardware_threads = std::thread::hardware_concurrency();
-    const std::size_t requested_compile_jobs = options.jobs.value_or(
-        hardware_threads == 0
-            ? std::size_t{1}
-            : static_cast<std::size_t>(hardware_threads));
-    const std::size_t compile_jobs = std::max<std::size_t>(
-        1,
-        std::min(requested_compile_jobs, sources.size()));
+    const mqb::orchestration::ParallelismPolicy parallelism = options.jobs.value_or(
+        mqb::orchestration::ParallelismPolicy::automatic());
 
     auto layout = mqb::ProjectArtifactLayout::create(project_root);
     if (!layout) {
@@ -390,7 +393,7 @@ int Application::run(const std::span<const std::string_view> arguments) {
                 .compiler_options = std::move(compiler_options),
                 .project_root = project_root,
                 .target_name = target_name,
-                .max_parallel_jobs = compile_jobs,
+                .parallelism = parallelism,
                 .timings = &timing_session,
                 .force_downstream_rebuild = pch_compiled,
                 .verbose = options.verbose,
@@ -421,9 +424,8 @@ int Application::run(const std::span<const std::string_view> arguments) {
                     ? std::optional<fs::path>{project_config->file}
                     : std::nullopt,
                 .target_name = target_name,
-                .max_parallel_jobs = compile_jobs,
+                .parallelism = parallelism,
                 .timings = &timing_session,
-                .jobs_explicit = options.jobs.has_value(),
                 .force_named_modules = discovery_requires_module_pipeline
                     || has_external_module_providers,
                 .verbose = options.verbose,
@@ -441,10 +443,9 @@ int Application::run(const std::span<const std::string_view> arguments) {
             std::cout << "  config:  " << diagnostics::path_text(project_config->file) << '\n';
         }
         std::cout << "  type:    " << mqb::to_string(options.build.target_kind) << '\n'
-                  << "  ltcg:    " << (effective.link_time_code_generation ? "on" : "off") << '\n'
-                  << "  jobs:    " << compile_jobs
-                  << (options.jobs ? "" : " (auto)") << '\n'
-                  << "  cl:      " << diagnostics::path_text(toolchain->identity.compiler) << '\n'
+                  << "  ltcg:    " << (effective.link_time_code_generation ? "on" : "off") << '\n';
+        print_jobs(parallelism);
+        std::cout << "  cl:      " << diagnostics::path_text(toolchain->identity.compiler) << '\n'
                   << "  link:    " << diagnostics::path_text(toolchain->linker) << '\n';
         if (pch_artifacts && effective.precompiled_header) {
             std::cout << "  pch:     " << diagnostics::path_text(*effective.precompiled_header) << '\n'
@@ -489,7 +490,7 @@ int Application::run(const std::span<const std::string_view> arguments) {
         .compiler_options = std::move(compiler_options),
         .link_options = std::move(link_options),
         .working_directory = project_root,
-        .max_parallel_compiles = compile_jobs,
+        .compile_parallelism = parallelism,
         .force_downstream_rebuild = pch_compiled,
     };
 

--- a/cpp/src/app/Application.cpp
+++ b/cpp/src/app/Application.cpp
@@ -393,7 +393,7 @@ int Application::run(const std::span<const std::string_view> arguments) {
                 .compiler_options = std::move(compiler_options),
                 .project_root = project_root,
                 .target_name = target_name,
-                .parallelism = parallelism,
+                .max_parallel_jobs = parallelism,
                 .timings = &timing_session,
                 .force_downstream_rebuild = pch_compiled,
                 .verbose = options.verbose,
@@ -424,7 +424,7 @@ int Application::run(const std::span<const std::string_view> arguments) {
                     ? std::optional<fs::path>{project_config->file}
                     : std::nullopt,
                 .target_name = target_name,
-                .parallelism = parallelism,
+                .max_parallel_jobs = parallelism,
                 .timings = &timing_session,
                 .force_named_modules = discovery_requires_module_pipeline
                     || has_external_module_providers,
@@ -490,7 +490,7 @@ int Application::run(const std::span<const std::string_view> arguments) {
         .compiler_options = std::move(compiler_options),
         .link_options = std::move(link_options),
         .working_directory = project_root,
-        .compile_parallelism = parallelism,
+        .max_parallel_compiles = parallelism,
         .force_downstream_rebuild = pch_compiled,
     };
 

--- a/cpp/src/app/cli/Cli.cpp
+++ b/cpp/src/app/cli/Cli.cpp
@@ -110,18 +110,22 @@ parse_subsystem(const std::string_view value) {
         + "' (expected console or windows)"));
 }
 
-[[nodiscard]] std::expected<std::size_t, Error>
+[[nodiscard]] std::expected<orchestration::ParallelismPolicy, Error>
 parse_jobs(const std::string_view value) {
+    if (value == "auto") {
+        return orchestration::ParallelismPolicy::automatic();
+    }
+
     std::size_t jobs = 0;
     const char* const begin = value.data();
     const char* const end = value.data() + value.size();
     const auto [parsed_end, parse_error] = std::from_chars(begin, end, jobs);
     if (parse_error != std::errc{} || parsed_end != end || jobs == 0) {
         return std::unexpected(error(
-            "invalid compile job count '" + std::string{value}
-            + "' (expected a positive integer)"));
+            "invalid compile job policy '" + std::string{value}
+            + "' (expected auto or a positive integer)"));
     }
-    return jobs;
+    return orchestration::ParallelismPolicy::fixed(jobs);
 }
 
 [[nodiscard]] std::expected<msvc::ToolchainPreference, Error>
@@ -589,7 +593,7 @@ parse_arguments(const std::span<const std::string_view> arguments) {
             auto value = attached_or_next(arguments, index, argument, "-l");
             if (!value) return std::unexpected(value.error());
             if (value->empty()) return std::unexpected(error("empty library name"));
-            options.libraries.emplace_back(std::string{*value});
+            options.libraries.emplace_back(*value);
             continue;
         }
         if (!argument.empty() && argument.front() == '@') {
@@ -689,7 +693,7 @@ Options:
   --subsystem <console|windows>
                            Explicitly select PE subsystem for executable/DLL targets
   --x86 | --x64           Explicitly select target architecture
-  -j, --jobs <N>          Maximum concurrent TU scans/compiles (default: hardware concurrency)
+  -j, --jobs <auto|N>     Adaptive or fixed maximum concurrent TU scans/compiles (default: auto)
   -o, --output <name>     Set target name under .mqb/bin/
   --run                   Legacy source-first alias for build-then-run; prefer `mqb run`
   --timings               Show phase timings and cache hit/miss counters
@@ -743,7 +747,9 @@ MQB v5 intentionally does not accept the PowerShell-era single-dash command alia
 native options shown above; unknown legacy spellings fail instead of silently entering a
 compatibility path.
 
-Job count is execution policy only; changing -j does not invalidate build caches.
+Job policy is execution-only and never enters build/cache identity. `auto` resolves against the
+current ready batch and the operating system's available hardware concurrency; a positive N is
+a hard user ceiling. MQB owns this process-level parallelism and does not stack compiler /MP.
 Timing output is observation-only and never participates in build/cache identity.
 Discovery is source selection only. Incremental header freshness uses MSVC
 /sourceDependencies metadata; /scanDependencies is module topology only.

--- a/cpp/src/app/cli/Cli.hpp
+++ b/cpp/src/app/cli/Cli.hpp
@@ -14,6 +14,7 @@
 #include "mqb/core/CompilerOptions.hpp"
 #include "mqb/core/LinkOptions.hpp"
 #include "mqb/msvc/MsvcToolchainLocator.hpp"
+#include "mqb/orchestration/ParallelismPolicy.hpp"
 
 namespace mqb::cli {
 
@@ -45,7 +46,7 @@ struct Options {
     msvc::ToolchainPreference toolchain_preference{msvc::ToolchainPreference::automatic};
     std::vector<std::filesystem::path> portable_roots;
     std::optional<bool> discovery_override;
-    std::optional<std::size_t> jobs;
+    std::optional<orchestration::ParallelismPolicy> jobs;
     app::performance::Format timings{app::performance::Format::disabled};
     bool discover_sources{true};
     bool verbose{false};

--- a/cpp/src/app/targets/ModuleCliTarget.cpp
+++ b/cpp/src/app/targets/ModuleCliTarget.cpp
@@ -42,6 +42,15 @@ namespace diagnostics = mqb::app::diagnostics;
     return safe_relative(relative) ? relative : source;
 }
 
+void print_jobs(const orchestration::ParallelismPolicy policy) {
+    std::cout << "  jobs:    ";
+    if (policy.is_automatic()) {
+        std::cout << "auto\n";
+    } else {
+        std::cout << policy.fixed_jobs << '\n';
+    }
+}
+
 } // namespace
 
 bool is_module_interface_source(const fs::path& source) {
@@ -76,10 +85,9 @@ int run_module_target(
             std::cout << "  config:  " << diagnostics::path_text(*request.config_file) << '\n';
         }
         std::cout << "  pipeline: named-modules\n"
-                  << "  type:    " << to_string(request.link_options.target_kind) << '\n'
-                  << "  jobs:    " << request.max_parallel_jobs
-                  << (request.jobs_explicit ? "" : " (auto)") << '\n'
-                  << "  cl:      " << diagnostics::path_text(toolchain.identity.compiler) << '\n'
+                  << "  type:    " << to_string(request.link_options.target_kind) << '\n';
+        print_jobs(request.parallelism);
+        std::cout << "  cl:      " << diagnostics::path_text(toolchain.identity.compiler) << '\n'
                   << "  link:    " << diagnostics::path_text(toolchain.linker) << '\n';
         for (const auto& source : routed_sources) {
             std::cout << "  source:  "
@@ -136,7 +144,7 @@ int run_module_target(
         .compiler_options = std::move(request.compiler_options),
         .link_options = std::move(request.link_options),
         .working_directory = request.project_root,
-        .max_parallel_jobs = request.max_parallel_jobs,
+        .parallelism = request.parallelism,
         .force_named_modules = request.force_named_modules,
     };
     auto result = router.run(target_request);

--- a/cpp/src/app/targets/ModuleCliTarget.cpp
+++ b/cpp/src/app/targets/ModuleCliTarget.cpp
@@ -86,7 +86,7 @@ int run_module_target(
         }
         std::cout << "  pipeline: named-modules\n"
                   << "  type:    " << to_string(request.link_options.target_kind) << '\n';
-        print_jobs(request.parallelism);
+        print_jobs(request.max_parallel_jobs);
         std::cout << "  cl:      " << diagnostics::path_text(toolchain.identity.compiler) << '\n'
                   << "  link:    " << diagnostics::path_text(toolchain.linker) << '\n';
         for (const auto& source : routed_sources) {
@@ -144,7 +144,7 @@ int run_module_target(
         .compiler_options = std::move(request.compiler_options),
         .link_options = std::move(request.link_options),
         .working_directory = request.project_root,
-        .parallelism = request.parallelism,
+        .max_parallel_jobs = request.max_parallel_jobs,
         .force_named_modules = request.force_named_modules,
     };
     auto result = router.run(target_request);

--- a/cpp/src/app/targets/ModuleCliTarget.hpp
+++ b/cpp/src/app/targets/ModuleCliTarget.hpp
@@ -11,6 +11,7 @@
 #include "mqb/core/ProjectArtifactLayout.hpp"
 #include "mqb/msvc/MsvcToolchainLocator.hpp"
 #include "mqb/orchestration/MsvcIncrementalTargetCoordinator.hpp"
+#include "mqb/orchestration/ParallelismPolicy.hpp"
 #include "mqb/process/Process.hpp"
 
 namespace mqb::app::performance {
@@ -29,9 +30,8 @@ struct ModuleCliTargetRequest {
     std::filesystem::path project_root;
     std::optional<std::filesystem::path> config_file;
     std::string target_name;
-    std::size_t max_parallel_jobs{1};
+    orchestration::ParallelismPolicy parallelism{};
     app::performance::Session* timings{};
-    bool jobs_explicit{false};
     bool force_named_modules{false};
     bool verbose{false};
     bool run_after_build{false};

--- a/cpp/src/app/targets/ModuleCliTarget.hpp
+++ b/cpp/src/app/targets/ModuleCliTarget.hpp
@@ -30,7 +30,7 @@ struct ModuleCliTargetRequest {
     std::filesystem::path project_root;
     std::optional<std::filesystem::path> config_file;
     std::string target_name;
-    orchestration::ParallelismPolicy parallelism{};
+    orchestration::ParallelismPolicy max_parallel_jobs{};
     app::performance::Session* timings{};
     bool force_named_modules{false};
     bool verbose{false};

--- a/cpp/src/app/targets/StaticCliTarget.cpp
+++ b/cpp/src/app/targets/StaticCliTarget.cpp
@@ -17,6 +17,15 @@ namespace {
 
 namespace diagnostics = mqb::app::diagnostics;
 
+void print_jobs(const orchestration::ParallelismPolicy policy) {
+    std::cout << "  jobs:    ";
+    if (policy.is_automatic()) {
+        std::cout << "auto\n";
+    } else {
+        std::cout << policy.fixed_jobs << '\n';
+    }
+}
+
 } // namespace
 
 int run_static_target(
@@ -26,8 +35,9 @@ int run_static_target(
     if (request.verbose) {
         std::cout << "[target] " << request.target_name << '\n'
                   << "  project: " << diagnostics::path_text(request.project_root) << '\n'
-                  << "  type:    static\n"
-                  << "  cl:      " << diagnostics::path_text(toolchain.identity.compiler) << '\n'
+                  << "  type:    static\n";
+        print_jobs(request.parallelism);
+        std::cout << "  cl:      " << diagnostics::path_text(toolchain.identity.compiler) << '\n'
                   << "  lib:     " << diagnostics::path_text(toolchain.librarian) << '\n';
         for (const auto& object : request.additional_objects) {
             std::cout << "  object:  " << diagnostics::path_text(object) << " (MQB-owned)\n";
@@ -50,7 +60,7 @@ int run_static_target(
         .target = request.target,
         .compiler_options = std::move(request.compiler_options),
         .working_directory = request.project_root,
-        .max_parallel_compiles = request.max_parallel_jobs,
+        .compile_parallelism = request.parallelism,
         .force_downstream_rebuild = request.force_downstream_rebuild,
     });
     if (!result) {

--- a/cpp/src/app/targets/StaticCliTarget.cpp
+++ b/cpp/src/app/targets/StaticCliTarget.cpp
@@ -36,7 +36,7 @@ int run_static_target(
         std::cout << "[target] " << request.target_name << '\n'
                   << "  project: " << diagnostics::path_text(request.project_root) << '\n'
                   << "  type:    static\n";
-        print_jobs(request.parallelism);
+        print_jobs(request.max_parallel_jobs);
         std::cout << "  cl:      " << diagnostics::path_text(toolchain.identity.compiler) << '\n'
                   << "  lib:     " << diagnostics::path_text(toolchain.librarian) << '\n';
         for (const auto& object : request.additional_objects) {
@@ -60,7 +60,7 @@ int run_static_target(
         .target = request.target,
         .compiler_options = std::move(request.compiler_options),
         .working_directory = request.project_root,
-        .compile_parallelism = request.parallelism,
+        .max_parallel_compiles = request.max_parallel_jobs,
         .force_downstream_rebuild = request.force_downstream_rebuild,
     });
     if (!result) {

--- a/cpp/src/app/targets/StaticCliTarget.hpp
+++ b/cpp/src/app/targets/StaticCliTarget.hpp
@@ -25,7 +25,7 @@ struct StaticCliTargetRequest {
     CompilerOptions compiler_options;
     std::filesystem::path project_root;
     std::string target_name;
-    orchestration::ParallelismPolicy parallelism{};
+    orchestration::ParallelismPolicy max_parallel_jobs{};
     app::performance::Session* timings{};
     bool force_downstream_rebuild{false};
     bool verbose{false};

--- a/cpp/src/app/targets/StaticCliTarget.hpp
+++ b/cpp/src/app/targets/StaticCliTarget.hpp
@@ -9,6 +9,7 @@
 #include "mqb/core/ProjectArtifactLayout.hpp"
 #include "mqb/msvc/MsvcToolchainLocator.hpp"
 #include "mqb/orchestration/MsvcIncrementalTargetCoordinator.hpp"
+#include "mqb/orchestration/ParallelismPolicy.hpp"
 #include "mqb/process/Process.hpp"
 
 namespace mqb::app::performance {
@@ -24,7 +25,7 @@ struct StaticCliTargetRequest {
     CompilerOptions compiler_options;
     std::filesystem::path project_root;
     std::string target_name;
-    std::size_t max_parallel_jobs{1};
+    orchestration::ParallelismPolicy parallelism{};
     app::performance::Session* timings{};
     bool force_downstream_rebuild{false};
     bool verbose{false};

--- a/cpp/src/orchestration/incremental/MsvcIncrementalStaticTargetCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalStaticTargetCoordinator.cpp
@@ -70,7 +70,7 @@ MsvcIncrementalStaticTargetCoordinator::run(const IncrementalStaticTargetRequest
             IncrementalStaticTargetErrorCode::no_sources,
             "static target build requires at least one source file"));
     }
-    if (!request.compile_parallelism.valid()) {
+    if (!request.max_parallel_compiles.valid()) {
         return std::unexpected(failure(
             IncrementalStaticTargetErrorCode::invalid_parallelism,
             "static target compile parallelism must be automatic or a positive fixed worker count"));
@@ -128,7 +128,7 @@ MsvcIncrementalStaticTargetCoordinator::run(const IncrementalStaticTargetRequest
 
     const auto compile_started = Clock::now();
     const auto scheduled = BoundedWorkScheduler::run(
-        request.sources.size(), request.compile_parallelism,
+        request.sources.size(), request.max_parallel_compiles,
         [&](const std::size_t index) {
             auto compile_request = compile_request_for(request.sources[index], request.compiler_options);
             attempts[index].emplace(compile_coordinator_.run(compile_request));

--- a/cpp/src/orchestration/incremental/MsvcIncrementalStaticTargetCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalStaticTargetCoordinator.cpp
@@ -70,10 +70,10 @@ MsvcIncrementalStaticTargetCoordinator::run(const IncrementalStaticTargetRequest
             IncrementalStaticTargetErrorCode::no_sources,
             "static target build requires at least one source file"));
     }
-    if (request.max_parallel_compiles == 0) {
+    if (!request.compile_parallelism.valid()) {
         return std::unexpected(failure(
             IncrementalStaticTargetErrorCode::invalid_parallelism,
-            "static target compile parallelism must be at least one"));
+            "static target compile parallelism must be automatic or a positive fixed worker count"));
     }
 
     TargetTimings timings;
@@ -128,7 +128,7 @@ MsvcIncrementalStaticTargetCoordinator::run(const IncrementalStaticTargetRequest
 
     const auto compile_started = Clock::now();
     const auto scheduled = BoundedWorkScheduler::run(
-        request.sources.size(), request.max_parallel_compiles,
+        request.sources.size(), request.compile_parallelism,
         [&](const std::size_t index) {
             auto compile_request = compile_request_for(request.sources[index], request.compiler_options);
             attempts[index].emplace(compile_coordinator_.run(compile_request));

--- a/cpp/src/orchestration/incremental/MsvcIncrementalTargetCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalTargetCoordinator.cpp
@@ -81,7 +81,7 @@ MsvcIncrementalTargetCoordinator::run(const IncrementalTargetRequest& request) c
             IncrementalTargetErrorCode::no_sources,
             "target build requires at least one source file"));
     }
-    if (!request.compile_parallelism.valid()) {
+    if (!request.max_parallel_compiles.valid()) {
         return std::unexpected(failure(
             IncrementalTargetErrorCode::invalid_parallelism,
             "target compile parallelism must be automatic or a positive fixed worker count"));
@@ -144,7 +144,7 @@ MsvcIncrementalTargetCoordinator::run(const IncrementalTargetRequest& request) c
     const auto compile_started = Clock::now();
     const auto scheduled = BoundedWorkScheduler::run(
         request.sources.size(),
-        request.compile_parallelism,
+        request.max_parallel_compiles,
         [&](const std::size_t index) {
             const auto& source = request.sources[index];
             auto compile_request = compile_request_for(source, request.compiler_options);

--- a/cpp/src/orchestration/incremental/MsvcIncrementalTargetCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalTargetCoordinator.cpp
@@ -81,10 +81,10 @@ MsvcIncrementalTargetCoordinator::run(const IncrementalTargetRequest& request) c
             IncrementalTargetErrorCode::no_sources,
             "target build requires at least one source file"));
     }
-    if (request.max_parallel_compiles == 0) {
+    if (!request.compile_parallelism.valid()) {
         return std::unexpected(failure(
             IncrementalTargetErrorCode::invalid_parallelism,
-            "target compile parallelism must be at least one"));
+            "target compile parallelism must be automatic or a positive fixed worker count"));
     }
 
     TargetTimings timings;
@@ -144,7 +144,7 @@ MsvcIncrementalTargetCoordinator::run(const IncrementalTargetRequest& request) c
     const auto compile_started = Clock::now();
     const auto scheduled = BoundedWorkScheduler::run(
         request.sources.size(),
-        request.max_parallel_compiles,
+        request.compile_parallelism,
         [&](const std::size_t index) {
             const auto& source = request.sources[index];
             auto compile_request = compile_request_for(source, request.compiler_options);

--- a/cpp/src/orchestration/modules/ModuleTargetPreparation.cpp
+++ b/cpp/src/orchestration/modules/ModuleTargetPreparation.cpp
@@ -54,10 +54,10 @@ prepare_module_target(
             IncrementalModuleTargetErrorCode::no_sources,
             "module target requires at least one source"));
     }
-    if (request.max_parallel_scans == 0 || request.max_parallel_compiles == 0) {
+    if (!request.scan_parallelism.valid() || !request.compile_parallelism.valid()) {
         return std::unexpected(failure(
             IncrementalModuleTargetErrorCode::invalid_parallelism,
-            "module target scan and compile parallelism must both be at least one"));
+            "module target scan and compile parallelism must be automatic or a positive fixed worker count"));
     }
 
     const auto preparation_started = Clock::now();
@@ -155,7 +155,7 @@ prepare_module_target(
         .plan = prepared.plan,
         .compiler_options = request.compiler_options,
         .working_directory = request.working_directory,
-        .max_parallel_compiles = request.max_parallel_compiles,
+        .compile_parallelism = request.compile_parallelism,
     };
 
     const auto preparation_total = std::chrono::duration_cast<std::chrono::nanoseconds>(

--- a/cpp/src/orchestration/modules/ModuleTargetPreparation.cpp
+++ b/cpp/src/orchestration/modules/ModuleTargetPreparation.cpp
@@ -54,7 +54,7 @@ prepare_module_target(
             IncrementalModuleTargetErrorCode::no_sources,
             "module target requires at least one source"));
     }
-    if (!request.scan_parallelism.valid() || !request.compile_parallelism.valid()) {
+    if (!request.max_parallel_scans.valid() || !request.max_parallel_compiles.valid()) {
         return std::unexpected(failure(
             IncrementalModuleTargetErrorCode::invalid_parallelism,
             "module target scan and compile parallelism must be automatic or a positive fixed worker count"));
@@ -155,7 +155,7 @@ prepare_module_target(
         .plan = prepared.plan,
         .compiler_options = request.compiler_options,
         .working_directory = request.working_directory,
-        .compile_parallelism = request.compile_parallelism,
+        .max_parallel_compiles = request.max_parallel_compiles,
     };
 
     const auto preparation_total = std::chrono::duration_cast<std::chrono::nanoseconds>(

--- a/cpp/src/orchestration/modules/ModuleTargetScanner.cpp
+++ b/cpp/src/orchestration/modules/ModuleTargetScanner.cpp
@@ -43,7 +43,7 @@ scan_requested_module_sources(
     std::vector<std::optional<ScanAttempt>> attempts(request.sources.size());
 
     const auto scheduled = BoundedWorkScheduler::run(
-        request.sources.size(), request.scan_parallelism,
+        request.sources.size(), request.max_parallel_scans,
         [&](const std::size_t index) {
             const auto& source = request.sources[index];
             msvc::ModuleScanInvocation invocation{

--- a/cpp/src/orchestration/modules/ModuleTargetScanner.cpp
+++ b/cpp/src/orchestration/modules/ModuleTargetScanner.cpp
@@ -43,7 +43,7 @@ scan_requested_module_sources(
     std::vector<std::optional<ScanAttempt>> attempts(request.sources.size());
 
     const auto scheduled = BoundedWorkScheduler::run(
-        request.sources.size(), request.max_parallel_scans,
+        request.sources.size(), request.scan_parallelism,
         [&](const std::size_t index) {
             const auto& source = request.sources[index];
             msvc::ModuleScanInvocation invocation{

--- a/cpp/src/orchestration/modules/MsvcModuleCompileCoordinator.cpp
+++ b/cpp/src/orchestration/modules/MsvcModuleCompileCoordinator.cpp
@@ -32,7 +32,7 @@ namespace fs = std::filesystem;
 
 std::expected<ModuleCompileWaveResult, ModuleCompileError>
 MsvcModuleCompileCoordinator::run(const ModuleCompileWaveRequest& request) const {
-    if (!request.compile_parallelism.valid()) {
+    if (!request.max_parallel_compiles.valid()) {
         return std::unexpected(failure(
             ModuleCompileErrorCode::invalid_parallelism,
             "module compile parallelism must be automatic or a positive fixed worker count"));
@@ -50,7 +50,7 @@ MsvcModuleCompileCoordinator::run(const ModuleCompileWaveRequest& request) const
 
     for (const auto& level : plan.level_indices) {
         const auto scheduled = BoundedWorkScheduler::run(
-            level.size(), request.compile_parallelism,
+            level.size(), request.max_parallel_compiles,
             [&](const std::size_t level_index) {
                 const std::size_t node_index = level[level_index];
                 bool force_rebuild = false;

--- a/cpp/src/orchestration/modules/MsvcModuleCompileCoordinator.cpp
+++ b/cpp/src/orchestration/modules/MsvcModuleCompileCoordinator.cpp
@@ -32,6 +32,12 @@ namespace fs = std::filesystem;
 
 std::expected<ModuleCompileWaveResult, ModuleCompileError>
 MsvcModuleCompileCoordinator::run(const ModuleCompileWaveRequest& request) const {
+    if (!request.compile_parallelism.valid()) {
+        return std::unexpected(failure(
+            ModuleCompileErrorCode::invalid_parallelism,
+            "module compile parallelism must be automatic or a positive fixed worker count"));
+    }
+
     auto planned = detail::build_module_compile_plan(request);
     if (!planned) {
         return std::unexpected(std::move(planned.error()));
@@ -44,7 +50,7 @@ MsvcModuleCompileCoordinator::run(const ModuleCompileWaveRequest& request) const
 
     for (const auto& level : plan.level_indices) {
         const auto scheduled = BoundedWorkScheduler::run(
-            level.size(), request.max_parallel_compiles,
+            level.size(), request.compile_parallelism,
             [&](const std::size_t level_index) {
                 const std::size_t node_index = level[level_index];
                 bool force_rebuild = false;

--- a/cpp/src/orchestration/routing/MsvcTargetRouter.cpp
+++ b/cpp/src/orchestration/routing/MsvcTargetRouter.cpp
@@ -47,7 +47,7 @@ MsvcTargetRouter::run(const RoutedTargetRequest& request) const {
             .compiler_options = request.compiler_options,
             .link_options = request.link_options,
             .working_directory = request.working_directory,
-            .max_parallel_compiles = request.max_parallel_jobs,
+            .compile_parallelism = request.parallelism,
         };
         auto result = ordinary_target_.run(ordinary_request);
         if (!result) {
@@ -92,8 +92,8 @@ MsvcTargetRouter::run(const RoutedTargetRequest& request) const {
         .compiler_options = request.compiler_options,
         .link_options = request.link_options,
         .working_directory = request.working_directory,
-        .max_parallel_scans = request.max_parallel_jobs,
-        .max_parallel_compiles = request.max_parallel_jobs,
+        .scan_parallelism = request.parallelism,
+        .compile_parallelism = request.parallelism,
     };
     auto result = module_target_.run(module_request);
     if (!result) {

--- a/cpp/src/orchestration/routing/MsvcTargetRouter.cpp
+++ b/cpp/src/orchestration/routing/MsvcTargetRouter.cpp
@@ -47,7 +47,7 @@ MsvcTargetRouter::run(const RoutedTargetRequest& request) const {
             .compiler_options = request.compiler_options,
             .link_options = request.link_options,
             .working_directory = request.working_directory,
-            .compile_parallelism = request.parallelism,
+            .max_parallel_compiles = request.max_parallel_jobs,
         };
         auto result = ordinary_target_.run(ordinary_request);
         if (!result) {
@@ -92,8 +92,8 @@ MsvcTargetRouter::run(const RoutedTargetRequest& request) const {
         .compiler_options = request.compiler_options,
         .link_options = request.link_options,
         .working_directory = request.working_directory,
-        .scan_parallelism = request.parallelism,
-        .compile_parallelism = request.parallelism,
+        .max_parallel_scans = request.max_parallel_jobs,
+        .max_parallel_compiles = request.max_parallel_jobs,
     };
     auto result = module_target_.run(module_request);
     if (!result) {

--- a/cpp/src/orchestration/scheduling/BoundedWorkScheduler.cpp
+++ b/cpp/src/orchestration/scheduling/BoundedWorkScheduler.cpp
@@ -123,4 +123,25 @@ BoundedWorkScheduler::run(
     };
 }
 
+std::expected<BoundedWorkSummary, BoundedWorkError>
+BoundedWorkScheduler::run(
+    const std::size_t item_count,
+    const ParallelismPolicy policy,
+    const std::function<bool(std::size_t)>& work) {
+    if (!policy.valid()) {
+        return std::unexpected(failure(
+            BoundedWorkErrorCode::invalid_worker_count,
+            "fixed parallelism policy requires at least one worker"));
+    }
+    if (item_count == 0) {
+        return BoundedWorkSummary{};
+    }
+
+    const ParallelismDecision decision = ParallelismResolver::resolve(
+        policy,
+        item_count,
+        std::thread::hardware_concurrency());
+    return run(item_count, decision.workers, work);
+}
+
 } // namespace mqb::orchestration

--- a/cpp/tests/app/cli/build_policy_cli_tests.cpp
+++ b/cpp/tests/app/cli/build_policy_cli_tests.cpp
@@ -64,6 +64,23 @@ int main() {
     }
 
     {
+        const std::vector<std::vector<std::string_view>> autoJobsCases{
+            {"main.cpp"sv, "-j"sv, "auto"sv},
+            {"main.cpp"sv, "-jauto"sv},
+            {"main.cpp"sv, "--jobs"sv, "auto"sv},
+            {"main.cpp"sv, "--jobs=auto"sv},
+        };
+        for (const auto& arguments : autoJobsCases) {
+            auto parsed = mqb::cli::parse_arguments(arguments);
+            expect(parsed.has_value(), "every documented auto jobs spelling should parse");
+            if (parsed) {
+                expect(parsed->jobs.has_value() && parsed->jobs->is_automatic(),
+                       "auto jobs spelling should preserve typed automatic policy");
+            }
+        }
+    }
+
+    {
         const std::vector<std::vector<std::string_view>> legacyCases{
             {"main.cpp"sv, "-type"sv, "dll"sv},
             {"main.cpp"sv, "-runtime"sv, "MDd"sv},

--- a/cpp/tests/e2e/mqb_parallel_cli_e2e_tests.cpp
+++ b/cpp/tests/e2e/mqb_parallel_cli_e2e_tests.cpp
@@ -235,6 +235,23 @@ int main() {
                "changing -j must not invalidate link cache");
     }
 
+    auto automatic = run_mqb(runner, mqb_executable, tree.root, "auto");
+    expect(automatic.has_value(), "warm adaptive-policy MQB invocation should launch");
+    if (automatic) {
+        if (automatic->exit_code != 0) dump_failure(*automatic);
+        expect(automatic->exit_code == 0,
+               "warm build should accept explicit -j auto");
+        expect(automatic->stdout_text.find("  jobs:    auto") != std::string::npos,
+               "verbose target output should preserve automatic policy identity");
+        expect(contains_line(automatic->stdout_text, "[up-to-date] main.cpp")
+                   && contains_line(automatic->stdout_text, "[up-to-date] a.cpp")
+                   && contains_line(automatic->stdout_text, "[up-to-date] b.cpp")
+                   && contains_line(automatic->stdout_text, "[up-to-date] c.cpp"),
+               "switching fixed jobs to auto must preserve all compile-cache hits");
+        expect(contains_line(automatic->stdout_text, "[up-to-date] parallel.exe"),
+               "switching fixed jobs to auto must preserve link-cache identity");
+    }
+
     auto warm_run = run_executable(runner, executable, tree.root);
     expect(warm_run.has_value() && warm_run->exit_code == 0,
            "warm reused executable should still launch");
@@ -293,7 +310,7 @@ int main() {
         runner,
         mqb_executable,
         std_tree.root,
-        "1",
+        "auto",
         "latest",
         "import-std",
         true);
@@ -301,11 +318,13 @@ int main() {
     if (std_warm) {
         if (std_warm->exit_code != 0) dump_failure(*std_warm);
         expect(std_warm->exit_code == 0,
-               "warm import std target should reuse toolchain-provider and consumer caches");
+               "warm import std target should reuse toolchain-provider and consumer caches under auto policy");
+        expect(std_warm->stdout_text.find("  jobs:    auto") != std::string::npos,
+               "module target verbose output should preserve automatic policy identity");
         expect(contains_line(std_warm->stdout_text, "[up-to-date] main.cpp"),
-               "warm import std consumer should remain compile-cache clean when only -j changes");
+               "warm import std consumer should remain compile-cache clean when fixed jobs become auto");
         expect(contains_line(std_warm->stdout_text, "[up-to-date] import-std.exe"),
-               "warm import std target should preserve final link cache");
+               "warm import std target should preserve final link cache under auto policy");
     }
 
     TempTree wrong_std_mode_tree{

--- a/cpp/tests/orchestration/scheduling/bounded_work_scheduler_tests.cpp
+++ b/cpp/tests/orchestration/scheduling/bounded_work_scheduler_tests.cpp
@@ -36,6 +36,58 @@ void update_max(std::atomic<int>& maximum, const int value) {
 int main() {
     using mqb::orchestration::BoundedWorkErrorCode;
     using mqb::orchestration::BoundedWorkScheduler;
+    using mqb::orchestration::ParallelismMode;
+    using mqb::orchestration::ParallelismPolicy;
+    using mqb::orchestration::ParallelismResolver;
+
+    {
+        const ParallelismPolicy automatic;
+        expect(automatic.is_automatic() && automatic.valid(),
+               "default parallelism policy should be valid automatic policy");
+
+        const ParallelismPolicy numeric_compatibility = 4;
+        expect(!numeric_compatibility.is_automatic()
+                   && numeric_compatibility.fixed_jobs == 4
+                   && numeric_compatibility == 4,
+               "legacy numeric request initializer should become fixed policy");
+        const ParallelismPolicy zero_compatibility = 0;
+        expect(!zero_compatibility.valid() && zero_compatibility == 0,
+               "legacy zero request initializer should remain invalid");
+    }
+
+    {
+        const auto unknown_hardware = ParallelismResolver::resolve(
+            ParallelismPolicy::automatic(), 8, 0);
+        expect(unknown_hardware.workers == 1,
+               "automatic policy should fall back to one worker when hardware count is unknown");
+
+        const auto work_limited = ParallelismResolver::resolve(
+            ParallelismPolicy::automatic(), 3, 16);
+        expect(work_limited.workers == 3
+                   && work_limited.mode == ParallelismMode::automatic,
+               "automatic policy should clamp hardware budget to ready work width");
+
+        const auto hardware_limited = ParallelismResolver::resolve(
+            ParallelismPolicy::automatic(), 12, 4);
+        expect(hardware_limited.workers == 4,
+               "automatic policy should respect the available hardware budget");
+
+        const auto fixed_work_limited = ParallelismResolver::resolve(
+            ParallelismPolicy::fixed(9), 2, 64);
+        expect(fixed_work_limited.workers == 2
+                   && fixed_work_limited.mode == ParallelismMode::fixed,
+               "fixed policy should still clamp to ready work width");
+
+        const auto fixed_limit = ParallelismResolver::resolve(
+            ParallelismPolicy::fixed(2), 12, 64);
+        expect(fixed_limit.workers == 2,
+               "fixed policy should remain a hard user ceiling regardless of hardware count");
+
+        const auto no_work = ParallelismResolver::resolve(
+            ParallelismPolicy::automatic(), 0, 16);
+        expect(no_work.workers == 0,
+               "zero ready work should resolve to zero workers");
+    }
 
     {
         const auto invalid = BoundedWorkScheduler::run(4, 0, [](std::size_t) { return true; });
@@ -43,6 +95,16 @@ int main() {
         if (!invalid) {
             expect(invalid.error().code == BoundedWorkErrorCode::invalid_worker_count,
                    "zero workers should report invalid_worker_count");
+        }
+
+        const auto invalid_policy = BoundedWorkScheduler::run(
+            4,
+            ParallelismPolicy::fixed(0),
+            [](std::size_t) { return true; });
+        expect(!invalid_policy, "fixed zero policy should be rejected");
+        if (!invalid_policy) {
+            expect(invalid_policy.error().code == BoundedWorkErrorCode::invalid_worker_count,
+                   "fixed zero policy should report invalid_worker_count");
         }
     }
 

--- a/docs/PARALLELISM.md
+++ b/docs/PARALLELISM.md
@@ -1,0 +1,109 @@
+# MQB 并行调度契约
+
+MQB 的并行度是**执行策略**，不属于编译/链接配方，也不参与 cache identity。
+
+## CLI
+
+```powershell
+mqb build main.cpp -j auto
+mqb build main.cpp -j 8
+mqb build main.cpp -jauto
+mqb build main.cpp --jobs=8
+```
+
+`auto` 是默认策略。正整数 `N` 表示固定的最大 worker 上限。`0`、负数和其他文本都会 fail closed。
+
+支持的 auto 写法：
+
+- `-j auto`
+- `-jauto`
+- `--jobs auto`
+- `--jobs=auto`
+
+## 两种策略
+
+### `automatic`
+
+`auto` 不会在 `Application.cpp` 里提前换算成一个整数。typed `ParallelismPolicy` 会一路保留到真正的 scheduler dispatch。
+
+每次 scheduler 面对一个 ready batch 时，worker 数按以下规则解析：
+
+```text
+hardware budget = OS / std::thread::hardware_concurrency()
+if hardware budget == 0: hardware budget = 1
+workers = min(hardware budget, ready work items)
+```
+
+因此：
+
+- 单 TU / 单 ready node 不会创建多余 worker；
+- ordinary target 会按当前 source batch 解析；
+- module scan 会按当前 scan batch 解析；
+- named-module compile 会**逐 dependency level**按该层 ready width 重新解析；
+- header unit / toolchain-owned module provider 进入对应 ready level 后使用同一策略。
+
+PR8 不加入诸如“只用 75% 核心”之类经验常数。内存压力、机器负载、TU 成本估计等资源自适应属于后续 throughput 阶段。
+
+### `fixed(N)`
+
+显式 `-j N` 是用户给出的硬上限：
+
+```text
+workers = min(N, ready work items)
+```
+
+硬件线程数不会把用户明确指定的 `N` 再改写成另一策略。最终是否适合该机器由用户负责选择。
+
+## 单一并行所有权
+
+MQB 自己按 TU 启动独立 `cl.exe`，所以不会再叠加 MSVC `/MP`。否则会形成：
+
+```text
+MQB workers × cl.exe /MP workers
+```
+
+这种嵌套并行容易 oversubscription，并让 `-j` 不再是可理解的进程级上限。
+
+因此 `/MP` 继续由 MSVC Parameter Engine 明确拒绝；MQB 是 process-level compile parallelism 的唯一所有者。
+
+## Cache 与产物身份
+
+从 `-j 1` 切到 `-j auto`，或从 `-j 4` 切到 `-j 2`，不会改变：
+
+- compile signature；
+- link/archive signature；
+- object / IFC / PCH / executable / library 路径；
+- compile/link/archive cache key；
+- dependency freshness 证据。
+
+只要源码、依赖、工具链和构建配方不变，改变 jobs policy 后仍应保持 warm cache hit。
+
+## C++ API 兼容性
+
+原有 request 字段名保持不变，例如：
+
+```cpp
+.max_parallel_compiles = 4
+.max_parallel_scans = 2
+.max_parallel_jobs = 8
+```
+
+这些字段的类型从裸 `std::size_t` 升级为 `ParallelismPolicy`。正整数可隐式转换为 `fixed(N)`，因此已有 numeric designated initializer 保持 source-compatible；`0` 转为 invalid fixed policy，并继续触发原来的 fail-closed validation。
+
+新代码可显式写：
+
+```cpp
+.max_parallel_compiles = ParallelismPolicy::automatic()
+.max_parallel_compiles = ParallelismPolicy::fixed(8)
+```
+
+## 测试契约
+
+PR8 使用结构性测试而不是 hosted-runner 毫秒阈值：
+
+- resolver 可注入 hardware concurrency，验证 unknown / hardware-limited / work-limited / fixed ceiling；
+- numeric C++ API compatibility 和 fixed(0) fail-closed 被锁定；
+- CLI parser 覆盖四种 `auto` 写法；
+- ordinary 四 TU E2E 在 fixed → auto 后必须全部 compile/link cache hit；
+- `import std` P1689 module E2E 在 fixed → auto 后必须保持 consumer/provider/link warm reuse；
+- Debug/Release self-host、完整 native test graph 和 Release package validation 仍是最终合并门。

--- a/docs/PARALLELISM_EN.md
+++ b/docs/PARALLELISM_EN.md
@@ -1,0 +1,109 @@
+# MQB Parallelism Contract
+
+MQB parallelism is an **execution policy**. It is not part of the compile/link recipe and never participates in cache identity.
+
+## CLI
+
+```powershell
+mqb build main.cpp -j auto
+mqb build main.cpp -j 8
+mqb build main.cpp -jauto
+mqb build main.cpp --jobs=8
+```
+
+`auto` is the default policy. A positive integer `N` is a fixed maximum worker ceiling. Zero, negative values, and other text fail closed.
+
+Supported auto spellings:
+
+- `-j auto`
+- `-jauto`
+- `--jobs auto`
+- `--jobs=auto`
+
+## Policies
+
+### `automatic`
+
+`auto` is not converted to an integer early in `Application.cpp`. The typed `ParallelismPolicy` is preserved until the scheduler sees the actual ready work batch.
+
+For each scheduler dispatch:
+
+```text
+hardware budget = OS / std::thread::hardware_concurrency()
+if hardware budget == 0: hardware budget = 1
+workers = min(hardware budget, ready work items)
+```
+
+Consequently:
+
+- a single TU or single ready node does not create unnecessary workers;
+- ordinary targets resolve against the current source batch;
+- module scanning resolves against the current scan batch;
+- named-module compilation resolves **per dependency level** against that level's ready width;
+- header units and toolchain-owned module providers use the same policy when they enter a ready level.
+
+PR8 deliberately avoids arbitrary heuristics such as “use 75% of cores”. Memory pressure, machine load, and TU-cost-aware scheduling belong to later throughput work.
+
+### `fixed(N)`
+
+Explicit `-j N` is a hard user ceiling:
+
+```text
+workers = min(N, ready work items)
+```
+
+Hardware concurrency does not silently rewrite an explicitly selected fixed policy. The user owns the decision to choose an appropriate explicit ceiling for the machine.
+
+## One owner of compile parallelism
+
+MQB launches independent `cl.exe` processes per translation unit, so it does not stack MSVC `/MP` on top. Doing so would create nested parallelism:
+
+```text
+MQB workers × cl.exe /MP workers
+```
+
+That can oversubscribe the machine and makes `-j` cease to be an understandable process-level limit.
+
+The MSVC Parameter Engine therefore continues to reject `/MP`; MQB remains the sole owner of process-level compile parallelism.
+
+## Cache and artifact identity
+
+Switching from `-j 1` to `-j auto`, or from `-j 4` to `-j 2`, does not change:
+
+- compile signatures;
+- link/archive signatures;
+- object / IFC / PCH / executable / library paths;
+- compile/link/archive cache keys;
+- dependency freshness evidence.
+
+If source, dependencies, toolchain, and build recipe are unchanged, changing only the jobs policy must remain a warm cache hit.
+
+## C++ API compatibility
+
+Existing request field names remain unchanged, for example:
+
+```cpp
+.max_parallel_compiles = 4
+.max_parallel_scans = 2
+.max_parallel_jobs = 8
+```
+
+Their type is upgraded from a raw `std::size_t` to `ParallelismPolicy`. Positive integers implicitly convert to `fixed(N)`, keeping existing numeric designated initializers source-compatible. Zero converts to an invalid fixed policy and continues to trigger fail-closed validation.
+
+New code may be explicit:
+
+```cpp
+.max_parallel_compiles = ParallelismPolicy::automatic()
+.max_parallel_compiles = ParallelismPolicy::fixed(8)
+```
+
+## Validation contract
+
+PR8 uses structural tests instead of hosted-runner timing thresholds:
+
+- the resolver accepts injected hardware concurrency and tests unknown, hardware-limited, work-limited, and fixed-ceiling cases;
+- numeric C++ API compatibility and fixed(0) fail-closed behavior are locked;
+- the CLI parser covers all four `auto` spellings;
+- the ordinary four-TU E2E must preserve every compile/link cache hit after fixed → auto;
+- the `import std` P1689 module E2E must preserve provider/consumer/link warm reuse after fixed → auto;
+- Debug/Release self-host, the complete native test graph, and Release package validation remain the final merge gates.


### PR DESCRIPTION
## Summary

Implements PR 8 of the MQB productization track: make `-j auto` a first-class adaptive scheduling policy while preserving explicit `-j N` behavior, cache identity, and source compatibility for existing orchestration request initializers.

## Delivered

- add typed `ParallelismPolicy` with `automatic` and fixed positive-worker modes
- add deterministic `ParallelismResolver` whose hardware concurrency is injectable in tests
- preserve automatic policy until the scheduler sees the actual ready work batch instead of converting it to an integer in `Application.cpp`
- resolve ordinary/static target workers against the current source batch
- resolve module scan workers against the current scan batch
- resolve named-module/header-unit/toolchain-provider compile workers separately for every dependency level's ready width
- centralize the real `std::thread::hardware_concurrency()` observation inside `BoundedWorkScheduler`
- fall back to one worker when hardware concurrency is unknown/zero
- keep explicit `-j N` as a hard user ceiling, clamped only by the current ready work count
- accept `-j auto`, `-jauto`, `--jobs auto`, and `--jobs=auto`
- preserve existing numeric C++ request syntax such as `.max_parallel_compiles = 4`: existing `max_parallel_*` field names remain, while their type upgrades from a raw integer to `ParallelismPolicy`
- preserve existing fixed-zero fail-closed behavior through an invalid `fixed(0)` policy
- keep jobs execution-only: no compile/link/archive signature, cache key, dependency freshness, or artifact-layout changes
- keep MQB as the single process-level compile parallelism owner; compiler `/MP` remains rejected rather than stacked on top of MQB workers
- add Chinese/English parallelism contract documentation

## Automatic policy

For a scheduler dispatch with a ready batch:

```text
hardware budget = std::thread::hardware_concurrency()
if hardware budget == 0: hardware budget = 1
workers = min(hardware budget, ready work items)
```

PR8 deliberately does not add arbitrary percentage-of-core heuristics. Memory pressure, machine load, TU-cost estimation, and more advanced throughput calibration remain later-stage work.

## Compatibility and correctness

The existing numeric scheduler overload remains available. Public orchestration request field names also remain source-compatible; positive numeric designated initializers convert to fixed policies, while zero remains invalid and fails closed.

Parallelism never enters build/cache identity. E2E explicitly switches ordinary and P1689 `import std` targets from fixed jobs to `auto` and requires all warm compile/link cache hits to remain reusable.

MQB continues to launch one independently scheduled `cl.exe` process per TU rather than multiplying its scheduler by compiler `/MP` workers.

## Validation

Exact validated head: `cc52ef0006b544acb36d85cfe9b7a2c8b925ab89`

Native C++ #237 / run `31807182741`:
- Debug candidate self-build: success
- 67-TU shared native-test product: success
- 71-test graph, 4/4 Debug shards: success
- final Native C++ gate: success

Native Release #202 / run `31807182709`:
- Stage 0 Release self-build + shared product: success
- 71-test graph, 4/4 Release shards: success
- Stage 1 stable self-host: success
- runtime-only package staging: success
- exact packaged-artifact validation: success
- validated artifact upload: success
- `publish-release`: skipped as expected for a PR

Behavior coverage includes deterministic resolver cases (unknown hardware, hardware-limited, work-limited, fixed ceiling), numeric API compatibility, fixed-zero fail-closed behavior, all four public `auto` CLI spellings, ordinary fixed→auto warm reuse, and P1689 `import std` fixed→auto warm reuse.

## Deliberate non-goals

PR8 does not implement memory-aware scheduling, dynamic CPU-load sensing, TU-cost prediction, cross-target scheduling, or other advanced throughput heuristics. Those belong to PR9.