### PR TITLE
perf: advance MQB throughput

### DIFF
--- a/cpp/include/mqb/core/BuildSignature.hpp
+++ b/cpp/include/mqb/core/BuildSignature.hpp
@@ -29,6 +29,12 @@ public:
         const ToolchainIdentity& toolchain,
         const CompilerOptions& options);
 
+    [[nodiscard]] static BuildSignature for_module_scan(
+        const std::filesystem::path& source,
+        TranslationUnitKind kind,
+        const ToolchainIdentity& toolchain,
+        const CompilerOptions& options);
+
     [[nodiscard]] static BuildSignature for_link(
         std::span<const std::filesystem::path> objects,
         const std::filesystem::path& output,

--- a/cpp/include/mqb/core/CompileCache.hpp
+++ b/cpp/include/mqb/core/CompileCache.hpp
@@ -15,6 +15,17 @@
 
 namespace mqb {
 
+// P1689 topology can only be reused when it is sealed by a successful compile.
+// The compile cache is that transaction boundary: the evidence below records
+// the exact scan recipe and filesystem state that produced the topology which
+// this successful compile consumed.
+struct ModuleScanEvidence {
+    BuildSignature signature;
+    FileSnapshot source;
+    FileSnapshot output;
+    std::vector<FileSnapshot> dependencies;
+};
+
 struct CompileCacheEntry {
     std::filesystem::path source;
     TranslationUnitKind kind{TranslationUnitKind::source};
@@ -22,6 +33,7 @@ struct CompileCacheEntry {
     BuildSignature signature;
     std::vector<Artifact> outputs;
     std::vector<std::filesystem::path> dependencies;
+    std::optional<ModuleScanEvidence> module_scan;
 };
 
 struct CompileCacheValidation {
@@ -42,6 +54,16 @@ public:
         const FileSnapshot& source_snapshot,
         std::span<const FileSnapshot> output_snapshots,
         std::span<const FileSnapshot> dependency_snapshots);
+};
+
+class ModuleScanEvidenceValidator {
+public:
+    [[nodiscard]] static bool reusable(
+        const ModuleScanEvidence& evidence,
+        const BuildSignature& current_signature,
+        const FileSnapshot& current_source,
+        const FileSnapshot& current_output,
+        std::span<const FileSnapshot> current_dependencies) noexcept;
 };
 
 } // namespace mqb

--- a/cpp/include/mqb/core/CompileCache.hpp
+++ b/cpp/include/mqb/core/CompileCache.hpp
@@ -34,7 +34,10 @@ struct CompileCacheEntry {
 
 struct CompileCacheValidation {
     std::vector<BuildReason> reasons;
-    [[nodiscard]] bool reusable() const noexcept { return reasons.empty(); }
+
+    [[nodiscard]] bool reusable() const noexcept {
+        return reasons.empty();
+    }
 };
 
 class CompileCacheValidator {

--- a/cpp/include/mqb/core/CompileCache.hpp
+++ b/cpp/include/mqb/core/CompileCache.hpp
@@ -15,10 +15,6 @@
 
 namespace mqb {
 
-// P1689 topology can only be reused when it is sealed by a successful compile.
-// The compile cache is that transaction boundary: the evidence below records
-// the exact scan recipe and filesystem state that produced the topology which
-// this successful compile consumed.
 struct ModuleScanEvidence {
     BuildSignature signature;
     FileSnapshot source;
@@ -38,10 +34,7 @@ struct CompileCacheEntry {
 
 struct CompileCacheValidation {
     std::vector<BuildReason> reasons;
-
-    [[nodiscard]] bool reusable() const noexcept {
-        return reasons.empty();
-    }
+    [[nodiscard]] bool reusable() const noexcept { return reasons.empty(); }
 };
 
 class CompileCacheValidator {
@@ -63,7 +56,7 @@ public:
         const BuildSignature& current_signature,
         const FileSnapshot& current_source,
         const FileSnapshot& current_output,
-        std::span<const FileSnapshot> current_dependencies) noexcept;
+        std::span<const FileSnapshot> current_dependencies);
 };
 
 } // namespace mqb

--- a/cpp/include/mqb/msvc/MsvcModuleDependencyScanner.hpp
+++ b/cpp/include/mqb/msvc/MsvcModuleDependencyScanner.hpp
@@ -25,6 +25,7 @@ struct ModuleScanInvocation {
 struct ModuleScanResult {
     process::ProcessResult process;
     modules::P1689Document dependencies;
+    bool reused{false};
 };
 
 enum class ModuleScanErrorCode {

--- a/cpp/include/mqb/orchestration/MsvcIncrementalCompileCoordinator.hpp
+++ b/cpp/include/mqb/orchestration/MsvcIncrementalCompileCoordinator.hpp
@@ -23,6 +23,10 @@ struct IncrementalCompileRequest {
     CompilerOptions options;
     std::filesystem::path cache_file;
     std::filesystem::path source_dependencies_file;
+    // Named-module sources carry the P1689 artifact that preceded this compile.
+    // A successful compile can then seal scan-reuse evidence into its compile
+    // cache. Ordinary and header-unit compile requests leave this empty.
+    std::optional<std::filesystem::path> module_scan_output;
     std::optional<std::filesystem::path> working_directory;
     bool force_rebuild{false};
 };

--- a/cpp/src/core/cache/CompileCache.cpp
+++ b/cpp/src/core/cache/CompileCache.cpp
@@ -8,112 +8,15 @@
 namespace mqb {
 namespace {
 
-[[nodiscard]] bool same_path(
-    const std::filesystem::path& left,
-    const std::filesystem::path& right) {
-    return left == right || left.lexically_normal() == right.lexically_normal();
-}
-
-[[nodiscard]] bool same_toolchain(
-    const ToolchainIdentity& left,
-    const ToolchainIdentity& right) {
-    return same_path(left.compiler, right.compiler)
-        && left.version == right.version
-        && left.binary_stamp == right.binary_stamp;
-}
-
-[[nodiscard]] bool same_artifact(
-    const Artifact& left,
-    const Artifact& right) {
-    return left.kind == right.kind && same_path(left.path, right.path);
-}
-
-[[nodiscard]] bool same_snapshot(
-    const FileSnapshot& left,
-    const FileSnapshot& right) noexcept {
-    return same_path(left.path, right.path)
-        && left.exists == right.exists
-        && (!left.exists || left.modified == right.modified);
-}
-
-void add_reason(std::vector<BuildReason>& reasons, const BuildReason reason) {
-    if (std::find(reasons.begin(), reasons.end(), reason) == reasons.end()) {
-        reasons.push_back(reason);
-    }
-}
-
-[[nodiscard]] const FileSnapshot* find_snapshot(
-    const std::span<const FileSnapshot> snapshots,
-    const std::filesystem::path& path) {
-    const auto it = std::find_if(
-        snapshots.begin(),
-        snapshots.end(),
-        [&path](const FileSnapshot& snapshot) {
-            return same_path(snapshot.path, path);
-        });
-
-    return it == snapshots.end() ? nullptr : &*it;
-}
-
-[[nodiscard]] const FileSnapshot* aligned_snapshot_or_find(
-    const std::span<const FileSnapshot> snapshots,
-    const std::filesystem::path& path,
-    const std::size_t preferred_index) {
-    if (preferred_index < snapshots.size()
-        && same_path(snapshots[preferred_index].path, path)) {
-        return &snapshots[preferred_index];
-    }
-    return find_snapshot(snapshots, path);
-}
-
-[[nodiscard]] bool same_outputs(
-    const std::vector<Artifact>& cached,
-    const std::vector<Artifact>& current) {
-    if (cached.size() != current.size()) {
-        return false;
-    }
-
-    std::vector<bool> matched(cached.size(), false);
-    for (const auto& current_output : current) {
-        bool found = false;
-        for (std::size_t index = 0; index < cached.size(); ++index) {
-            if (!matched[index] && same_artifact(cached[index], current_output)) {
-                matched[index] = true;
-                found = true;
-                break;
-            }
-        }
-        if (!found) {
-            return false;
-        }
-    }
-    return true;
-}
-
-[[nodiscard]] std::optional<std::filesystem::file_time_type>
-oldest_output_time(
-    const TranslationUnit& unit,
-    const std::span<const FileSnapshot> output_snapshots) {
-    if (unit.outputs.empty()) {
-        return std::nullopt;
-    }
-
-    std::optional<std::filesystem::file_time_type> oldest;
-    for (std::size_t index = 0; index < unit.outputs.size(); ++index) {
-        const auto& output = unit.outputs[index];
-        const FileSnapshot* snapshot = aligned_snapshot_or_find(
-            output_snapshots,
-            output.path,
-            index);
-        if (snapshot == nullptr || !snapshot->exists) {
-            return std::nullopt;
-        }
-        if (!oldest || snapshot->modified < *oldest) {
-            oldest = snapshot->modified;
-        }
-    }
-    return oldest;
-}
+[[nodiscard]] bool same_path(const std::filesystem::path& left,const std::filesystem::path& right){return left==right||left.lexically_normal()==right.lexically_normal();}
+[[nodiscard]] bool same_toolchain(const ToolchainIdentity& left,const ToolchainIdentity& right){return same_path(left.compiler,right.compiler)&&left.version==right.version&&left.binary_stamp==right.binary_stamp;}
+[[nodiscard]] bool same_artifact(const Artifact& left,const Artifact& right){return left.kind==right.kind&&same_path(left.path,right.path);}
+[[nodiscard]] bool same_snapshot(const FileSnapshot& left,const FileSnapshot& right){return same_path(left.path,right.path)&&left.exists==right.exists&&(!left.exists||left.modified==right.modified);}
+void add_reason(std::vector<BuildReason>& reasons,const BuildReason reason){if(std::find(reasons.begin(),reasons.end(),reason)==reasons.end())reasons.push_back(reason);}
+[[nodiscard]] const FileSnapshot* find_snapshot(const std::span<const FileSnapshot> snapshots,const std::filesystem::path& path){const auto it=std::find_if(snapshots.begin(),snapshots.end(),[&path](const FileSnapshot& snapshot){return same_path(snapshot.path,path);});return it==snapshots.end()?nullptr:&*it;}
+[[nodiscard]] const FileSnapshot* aligned_snapshot_or_find(const std::span<const FileSnapshot> snapshots,const std::filesystem::path& path,const std::size_t preferred_index){if(preferred_index<snapshots.size()&&same_path(snapshots[preferred_index].path,path))return &snapshots[preferred_index];return find_snapshot(snapshots,path);}
+[[nodiscard]] bool same_outputs(const std::vector<Artifact>& cached,const std::vector<Artifact>& current){if(cached.size()!=current.size())return false;std::vector<bool> matched(cached.size(),false);for(const auto& current_output:current){bool found=false;for(std::size_t index=0;index<cached.size();++index){if(!matched[index]&&same_artifact(cached[index],current_output)){matched[index]=true;found=true;break;}}if(!found)return false;}return true;}
+[[nodiscard]] std::optional<std::filesystem::file_time_type> oldest_output_time(const TranslationUnit& unit,const std::span<const FileSnapshot> output_snapshots){if(unit.outputs.empty())return std::nullopt;std::optional<std::filesystem::file_time_type> oldest;for(std::size_t index=0;index<unit.outputs.size();++index){const auto& output=unit.outputs[index];const FileSnapshot* snapshot=aligned_snapshot_or_find(output_snapshots,output.path,index);if(snapshot==nullptr||!snapshot->exists)return std::nullopt;if(!oldest||snapshot->modified<*oldest)oldest=snapshot->modified;}return oldest;}
 
 } // namespace
 
@@ -126,78 +29,20 @@ CompileCacheValidation CompileCacheValidator::validate(
     const std::span<const FileSnapshot> output_snapshots,
     const std::span<const FileSnapshot> dependency_snapshots) {
     CompileCacheValidation result;
-
-    const auto validate_outputs = [&] {
-        if (current_unit.outputs.empty()) {
-            add_reason(result.reasons, BuildReason::missing_output);
-            return;
-        }
-        for (std::size_t index = 0; index < current_unit.outputs.size(); ++index) {
-            const auto& output = current_unit.outputs[index];
-            const auto* snapshot = aligned_snapshot_or_find(
-                output_snapshots,
-                output.path,
-                index);
-            if (output.path.empty() || snapshot == nullptr || !snapshot->exists) {
-                add_reason(result.reasons, BuildReason::missing_output);
-            }
-        }
-    };
-
-    if (!cached_entry) {
-        add_reason(result.reasons, BuildReason::missing_cache_entry);
-        validate_outputs();
-        return result;
-    }
-
-    const auto& cached = *cached_entry;
-    const bool same_source_identity = same_path(cached.source, current_unit.source)
-        && cached.kind == current_unit.kind;
-    if (!same_source_identity) {
-        add_reason(result.reasons, BuildReason::source_changed);
-    }
-
-    const bool toolchain_matches = same_toolchain(cached.toolchain, current_toolchain);
-    if (!toolchain_matches) {
-        add_reason(result.reasons, BuildReason::toolchain_changed);
-    }
-
-    const auto current_signature = BuildSignature::for_compile(
-        current_unit,
-        current_toolchain,
-        current_options);
-    if (cached.signature != current_signature && same_source_identity && toolchain_matches) {
-        add_reason(result.reasons, BuildReason::compiler_options_changed);
-    }
-
-    if (!same_outputs(cached.outputs, current_unit.outputs)) {
-        add_reason(result.reasons, BuildReason::missing_output);
-    }
+    const auto validate_outputs=[&]{if(current_unit.outputs.empty()){add_reason(result.reasons,BuildReason::missing_output);return;}for(std::size_t index=0;index<current_unit.outputs.size();++index){const auto& output=current_unit.outputs[index];const auto* snapshot=aligned_snapshot_or_find(output_snapshots,output.path,index);if(output.path.empty()||snapshot==nullptr||!snapshot->exists)add_reason(result.reasons,BuildReason::missing_output);}};
+    if(!cached_entry){add_reason(result.reasons,BuildReason::missing_cache_entry);validate_outputs();return result;}
+    const auto& cached=*cached_entry;
+    const bool same_source_identity=same_path(cached.source,current_unit.source)&&cached.kind==current_unit.kind;
+    if(!same_source_identity)add_reason(result.reasons,BuildReason::source_changed);
+    const bool toolchain_matches=same_toolchain(cached.toolchain,current_toolchain);
+    if(!toolchain_matches)add_reason(result.reasons,BuildReason::toolchain_changed);
+    const auto current_signature=BuildSignature::for_compile(current_unit,current_toolchain,current_options);
+    if(cached.signature!=current_signature&&same_source_identity&&toolchain_matches)add_reason(result.reasons,BuildReason::compiler_options_changed);
+    if(!same_outputs(cached.outputs,current_unit.outputs))add_reason(result.reasons,BuildReason::missing_output);
     validate_outputs();
-
-    const auto freshness_anchor = oldest_output_time(current_unit, output_snapshots);
-    if (!source_snapshot.exists) {
-        add_reason(result.reasons, BuildReason::source_changed);
-    } else if (freshness_anchor && source_snapshot.modified > *freshness_anchor) {
-        add_reason(result.reasons, BuildReason::source_changed);
-    }
-
-    for (std::size_t index = 0; index < cached.dependencies.size(); ++index) {
-        const auto& dependency = cached.dependencies[index];
-        const auto* snapshot = aligned_snapshot_or_find(
-            dependency_snapshots,
-            dependency,
-            index);
-        if (snapshot == nullptr || !snapshot->exists) {
-            add_reason(result.reasons, BuildReason::dependency_changed);
-            continue;
-        }
-
-        if (freshness_anchor && snapshot->modified > *freshness_anchor) {
-            add_reason(result.reasons, BuildReason::dependency_changed);
-        }
-    }
-
+    const auto freshness_anchor=oldest_output_time(current_unit,output_snapshots);
+    if(!source_snapshot.exists)add_reason(result.reasons,BuildReason::source_changed);else if(freshness_anchor&&source_snapshot.modified>*freshness_anchor)add_reason(result.reasons,BuildReason::source_changed);
+    for(std::size_t index=0;index<cached.dependencies.size();++index){const auto& dependency=cached.dependencies[index];const auto* snapshot=aligned_snapshot_or_find(dependency_snapshots,dependency,index);if(snapshot==nullptr||!snapshot->exists){add_reason(result.reasons,BuildReason::dependency_changed);continue;}if(freshness_anchor&&snapshot->modified>*freshness_anchor)add_reason(result.reasons,BuildReason::dependency_changed);}
     return result;
 }
 
@@ -206,22 +51,9 @@ bool ModuleScanEvidenceValidator::reusable(
     const BuildSignature& current_signature,
     const FileSnapshot& current_source,
     const FileSnapshot& current_output,
-    const std::span<const FileSnapshot> current_dependencies) noexcept {
-    if (evidence.signature != current_signature
-        || !same_snapshot(evidence.source, current_source)
-        || !same_snapshot(evidence.output, current_output)
-        || !evidence.source.exists
-        || !evidence.output.exists
-        || evidence.dependencies.size() != current_dependencies.size()) {
-        return false;
-    }
-
-    for (std::size_t index = 0; index < evidence.dependencies.size(); ++index) {
-        if (!same_snapshot(evidence.dependencies[index], current_dependencies[index])
-            || !current_dependencies[index].exists) {
-            return false;
-        }
-    }
+    const std::span<const FileSnapshot> current_dependencies) {
+    if(evidence.signature!=current_signature||!same_snapshot(evidence.source,current_source)||!same_snapshot(evidence.output,current_output)||!evidence.source.exists||!evidence.output.exists||evidence.dependencies.size()!=current_dependencies.size())return false;
+    for(std::size_t index=0;index<evidence.dependencies.size();++index){if(!same_snapshot(evidence.dependencies[index],current_dependencies[index])||!current_dependencies[index].exists)return false;}
     return true;
 }
 

--- a/cpp/src/core/cache/CompileCache.cpp
+++ b/cpp/src/core/cache/CompileCache.cpp
@@ -8,15 +8,113 @@
 namespace mqb {
 namespace {
 
-[[nodiscard]] bool same_path(const std::filesystem::path& left,const std::filesystem::path& right){return left==right||left.lexically_normal()==right.lexically_normal();}
-[[nodiscard]] bool same_toolchain(const ToolchainIdentity& left,const ToolchainIdentity& right){return same_path(left.compiler,right.compiler)&&left.version==right.version&&left.binary_stamp==right.binary_stamp;}
-[[nodiscard]] bool same_artifact(const Artifact& left,const Artifact& right){return left.kind==right.kind&&same_path(left.path,right.path);}
-[[nodiscard]] bool same_snapshot(const FileSnapshot& left,const FileSnapshot& right){return same_path(left.path,right.path)&&left.exists==right.exists&&(!left.exists||left.modified==right.modified);}
-void add_reason(std::vector<BuildReason>& reasons,const BuildReason reason){if(std::find(reasons.begin(),reasons.end(),reason)==reasons.end())reasons.push_back(reason);}
-[[nodiscard]] const FileSnapshot* find_snapshot(const std::span<const FileSnapshot> snapshots,const std::filesystem::path& path){const auto it=std::find_if(snapshots.begin(),snapshots.end(),[&path](const FileSnapshot& snapshot){return same_path(snapshot.path,path);});return it==snapshots.end()?nullptr:&*it;}
-[[nodiscard]] const FileSnapshot* aligned_snapshot_or_find(const std::span<const FileSnapshot> snapshots,const std::filesystem::path& path,const std::size_t preferred_index){if(preferred_index<snapshots.size()&&same_path(snapshots[preferred_index].path,path))return &snapshots[preferred_index];return find_snapshot(snapshots,path);}
-[[nodiscard]] bool same_outputs(const std::vector<Artifact>& cached,const std::vector<Artifact>& current){if(cached.size()!=current.size())return false;std::vector<bool> matched(cached.size(),false);for(const auto& current_output:current){bool found=false;for(std::size_t index=0;index<cached.size();++index){if(!matched[index]&&same_artifact(cached[index],current_output)){matched[index]=true;found=true;break;}}if(!found)return false;}return true;}
-[[nodiscard]] std::optional<std::filesystem::file_time_type> oldest_output_time(const TranslationUnit& unit,const std::span<const FileSnapshot> output_snapshots){if(unit.outputs.empty())return std::nullopt;std::optional<std::filesystem::file_time_type> oldest;for(std::size_t index=0;index<unit.outputs.size();++index){const auto& output=unit.outputs[index];const FileSnapshot* snapshot=aligned_snapshot_or_find(output_snapshots,output.path,index);if(snapshot==nullptr||!snapshot->exists)return std::nullopt;if(!oldest||snapshot->modified<*oldest)oldest=snapshot->modified;}return oldest;}
+[[nodiscard]] bool same_path(
+    const std::filesystem::path& left,
+    const std::filesystem::path& right) {
+    return left == right || left.lexically_normal() == right.lexically_normal();
+}
+
+[[nodiscard]] bool same_toolchain(
+    const ToolchainIdentity& left,
+    const ToolchainIdentity& right) {
+    return same_path(left.compiler, right.compiler)
+        && left.version == right.version
+        && left.binary_stamp == right.binary_stamp;
+}
+
+[[nodiscard]] bool same_artifact(
+    const Artifact& left,
+    const Artifact& right) {
+    return left.kind == right.kind && same_path(left.path, right.path);
+}
+
+[[nodiscard]] bool same_snapshot(
+    const FileSnapshot& left,
+    const FileSnapshot& right) {
+    return same_path(left.path, right.path)
+        && left.exists == right.exists
+        && (!left.exists || left.modified == right.modified);
+}
+
+void add_reason(
+    std::vector<BuildReason>& reasons,
+    const BuildReason reason) {
+    if (std::find(reasons.begin(), reasons.end(), reason) == reasons.end()) {
+        reasons.push_back(reason);
+    }
+}
+
+[[nodiscard]] const FileSnapshot* find_snapshot(
+    const std::span<const FileSnapshot> snapshots,
+    const std::filesystem::path& path) {
+    const auto it = std::find_if(
+        snapshots.begin(),
+        snapshots.end(),
+        [&path](const FileSnapshot& snapshot) {
+            return same_path(snapshot.path, path);
+        });
+    return it == snapshots.end() ? nullptr : &*it;
+}
+
+[[nodiscard]] const FileSnapshot* aligned_snapshot_or_find(
+    const std::span<const FileSnapshot> snapshots,
+    const std::filesystem::path& path,
+    const std::size_t preferred_index) {
+    if (preferred_index < snapshots.size()
+        && same_path(snapshots[preferred_index].path, path)) {
+        return &snapshots[preferred_index];
+    }
+    return find_snapshot(snapshots, path);
+}
+
+[[nodiscard]] bool same_outputs(
+    const std::vector<Artifact>& cached,
+    const std::vector<Artifact>& current) {
+    if (cached.size() != current.size()) {
+        return false;
+    }
+
+    std::vector<bool> matched(cached.size(), false);
+    for (const auto& current_output : current) {
+        bool found = false;
+        for (std::size_t index = 0; index < cached.size(); ++index) {
+            if (!matched[index] && same_artifact(cached[index], current_output)) {
+                matched[index] = true;
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            return false;
+        }
+    }
+    return true;
+}
+
+[[nodiscard]] std::optional<std::filesystem::file_time_type>
+oldest_output_time(
+    const TranslationUnit& unit,
+    const std::span<const FileSnapshot> output_snapshots) {
+    if (unit.outputs.empty()) {
+        return std::nullopt;
+    }
+
+    std::optional<std::filesystem::file_time_type> oldest;
+    for (std::size_t index = 0; index < unit.outputs.size(); ++index) {
+        const auto& output = unit.outputs[index];
+        const FileSnapshot* snapshot = aligned_snapshot_or_find(
+            output_snapshots,
+            output.path,
+            index);
+        if (snapshot == nullptr || !snapshot->exists) {
+            return std::nullopt;
+        }
+        if (!oldest || snapshot->modified < *oldest) {
+            oldest = snapshot->modified;
+        }
+    }
+    return oldest;
+}
 
 } // namespace
 
@@ -29,20 +127,81 @@ CompileCacheValidation CompileCacheValidator::validate(
     const std::span<const FileSnapshot> output_snapshots,
     const std::span<const FileSnapshot> dependency_snapshots) {
     CompileCacheValidation result;
-    const auto validate_outputs=[&]{if(current_unit.outputs.empty()){add_reason(result.reasons,BuildReason::missing_output);return;}for(std::size_t index=0;index<current_unit.outputs.size();++index){const auto& output=current_unit.outputs[index];const auto* snapshot=aligned_snapshot_or_find(output_snapshots,output.path,index);if(output.path.empty()||snapshot==nullptr||!snapshot->exists)add_reason(result.reasons,BuildReason::missing_output);}};
-    if(!cached_entry){add_reason(result.reasons,BuildReason::missing_cache_entry);validate_outputs();return result;}
-    const auto& cached=*cached_entry;
-    const bool same_source_identity=same_path(cached.source,current_unit.source)&&cached.kind==current_unit.kind;
-    if(!same_source_identity)add_reason(result.reasons,BuildReason::source_changed);
-    const bool toolchain_matches=same_toolchain(cached.toolchain,current_toolchain);
-    if(!toolchain_matches)add_reason(result.reasons,BuildReason::toolchain_changed);
-    const auto current_signature=BuildSignature::for_compile(current_unit,current_toolchain,current_options);
-    if(cached.signature!=current_signature&&same_source_identity&&toolchain_matches)add_reason(result.reasons,BuildReason::compiler_options_changed);
-    if(!same_outputs(cached.outputs,current_unit.outputs))add_reason(result.reasons,BuildReason::missing_output);
+
+    const auto validate_outputs = [&] {
+        if (current_unit.outputs.empty()) {
+            add_reason(result.reasons, BuildReason::missing_output);
+            return;
+        }
+        for (std::size_t index = 0; index < current_unit.outputs.size(); ++index) {
+            const auto& output = current_unit.outputs[index];
+            const auto* snapshot = aligned_snapshot_or_find(
+                output_snapshots,
+                output.path,
+                index);
+            if (output.path.empty() || snapshot == nullptr || !snapshot->exists) {
+                add_reason(result.reasons, BuildReason::missing_output);
+            }
+        }
+    };
+
+    if (!cached_entry) {
+        add_reason(result.reasons, BuildReason::missing_cache_entry);
+        validate_outputs();
+        return result;
+    }
+
+    const auto& cached = *cached_entry;
+    const bool same_source_identity = same_path(cached.source, current_unit.source)
+        && cached.kind == current_unit.kind;
+    if (!same_source_identity) {
+        add_reason(result.reasons, BuildReason::source_changed);
+    }
+
+    const bool toolchain_matches = same_toolchain(cached.toolchain, current_toolchain);
+    if (!toolchain_matches) {
+        add_reason(result.reasons, BuildReason::toolchain_changed);
+    }
+
+    const auto current_signature = BuildSignature::for_compile(
+        current_unit,
+        current_toolchain,
+        current_options);
+    if (cached.signature != current_signature
+        && same_source_identity
+        && toolchain_matches) {
+        add_reason(result.reasons, BuildReason::compiler_options_changed);
+    }
+
+    if (!same_outputs(cached.outputs, current_unit.outputs)) {
+        add_reason(result.reasons, BuildReason::missing_output);
+    }
     validate_outputs();
-    const auto freshness_anchor=oldest_output_time(current_unit,output_snapshots);
-    if(!source_snapshot.exists)add_reason(result.reasons,BuildReason::source_changed);else if(freshness_anchor&&source_snapshot.modified>*freshness_anchor)add_reason(result.reasons,BuildReason::source_changed);
-    for(std::size_t index=0;index<cached.dependencies.size();++index){const auto& dependency=cached.dependencies[index];const auto* snapshot=aligned_snapshot_or_find(dependency_snapshots,dependency,index);if(snapshot==nullptr||!snapshot->exists){add_reason(result.reasons,BuildReason::dependency_changed);continue;}if(freshness_anchor&&snapshot->modified>*freshness_anchor)add_reason(result.reasons,BuildReason::dependency_changed);}
+
+    const auto freshness_anchor = oldest_output_time(
+        current_unit,
+        output_snapshots);
+    if (!source_snapshot.exists) {
+        add_reason(result.reasons, BuildReason::source_changed);
+    } else if (freshness_anchor && source_snapshot.modified > *freshness_anchor) {
+        add_reason(result.reasons, BuildReason::source_changed);
+    }
+
+    for (std::size_t index = 0; index < cached.dependencies.size(); ++index) {
+        const auto& dependency = cached.dependencies[index];
+        const auto* snapshot = aligned_snapshot_or_find(
+            dependency_snapshots,
+            dependency,
+            index);
+        if (snapshot == nullptr || !snapshot->exists) {
+            add_reason(result.reasons, BuildReason::dependency_changed);
+            continue;
+        }
+        if (freshness_anchor && snapshot->modified > *freshness_anchor) {
+            add_reason(result.reasons, BuildReason::dependency_changed);
+        }
+    }
+
     return result;
 }
 
@@ -52,8 +211,21 @@ bool ModuleScanEvidenceValidator::reusable(
     const FileSnapshot& current_source,
     const FileSnapshot& current_output,
     const std::span<const FileSnapshot> current_dependencies) {
-    if(evidence.signature!=current_signature||!same_snapshot(evidence.source,current_source)||!same_snapshot(evidence.output,current_output)||!evidence.source.exists||!evidence.output.exists||evidence.dependencies.size()!=current_dependencies.size())return false;
-    for(std::size_t index=0;index<evidence.dependencies.size();++index){if(!same_snapshot(evidence.dependencies[index],current_dependencies[index])||!current_dependencies[index].exists)return false;}
+    if (evidence.signature != current_signature
+        || !same_snapshot(evidence.source, current_source)
+        || !same_snapshot(evidence.output, current_output)
+        || !evidence.source.exists
+        || !evidence.output.exists
+        || evidence.dependencies.size() != current_dependencies.size()) {
+        return false;
+    }
+
+    for (std::size_t index = 0; index < evidence.dependencies.size(); ++index) {
+        if (!same_snapshot(evidence.dependencies[index], current_dependencies[index])
+            || !current_dependencies[index].exists) {
+            return false;
+        }
+    }
     return true;
 }
 

--- a/cpp/src/core/cache/CompileCache.cpp
+++ b/cpp/src/core/cache/CompileCache.cpp
@@ -28,6 +28,14 @@ namespace {
     return left.kind == right.kind && same_path(left.path, right.path);
 }
 
+[[nodiscard]] bool same_snapshot(
+    const FileSnapshot& left,
+    const FileSnapshot& right) noexcept {
+    return same_path(left.path, right.path)
+        && left.exists == right.exists
+        && (!left.exists || left.modified == right.modified);
+}
+
 void add_reason(std::vector<BuildReason>& reasons, const BuildReason reason) {
     if (std::find(reasons.begin(), reasons.end(), reason) == reasons.end()) {
         reasons.push_back(reason);
@@ -191,6 +199,30 @@ CompileCacheValidation CompileCacheValidator::validate(
     }
 
     return result;
+}
+
+bool ModuleScanEvidenceValidator::reusable(
+    const ModuleScanEvidence& evidence,
+    const BuildSignature& current_signature,
+    const FileSnapshot& current_source,
+    const FileSnapshot& current_output,
+    const std::span<const FileSnapshot> current_dependencies) noexcept {
+    if (evidence.signature != current_signature
+        || !same_snapshot(evidence.source, current_source)
+        || !same_snapshot(evidence.output, current_output)
+        || !evidence.source.exists
+        || !evidence.output.exists
+        || evidence.dependencies.size() != current_dependencies.size()) {
+        return false;
+    }
+
+    for (std::size_t index = 0; index < evidence.dependencies.size(); ++index) {
+        if (!same_snapshot(evidence.dependencies[index], current_dependencies[index])
+            || !current_dependencies[index].exists) {
+            return false;
+        }
+    }
+    return true;
 }
 
 } // namespace mqb

--- a/cpp/src/core/cache/CompileCacheFile.cpp
+++ b/cpp/src/core/cache/CompileCacheFile.cpp
@@ -1,6 +1,7 @@
 #include "mqb/core/CompileCacheFile.hpp"
 
 #include <array>
+#include <bit>
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
@@ -18,6 +19,7 @@
 
 #include "mqb/core/Artifact.hpp"
 #include "mqb/core/BuildSignature.hpp"
+#include "mqb/core/FileSnapshot.hpp"
 #include "mqb/core/ToolchainIdentity.hpp"
 #include "mqb/core/TranslationUnit.hpp"
 
@@ -28,7 +30,8 @@ namespace fs = std::filesystem;
 
 constexpr std::array<std::uint8_t, 8> magic{
     'M', 'Q', 'B', 'C', 'A', 'C', 'H', 'E'};
-constexpr std::uint32_t format_version = 2;
+constexpr std::uint32_t legacy_format_version = 2;
+constexpr std::uint32_t format_version = 3;
 constexpr std::size_t max_cache_file_size = 64u * 1024u * 1024u;
 constexpr std::uint32_t max_string_size = 4u * 1024u * 1024u;
 constexpr std::uint32_t max_output_count = 100000u;
@@ -62,11 +65,22 @@ constexpr std::uint32_t max_dependency_count = 100000u;
     return fs::path{bytes}.lexically_normal();
 }
 
+[[nodiscard]] std::int64_t timestamp_to_i64(
+    const fs::file_time_type value) noexcept {
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(
+        value.time_since_epoch()).count();
+}
+
+[[nodiscard]] fs::file_time_type timestamp_from_i64(
+    const std::int64_t value) noexcept {
+    return fs::file_time_type{
+        std::chrono::duration_cast<fs::file_time_type::duration>(
+            std::chrono::nanoseconds{value})};
+}
+
 class BinaryWriter {
 public:
-    void write_u8(const std::uint8_t value) {
-        bytes_.push_back(value);
-    }
+    void write_u8(const std::uint8_t value) { bytes_.push_back(value); }
 
     void write_u32(const std::uint32_t value) {
         for (std::uint32_t shift = 0; shift < 32u; shift += 8u) {
@@ -78,6 +92,10 @@ public:
         for (std::uint32_t shift = 0; shift < 64u; shift += 8u) {
             write_u8(static_cast<std::uint8_t>((value >> shift) & 0xffu));
         }
+    }
+
+    void write_i64(const std::int64_t value) {
+        write_u64(std::bit_cast<std::uint64_t>(value));
     }
 
     void write_bytes(const std::span<const std::uint8_t> bytes) {
@@ -108,18 +126,11 @@ private:
 
 class BinaryReader {
 public:
-    BinaryReader(
-        const fs::path& file,
-        const std::span<const std::uint8_t> bytes)
+    BinaryReader(const fs::path& file, const std::span<const std::uint8_t> bytes)
         : file_(file), bytes_(bytes) {}
 
-    [[nodiscard]] std::size_t offset() const noexcept {
-        return offset_;
-    }
-
-    [[nodiscard]] bool at_end() const noexcept {
-        return offset_ == bytes_.size();
-    }
+    [[nodiscard]] std::size_t offset() const noexcept { return offset_; }
+    [[nodiscard]] bool at_end() const noexcept { return offset_ == bytes_.size(); }
 
     [[nodiscard]] std::expected<std::uint8_t, CompileCacheFileError> read_u8() {
         if (offset_ >= bytes_.size()) {
@@ -132,9 +143,7 @@ public:
         std::uint32_t value = 0;
         for (std::uint32_t shift = 0; shift < 32u; shift += 8u) {
             auto byte = read_u8();
-            if (!byte) {
-                return std::unexpected(byte.error());
-            }
+            if (!byte) return std::unexpected(byte.error());
             value |= static_cast<std::uint32_t>(*byte) << shift;
         }
         return value;
@@ -144,26 +153,27 @@ public:
         std::uint64_t value = 0;
         for (std::uint32_t shift = 0; shift < 64u; shift += 8u) {
             auto byte = read_u8();
-            if (!byte) {
-                return std::unexpected(byte.error());
-            }
+            if (!byte) return std::unexpected(byte.error());
             value |= static_cast<std::uint64_t>(*byte) << shift;
         }
         return value;
     }
 
+    [[nodiscard]] std::expected<std::int64_t, CompileCacheFileError> read_i64() {
+        auto value = read_u64();
+        if (!value) return std::unexpected(value.error());
+        return std::bit_cast<std::int64_t>(*value);
+    }
+
     [[nodiscard]] std::expected<std::string, CompileCacheFileError> read_string() {
         auto length = read_u32();
-        if (!length) {
-            return std::unexpected(length.error());
-        }
+        if (!length) return std::unexpected(length.error());
         if (*length > max_string_size) {
             return std::unexpected(corrupt("cache string length exceeds safety limit"));
         }
         if (static_cast<std::size_t>(*length) > bytes_.size() - offset_) {
             return std::unexpected(corrupt("cache string extends past end of file"));
         }
-
         const char* begin = reinterpret_cast<const char*>(bytes_.data() + offset_);
         std::string value{begin, begin + *length};
         offset_ += *length;
@@ -172,9 +182,7 @@ public:
 
     [[nodiscard]] std::expected<fs::path, CompileCacheFileError> read_path() {
         auto value = read_string();
-        if (!value) {
-            return std::unexpected(value.error());
-        }
+        if (!value) return std::unexpected(value.error());
         return path_from_utf8(*value);
     }
 
@@ -200,6 +208,46 @@ private:
     return value <= static_cast<std::uint32_t>(ArtifactKind::static_library);
 }
 
+[[nodiscard]] std::expected<void, CompileCacheFileError> write_snapshot(
+    BinaryWriter& writer,
+    const fs::path& file,
+    const FileSnapshot& snapshot,
+    const std::string_view role) {
+    if (snapshot.path.empty() || !snapshot.exists) {
+        return std::unexpected(make_error(
+            CompileCacheFileErrorCode::file_write_failed,
+            file,
+            0,
+            std::string{role} + " snapshot must be an existing non-empty path"));
+    }
+    if (!writer.write_path(snapshot.path)) {
+        return std::unexpected(make_error(
+            CompileCacheFileErrorCode::file_write_failed,
+            file,
+            0,
+            std::string{role} + " snapshot path is too long for cache format"));
+    }
+    writer.write_i64(timestamp_to_i64(snapshot.modified));
+    return {};
+}
+
+[[nodiscard]] std::expected<FileSnapshot, CompileCacheFileError> read_snapshot(
+    BinaryReader& reader,
+    const std::string_view role) {
+    auto path = reader.read_path();
+    auto modified = reader.read_i64();
+    if (!path) return std::unexpected(path.error());
+    if (!modified) return std::unexpected(modified.error());
+    if (path->empty()) {
+        return std::unexpected(reader.corrupt(std::string{role} + " snapshot path is empty"));
+    }
+    return FileSnapshot{
+        .path = std::move(*path),
+        .exists = true,
+        .modified = timestamp_from_i64(*modified),
+    };
+}
+
 [[nodiscard]] std::expected<std::vector<std::uint8_t>, CompileCacheFileError>
 serialize(const fs::path& file, const CompileCacheEntry& entry) {
     if (entry.outputs.empty()) {
@@ -209,19 +257,15 @@ serialize(const fs::path& file, const CompileCacheEntry& entry) {
             0,
             "compile cache entry must contain at least one planned output"));
     }
-    if (entry.outputs.size() > max_output_count) {
+    if (entry.outputs.size() > max_output_count
+        || entry.dependencies.size() > max_dependency_count
+        || (entry.module_scan
+            && entry.module_scan->dependencies.size() > max_dependency_count)) {
         return std::unexpected(make_error(
             CompileCacheFileErrorCode::file_write_failed,
             file,
             0,
-            "output count exceeds cache format safety limit"));
-    }
-    if (entry.dependencies.size() > max_dependency_count) {
-        return std::unexpected(make_error(
-            CompileCacheFileErrorCode::file_write_failed,
-            file,
-            0,
-            "dependency count exceeds cache format safety limit"));
+            "cache entry count exceeds format safety limit"));
     }
 
     BinaryWriter writer;
@@ -230,41 +274,26 @@ serialize(const fs::path& file, const CompileCacheEntry& entry) {
 
     if (!writer.write_path(entry.source)) {
         return std::unexpected(make_error(
-            CompileCacheFileErrorCode::file_write_failed,
-            file,
-            0,
+            CompileCacheFileErrorCode::file_write_failed, file, 0,
             "source path is too long for cache format"));
     }
     writer.write_u32(static_cast<std::uint32_t>(entry.kind));
-
     if (!writer.write_path(entry.toolchain.compiler)
         || !writer.write_string(entry.toolchain.version)
         || !writer.write_string(entry.toolchain.binary_stamp)) {
         return std::unexpected(make_error(
-            CompileCacheFileErrorCode::file_write_failed,
-            file,
-            0,
+            CompileCacheFileErrorCode::file_write_failed, file, 0,
             "toolchain identity is too large for cache format"));
     }
-
     writer.write_u64(entry.signature.digest().high);
     writer.write_u64(entry.signature.digest().low);
 
     writer.write_u32(static_cast<std::uint32_t>(entry.outputs.size()));
     for (const auto& output : entry.outputs) {
-        if (output.path.empty()) {
+        if (output.path.empty() || !writer.write_path(output.path)) {
             return std::unexpected(make_error(
-                CompileCacheFileErrorCode::file_write_failed,
-                file,
-                0,
-                "compile cache output path must not be empty"));
-        }
-        if (!writer.write_path(output.path)) {
-            return std::unexpected(make_error(
-                CompileCacheFileErrorCode::file_write_failed,
-                file,
-                0,
-                "output path is too long for cache format"));
+                CompileCacheFileErrorCode::file_write_failed, file, 0,
+                "compile cache output path is empty or too long"));
         }
         writer.write_u32(static_cast<std::uint32_t>(output.kind));
     }
@@ -273,10 +302,27 @@ serialize(const fs::path& file, const CompileCacheEntry& entry) {
     for (const auto& dependency : entry.dependencies) {
         if (!writer.write_path(dependency)) {
             return std::unexpected(make_error(
-                CompileCacheFileErrorCode::file_write_failed,
-                file,
-                0,
+                CompileCacheFileErrorCode::file_write_failed, file, 0,
                 "dependency path is too long for cache format"));
+        }
+    }
+
+    writer.write_u8(entry.module_scan ? 1u : 0u);
+    if (entry.module_scan) {
+        const auto& evidence = *entry.module_scan;
+        writer.write_u64(evidence.signature.digest().high);
+        writer.write_u64(evidence.signature.digest().low);
+        if (auto written = write_snapshot(writer, file, evidence.source, "source"); !written) {
+            return std::unexpected(written.error());
+        }
+        if (auto written = write_snapshot(writer, file, evidence.output, "scan output"); !written) {
+            return std::unexpected(written.error());
+        }
+        writer.write_u32(static_cast<std::uint32_t>(evidence.dependencies.size()));
+        for (const auto& dependency : evidence.dependencies) {
+            if (auto written = write_snapshot(writer, file, dependency, "scan dependency"); !written) {
+                return std::unexpected(written.error());
+            }
         }
     }
 
@@ -287,18 +333,13 @@ serialize(const fs::path& file, const CompileCacheEntry& entry) {
 deserialize(const fs::path& file, const std::span<const std::uint8_t> bytes) {
     if (bytes.size() < magic.size() + sizeof(std::uint32_t)) {
         return std::unexpected(make_error(
-            CompileCacheFileErrorCode::invalid_magic,
-            file,
-            0,
+            CompileCacheFileErrorCode::invalid_magic, file, 0,
             "cache file is too short"));
     }
-
     for (std::size_t index = 0; index < magic.size(); ++index) {
         if (bytes[index] != magic[index]) {
             return std::unexpected(make_error(
-                CompileCacheFileErrorCode::invalid_magic,
-                file,
-                index,
+                CompileCacheFileErrorCode::invalid_magic, file, index,
                 "cache magic does not match MQB format"));
         }
     }
@@ -306,16 +347,11 @@ deserialize(const fs::path& file, const std::span<const std::uint8_t> bytes) {
     BinaryReader reader{file, bytes};
     for (std::size_t index = 0; index < magic.size(); ++index) {
         auto ignored = reader.read_u8();
-        if (!ignored) {
-            return std::unexpected(ignored.error());
-        }
+        if (!ignored) return std::unexpected(ignored.error());
     }
-
     auto version = reader.read_u32();
-    if (!version) {
-        return std::unexpected(version.error());
-    }
-    if (*version != format_version) {
+    if (!version) return std::unexpected(version.error());
+    if (*version != legacy_format_version && *version != format_version) {
         return std::unexpected(make_error(
             CompileCacheFileErrorCode::unsupported_version,
             file,
@@ -331,7 +367,6 @@ deserialize(const fs::path& file, const std::span<const std::uint8_t> bytes) {
     auto signature_high = reader.read_u64();
     auto signature_low = reader.read_u64();
     auto output_count = reader.read_u32();
-
     if (!source) return std::unexpected(source.error());
     if (!kind_value) return std::unexpected(kind_value.error());
     if (!compiler) return std::unexpected(compiler.error());
@@ -340,12 +375,12 @@ deserialize(const fs::path& file, const std::span<const std::uint8_t> bytes) {
     if (!signature_high) return std::unexpected(signature_high.error());
     if (!signature_low) return std::unexpected(signature_low.error());
     if (!output_count) return std::unexpected(output_count.error());
-
     if (!valid_translation_unit_kind(*kind_value)) {
         return std::unexpected(reader.corrupt("invalid translation-unit kind in cache file"));
     }
     if (*output_count == 0 || *output_count > max_output_count) {
-        return std::unexpected(reader.corrupt("output count is outside the supported safety range"));
+        return std::unexpected(reader.corrupt(
+            "output count is outside the supported safety range"));
     }
 
     std::vector<Artifact> outputs;
@@ -372,15 +407,55 @@ deserialize(const fs::path& file, const std::span<const std::uint8_t> bytes) {
     if (*dependency_count > max_dependency_count) {
         return std::unexpected(reader.corrupt("dependency count exceeds safety limit"));
     }
-
     std::vector<fs::path> dependencies;
     dependencies.reserve(*dependency_count);
     for (std::uint32_t index = 0; index < *dependency_count; ++index) {
         auto dependency = reader.read_path();
-        if (!dependency) {
-            return std::unexpected(dependency.error());
-        }
+        if (!dependency) return std::unexpected(dependency.error());
         dependencies.push_back(std::move(*dependency));
+    }
+
+    std::optional<ModuleScanEvidence> module_scan;
+    if (*version == format_version) {
+        auto present = reader.read_u8();
+        if (!present) return std::unexpected(present.error());
+        if (*present > 1u) {
+            return std::unexpected(reader.corrupt("invalid module scan evidence presence marker"));
+        }
+        if (*present == 1u) {
+            auto scan_signature_high = reader.read_u64();
+            auto scan_signature_low = reader.read_u64();
+            if (!scan_signature_high) return std::unexpected(scan_signature_high.error());
+            if (!scan_signature_low) return std::unexpected(scan_signature_low.error());
+            auto scan_source = read_snapshot(reader, "source");
+            auto scan_output = read_snapshot(reader, "scan output");
+            if (!scan_source) return std::unexpected(scan_source.error());
+            if (!scan_output) return std::unexpected(scan_output.error());
+            auto scan_dependency_count = reader.read_u32();
+            if (!scan_dependency_count) {
+                return std::unexpected(scan_dependency_count.error());
+            }
+            if (*scan_dependency_count > max_dependency_count) {
+                return std::unexpected(reader.corrupt(
+                    "scan dependency count exceeds safety limit"));
+            }
+            std::vector<FileSnapshot> scan_dependencies;
+            scan_dependencies.reserve(*scan_dependency_count);
+            for (std::uint32_t index = 0; index < *scan_dependency_count; ++index) {
+                auto dependency = read_snapshot(reader, "scan dependency");
+                if (!dependency) return std::unexpected(dependency.error());
+                scan_dependencies.push_back(std::move(*dependency));
+            }
+            module_scan = ModuleScanEvidence{
+                .signature = BuildSignature::from_digest(SignatureDigest{
+                    .high = *scan_signature_high,
+                    .low = *scan_signature_low,
+                }),
+                .source = std::move(*scan_source),
+                .output = std::move(*scan_output),
+                .dependencies = std::move(scan_dependencies),
+            };
+        }
     }
 
     if (!reader.at_end()) {
@@ -401,6 +476,7 @@ deserialize(const fs::path& file, const std::span<const std::uint8_t> bytes) {
         }),
         .outputs = std::move(outputs),
         .dependencies = std::move(dependencies),
+        .module_scan = std::move(module_scan),
     };
 }
 
@@ -424,9 +500,7 @@ CompileCacheFile::load(const fs::path& file) {
             0,
             "failed to query cache file"));
     }
-    if (!exists) {
-        return std::optional<CompileCacheEntry>{};
-    }
+    if (!exists) return std::optional<CompileCacheEntry>{};
 
     const auto size = fs::file_size(file, error_code);
     if (error_code) {
@@ -452,7 +526,6 @@ CompileCacheFile::load(const fs::path& file) {
             0,
             "failed to open cache file"));
     }
-
     std::vector<std::uint8_t> bytes(static_cast<std::size_t>(size));
     if (!bytes.empty()) {
         stream.read(
@@ -468,18 +541,14 @@ CompileCacheFile::load(const fs::path& file) {
     }
 
     auto entry = deserialize(file, bytes);
-    if (!entry) {
-        return std::unexpected(entry.error());
-    }
+    if (!entry) return std::unexpected(entry.error());
     return std::optional<CompileCacheEntry>{std::move(*entry)};
 }
 
 std::expected<void, CompileCacheFileError>
 CompileCacheFile::save(const fs::path& file, const CompileCacheEntry& entry) {
     auto bytes = serialize(file, entry);
-    if (!bytes) {
-        return std::unexpected(bytes.error());
-    }
+    if (!bytes) return std::unexpected(bytes.error());
 
     std::error_code error_code;
     if (!file.parent_path().empty()) {
@@ -503,7 +572,6 @@ CompileCacheFile::save(const fs::path& file, const CompileCacheEntry& entry) {
                 0,
                 "failed to open temporary cache file for writing"));
         }
-
         if (!bytes->empty()) {
             stream.write(
                 reinterpret_cast<const char*>(bytes->data()),
@@ -550,7 +618,6 @@ CompileCacheFile::save(const fs::path& file, const CompileCacheEntry& entry) {
             0,
             "failed to install new cache entry"));
     }
-
     return {};
 }
 

--- a/cpp/src/core/cache/CompileCacheFile.cpp
+++ b/cpp/src/core/cache/CompileCacheFile.cpp
@@ -14,6 +14,7 @@
 #include <string>
 #include <string_view>
 #include <system_error>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -27,6 +28,8 @@ namespace mqb {
 namespace {
 
 namespace fs = std::filesystem;
+using FileTimeRep = fs::file_time_type::duration::rep;
+static_assert(std::is_integral_v<FileTimeRep> && sizeof(FileTimeRep) <= sizeof(std::int64_t));
 
 constexpr std::array<std::uint8_t, 8> magic{
     'M', 'Q', 'B', 'C', 'A', 'C', 'H', 'E'};
@@ -67,15 +70,13 @@ constexpr std::uint32_t max_dependency_count = 100000u;
 
 [[nodiscard]] std::int64_t timestamp_to_i64(
     const fs::file_time_type value) noexcept {
-    return std::chrono::duration_cast<std::chrono::nanoseconds>(
-        value.time_since_epoch()).count();
+    return static_cast<std::int64_t>(value.time_since_epoch().count());
 }
 
 [[nodiscard]] fs::file_time_type timestamp_from_i64(
     const std::int64_t value) noexcept {
     return fs::file_time_type{
-        std::chrono::duration_cast<fs::file_time_type::duration>(
-            std::chrono::nanoseconds{value})};
+        fs::file_time_type::duration{static_cast<FileTimeRep>(value)}};
 }
 
 class BinaryWriter {
@@ -325,7 +326,6 @@ serialize(const fs::path& file, const CompileCacheEntry& entry) {
             }
         }
     }
-
     return writer.bytes();
 }
 
@@ -432,12 +432,9 @@ deserialize(const fs::path& file, const std::span<const std::uint8_t> bytes) {
             if (!scan_source) return std::unexpected(scan_source.error());
             if (!scan_output) return std::unexpected(scan_output.error());
             auto scan_dependency_count = reader.read_u32();
-            if (!scan_dependency_count) {
-                return std::unexpected(scan_dependency_count.error());
-            }
+            if (!scan_dependency_count) return std::unexpected(scan_dependency_count.error());
             if (*scan_dependency_count > max_dependency_count) {
-                return std::unexpected(reader.corrupt(
-                    "scan dependency count exceeds safety limit"));
+                return std::unexpected(reader.corrupt("scan dependency count exceeds safety limit"));
             }
             std::vector<FileSnapshot> scan_dependencies;
             scan_dependencies.reserve(*scan_dependency_count);

--- a/cpp/src/core/model/BuildSignature.cpp
+++ b/cpp/src/core/model/BuildSignature.cpp
@@ -192,6 +192,29 @@ BuildSignature BuildSignature::for_compile(
     return BuildSignature{hasher.finish()};
 }
 
+BuildSignature BuildSignature::for_module_scan(
+    const std::filesystem::path& source,
+    const TranslationUnitKind kind,
+    const ToolchainIdentity& toolchain,
+    const CompilerOptions& options) {
+    StableHasher hasher;
+    hasher.add_string("mqb.module-scan.signature.v1");
+    hasher.add_path(source);
+    hasher.add_enum(kind);
+    hasher.add_path(toolchain.compiler);
+    hasher.add_string(toolchain.version);
+    hasher.add_string(toolchain.binary_stamp);
+
+    // Keep this recipe aligned with MsvcModuleDependencyScanner::build_arguments:
+    // only policy that can change P1689 topology belongs in the scan identity.
+    hasher.add_enum(options.configuration);
+    hasher.add_enum(options.standard);
+    hasher.add_strings(options.defines);
+    hasher.add_paths(options.include_directories);
+    hasher.add_strings(options.additional_arguments);
+    return BuildSignature{hasher.finish()};
+}
+
 BuildSignature BuildSignature::for_link(
     const std::span<const std::filesystem::path> objects,
     const std::filesystem::path& output,

--- a/cpp/src/core/model/BuildSignature.cpp
+++ b/cpp/src/core/model/BuildSignature.cpp
@@ -32,44 +32,31 @@ class StableHasher {
 public:
     void add_string(const std::string_view value) noexcept {
         add_u64(static_cast<std::uint64_t>(value.size()));
-        for (const unsigned char byte : value) {
-            add_byte(byte);
-        }
+        for (const unsigned char byte : value) add_byte(byte);
     }
 
     void add_path(const std::filesystem::path& value) noexcept {
         const auto normalized = value.lexically_normal().generic_u8string();
         add_u64(static_cast<std::uint64_t>(normalized.size()));
-        for (const char8_t byte : normalized) {
-            add_byte(static_cast<std::uint8_t>(byte));
-        }
+        for (const char8_t byte : normalized) add_byte(static_cast<std::uint8_t>(byte));
     }
 
     template <typename Enum>
         requires std::is_enum_v<Enum>
-    void add_enum(const Enum value) noexcept {
-        add_u64(static_cast<std::uint64_t>(value));
-    }
+    void add_enum(const Enum value) noexcept { add_u64(static_cast<std::uint64_t>(value)); }
 
     void add_strings(const std::vector<std::string>& values) noexcept {
         add_u64(static_cast<std::uint64_t>(values.size()));
-        for (const auto& value : values) {
-            add_string(value);
-        }
+        for (const auto& value : values) add_string(value);
     }
 
     void add_paths(const std::span<const std::filesystem::path> values) noexcept {
         add_u64(static_cast<std::uint64_t>(values.size()));
-        for (const auto& value : values) {
-            add_path(value);
-        }
+        for (const auto& value : values) add_path(value);
     }
 
-    void add_header_unit_identity(
-        const std::optional<HeaderUnitIdentity>& identity) noexcept {
-        if (!identity) {
-            return;
-        }
+    void add_header_unit_identity(const std::optional<HeaderUnitIdentity>& identity) noexcept {
+        if (!identity) return;
         add_string("mqb.header-unit.producer.v1");
         add_string(identity->header_name);
         add_enum(identity->lookup_method);
@@ -83,8 +70,7 @@ public:
         }
     }
 
-    void add_header_unit_references(
-        const std::vector<HeaderUnitReference>& references) noexcept {
+    void add_header_unit_references(const std::vector<HeaderUnitReference>& references) noexcept {
         add_u64(static_cast<std::uint64_t>(references.size()));
         for (const auto& reference : references) {
             add_string(reference.header_name);
@@ -96,23 +82,16 @@ public:
     void add_module_outputs(const std::vector<Artifact>& outputs) noexcept {
         std::uint64_t count = 0;
         for (const auto& output : outputs) {
-            if (output.kind == ArtifactKind::module_interface) {
-                ++count;
-            }
+            if (output.kind == ArtifactKind::module_interface) ++count;
         }
         add_u64(count);
         for (const auto& output : outputs) {
-            if (output.kind == ArtifactKind::module_interface) {
-                add_path(output.path);
-            }
+            if (output.kind == ArtifactKind::module_interface) add_path(output.path);
         }
     }
 
     [[nodiscard]] SignatureDigest finish() const noexcept {
-        return SignatureDigest{
-            .high = avalanche(primary_),
-            .low = avalanche(secondary_),
-        };
+        return SignatureDigest{.high = avalanche(primary_), .low = avalanche(secondary_)};
     }
 
 private:
@@ -125,7 +104,6 @@ private:
     void add_byte(const std::uint8_t byte) noexcept {
         primary_ ^= byte;
         primary_ *= fnv_prime;
-
         secondary_ ^= static_cast<std::uint64_t>(byte) + secondary_seed
             + (secondary_ << 6u) + (secondary_ >> 2u);
         secondary_ = std::rotl(secondary_, 13);
@@ -141,8 +119,7 @@ private:
 std::string SignatureDigest::hex() const {
     std::ostringstream stream;
     stream << std::hex << std::setfill('0')
-           << std::setw(16) << high
-           << std::setw(16) << low;
+           << std::setw(16) << high << std::setw(16) << low;
     return stream.str();
 }
 
@@ -152,25 +129,19 @@ BuildSignature BuildSignature::for_compile(
     const CompilerOptions& options) {
     StableHasher hasher;
     hasher.add_string("mqb.compile.signature.v4");
-
     hasher.add_path(unit.source);
     hasher.add_enum(unit.kind);
     hasher.add_module_references(unit.module_references);
     hasher.add_header_unit_references(unit.header_unit_references);
     hasher.add_module_outputs(unit.outputs);
     hasher.add_header_unit_identity(unit.header_unit);
-
     hasher.add_path(toolchain.compiler);
     hasher.add_string(toolchain.version);
     hasher.add_string(toolchain.binary_stamp);
-
     hasher.add_enum(options.configuration);
     hasher.add_enum(options.architecture);
-    if (is_c_translation_unit_path(unit.source)) {
-        hasher.add_string("mqb.c.language.v1");
-    } else {
-        hasher.add_enum(options.standard);
-    }
+    if (is_c_translation_unit_path(unit.source)) hasher.add_string("mqb.c.language.v1");
+    else hasher.add_enum(options.standard);
     hasher.add_strings(options.defines);
     hasher.add_paths(options.include_directories);
     hasher.add_strings(options.additional_arguments);
@@ -178,17 +149,13 @@ BuildSignature BuildSignature::for_compile(
         hasher.add_string("mqb.runtime-library.v1");
         hasher.add_enum(*options.runtime_library);
     }
-    if (options.link_time_code_generation) {
-        // Preserve the historical signature byte stream when typed LTCG is off.
-        hasher.add_string("mqb.ltcg.compile.v1");
-    }
+    if (options.link_time_code_generation) hasher.add_string("mqb.ltcg.compile.v1");
     if (options.precompiled_header) {
         hasher.add_string("mqb.precompiled-header.compile.v1");
         hasher.add_path(options.precompiled_header->header);
         hasher.add_path(options.precompiled_header->artifact);
         hasher.add_enum(options.precompiled_header->role);
     }
-
     return BuildSignature{hasher.finish()};
 }
 
@@ -204,10 +171,8 @@ BuildSignature BuildSignature::for_module_scan(
     hasher.add_path(toolchain.compiler);
     hasher.add_string(toolchain.version);
     hasher.add_string(toolchain.binary_stamp);
-
-    // Keep this recipe aligned with MsvcModuleDependencyScanner::build_arguments:
-    // only policy that can change P1689 topology belongs in the scan identity.
     hasher.add_enum(options.configuration);
+    hasher.add_enum(options.architecture);
     hasher.add_enum(options.standard);
     hasher.add_strings(options.defines);
     hasher.add_paths(options.include_directories);
@@ -220,12 +185,7 @@ BuildSignature BuildSignature::for_link(
     const std::filesystem::path& output,
     const LinkerIdentity& linker,
     const LinkOptions& options) {
-    return for_link(
-        objects,
-        std::span<const std::filesystem::path>{},
-        output,
-        linker,
-        options);
+    return for_link(objects, std::span<const std::filesystem::path>{}, output, linker, options);
 }
 
 BuildSignature BuildSignature::for_link(
@@ -249,15 +209,10 @@ BuildSignature BuildSignature::for_link(
     hasher.add_strings(options.libraries);
     hasher.add_strings(options.additional_arguments);
     if (options.target_kind != TargetKind::executable) {
-        // Preserve the exact historical v2 byte stream for executable links.
-        // New executable-style targets append a versioned kind domain only.
         hasher.add_string("mqb.link.target-kind.v1");
         hasher.add_enum(options.target_kind);
     }
-    if (options.link_time_code_generation) {
-        // Preserve historical executable/DLL link identities when LTCG is off.
-        hasher.add_string("mqb.ltcg.link.v1");
-    }
+    if (options.link_time_code_generation) hasher.add_string("mqb.ltcg.link.v1");
     return BuildSignature{hasher.finish()};
 }
 
@@ -273,10 +228,7 @@ BuildSignature BuildSignature::for_archive(
     hasher.add_path(librarian.librarian);
     hasher.add_string(librarian.version);
     hasher.add_string(librarian.binary_stamp);
-    if (link_time_code_generation) {
-        // Preserve historical archive identities when LTCG is off.
-        hasher.add_string("mqb.ltcg.archive.v1");
-    }
+    if (link_time_code_generation) hasher.add_string("mqb.ltcg.archive.v1");
     return BuildSignature{hasher.finish()};
 }
 

--- a/cpp/src/core/model/BuildSignature.cpp
+++ b/cpp/src/core/model/BuildSignature.cpp
@@ -32,31 +32,44 @@ class StableHasher {
 public:
     void add_string(const std::string_view value) noexcept {
         add_u64(static_cast<std::uint64_t>(value.size()));
-        for (const unsigned char byte : value) add_byte(byte);
+        for (const unsigned char byte : value) {
+            add_byte(byte);
+        }
     }
 
     void add_path(const std::filesystem::path& value) noexcept {
         const auto normalized = value.lexically_normal().generic_u8string();
         add_u64(static_cast<std::uint64_t>(normalized.size()));
-        for (const char8_t byte : normalized) add_byte(static_cast<std::uint8_t>(byte));
+        for (const char8_t byte : normalized) {
+            add_byte(static_cast<std::uint8_t>(byte));
+        }
     }
 
     template <typename Enum>
         requires std::is_enum_v<Enum>
-    void add_enum(const Enum value) noexcept { add_u64(static_cast<std::uint64_t>(value)); }
+    void add_enum(const Enum value) noexcept {
+        add_u64(static_cast<std::uint64_t>(value));
+    }
 
     void add_strings(const std::vector<std::string>& values) noexcept {
         add_u64(static_cast<std::uint64_t>(values.size()));
-        for (const auto& value : values) add_string(value);
+        for (const auto& value : values) {
+            add_string(value);
+        }
     }
 
     void add_paths(const std::span<const std::filesystem::path> values) noexcept {
         add_u64(static_cast<std::uint64_t>(values.size()));
-        for (const auto& value : values) add_path(value);
+        for (const auto& value : values) {
+            add_path(value);
+        }
     }
 
-    void add_header_unit_identity(const std::optional<HeaderUnitIdentity>& identity) noexcept {
-        if (!identity) return;
+    void add_header_unit_identity(
+        const std::optional<HeaderUnitIdentity>& identity) noexcept {
+        if (!identity) {
+            return;
+        }
         add_string("mqb.header-unit.producer.v1");
         add_string(identity->header_name);
         add_enum(identity->lookup_method);
@@ -70,7 +83,8 @@ public:
         }
     }
 
-    void add_header_unit_references(const std::vector<HeaderUnitReference>& references) noexcept {
+    void add_header_unit_references(
+        const std::vector<HeaderUnitReference>& references) noexcept {
         add_u64(static_cast<std::uint64_t>(references.size()));
         for (const auto& reference : references) {
             add_string(reference.header_name);
@@ -82,16 +96,23 @@ public:
     void add_module_outputs(const std::vector<Artifact>& outputs) noexcept {
         std::uint64_t count = 0;
         for (const auto& output : outputs) {
-            if (output.kind == ArtifactKind::module_interface) ++count;
+            if (output.kind == ArtifactKind::module_interface) {
+                ++count;
+            }
         }
         add_u64(count);
         for (const auto& output : outputs) {
-            if (output.kind == ArtifactKind::module_interface) add_path(output.path);
+            if (output.kind == ArtifactKind::module_interface) {
+                add_path(output.path);
+            }
         }
     }
 
     [[nodiscard]] SignatureDigest finish() const noexcept {
-        return SignatureDigest{.high = avalanche(primary_), .low = avalanche(secondary_)};
+        return SignatureDigest{
+            .high = avalanche(primary_),
+            .low = avalanche(secondary_),
+        };
     }
 
 private:
@@ -104,6 +125,7 @@ private:
     void add_byte(const std::uint8_t byte) noexcept {
         primary_ ^= byte;
         primary_ *= fnv_prime;
+
         secondary_ ^= static_cast<std::uint64_t>(byte) + secondary_seed
             + (secondary_ << 6u) + (secondary_ >> 2u);
         secondary_ = std::rotl(secondary_, 13);
@@ -119,7 +141,8 @@ private:
 std::string SignatureDigest::hex() const {
     std::ostringstream stream;
     stream << std::hex << std::setfill('0')
-           << std::setw(16) << high << std::setw(16) << low;
+           << std::setw(16) << high
+           << std::setw(16) << low;
     return stream.str();
 }
 
@@ -129,19 +152,25 @@ BuildSignature BuildSignature::for_compile(
     const CompilerOptions& options) {
     StableHasher hasher;
     hasher.add_string("mqb.compile.signature.v4");
+
     hasher.add_path(unit.source);
     hasher.add_enum(unit.kind);
     hasher.add_module_references(unit.module_references);
     hasher.add_header_unit_references(unit.header_unit_references);
     hasher.add_module_outputs(unit.outputs);
     hasher.add_header_unit_identity(unit.header_unit);
+
     hasher.add_path(toolchain.compiler);
     hasher.add_string(toolchain.version);
     hasher.add_string(toolchain.binary_stamp);
+
     hasher.add_enum(options.configuration);
     hasher.add_enum(options.architecture);
-    if (is_c_translation_unit_path(unit.source)) hasher.add_string("mqb.c.language.v1");
-    else hasher.add_enum(options.standard);
+    if (is_c_translation_unit_path(unit.source)) {
+        hasher.add_string("mqb.c.language.v1");
+    } else {
+        hasher.add_enum(options.standard);
+    }
     hasher.add_strings(options.defines);
     hasher.add_paths(options.include_directories);
     hasher.add_strings(options.additional_arguments);
@@ -149,13 +178,17 @@ BuildSignature BuildSignature::for_compile(
         hasher.add_string("mqb.runtime-library.v1");
         hasher.add_enum(*options.runtime_library);
     }
-    if (options.link_time_code_generation) hasher.add_string("mqb.ltcg.compile.v1");
+    if (options.link_time_code_generation) {
+        // Preserve the historical signature byte stream when typed LTCG is off.
+        hasher.add_string("mqb.ltcg.compile.v1");
+    }
     if (options.precompiled_header) {
         hasher.add_string("mqb.precompiled-header.compile.v1");
         hasher.add_path(options.precompiled_header->header);
         hasher.add_path(options.precompiled_header->artifact);
         hasher.add_enum(options.precompiled_header->role);
     }
+
     return BuildSignature{hasher.finish()};
 }
 
@@ -166,17 +199,24 @@ BuildSignature BuildSignature::for_module_scan(
     const CompilerOptions& options) {
     StableHasher hasher;
     hasher.add_string("mqb.module-scan.signature.v1");
+
     hasher.add_path(source);
     hasher.add_enum(kind);
+
     hasher.add_path(toolchain.compiler);
     hasher.add_string(toolchain.version);
     hasher.add_string(toolchain.binary_stamp);
+
+    // Keep this identity aligned with policy that can affect the P1689 topology
+    // scan. Runtime library, LTCG, PCH bindings, and graph-selected IFC
+    // references are compile/link policy and intentionally do not invalidate it.
     hasher.add_enum(options.configuration);
     hasher.add_enum(options.architecture);
     hasher.add_enum(options.standard);
     hasher.add_strings(options.defines);
     hasher.add_paths(options.include_directories);
     hasher.add_strings(options.additional_arguments);
+
     return BuildSignature{hasher.finish()};
 }
 
@@ -185,7 +225,12 @@ BuildSignature BuildSignature::for_link(
     const std::filesystem::path& output,
     const LinkerIdentity& linker,
     const LinkOptions& options) {
-    return for_link(objects, std::span<const std::filesystem::path>{}, output, linker, options);
+    return for_link(
+        objects,
+        std::span<const std::filesystem::path>{},
+        output,
+        linker,
+        options);
 }
 
 BuildSignature BuildSignature::for_link(
@@ -209,10 +254,15 @@ BuildSignature BuildSignature::for_link(
     hasher.add_strings(options.libraries);
     hasher.add_strings(options.additional_arguments);
     if (options.target_kind != TargetKind::executable) {
+        // Preserve the exact historical v2 byte stream for executable links.
+        // New executable-style targets append a versioned kind domain only.
         hasher.add_string("mqb.link.target-kind.v1");
         hasher.add_enum(options.target_kind);
     }
-    if (options.link_time_code_generation) hasher.add_string("mqb.ltcg.link.v1");
+    if (options.link_time_code_generation) {
+        // Preserve historical executable/DLL link identities when LTCG is off.
+        hasher.add_string("mqb.ltcg.link.v1");
+    }
     return BuildSignature{hasher.finish()};
 }
 
@@ -228,7 +278,10 @@ BuildSignature BuildSignature::for_archive(
     hasher.add_path(librarian.librarian);
     hasher.add_string(librarian.version);
     hasher.add_string(librarian.binary_stamp);
-    if (link_time_code_generation) hasher.add_string("mqb.ltcg.archive.v1");
+    if (link_time_code_generation) {
+        // Preserve historical archive identities when LTCG is off.
+        hasher.add_string("mqb.ltcg.archive.v1");
+    }
     return BuildSignature{hasher.finish()};
 }
 

--- a/cpp/src/orchestration/incremental/MsvcIncrementalCompileCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalCompileCoordinator.cpp
@@ -13,6 +13,7 @@
 #include "mqb/core/CompileCache.hpp"
 #include "mqb/core/CompileCacheFile.hpp"
 #include "mqb/msvc/MsvcCompileExecutor.hpp"
+#include "mqb/msvc/MsvcSourceDependenciesReader.hpp"
 
 #include "IncrementalFileSnapshot.hpp"
 
@@ -49,6 +50,68 @@ void add_reason_once(
     if (std::find(reasons.begin(), reasons.end(), reason) == reasons.end()) {
         reasons.push_back(reason);
     }
+}
+
+void seal_module_scan_evidence(
+    CompileCacheEntry& cache_entry,
+    const IncrementalCompileRequest& request,
+    const ToolchainIdentity& toolchain,
+    std::vector<IncrementalCompileWarning>& warnings) {
+    if (!request.module_scan_output) {
+        return;
+    }
+
+    // Re-read the compiler's successful /sourceDependencies output instead of
+    // using cache_entry.dependencies: the latter also contains generated IFC
+    // and PCH inputs which can legitimately be newer than the P1689 scan.
+    const auto dependencies = msvc::MsvcSourceDependenciesReader::read(
+        request.source_dependencies_file);
+    if (!dependencies) {
+        return;
+    }
+
+    auto source = detail::snapshot_regular_file(request.unit.source);
+    append_snapshot_warning(warnings, request.unit.source, std::move(source.failure));
+    auto output = detail::snapshot_regular_file(*request.module_scan_output);
+    append_snapshot_warning(warnings, *request.module_scan_output, std::move(output.failure));
+    if (!source.snapshot.exists || !output.snapshot.exists) {
+        return;
+    }
+
+    std::vector<FileSnapshot> include_snapshots;
+    include_snapshots.reserve(dependencies->includes.size());
+    for (const auto& dependency : dependencies->includes) {
+        auto snapshot = detail::snapshot_regular_file(dependency);
+        append_snapshot_warning(warnings, dependency, std::move(snapshot.failure));
+        if (!snapshot.snapshot.exists) {
+            return;
+        }
+        include_snapshots.push_back(std::move(snapshot.snapshot));
+    }
+
+    // A source/header mutation after /scanDependencies but before the compile
+    // completed means the topology artifact is not a trustworthy description
+    // of the successful compile. In that case keep the normal compile cache but
+    // deliberately omit scan evidence so the next build rescans.
+    if (source.snapshot.modified > output.snapshot.modified) {
+        return;
+    }
+    for (const auto& dependency : include_snapshots) {
+        if (dependency.modified > output.snapshot.modified) {
+            return;
+        }
+    }
+
+    cache_entry.module_scan = ModuleScanEvidence{
+        .signature = BuildSignature::for_module_scan(
+            request.unit.source,
+            request.unit.kind,
+            toolchain,
+            request.options),
+        .source = std::move(source.snapshot),
+        .output = std::move(output.snapshot),
+        .dependencies = std::move(include_snapshots),
+    };
 }
 
 } // namespace
@@ -157,6 +220,12 @@ MsvcIncrementalCompileCoordinator::run(const IncrementalCompileRequest& request)
 
     result.compiled = true;
     result.process = std::move(executed->process);
+
+    seal_module_scan_evidence(
+        executed->cache_entry,
+        request,
+        toolchain_.identity,
+        result.warnings);
 
     auto saved_cache = CompileCacheFile::save(
         request.cache_file,

--- a/cpp/src/orchestration/modules/ModuleCompileRequestFactory.cpp
+++ b/cpp/src/orchestration/modules/ModuleCompileRequestFactory.cpp
@@ -37,6 +37,7 @@ IncrementalCompileRequest make_module_compile_request(
         .options = options,
         .cache_file = source.artifacts.compile_cache,
         .source_dependencies_file = source.artifacts.dependencies,
+        .module_scan_output = source.artifacts.module_dependencies,
         .working_directory = working_directory.empty()
             ? std::optional<fs::path>{source.source.parent_path()}
             : std::optional<fs::path>{working_directory},

--- a/cpp/src/orchestration/modules/ModuleTargetScanner.cpp
+++ b/cpp/src/orchestration/modules/ModuleTargetScanner.cpp
@@ -2,11 +2,18 @@
 
 #include <expected>
 #include <filesystem>
+#include <fstream>
+#include <iterator>
 #include <optional>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "mqb/core/BuildSignature.hpp"
+#include "mqb/core/CompileCache.hpp"
+#include "mqb/core/CompileCacheFile.hpp"
+#include "mqb/core/FileSnapshot.hpp"
+#include "mqb/modules/P1689.hpp"
 #include "mqb/orchestration/BoundedWorkScheduler.hpp"
 
 namespace mqb::orchestration::detail {
@@ -33,7 +40,100 @@ namespace fs = std::filesystem;
     return std::nullopt;
 }
 
+[[nodiscard]] std::optional<FileSnapshot> snapshot_regular_file(const fs::path& path) {
+    if (path.empty()) return std::nullopt;
+    std::error_code error_code;
+    const auto status = fs::status(path, error_code);
+    if (error_code || !fs::is_regular_file(status)) return std::nullopt;
+    const auto modified = fs::last_write_time(path, error_code);
+    if (error_code) return std::nullopt;
+    return FileSnapshot{
+        .path = path,
+        .exists = true,
+        .modified = modified,
+    };
+}
+
+[[nodiscard]] std::optional<std::string> read_text_file(const fs::path& path) {
+    std::ifstream stream{path, std::ios::binary};
+    if (!stream) return std::nullopt;
+    std::string text{
+        std::istreambuf_iterator<char>{stream},
+        std::istreambuf_iterator<char>{}};
+    if (stream.bad()) return std::nullopt;
+    return text;
+}
+
+[[nodiscard]] std::optional<msvc::ModuleScanResult> try_reuse_scan(
+    const ModuleCompileSourceRequest& source,
+    const CompilerOptions& options,
+    msvc::MsvcModuleDependencyScanner& scanner) {
+    auto loaded = CompileCacheFile::load(source.artifacts.compile_cache);
+    if (!loaded || !*loaded || !(**loaded).module_scan) {
+        return std::nullopt;
+    }
+    const auto& evidence = *(**loaded).module_scan;
+
+    const BuildSignature signature = BuildSignature::for_module_scan(
+        source.source,
+        source.kind,
+        scanner.toolchain().identity,
+        options);
+    auto source_snapshot = snapshot_regular_file(source.source);
+    auto output_snapshot = snapshot_regular_file(source.artifacts.module_dependencies);
+    if (!source_snapshot || !output_snapshot) {
+        return std::nullopt;
+    }
+
+    std::vector<FileSnapshot> dependency_snapshots;
+    dependency_snapshots.reserve(evidence.dependencies.size());
+    for (const auto& dependency : evidence.dependencies) {
+        auto snapshot = snapshot_regular_file(dependency.path);
+        if (!snapshot) return std::nullopt;
+        dependency_snapshots.push_back(std::move(*snapshot));
+    }
+
+    if (!ModuleScanEvidenceValidator::reusable(
+            evidence,
+            signature,
+            *source_snapshot,
+            *output_snapshot,
+            dependency_snapshots)) {
+        return std::nullopt;
+    }
+
+    auto text = read_text_file(source.artifacts.module_dependencies);
+    if (!text) return std::nullopt;
+    auto dependencies = modules::P1689Parser::parse(*text);
+    if (!dependencies) return std::nullopt;
+
+    return msvc::ModuleScanResult{
+        .process = process::ProcessResult{},
+        .dependencies = std::move(*dependencies),
+        .reused = true,
+    };
+}
+
 } // namespace
+
+std::expected<msvc::ModuleScanResult, msvc::ModuleScanError>
+scan_module_source(
+    const ModuleCompileSourceRequest& source,
+    const CompilerOptions& options,
+    const fs::path& working_directory,
+    msvc::MsvcModuleDependencyScanner& scanner) {
+    if (auto reused = try_reuse_scan(source, options, scanner)) {
+        return std::move(*reused);
+    }
+
+    return scanner.scan(msvc::ModuleScanInvocation{
+        .source = source.source,
+        .output_file = source.artifacts.module_dependencies,
+        .options = options,
+        .kind = source.kind,
+        .working_directory = working_directory_for(working_directory, source.source),
+    });
+}
 
 std::expected<ModuleTargetScanBatch, IncrementalModuleTargetError>
 scan_requested_module_sources(
@@ -45,17 +145,11 @@ scan_requested_module_sources(
     const auto scheduled = BoundedWorkScheduler::run(
         request.sources.size(), request.max_parallel_scans,
         [&](const std::size_t index) {
-            const auto& source = request.sources[index];
-            msvc::ModuleScanInvocation invocation{
-                .source = source.source,
-                .output_file = source.artifacts.module_dependencies,
-                .options = request.compiler_options,
-                .kind = source.kind,
-                .working_directory = working_directory_for(
-                    request.working_directory,
-                    source.source),
-            };
-            attempts[index].emplace(scanner.scan(invocation));
+            attempts[index].emplace(scan_module_source(
+                request.sources[index],
+                request.compiler_options,
+                request.working_directory,
+                scanner));
             return attempts[index]->has_value();
         });
     if (!scheduled) {

--- a/cpp/src/orchestration/modules/ModuleTargetScanner.hpp
+++ b/cpp/src/orchestration/modules/ModuleTargetScanner.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <expected>
+#include <filesystem>
 #include <vector>
 
 #include "mqb/orchestration/MsvcModuleTargetCoordinator.hpp"
@@ -11,6 +12,13 @@ struct ModuleTargetScanBatch {
     std::vector<ModuleTargetScanResult> scans;
     std::vector<modules::ScannedModuleUnit> units;
 };
+
+[[nodiscard]] std::expected<msvc::ModuleScanResult, msvc::ModuleScanError>
+scan_module_source(
+    const ModuleCompileSourceRequest& source,
+    const CompilerOptions& options,
+    const std::filesystem::path& working_directory,
+    msvc::MsvcModuleDependencyScanner& scanner);
 
 [[nodiscard]] std::expected<ModuleTargetScanBatch, IncrementalModuleTargetError>
 scan_requested_module_sources(

--- a/cpp/src/orchestration/modules/StandardLibraryModuleProvider.cpp
+++ b/cpp/src/orchestration/modules/StandardLibraryModuleProvider.cpp
@@ -10,6 +10,8 @@
 #include <utility>
 #include <vector>
 
+#include "ModuleTargetScanner.hpp"
+
 namespace mqb::orchestration::detail {
 namespace {
 
@@ -24,14 +26,6 @@ namespace fs = std::filesystem;
         .message = std::move(message),
         .source = std::move(source),
     };
-}
-
-[[nodiscard]] std::optional<fs::path> working_directory_for(
-    const fs::path& requested,
-    const fs::path& source) {
-    if (!requested.empty()) return requested;
-    if (!source.parent_path().empty()) return source.parent_path();
-    return std::nullopt;
 }
 
 [[nodiscard]] bool standard_library_module_name(
@@ -105,10 +99,6 @@ inject_standard_library_module_providers(
     ModuleTargetArtifactRegistry& artifacts,
     std::vector<modules::ScannedModuleUnit>& scanned_units,
     std::vector<ModuleCompileSourceRequest>& compile_sources) {
-    // P1689 from the user's selected TUs is the only trigger for standard-library
-    // provider injection. Newly scanned toolchain providers may in turn require
-    // another toolchain-owned standard module (std.compat -> std), so repeat to
-    // a fixed point before handing the complete topology to the graph owner.
     std::unordered_set<std::string> injected_standard_modules;
     while (auto pending = next_standard_library_requirement(
                scanned_units,
@@ -160,16 +150,16 @@ inject_standard_library_module_providers(
             return std::unexpected(std::move(registered.error()));
         }
 
-        msvc::ModuleScanInvocation invocation{
+        ModuleCompileSourceRequest provider{
             .source = *source,
-            .output_file = source_artifacts->module_dependencies,
-            .options = request.compiler_options,
+            .artifacts = *source_artifacts,
             .kind = TranslationUnitKind::module_interface,
-            .working_directory = working_directory_for(
-                request.working_directory,
-                *source),
         };
-        auto scan = scanner.scan(invocation);
+        auto scan = scan_module_source(
+            provider,
+            request.compiler_options,
+            request.working_directory,
+            scanner);
         if (!scan) {
             IncrementalModuleTargetError error = failure(
                 IncrementalModuleTargetErrorCode::scan_failed,
@@ -194,11 +184,7 @@ inject_standard_library_module_providers(
             .rule = scan->dependencies.rules.front(),
             .toolchain_owned = true,
         });
-        compile_sources.push_back(ModuleCompileSourceRequest{
-            .source = *source,
-            .artifacts = std::move(*source_artifacts),
-            .kind = TranslationUnitKind::module_interface,
-        });
+        compile_sources.push_back(std::move(provider));
         injected_standard_modules.emplace(std::move(pending->logical_name));
     }
 

--- a/cpp/src/orchestration/scheduling/BoundedWorkScheduler.cpp
+++ b/cpp/src/orchestration/scheduling/BoundedWorkScheduler.cpp
@@ -81,30 +81,39 @@ BoundedWorkScheduler::run(
         stop_requested.store(true, std::memory_order_release);
     };
 
-    std::vector<std::thread> workers;
-    workers.reserve(worker_count);
-    for (std::size_t worker_index = 0; worker_index < worker_count; ++worker_index) {
-        workers.emplace_back([&] {
-            while (!stop_requested.load(std::memory_order_acquire)) {
-                const std::size_t index = next_index.fetch_add(1, std::memory_order_relaxed);
-                if (index >= item_count) {
-                    return;
-                }
+    const auto worker_loop = [&] {
+        while (!stop_requested.load(std::memory_order_acquire)) {
+            const std::size_t index = next_index.fetch_add(1, std::memory_order_relaxed);
+            if (index >= item_count) {
+                return;
+            }
 
-                started_count.fetch_add(1, std::memory_order_relaxed);
-                try {
-                    if (!work(index)) {
-                        request_stop();
-                    }
-                } catch (...) {
-                    callback_threw.store(true, std::memory_order_release);
+            started_count.fetch_add(1, std::memory_order_relaxed);
+            try {
+                if (!work(index)) {
                     request_stop();
                 }
+            } catch (...) {
+                callback_threw.store(true, std::memory_order_release);
+                request_stop();
             }
-        });
+        }
+    };
+
+    // The caller is already an available execution context. Count it as one of
+    // the logical workers instead of creating worker_count background threads
+    // and immediately parking the caller in join(). This preserves the exact
+    // concurrency ceiling while removing one thread creation/destruction from
+    // every parallel dispatch (including every named-module dependency level).
+    std::vector<std::thread> background_workers;
+    background_workers.reserve(worker_count - 1);
+    for (std::size_t worker_index = 1; worker_index < worker_count; ++worker_index) {
+        background_workers.emplace_back(worker_loop);
     }
 
-    for (auto& worker : workers) {
+    worker_loop();
+
+    for (auto& worker : background_workers) {
         worker.join();
     }
 

--- a/cpp/tests/core/cache/compile_cache_file_tests.cpp
+++ b/cpp/tests/core/cache/compile_cache_file_tests.cpp
@@ -1,9 +1,9 @@
-#include <array>
 #include <chrono>
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <iterator>
 #include <string_view>
 #include <vector>
 
@@ -34,14 +34,11 @@ public:
         path_ = fs::temp_directory_path() / ("mqb-cache-file-test-" + std::to_string(tick));
         fs::create_directories(path_);
     }
-
     ~TemporaryDirectory() {
         std::error_code ignored;
         fs::remove_all(path_, ignored);
     }
-
     [[nodiscard]] const fs::path& path() const noexcept { return path_; }
-
 private:
     fs::path path_;
 };
@@ -64,14 +61,21 @@ mqb::CompilerOptions make_options() {
     return options;
 }
 
+mqb::FileSnapshot snapshot(const fs::path& path, const std::int64_t ticks) {
+    return mqb::FileSnapshot{
+        .path = path,
+        .exists = true,
+        .modified = fs::file_time_type{
+            std::chrono::duration_cast<fs::file_time_type::duration>(
+                std::chrono::nanoseconds{ticks})},
+    };
+}
+
 mqb::CompileCacheEntry make_entry(const std::string_view version = "19.50.10000") {
     mqb::TranslationUnit unit;
     unit.source = "src/main file.cpp";
     unit.kind = mqb::TranslationUnitKind::source;
-    unit.outputs = {
-        mqb::Artifact{"cache/main file.obj", mqb::ArtifactKind::object},
-    };
-
+    unit.outputs = {mqb::Artifact{"cache/main file.obj", mqb::ArtifactKind::object}};
     const auto toolchain = make_toolchain(version);
     const auto options = make_options();
     return mqb::CompileCacheEntry{
@@ -93,19 +97,15 @@ mqb::CompileCacheEntry make_module_entry(const bool ifc_only) {
     unit.source = ifc_only ? fs::path{"include/value.hpp"} : fs::path{"src/math.ixx"};
     unit.kind = mqb::TranslationUnitKind::module_interface;
     if (!ifc_only) {
-        unit.outputs.push_back(mqb::Artifact{
-            .path = "cache/math.obj",
-            .kind = mqb::ArtifactKind::object,
-        });
+        unit.outputs.push_back(mqb::Artifact{.path = "cache/math.obj", .kind = mqb::ArtifactKind::object});
     }
     unit.outputs.push_back(mqb::Artifact{
         .path = ifc_only ? fs::path{"ifc/value.ifc"} : fs::path{"ifc/math.ifc"},
         .kind = mqb::ArtifactKind::module_interface,
     });
-
     const auto toolchain = make_toolchain("19.51.modules");
     const auto options = make_options();
-    return mqb::CompileCacheEntry{
+    auto entry = mqb::CompileCacheEntry{
         .source = unit.source,
         .kind = unit.kind,
         .toolchain = toolchain,
@@ -113,13 +113,34 @@ mqb::CompileCacheEntry make_module_entry(const bool ifc_only) {
         .outputs = unit.outputs,
         .dependencies = {fs::path{"include/shared.hpp"}},
     };
+    if (!ifc_only) {
+        entry.module_scan = mqb::ModuleScanEvidence{
+            .signature = mqb::BuildSignature::for_module_scan(
+                unit.source, unit.kind, toolchain, options),
+            .source = snapshot(unit.source, 100),
+            .output = snapshot("scan/math.json", 200),
+            .dependencies = {
+                snapshot("include/shared.hpp", 150),
+                snapshot("include/config.hpp", 175),
+            },
+        };
+    }
+    return entry;
 }
 
 void write_bytes(const fs::path& file, const std::initializer_list<std::uint8_t> bytes) {
     std::ofstream stream{file, std::ios::binary | std::ios::trunc};
-    for (const auto byte : bytes) {
-        stream.put(static_cast<char>(byte));
-    }
+    for (const auto byte : bytes) stream.put(static_cast<char>(byte));
+}
+
+std::vector<char> read_all(const fs::path& file) {
+    std::ifstream stream{file, std::ios::binary};
+    return std::vector<char>{std::istreambuf_iterator<char>{stream}, std::istreambuf_iterator<char>{}};
+}
+
+void write_all(const fs::path& file, const std::vector<char>& bytes) {
+    std::ofstream stream{file, std::ios::binary | std::ios::trunc};
+    stream.write(bytes.data(), static_cast<std::streamsize>(bytes.size()));
 }
 
 void expect_round_trip(
@@ -129,35 +150,33 @@ void expect_round_trip(
     const auto saved = mqb::CompileCacheFile::save(file, original);
     expect(saved.has_value(), std::string{description} + " should save");
     const auto loaded = mqb::CompileCacheFile::load(file);
-    expect(loaded.has_value() && loaded->has_value(),
-           std::string{description} + " should load");
+    expect(loaded.has_value() && loaded->has_value(), std::string{description} + " should load");
     if (!loaded || !*loaded) return;
-
     const auto& entry = **loaded;
-    expect(entry.source == original.source,
-           std::string{description} + " source should round-trip");
-    expect(entry.kind == original.kind,
-           std::string{description} + " TU kind should round-trip");
+    expect(entry.source == original.source, std::string{description} + " source should round-trip");
+    expect(entry.kind == original.kind, std::string{description} + " TU kind should round-trip");
     expect(entry.toolchain.compiler == original.toolchain.compiler,
            std::string{description} + " compiler path should round-trip");
     expect(entry.toolchain.version == original.toolchain.version,
            std::string{description} + " toolchain version should round-trip");
     expect(entry.toolchain.binary_stamp == original.toolchain.binary_stamp,
            std::string{description} + " binary stamp should round-trip");
-    expect(entry.signature == original.signature,
-           std::string{description} + " signature should round-trip");
-    expect(entry.outputs.size() == original.outputs.size(),
-           std::string{description} + " output count should round-trip");
-    if (entry.outputs.size() == original.outputs.size()) {
-        for (std::size_t index = 0; index < entry.outputs.size(); ++index) {
-            expect(entry.outputs[index].path == original.outputs[index].path,
-                   std::string{description} + " output path ordering should round-trip");
-            expect(entry.outputs[index].kind == original.outputs[index].kind,
-                   std::string{description} + " output kind ordering should round-trip");
-        }
-    }
+    expect(entry.signature == original.signature, std::string{description} + " signature should round-trip");
+    expect(entry.outputs == original.outputs, std::string{description} + " outputs should round-trip");
     expect(entry.dependencies == original.dependencies,
            std::string{description} + " dependencies should round-trip");
+    expect(entry.module_scan.has_value() == original.module_scan.has_value(),
+           std::string{description} + " scan-evidence presence should round-trip");
+    if (entry.module_scan && original.module_scan) {
+        expect(entry.module_scan->signature == original.module_scan->signature,
+               "scan signature should round-trip");
+        expect(entry.module_scan->source == original.module_scan->source,
+               "scan source snapshot should round-trip");
+        expect(entry.module_scan->output == original.module_scan->output,
+               "scan output snapshot should round-trip");
+        expect(entry.module_scan->dependencies == original.module_scan->dependencies,
+               "scan dependency snapshots should round-trip");
+    }
 }
 
 } // namespace
@@ -167,53 +186,56 @@ int main() {
     const fs::path file = fixture.path() / "nested" / "main.mqbcache";
 
     const auto missing = mqb::CompileCacheFile::load(file);
-    expect(missing.has_value(), "missing cache file should be a normal cache miss");
-    if (missing) {
-        expect(!missing->has_value(), "missing cache file should return null optional entry");
-    }
+    expect(missing.has_value() && !missing->has_value(),
+           "missing cache file should be a normal cache miss");
 
     const auto original = make_entry();
     expect_round_trip(file, original, "ordinary object-only cache entry");
     expect(fs::is_regular_file(file), "save should install the final cache file");
 
     const auto module_entry = make_module_entry(false);
-    expect_round_trip(
-        fixture.path() / "module.mqbcache",
-        module_entry,
-        "module object+IFC cache entry");
+    const fs::path module_file = fixture.path() / "module.mqbcache";
+    expect_round_trip(module_file, module_entry, "module object+IFC cache entry with scan evidence");
 
     const auto ifc_only_entry = make_module_entry(true);
-    expect_round_trip(
-        fixture.path() / "ifc-only.mqbcache",
-        ifc_only_entry,
-        "IFC-only cache entry");
+    expect_round_trip(fixture.path() / "ifc-only.mqbcache", ifc_only_entry, "IFC-only cache entry");
+
+    // A v3 entry without scan evidence is byte-for-byte v2 plus one presence
+    // marker. Drop that marker and rewrite the version to prove old v2 cache
+    // files remain readable and simply lack the new optimization evidence.
+    const fs::path v2_file = fixture.path() / "legacy-v2.mqbcache";
+    expect(mqb::CompileCacheFile::save(v2_file, original).has_value(), "v2 fixture should start as v3");
+    auto v2_bytes = read_all(v2_file);
+    expect(v2_bytes.size() > 13, "v2 fixture should contain payload and presence marker");
+    if (v2_bytes.size() > 13) {
+        v2_bytes[8] = 2;
+        v2_bytes[9] = 0;
+        v2_bytes[10] = 0;
+        v2_bytes[11] = 0;
+        v2_bytes.pop_back();
+        write_all(v2_file, v2_bytes);
+        const auto v2 = mqb::CompileCacheFile::load(v2_file);
+        expect(v2 && *v2 && !(**v2).module_scan,
+               "legacy v2 cache should load conservatively without scan evidence");
+    }
 
     auto empty_outputs = original;
     empty_outputs.outputs.clear();
     const auto empty_output_save = mqb::CompileCacheFile::save(
-        fixture.path() / "empty-output.mqbcache",
-        empty_outputs);
-    expect(!empty_output_save.has_value(),
-           "cache serializer should reject entries without planned outputs");
-    if (!empty_output_save) {
-        expect(empty_output_save.error().code == mqb::CompileCacheFileErrorCode::file_write_failed,
-               "empty planned outputs should report file_write_failed");
-    }
+        fixture.path() / "empty-output.mqbcache", empty_outputs);
+    expect(!empty_output_save, "cache serializer should reject entries without planned outputs");
 
     const auto replacement = make_entry("19.51.20000");
     expect(mqb::CompileCacheFile::save(file, replacement).has_value(),
            "saving an existing cache path should replace the previous entry");
     const auto reloaded = mqb::CompileCacheFile::load(file);
-    expect(reloaded.has_value() && reloaded->has_value(), "replacement cache entry should load");
-    if (reloaded && *reloaded) {
-        expect((**reloaded).toolchain.version == "19.51.20000",
-               "replacement should not leave stale metadata behind");
-    }
+    expect(reloaded && *reloaded && (**reloaded).toolchain.version == "19.51.20000",
+           "replacement should not leave stale metadata behind");
 
     const fs::path bad_magic = fixture.path() / "bad-magic.mqbcache";
-    write_bytes(bad_magic, {0, 1, 2, 3, 4, 5, 6, 7, 2, 0, 0, 0});
+    write_bytes(bad_magic, {0, 1, 2, 3, 4, 5, 6, 7, 3, 0, 0, 0});
     const auto bad_magic_result = mqb::CompileCacheFile::load(bad_magic);
-    expect(!bad_magic_result.has_value(), "invalid cache magic should fail loading");
+    expect(!bad_magic_result, "invalid cache magic should fail loading");
     if (!bad_magic_result) {
         expect(bad_magic_result.error().code == mqb::CompileCacheFileErrorCode::invalid_magic,
                "invalid magic should have a precise error code");
@@ -222,17 +244,16 @@ int main() {
     const fs::path legacy_v1 = fixture.path() / "legacy-v1.mqbcache";
     write_bytes(legacy_v1, {'M', 'Q', 'B', 'C', 'A', 'C', 'H', 'E', 1, 0, 0, 0});
     const auto legacy_v1_result = mqb::CompileCacheFile::load(legacy_v1);
-    expect(!legacy_v1_result.has_value(),
-           "object-only v1 cache must not be interpreted as v2 planned-output metadata");
+    expect(!legacy_v1_result, "v1 cache must remain unsupported");
     if (!legacy_v1_result) {
         expect(legacy_v1_result.error().code == mqb::CompileCacheFileErrorCode::unsupported_version,
                "legacy v1 should request a conservative cache epoch rebuild");
     }
 
     const fs::path future_version = fixture.path() / "future.mqbcache";
-    write_bytes(future_version, {'M', 'Q', 'B', 'C', 'A', 'C', 'H', 'E', 3, 0, 0, 0});
+    write_bytes(future_version, {'M', 'Q', 'B', 'C', 'A', 'C', 'H', 'E', 4, 0, 0, 0});
     const auto future_result = mqb::CompileCacheFile::load(future_version);
-    expect(!future_result.has_value(), "future cache version should fail loading");
+    expect(!future_result, "future cache version should fail loading");
     if (!future_result) {
         expect(future_result.error().code == mqb::CompileCacheFileErrorCode::unsupported_version,
                "future version should have a precise error code");
@@ -240,20 +261,20 @@ int main() {
 
     const fs::path truncated = fixture.path() / "truncated.mqbcache";
     expect(mqb::CompileCacheFile::save(truncated, module_entry).has_value(),
-           "truncation fixture should start as a valid multi-output cache file");
+           "truncation fixture should start valid");
     fs::resize_file(truncated, 20);
-    const auto truncated_result = mqb::CompileCacheFile::load(truncated);
-    expect(!truncated_result.has_value(), "truncated cache file should never deserialize partially");
+    expect(!mqb::CompileCacheFile::load(truncated),
+           "truncated cache file should never deserialize partially");
 
     const fs::path trailing = fixture.path() / "trailing.mqbcache";
     expect(mqb::CompileCacheFile::save(trailing, original).has_value(),
-           "trailing-byte fixture should start as a valid cache file");
+           "trailing-byte fixture should start valid");
     {
         std::ofstream stream{trailing, std::ios::binary | std::ios::app};
         stream.put(static_cast<char>(0x7f));
     }
     const auto trailing_result = mqb::CompileCacheFile::load(trailing);
-    expect(!trailing_result.has_value(), "trailing bytes should be rejected instead of ignored");
+    expect(!trailing_result, "trailing bytes should be rejected instead of ignored");
     if (!trailing_result) {
         expect(trailing_result.error().code == mqb::CompileCacheFileErrorCode::corrupt_data,
                "trailing bytes should report corrupt_data");
@@ -263,7 +284,6 @@ int main() {
         std::cerr << failures << " test(s) failed\n";
         return 1;
     }
-
     std::cout << "mqb_compile_cache_file_tests passed\n";
     return 0;
 }

--- a/cpp/tests/core/cache/compile_cache_file_tests.cpp
+++ b/cpp/tests/core/cache/compile_cache_file_tests.cpp
@@ -16,116 +16,389 @@
 #include "mqb/core/TranslationUnit.hpp"
 
 namespace {
+
 namespace fs = std::filesystem;
 int failures = 0;
+
 void expect(const bool condition, const std::string_view message) {
-    if (!condition) { ++failures; std::cerr << "FAIL: " << message << '\n'; }
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
 }
+
 class TemporaryDirectory {
 public:
     TemporaryDirectory() {
         const auto tick = std::chrono::steady_clock::now().time_since_epoch().count();
-        path_ = fs::temp_directory_path() / ("mqb-cache-file-test-" + std::to_string(tick));
+        path_ = fs::temp_directory_path()
+            / ("mqb-cache-file-test-" + std::to_string(tick));
         fs::create_directories(path_);
     }
-    ~TemporaryDirectory() { std::error_code ignored; fs::remove_all(path_, ignored); }
-    [[nodiscard]] const fs::path& path() const noexcept { return path_; }
-private: fs::path path_;
+
+    ~TemporaryDirectory() {
+        std::error_code ignored;
+        fs::remove_all(path_, ignored);
+    }
+
+    [[nodiscard]] const fs::path& path() const noexcept {
+        return path_;
+    }
+
+private:
+    fs::path path_;
 };
-mqb::ToolchainIdentity make_toolchain(const std::string_view version) {
-    return {.compiler="toolchain/cl.exe", .version=std::string{version}, .binary_stamp="size=123;mtime=456"};
+
+[[nodiscard]] mqb::ToolchainIdentity make_toolchain(
+    const std::string_view version) {
+    return mqb::ToolchainIdentity{
+        .compiler = "toolchain/cl.exe",
+        .version = std::string{version},
+        .binary_stamp = "size=123;mtime=456",
+    };
 }
-mqb::CompilerOptions make_options() {
+
+[[nodiscard]] mqb::CompilerOptions make_options() {
     mqb::CompilerOptions options;
-    options.configuration=mqb::BuildConfiguration::debug; options.architecture=mqb::Architecture::x64;
-    options.standard=mqb::CppStandard::cpp23; options.defines={"FEATURE=1"}; options.include_directories={"include"};
+    options.configuration = mqb::BuildConfiguration::debug;
+    options.architecture = mqb::Architecture::x64;
+    options.standard = mqb::CppStandard::cpp23;
+    options.defines = {"FEATURE=1"};
+    options.include_directories = {"include"};
     return options;
 }
-mqb::FileSnapshot snapshot(const fs::path& path, const std::int64_t ticks) {
-    return {.path=path,.exists=true,.modified=fs::file_time_type{
-        std::chrono::duration_cast<fs::file_time_type::duration>(std::chrono::nanoseconds{ticks})}};
+
+[[nodiscard]] mqb::FileSnapshot snapshot(
+    const fs::path& path,
+    const std::int64_t ticks) {
+    return mqb::FileSnapshot{
+        .path = path,
+        .exists = true,
+        .modified = fs::file_time_type{
+            std::chrono::duration_cast<fs::file_time_type::duration>(
+                std::chrono::nanoseconds{ticks})},
+    };
 }
-bool same_snapshot(const mqb::FileSnapshot& a,const mqb::FileSnapshot& b) {
-    return a.path==b.path && a.exists==b.exists && a.modified==b.modified;
+
+[[nodiscard]] bool same_snapshot(
+    const mqb::FileSnapshot& left,
+    const mqb::FileSnapshot& right) {
+    return left.path == right.path
+        && left.exists == right.exists
+        && left.modified == right.modified;
 }
-mqb::CompileCacheEntry make_entry(const std::string_view version="19.50.10000") {
-    mqb::TranslationUnit unit; unit.source="src/main file.cpp"; unit.kind=mqb::TranslationUnitKind::source;
-    unit.outputs={mqb::Artifact{"cache/main file.obj",mqb::ArtifactKind::object}};
-    const auto toolchain=make_toolchain(version); const auto options=make_options();
-    return {.source=unit.source,.kind=unit.kind,.toolchain=toolchain,
-        .signature=mqb::BuildSignature::for_compile(unit,toolchain,options),.outputs=unit.outputs,
-        .dependencies={fs::path{"src/main file.cpp"},fs::path{"include/a.hpp"},fs::path{"include/nested/b.hpp"}}};
+
+[[nodiscard]] mqb::CompileCacheEntry make_entry(
+    const std::string_view version = "19.50.10000") {
+    mqb::TranslationUnit unit;
+    unit.source = "src/main file.cpp";
+    unit.kind = mqb::TranslationUnitKind::source;
+    unit.outputs = {
+        mqb::Artifact{
+            "cache/main file.obj",
+            mqb::ArtifactKind::object,
+        },
+    };
+
+    const auto toolchain = make_toolchain(version);
+    const auto options = make_options();
+    return mqb::CompileCacheEntry{
+        .source = unit.source,
+        .kind = unit.kind,
+        .toolchain = toolchain,
+        .signature = mqb::BuildSignature::for_compile(
+            unit,
+            toolchain,
+            options),
+        .outputs = unit.outputs,
+        .dependencies = {
+            fs::path{"src/main file.cpp"},
+            fs::path{"include/a.hpp"},
+            fs::path{"include/nested/b.hpp"},
+        },
+    };
 }
-mqb::CompileCacheEntry make_module_entry(const bool ifc_only) {
-    mqb::TranslationUnit unit; unit.source=ifc_only?fs::path{"include/value.hpp"}:fs::path{"src/math.ixx"};
-    unit.kind=mqb::TranslationUnitKind::module_interface;
-    if(!ifc_only) unit.outputs.push_back({.path="cache/math.obj",.kind=mqb::ArtifactKind::object});
-    unit.outputs.push_back({.path=ifc_only?fs::path{"ifc/value.ifc"}:fs::path{"ifc/math.ifc"},.kind=mqb::ArtifactKind::module_interface});
-    const auto toolchain=make_toolchain("19.51.modules"); const auto options=make_options();
-    mqb::CompileCacheEntry entry{.source=unit.source,.kind=unit.kind,.toolchain=toolchain,
-        .signature=mqb::BuildSignature::for_compile(unit,toolchain,options),.outputs=unit.outputs,
-        .dependencies={fs::path{"include/shared.hpp"}}};
-    if(!ifc_only) entry.module_scan=mqb::ModuleScanEvidence{
-        .signature=mqb::BuildSignature::for_module_scan(unit.source,unit.kind,toolchain,options),
-        .source=snapshot(unit.source,100),.output=snapshot("scan/math.json",200),
-        .dependencies={snapshot("include/shared.hpp",150),snapshot("include/config.hpp",175)}};
+
+[[nodiscard]] mqb::CompileCacheEntry make_module_entry(
+    const bool ifc_only) {
+    mqb::TranslationUnit unit;
+    unit.source = ifc_only
+        ? fs::path{"include/value.hpp"}
+        : fs::path{"src/math.ixx"};
+    unit.kind = mqb::TranslationUnitKind::module_interface;
+    if (!ifc_only) {
+        unit.outputs.push_back(mqb::Artifact{
+            .path = "cache/math.obj",
+            .kind = mqb::ArtifactKind::object,
+        });
+    }
+    unit.outputs.push_back(mqb::Artifact{
+        .path = ifc_only
+            ? fs::path{"ifc/value.ifc"}
+            : fs::path{"ifc/math.ifc"},
+        .kind = mqb::ArtifactKind::module_interface,
+    });
+
+    const auto toolchain = make_toolchain("19.51.modules");
+    const auto options = make_options();
+    mqb::CompileCacheEntry entry{
+        .source = unit.source,
+        .kind = unit.kind,
+        .toolchain = toolchain,
+        .signature = mqb::BuildSignature::for_compile(
+            unit,
+            toolchain,
+            options),
+        .outputs = unit.outputs,
+        .dependencies = {fs::path{"include/shared.hpp"}},
+    };
+    if (!ifc_only) {
+        entry.module_scan = mqb::ModuleScanEvidence{
+            .signature = mqb::BuildSignature::for_module_scan(
+                unit.source,
+                unit.kind,
+                toolchain,
+                options),
+            .source = snapshot(unit.source, 100),
+            .output = snapshot("scan/math.json", 200),
+            .dependencies = {
+                snapshot("include/shared.hpp", 150),
+                snapshot("include/config.hpp", 175),
+            },
+        };
+    }
     return entry;
 }
-void write_bytes(const fs::path& file,const std::initializer_list<std::uint8_t> bytes) {
-    std::ofstream stream{file,std::ios::binary|std::ios::trunc}; for(const auto byte:bytes) stream.put(static_cast<char>(byte));
-}
-std::vector<char> read_all(const fs::path& file) {
-    std::ifstream stream{file,std::ios::binary}; return {std::istreambuf_iterator<char>{stream},std::istreambuf_iterator<char>{}};
-}
-void write_all(const fs::path& file,const std::vector<char>& bytes) {
-    std::ofstream stream{file,std::ios::binary|std::ios::trunc}; stream.write(bytes.data(),static_cast<std::streamsize>(bytes.size()));
-}
-void expect_round_trip(const fs::path& file,const mqb::CompileCacheEntry& original,const std::string_view description) {
-    expect(mqb::CompileCacheFile::save(file,original).has_value(),std::string{description}+" should save");
-    const auto loaded=mqb::CompileCacheFile::load(file); expect(loaded&&*loaded,std::string{description}+" should load"); if(!loaded||!*loaded)return;
-    const auto& entry=**loaded;
-    expect(entry.source==original.source,std::string{description}+" source should round-trip");
-    expect(entry.kind==original.kind,std::string{description}+" TU kind should round-trip");
-    expect(entry.toolchain.compiler==original.toolchain.compiler && entry.toolchain.version==original.toolchain.version
-        && entry.toolchain.binary_stamp==original.toolchain.binary_stamp,std::string{description}+" toolchain should round-trip");
-    expect(entry.signature==original.signature,std::string{description}+" signature should round-trip");
-    expect(entry.outputs.size()==original.outputs.size(),std::string{description}+" output count should round-trip");
-    if(entry.outputs.size()==original.outputs.size()) for(std::size_t i=0;i<entry.outputs.size();++i)
-        expect(entry.outputs[i].path==original.outputs[i].path && entry.outputs[i].kind==original.outputs[i].kind,"output should round-trip");
-    expect(entry.dependencies==original.dependencies,std::string{description}+" dependencies should round-trip");
-    expect(entry.module_scan.has_value()==original.module_scan.has_value(),std::string{description}+" scan evidence presence should round-trip");
-    if(entry.module_scan&&original.module_scan){
-        expect(entry.module_scan->signature==original.module_scan->signature,"scan signature should round-trip");
-        expect(same_snapshot(entry.module_scan->source,original.module_scan->source),"scan source snapshot should round-trip");
-        expect(same_snapshot(entry.module_scan->output,original.module_scan->output),"scan output snapshot should round-trip");
-        expect(entry.module_scan->dependencies.size()==original.module_scan->dependencies.size(),"scan dependency count should round-trip");
-        if(entry.module_scan->dependencies.size()==original.module_scan->dependencies.size()) for(std::size_t i=0;i<entry.module_scan->dependencies.size();++i)
-            expect(same_snapshot(entry.module_scan->dependencies[i],original.module_scan->dependencies[i]),"scan dependency snapshot should round-trip");
+
+void write_bytes(
+    const fs::path& file,
+    const std::initializer_list<std::uint8_t> bytes) {
+    std::ofstream stream{file, std::ios::binary | std::ios::trunc};
+    for (const auto byte : bytes) {
+        stream.put(static_cast<char>(byte));
     }
 }
+
+[[nodiscard]] std::vector<char> read_all(const fs::path& file) {
+    std::ifstream stream{file, std::ios::binary};
+    return std::vector<char>{
+        std::istreambuf_iterator<char>{stream},
+        std::istreambuf_iterator<char>{}};
+}
+
+void write_all(const fs::path& file, const std::vector<char>& bytes) {
+    std::ofstream stream{file, std::ios::binary | std::ios::trunc};
+    stream.write(bytes.data(), static_cast<std::streamsize>(bytes.size()));
+}
+
+void expect_round_trip(
+    const fs::path& file,
+    const mqb::CompileCacheEntry& original,
+    const std::string_view description) {
+    expect(
+        mqb::CompileCacheFile::save(file, original).has_value(),
+        std::string{description} + " should save");
+
+    const auto loaded = mqb::CompileCacheFile::load(file);
+    expect(
+        loaded && *loaded,
+        std::string{description} + " should load");
+    if (!loaded || !*loaded) return;
+
+    const auto& entry = **loaded;
+    expect(
+        entry.source == original.source,
+        std::string{description} + " source should round-trip");
+    expect(
+        entry.kind == original.kind,
+        std::string{description} + " TU kind should round-trip");
+    expect(
+        entry.toolchain.compiler == original.toolchain.compiler
+            && entry.toolchain.version == original.toolchain.version
+            && entry.toolchain.binary_stamp == original.toolchain.binary_stamp,
+        std::string{description} + " toolchain should round-trip");
+    expect(
+        entry.signature == original.signature,
+        std::string{description} + " signature should round-trip");
+    expect(
+        entry.outputs.size() == original.outputs.size(),
+        std::string{description} + " output count should round-trip");
+    if (entry.outputs.size() == original.outputs.size()) {
+        for (std::size_t index = 0; index < entry.outputs.size(); ++index) {
+            expect(
+                entry.outputs[index].path == original.outputs[index].path
+                    && entry.outputs[index].kind == original.outputs[index].kind,
+                "output should round-trip");
+        }
+    }
+    expect(
+        entry.dependencies == original.dependencies,
+        std::string{description} + " dependencies should round-trip");
+    expect(
+        entry.module_scan.has_value() == original.module_scan.has_value(),
+        std::string{description} + " scan-evidence presence should round-trip");
+
+    if (entry.module_scan && original.module_scan) {
+        expect(
+            entry.module_scan->signature == original.module_scan->signature,
+            "scan signature should round-trip");
+        expect(
+            same_snapshot(entry.module_scan->source, original.module_scan->source),
+            "scan source snapshot should round-trip");
+        expect(
+            same_snapshot(entry.module_scan->output, original.module_scan->output),
+            "scan output snapshot should round-trip");
+        expect(
+            entry.module_scan->dependencies.size()
+                == original.module_scan->dependencies.size(),
+            "scan dependency count should round-trip");
+        if (entry.module_scan->dependencies.size()
+            == original.module_scan->dependencies.size()) {
+            for (std::size_t index = 0;
+                 index < entry.module_scan->dependencies.size();
+                 ++index) {
+                expect(
+                    same_snapshot(
+                        entry.module_scan->dependencies[index],
+                        original.module_scan->dependencies[index]),
+                    "scan dependency snapshot should round-trip");
+            }
+        }
+    }
+}
+
 } // namespace
-int main(){
-    TemporaryDirectory fixture; const fs::path file=fixture.path()/"nested"/"main.mqbcache";
-    const auto missing=mqb::CompileCacheFile::load(file); expect(missing&&!missing->has_value(),"missing cache file should be a normal miss");
-    const auto original=make_entry(); expect_round_trip(file,original,"ordinary object-only cache entry"); expect(fs::is_regular_file(file),"save should install final cache file");
-    const auto module_entry=make_module_entry(false); const fs::path module_file=fixture.path()/"module.mqbcache";
-    expect_round_trip(module_file,module_entry,"module object+IFC cache entry with scan evidence");
-    expect_round_trip(fixture.path()/"ifc-only.mqbcache",make_module_entry(true),"IFC-only cache entry");
-    const fs::path v2_file=fixture.path()/"legacy-v2.mqbcache"; expect(mqb::CompileCacheFile::save(v2_file,original).has_value(),"v2 fixture should start as v3");
-    auto v2_bytes=read_all(v2_file); expect(v2_bytes.size()>13,"v2 fixture should contain payload and presence marker");
-    if(v2_bytes.size()>13){v2_bytes[8]=2;v2_bytes[9]=0;v2_bytes[10]=0;v2_bytes[11]=0;v2_bytes.pop_back();write_all(v2_file,v2_bytes);
-        const auto v2=mqb::CompileCacheFile::load(v2_file);expect(v2&&*v2&&!(**v2).module_scan,"legacy v2 should load without scan evidence");}
-    auto empty_outputs=original;empty_outputs.outputs.clear();expect(!mqb::CompileCacheFile::save(fixture.path()/"empty.mqbcache",empty_outputs),"empty outputs should be rejected");
-    const auto replacement=make_entry("19.51.20000");expect(mqb::CompileCacheFile::save(file,replacement).has_value(),"replacement should save");
-    const auto reloaded=mqb::CompileCacheFile::load(file);expect(reloaded&&*reloaded&&(**reloaded).toolchain.version=="19.51.20000","replacement should not leave stale metadata");
-    const fs::path bad=fixture.path()/"bad.mqbcache";write_bytes(bad,{0,1,2,3,4,5,6,7,3,0,0,0});const auto bad_result=mqb::CompileCacheFile::load(bad);
-    expect(!bad_result,"bad magic should fail");if(!bad_result)expect(bad_result.error().code==mqb::CompileCacheFileErrorCode::invalid_magic,"bad magic code");
-    const fs::path v1=fixture.path()/"v1.mqbcache";write_bytes(v1,{'M','Q','B','C','A','C','H','E',1,0,0,0});const auto v1r=mqb::CompileCacheFile::load(v1);
-    expect(!v1r,"v1 should fail");if(!v1r)expect(v1r.error().code==mqb::CompileCacheFileErrorCode::unsupported_version,"v1 code");
-    const fs::path future=fixture.path()/"future.mqbcache";write_bytes(future,{'M','Q','B','C','A','C','H','E',4,0,0,0});const auto fr=mqb::CompileCacheFile::load(future);
-    expect(!fr,"future version should fail");if(!fr)expect(fr.error().code==mqb::CompileCacheFileErrorCode::unsupported_version,"future code");
-    const fs::path truncated=fixture.path()/"truncated.mqbcache";expect(mqb::CompileCacheFile::save(truncated,module_entry).has_value(),"truncation fixture valid");fs::resize_file(truncated,20);expect(!mqb::CompileCacheFile::load(truncated),"truncated file should fail");
-    const fs::path trailing=fixture.path()/"trailing.mqbcache";expect(mqb::CompileCacheFile::save(trailing,original).has_value(),"trailing fixture valid");{std::ofstream s{trailing,std::ios::binary|std::ios::app};s.put(static_cast<char>(0x7f));}
-    const auto tr=mqb::CompileCacheFile::load(trailing);expect(!tr,"trailing bytes should fail");if(!tr)expect(tr.error().code==mqb::CompileCacheFileErrorCode::corrupt_data,"trailing code");
-    if(failures){std::cerr<<failures<<" test(s) failed\n";return 1;}std::cout<<"mqb_compile_cache_file_tests passed\n";return 0;
+
+int main() {
+    TemporaryDirectory fixture;
+    const fs::path file = fixture.path() / "nested/main.mqbcache";
+
+    const auto missing = mqb::CompileCacheFile::load(file);
+    expect(
+        missing && !missing->has_value(),
+        "missing cache file should be a normal cache miss");
+
+    const auto original = make_entry();
+    expect_round_trip(file, original, "ordinary object-only cache entry");
+    expect(fs::is_regular_file(file), "save should install final cache file");
+
+    const auto module_entry = make_module_entry(false);
+    const fs::path module_file = fixture.path() / "module.mqbcache";
+    expect_round_trip(
+        module_file,
+        module_entry,
+        "module object+IFC cache entry with scan evidence");
+    expect_round_trip(
+        fixture.path() / "ifc-only.mqbcache",
+        make_module_entry(true),
+        "IFC-only cache entry");
+
+    // A v3 entry without scan evidence is exactly the v2 payload plus a zero
+    // presence marker. Remove the marker and rewrite the version to prove old
+    // v2 cache files remain readable and simply lack the new optimization.
+    const fs::path v2_file = fixture.path() / "legacy-v2.mqbcache";
+    expect(
+        mqb::CompileCacheFile::save(v2_file, original).has_value(),
+        "v2 fixture should start as v3");
+    auto v2_bytes = read_all(v2_file);
+    expect(
+        v2_bytes.size() > 13,
+        "v2 fixture should contain payload and presence marker");
+    if (v2_bytes.size() > 13) {
+        v2_bytes[8] = 2;
+        v2_bytes[9] = 0;
+        v2_bytes[10] = 0;
+        v2_bytes[11] = 0;
+        v2_bytes.pop_back();
+        write_all(v2_file, v2_bytes);
+
+        const auto v2 = mqb::CompileCacheFile::load(v2_file);
+        expect(
+            v2 && *v2 && !(**v2).module_scan,
+            "legacy v2 should load without scan evidence");
+    }
+
+    auto empty_outputs = original;
+    empty_outputs.outputs.clear();
+    expect(
+        !mqb::CompileCacheFile::save(
+            fixture.path() / "empty.mqbcache",
+            empty_outputs),
+        "empty outputs should be rejected");
+
+    const auto replacement = make_entry("19.51.20000");
+    expect(
+        mqb::CompileCacheFile::save(file, replacement).has_value(),
+        "replacement should save");
+    const auto reloaded = mqb::CompileCacheFile::load(file);
+    expect(
+        reloaded && *reloaded
+            && (**reloaded).toolchain.version == "19.51.20000",
+        "replacement should not leave stale metadata");
+
+    const fs::path bad_magic = fixture.path() / "bad.mqbcache";
+    write_bytes(bad_magic, {0, 1, 2, 3, 4, 5, 6, 7, 3, 0, 0, 0});
+    const auto bad_result = mqb::CompileCacheFile::load(bad_magic);
+    expect(!bad_result, "bad magic should fail");
+    if (!bad_result) {
+        expect(
+            bad_result.error().code
+                == mqb::CompileCacheFileErrorCode::invalid_magic,
+            "bad magic should report invalid_magic");
+    }
+
+    const fs::path v1 = fixture.path() / "v1.mqbcache";
+    write_bytes(v1, {'M', 'Q', 'B', 'C', 'A', 'C', 'H', 'E', 1, 0, 0, 0});
+    const auto v1_result = mqb::CompileCacheFile::load(v1);
+    expect(!v1_result, "v1 should fail");
+    if (!v1_result) {
+        expect(
+            v1_result.error().code
+                == mqb::CompileCacheFileErrorCode::unsupported_version,
+            "v1 should report unsupported_version");
+    }
+
+    const fs::path future = fixture.path() / "future.mqbcache";
+    write_bytes(future, {'M', 'Q', 'B', 'C', 'A', 'C', 'H', 'E', 4, 0, 0, 0});
+    const auto future_result = mqb::CompileCacheFile::load(future);
+    expect(!future_result, "future version should fail");
+    if (!future_result) {
+        expect(
+            future_result.error().code
+                == mqb::CompileCacheFileErrorCode::unsupported_version,
+            "future version should report unsupported_version");
+    }
+
+    const fs::path truncated = fixture.path() / "truncated.mqbcache";
+    expect(
+        mqb::CompileCacheFile::save(truncated, module_entry).has_value(),
+        "truncation fixture should start valid");
+    fs::resize_file(truncated, 20);
+    expect(
+        !mqb::CompileCacheFile::load(truncated),
+        "truncated file should fail to deserialize");
+
+    const fs::path trailing = fixture.path() / "trailing.mqbcache";
+    expect(
+        mqb::CompileCacheFile::save(trailing, original).has_value(),
+        "trailing-byte fixture should start valid");
+    {
+        std::ofstream stream{trailing, std::ios::binary | std::ios::app};
+        stream.put(static_cast<char>(0x7f));
+    }
+    const auto trailing_result = mqb::CompileCacheFile::load(trailing);
+    expect(!trailing_result, "trailing bytes should fail");
+    if (!trailing_result) {
+        expect(
+            trailing_result.error().code
+                == mqb::CompileCacheFileErrorCode::corrupt_data,
+            "trailing bytes should report corrupt_data");
+    }
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+    std::cout << "mqb_compile_cache_file_tests passed\n";
+    return 0;
 }

--- a/cpp/tests/core/cache/compile_cache_file_tests.cpp
+++ b/cpp/tests/core/cache/compile_cache_file_tests.cpp
@@ -16,17 +16,11 @@
 #include "mqb/core/TranslationUnit.hpp"
 
 namespace {
-
 namespace fs = std::filesystem;
 int failures = 0;
-
 void expect(const bool condition, const std::string_view message) {
-    if (!condition) {
-        ++failures;
-        std::cerr << "FAIL: " << message << '\n';
-    }
+    if (!condition) { ++failures; std::cerr << "FAIL: " << message << '\n'; }
 }
-
 class TemporaryDirectory {
 public:
     TemporaryDirectory() {
@@ -34,256 +28,104 @@ public:
         path_ = fs::temp_directory_path() / ("mqb-cache-file-test-" + std::to_string(tick));
         fs::create_directories(path_);
     }
-    ~TemporaryDirectory() {
-        std::error_code ignored;
-        fs::remove_all(path_, ignored);
-    }
+    ~TemporaryDirectory() { std::error_code ignored; fs::remove_all(path_, ignored); }
     [[nodiscard]] const fs::path& path() const noexcept { return path_; }
-private:
-    fs::path path_;
+private: fs::path path_;
 };
-
 mqb::ToolchainIdentity make_toolchain(const std::string_view version) {
-    return mqb::ToolchainIdentity{
-        .compiler = "toolchain/cl.exe",
-        .version = std::string{version},
-        .binary_stamp = "size=123;mtime=456",
-    };
+    return {.compiler="toolchain/cl.exe", .version=std::string{version}, .binary_stamp="size=123;mtime=456"};
 }
-
 mqb::CompilerOptions make_options() {
     mqb::CompilerOptions options;
-    options.configuration = mqb::BuildConfiguration::debug;
-    options.architecture = mqb::Architecture::x64;
-    options.standard = mqb::CppStandard::cpp23;
-    options.defines = {"FEATURE=1"};
-    options.include_directories = {"include"};
+    options.configuration=mqb::BuildConfiguration::debug; options.architecture=mqb::Architecture::x64;
+    options.standard=mqb::CppStandard::cpp23; options.defines={"FEATURE=1"}; options.include_directories={"include"};
     return options;
 }
-
 mqb::FileSnapshot snapshot(const fs::path& path, const std::int64_t ticks) {
-    return mqb::FileSnapshot{
-        .path = path,
-        .exists = true,
-        .modified = fs::file_time_type{
-            std::chrono::duration_cast<fs::file_time_type::duration>(
-                std::chrono::nanoseconds{ticks})},
-    };
+    return {.path=path,.exists=true,.modified=fs::file_time_type{
+        std::chrono::duration_cast<fs::file_time_type::duration>(std::chrono::nanoseconds{ticks})}};
 }
-
-mqb::CompileCacheEntry make_entry(const std::string_view version = "19.50.10000") {
-    mqb::TranslationUnit unit;
-    unit.source = "src/main file.cpp";
-    unit.kind = mqb::TranslationUnitKind::source;
-    unit.outputs = {mqb::Artifact{"cache/main file.obj", mqb::ArtifactKind::object}};
-    const auto toolchain = make_toolchain(version);
-    const auto options = make_options();
-    return mqb::CompileCacheEntry{
-        .source = unit.source,
-        .kind = unit.kind,
-        .toolchain = toolchain,
-        .signature = mqb::BuildSignature::for_compile(unit, toolchain, options),
-        .outputs = unit.outputs,
-        .dependencies = {
-            fs::path{"src/main file.cpp"},
-            fs::path{"include/a.hpp"},
-            fs::path{"include/nested/b.hpp"},
-        },
-    };
+bool same_snapshot(const mqb::FileSnapshot& a,const mqb::FileSnapshot& b) {
+    return a.path==b.path && a.exists==b.exists && a.modified==b.modified;
 }
-
+mqb::CompileCacheEntry make_entry(const std::string_view version="19.50.10000") {
+    mqb::TranslationUnit unit; unit.source="src/main file.cpp"; unit.kind=mqb::TranslationUnitKind::source;
+    unit.outputs={mqb::Artifact{"cache/main file.obj",mqb::ArtifactKind::object}};
+    const auto toolchain=make_toolchain(version); const auto options=make_options();
+    return {.source=unit.source,.kind=unit.kind,.toolchain=toolchain,
+        .signature=mqb::BuildSignature::for_compile(unit,toolchain,options),.outputs=unit.outputs,
+        .dependencies={fs::path{"src/main file.cpp"},fs::path{"include/a.hpp"},fs::path{"include/nested/b.hpp"}}};
+}
 mqb::CompileCacheEntry make_module_entry(const bool ifc_only) {
-    mqb::TranslationUnit unit;
-    unit.source = ifc_only ? fs::path{"include/value.hpp"} : fs::path{"src/math.ixx"};
-    unit.kind = mqb::TranslationUnitKind::module_interface;
-    if (!ifc_only) {
-        unit.outputs.push_back(mqb::Artifact{.path = "cache/math.obj", .kind = mqb::ArtifactKind::object});
-    }
-    unit.outputs.push_back(mqb::Artifact{
-        .path = ifc_only ? fs::path{"ifc/value.ifc"} : fs::path{"ifc/math.ifc"},
-        .kind = mqb::ArtifactKind::module_interface,
-    });
-    const auto toolchain = make_toolchain("19.51.modules");
-    const auto options = make_options();
-    auto entry = mqb::CompileCacheEntry{
-        .source = unit.source,
-        .kind = unit.kind,
-        .toolchain = toolchain,
-        .signature = mqb::BuildSignature::for_compile(unit, toolchain, options),
-        .outputs = unit.outputs,
-        .dependencies = {fs::path{"include/shared.hpp"}},
-    };
-    if (!ifc_only) {
-        entry.module_scan = mqb::ModuleScanEvidence{
-            .signature = mqb::BuildSignature::for_module_scan(
-                unit.source, unit.kind, toolchain, options),
-            .source = snapshot(unit.source, 100),
-            .output = snapshot("scan/math.json", 200),
-            .dependencies = {
-                snapshot("include/shared.hpp", 150),
-                snapshot("include/config.hpp", 175),
-            },
-        };
-    }
+    mqb::TranslationUnit unit; unit.source=ifc_only?fs::path{"include/value.hpp"}:fs::path{"src/math.ixx"};
+    unit.kind=mqb::TranslationUnitKind::module_interface;
+    if(!ifc_only) unit.outputs.push_back({.path="cache/math.obj",.kind=mqb::ArtifactKind::object});
+    unit.outputs.push_back({.path=ifc_only?fs::path{"ifc/value.ifc"}:fs::path{"ifc/math.ifc"},.kind=mqb::ArtifactKind::module_interface});
+    const auto toolchain=make_toolchain("19.51.modules"); const auto options=make_options();
+    mqb::CompileCacheEntry entry{.source=unit.source,.kind=unit.kind,.toolchain=toolchain,
+        .signature=mqb::BuildSignature::for_compile(unit,toolchain,options),.outputs=unit.outputs,
+        .dependencies={fs::path{"include/shared.hpp"}}};
+    if(!ifc_only) entry.module_scan=mqb::ModuleScanEvidence{
+        .signature=mqb::BuildSignature::for_module_scan(unit.source,unit.kind,toolchain,options),
+        .source=snapshot(unit.source,100),.output=snapshot("scan/math.json",200),
+        .dependencies={snapshot("include/shared.hpp",150),snapshot("include/config.hpp",175)}};
     return entry;
 }
-
-void write_bytes(const fs::path& file, const std::initializer_list<std::uint8_t> bytes) {
-    std::ofstream stream{file, std::ios::binary | std::ios::trunc};
-    for (const auto byte : bytes) stream.put(static_cast<char>(byte));
+void write_bytes(const fs::path& file,const std::initializer_list<std::uint8_t> bytes) {
+    std::ofstream stream{file,std::ios::binary|std::ios::trunc}; for(const auto byte:bytes) stream.put(static_cast<char>(byte));
 }
-
 std::vector<char> read_all(const fs::path& file) {
-    std::ifstream stream{file, std::ios::binary};
-    return std::vector<char>{std::istreambuf_iterator<char>{stream}, std::istreambuf_iterator<char>{}};
+    std::ifstream stream{file,std::ios::binary}; return {std::istreambuf_iterator<char>{stream},std::istreambuf_iterator<char>{}};
 }
-
-void write_all(const fs::path& file, const std::vector<char>& bytes) {
-    std::ofstream stream{file, std::ios::binary | std::ios::trunc};
-    stream.write(bytes.data(), static_cast<std::streamsize>(bytes.size()));
+void write_all(const fs::path& file,const std::vector<char>& bytes) {
+    std::ofstream stream{file,std::ios::binary|std::ios::trunc}; stream.write(bytes.data(),static_cast<std::streamsize>(bytes.size()));
 }
-
-void expect_round_trip(
-    const fs::path& file,
-    const mqb::CompileCacheEntry& original,
-    const std::string_view description) {
-    const auto saved = mqb::CompileCacheFile::save(file, original);
-    expect(saved.has_value(), std::string{description} + " should save");
-    const auto loaded = mqb::CompileCacheFile::load(file);
-    expect(loaded.has_value() && loaded->has_value(), std::string{description} + " should load");
-    if (!loaded || !*loaded) return;
-    const auto& entry = **loaded;
-    expect(entry.source == original.source, std::string{description} + " source should round-trip");
-    expect(entry.kind == original.kind, std::string{description} + " TU kind should round-trip");
-    expect(entry.toolchain.compiler == original.toolchain.compiler,
-           std::string{description} + " compiler path should round-trip");
-    expect(entry.toolchain.version == original.toolchain.version,
-           std::string{description} + " toolchain version should round-trip");
-    expect(entry.toolchain.binary_stamp == original.toolchain.binary_stamp,
-           std::string{description} + " binary stamp should round-trip");
-    expect(entry.signature == original.signature, std::string{description} + " signature should round-trip");
-    expect(entry.outputs == original.outputs, std::string{description} + " outputs should round-trip");
-    expect(entry.dependencies == original.dependencies,
-           std::string{description} + " dependencies should round-trip");
-    expect(entry.module_scan.has_value() == original.module_scan.has_value(),
-           std::string{description} + " scan-evidence presence should round-trip");
-    if (entry.module_scan && original.module_scan) {
-        expect(entry.module_scan->signature == original.module_scan->signature,
-               "scan signature should round-trip");
-        expect(entry.module_scan->source == original.module_scan->source,
-               "scan source snapshot should round-trip");
-        expect(entry.module_scan->output == original.module_scan->output,
-               "scan output snapshot should round-trip");
-        expect(entry.module_scan->dependencies == original.module_scan->dependencies,
-               "scan dependency snapshots should round-trip");
+void expect_round_trip(const fs::path& file,const mqb::CompileCacheEntry& original,const std::string_view description) {
+    expect(mqb::CompileCacheFile::save(file,original).has_value(),std::string{description}+" should save");
+    const auto loaded=mqb::CompileCacheFile::load(file); expect(loaded&&*loaded,std::string{description}+" should load"); if(!loaded||!*loaded)return;
+    const auto& entry=**loaded;
+    expect(entry.source==original.source,std::string{description}+" source should round-trip");
+    expect(entry.kind==original.kind,std::string{description}+" TU kind should round-trip");
+    expect(entry.toolchain.compiler==original.toolchain.compiler && entry.toolchain.version==original.toolchain.version
+        && entry.toolchain.binary_stamp==original.toolchain.binary_stamp,std::string{description}+" toolchain should round-trip");
+    expect(entry.signature==original.signature,std::string{description}+" signature should round-trip");
+    expect(entry.outputs.size()==original.outputs.size(),std::string{description}+" output count should round-trip");
+    if(entry.outputs.size()==original.outputs.size()) for(std::size_t i=0;i<entry.outputs.size();++i)
+        expect(entry.outputs[i].path==original.outputs[i].path && entry.outputs[i].kind==original.outputs[i].kind,"output should round-trip");
+    expect(entry.dependencies==original.dependencies,std::string{description}+" dependencies should round-trip");
+    expect(entry.module_scan.has_value()==original.module_scan.has_value(),std::string{description}+" scan evidence presence should round-trip");
+    if(entry.module_scan&&original.module_scan){
+        expect(entry.module_scan->signature==original.module_scan->signature,"scan signature should round-trip");
+        expect(same_snapshot(entry.module_scan->source,original.module_scan->source),"scan source snapshot should round-trip");
+        expect(same_snapshot(entry.module_scan->output,original.module_scan->output),"scan output snapshot should round-trip");
+        expect(entry.module_scan->dependencies.size()==original.module_scan->dependencies.size(),"scan dependency count should round-trip");
+        if(entry.module_scan->dependencies.size()==original.module_scan->dependencies.size()) for(std::size_t i=0;i<entry.module_scan->dependencies.size();++i)
+            expect(same_snapshot(entry.module_scan->dependencies[i],original.module_scan->dependencies[i]),"scan dependency snapshot should round-trip");
     }
 }
-
 } // namespace
-
-int main() {
-    TemporaryDirectory fixture;
-    const fs::path file = fixture.path() / "nested" / "main.mqbcache";
-
-    const auto missing = mqb::CompileCacheFile::load(file);
-    expect(missing.has_value() && !missing->has_value(),
-           "missing cache file should be a normal cache miss");
-
-    const auto original = make_entry();
-    expect_round_trip(file, original, "ordinary object-only cache entry");
-    expect(fs::is_regular_file(file), "save should install the final cache file");
-
-    const auto module_entry = make_module_entry(false);
-    const fs::path module_file = fixture.path() / "module.mqbcache";
-    expect_round_trip(module_file, module_entry, "module object+IFC cache entry with scan evidence");
-
-    const auto ifc_only_entry = make_module_entry(true);
-    expect_round_trip(fixture.path() / "ifc-only.mqbcache", ifc_only_entry, "IFC-only cache entry");
-
-    // A v3 entry without scan evidence is byte-for-byte v2 plus one presence
-    // marker. Drop that marker and rewrite the version to prove old v2 cache
-    // files remain readable and simply lack the new optimization evidence.
-    const fs::path v2_file = fixture.path() / "legacy-v2.mqbcache";
-    expect(mqb::CompileCacheFile::save(v2_file, original).has_value(), "v2 fixture should start as v3");
-    auto v2_bytes = read_all(v2_file);
-    expect(v2_bytes.size() > 13, "v2 fixture should contain payload and presence marker");
-    if (v2_bytes.size() > 13) {
-        v2_bytes[8] = 2;
-        v2_bytes[9] = 0;
-        v2_bytes[10] = 0;
-        v2_bytes[11] = 0;
-        v2_bytes.pop_back();
-        write_all(v2_file, v2_bytes);
-        const auto v2 = mqb::CompileCacheFile::load(v2_file);
-        expect(v2 && *v2 && !(**v2).module_scan,
-               "legacy v2 cache should load conservatively without scan evidence");
-    }
-
-    auto empty_outputs = original;
-    empty_outputs.outputs.clear();
-    const auto empty_output_save = mqb::CompileCacheFile::save(
-        fixture.path() / "empty-output.mqbcache", empty_outputs);
-    expect(!empty_output_save, "cache serializer should reject entries without planned outputs");
-
-    const auto replacement = make_entry("19.51.20000");
-    expect(mqb::CompileCacheFile::save(file, replacement).has_value(),
-           "saving an existing cache path should replace the previous entry");
-    const auto reloaded = mqb::CompileCacheFile::load(file);
-    expect(reloaded && *reloaded && (**reloaded).toolchain.version == "19.51.20000",
-           "replacement should not leave stale metadata behind");
-
-    const fs::path bad_magic = fixture.path() / "bad-magic.mqbcache";
-    write_bytes(bad_magic, {0, 1, 2, 3, 4, 5, 6, 7, 3, 0, 0, 0});
-    const auto bad_magic_result = mqb::CompileCacheFile::load(bad_magic);
-    expect(!bad_magic_result, "invalid cache magic should fail loading");
-    if (!bad_magic_result) {
-        expect(bad_magic_result.error().code == mqb::CompileCacheFileErrorCode::invalid_magic,
-               "invalid magic should have a precise error code");
-    }
-
-    const fs::path legacy_v1 = fixture.path() / "legacy-v1.mqbcache";
-    write_bytes(legacy_v1, {'M', 'Q', 'B', 'C', 'A', 'C', 'H', 'E', 1, 0, 0, 0});
-    const auto legacy_v1_result = mqb::CompileCacheFile::load(legacy_v1);
-    expect(!legacy_v1_result, "v1 cache must remain unsupported");
-    if (!legacy_v1_result) {
-        expect(legacy_v1_result.error().code == mqb::CompileCacheFileErrorCode::unsupported_version,
-               "legacy v1 should request a conservative cache epoch rebuild");
-    }
-
-    const fs::path future_version = fixture.path() / "future.mqbcache";
-    write_bytes(future_version, {'M', 'Q', 'B', 'C', 'A', 'C', 'H', 'E', 4, 0, 0, 0});
-    const auto future_result = mqb::CompileCacheFile::load(future_version);
-    expect(!future_result, "future cache version should fail loading");
-    if (!future_result) {
-        expect(future_result.error().code == mqb::CompileCacheFileErrorCode::unsupported_version,
-               "future version should have a precise error code");
-    }
-
-    const fs::path truncated = fixture.path() / "truncated.mqbcache";
-    expect(mqb::CompileCacheFile::save(truncated, module_entry).has_value(),
-           "truncation fixture should start valid");
-    fs::resize_file(truncated, 20);
-    expect(!mqb::CompileCacheFile::load(truncated),
-           "truncated cache file should never deserialize partially");
-
-    const fs::path trailing = fixture.path() / "trailing.mqbcache";
-    expect(mqb::CompileCacheFile::save(trailing, original).has_value(),
-           "trailing-byte fixture should start valid");
-    {
-        std::ofstream stream{trailing, std::ios::binary | std::ios::app};
-        stream.put(static_cast<char>(0x7f));
-    }
-    const auto trailing_result = mqb::CompileCacheFile::load(trailing);
-    expect(!trailing_result, "trailing bytes should be rejected instead of ignored");
-    if (!trailing_result) {
-        expect(trailing_result.error().code == mqb::CompileCacheFileErrorCode::corrupt_data,
-               "trailing bytes should report corrupt_data");
-    }
-
-    if (failures != 0) {
-        std::cerr << failures << " test(s) failed\n";
-        return 1;
-    }
-    std::cout << "mqb_compile_cache_file_tests passed\n";
-    return 0;
+int main(){
+    TemporaryDirectory fixture; const fs::path file=fixture.path()/"nested"/"main.mqbcache";
+    const auto missing=mqb::CompileCacheFile::load(file); expect(missing&&!missing->has_value(),"missing cache file should be a normal miss");
+    const auto original=make_entry(); expect_round_trip(file,original,"ordinary object-only cache entry"); expect(fs::is_regular_file(file),"save should install final cache file");
+    const auto module_entry=make_module_entry(false); const fs::path module_file=fixture.path()/"module.mqbcache";
+    expect_round_trip(module_file,module_entry,"module object+IFC cache entry with scan evidence");
+    expect_round_trip(fixture.path()/"ifc-only.mqbcache",make_module_entry(true),"IFC-only cache entry");
+    const fs::path v2_file=fixture.path()/"legacy-v2.mqbcache"; expect(mqb::CompileCacheFile::save(v2_file,original).has_value(),"v2 fixture should start as v3");
+    auto v2_bytes=read_all(v2_file); expect(v2_bytes.size()>13,"v2 fixture should contain payload and presence marker");
+    if(v2_bytes.size()>13){v2_bytes[8]=2;v2_bytes[9]=0;v2_bytes[10]=0;v2_bytes[11]=0;v2_bytes.pop_back();write_all(v2_file,v2_bytes);
+        const auto v2=mqb::CompileCacheFile::load(v2_file);expect(v2&&*v2&&!(**v2).module_scan,"legacy v2 should load without scan evidence");}
+    auto empty_outputs=original;empty_outputs.outputs.clear();expect(!mqb::CompileCacheFile::save(fixture.path()/"empty.mqbcache",empty_outputs),"empty outputs should be rejected");
+    const auto replacement=make_entry("19.51.20000");expect(mqb::CompileCacheFile::save(file,replacement).has_value(),"replacement should save");
+    const auto reloaded=mqb::CompileCacheFile::load(file);expect(reloaded&&*reloaded&&(**reloaded).toolchain.version=="19.51.20000","replacement should not leave stale metadata");
+    const fs::path bad=fixture.path()/"bad.mqbcache";write_bytes(bad,{0,1,2,3,4,5,6,7,3,0,0,0});const auto bad_result=mqb::CompileCacheFile::load(bad);
+    expect(!bad_result,"bad magic should fail");if(!bad_result)expect(bad_result.error().code==mqb::CompileCacheFileErrorCode::invalid_magic,"bad magic code");
+    const fs::path v1=fixture.path()/"v1.mqbcache";write_bytes(v1,{'M','Q','B','C','A','C','H','E',1,0,0,0});const auto v1r=mqb::CompileCacheFile::load(v1);
+    expect(!v1r,"v1 should fail");if(!v1r)expect(v1r.error().code==mqb::CompileCacheFileErrorCode::unsupported_version,"v1 code");
+    const fs::path future=fixture.path()/"future.mqbcache";write_bytes(future,{'M','Q','B','C','A','C','H','E',4,0,0,0});const auto fr=mqb::CompileCacheFile::load(future);
+    expect(!fr,"future version should fail");if(!fr)expect(fr.error().code==mqb::CompileCacheFileErrorCode::unsupported_version,"future code");
+    const fs::path truncated=fixture.path()/"truncated.mqbcache";expect(mqb::CompileCacheFile::save(truncated,module_entry).has_value(),"truncation fixture valid");fs::resize_file(truncated,20);expect(!mqb::CompileCacheFile::load(truncated),"truncated file should fail");
+    const fs::path trailing=fixture.path()/"trailing.mqbcache";expect(mqb::CompileCacheFile::save(trailing,original).has_value(),"trailing fixture valid");{std::ofstream s{trailing,std::ios::binary|std::ios::app};s.put(static_cast<char>(0x7f));}
+    const auto tr=mqb::CompileCacheFile::load(trailing);expect(!tr,"trailing bytes should fail");if(!tr)expect(tr.error().code==mqb::CompileCacheFileErrorCode::corrupt_data,"trailing code");
+    if(failures){std::cerr<<failures<<" test(s) failed\n";return 1;}std::cout<<"mqb_compile_cache_file_tests passed\n";return 0;
 }

--- a/cpp/tests/core/cache/module_scan_cache_tests.cpp
+++ b/cpp/tests/core/cache/module_scan_cache_tests.cpp
@@ -1,0 +1,268 @@
+#include <chrono>
+#include <filesystem>
+#include <iostream>
+#include <string_view>
+#include <vector>
+
+#include "mqb/core/BuildSignature.hpp"
+#include "mqb/core/CompileCache.hpp"
+#include "mqb/core/CompilerOptions.hpp"
+#include "mqb/core/FileSnapshot.hpp"
+#include "mqb/core/ToolchainIdentity.hpp"
+#include "mqb/core/TranslationUnit.hpp"
+
+namespace {
+
+namespace fs = std::filesystem;
+int failures = 0;
+
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+[[nodiscard]] fs::file_time_type time_at(const int seconds) {
+    return fs::file_time_type{} + std::chrono::seconds{seconds};
+}
+
+[[nodiscard]] mqb::FileSnapshot snapshot(
+    fs::path path,
+    const int seconds,
+    const bool exists = true) {
+    return mqb::FileSnapshot{
+        .path = std::move(path),
+        .exists = exists,
+        .modified = time_at(seconds),
+    };
+}
+
+[[nodiscard]] mqb::ToolchainIdentity make_toolchain() {
+    return mqb::ToolchainIdentity{
+        .compiler = "toolchain/cl.exe",
+        .version = "19.51.10000",
+        .binary_stamp = "size=123;mtime=456",
+    };
+}
+
+[[nodiscard]] mqb::CompilerOptions make_options() {
+    mqb::CompilerOptions options;
+    options.configuration = mqb::BuildConfiguration::debug;
+    options.architecture = mqb::Architecture::x64;
+    options.standard = mqb::CppStandard::latest;
+    options.defines = {"FEATURE=1"};
+    options.include_directories = {"include", "vendor/include"};
+    options.additional_arguments = {"/experimental:module"};
+    return options;
+}
+
+} // namespace
+
+int main() {
+    const fs::path source{"src/main.cpp"};
+    const auto toolchain = make_toolchain();
+    const auto options = make_options();
+
+    const auto baseline = mqb::BuildSignature::for_module_scan(
+        source,
+        mqb::TranslationUnitKind::source,
+        toolchain,
+        options);
+    expect(
+        baseline == mqb::BuildSignature::for_module_scan(
+            source,
+            mqb::TranslationUnitKind::source,
+            toolchain,
+            options),
+        "identical module-scan recipes should produce identical signatures");
+
+    expect(
+        baseline != mqb::BuildSignature::for_module_scan(
+            "src/other.cpp",
+            mqb::TranslationUnitKind::source,
+            toolchain,
+            options),
+        "source identity should participate in module-scan signature");
+    expect(
+        baseline != mqb::BuildSignature::for_module_scan(
+            source,
+            mqb::TranslationUnitKind::module_interface,
+            toolchain,
+            options),
+        "translation-unit kind should participate in module-scan signature");
+
+    auto changed_toolchain = toolchain;
+    changed_toolchain.binary_stamp = "size=123;mtime=457";
+    expect(
+        baseline != mqb::BuildSignature::for_module_scan(
+            source,
+            mqb::TranslationUnitKind::source,
+            changed_toolchain,
+            options),
+        "compiler binary identity should participate in module-scan signature");
+
+    auto release = options;
+    release.configuration = mqb::BuildConfiguration::release;
+    expect(
+        baseline != mqb::BuildSignature::for_module_scan(
+            source,
+            mqb::TranslationUnitKind::source,
+            toolchain,
+            release),
+        "configuration macro policy should participate in module-scan signature");
+
+    auto x86 = options;
+    x86.architecture = mqb::Architecture::x86;
+    expect(
+        baseline != mqb::BuildSignature::for_module_scan(
+            source,
+            mqb::TranslationUnitKind::source,
+            toolchain,
+            x86),
+        "target architecture should participate in module-scan signature");
+
+    auto standard = options;
+    standard.standard = mqb::CppStandard::cpp20;
+    expect(
+        baseline != mqb::BuildSignature::for_module_scan(
+            source,
+            mqb::TranslationUnitKind::source,
+            toolchain,
+            standard),
+        "language mode should participate in module-scan signature");
+
+    auto define = options;
+    define.defines.emplace_back("EXTRA=1");
+    expect(
+        baseline != mqb::BuildSignature::for_module_scan(
+            source,
+            mqb::TranslationUnitKind::source,
+            toolchain,
+            define),
+        "preprocessor definitions should participate in module-scan signature");
+
+    auto includes = options;
+    std::swap(includes.include_directories[0], includes.include_directories[1]);
+    expect(
+        baseline != mqb::BuildSignature::for_module_scan(
+            source,
+            mqb::TranslationUnitKind::source,
+            toolchain,
+            includes),
+        "include search order should participate in module-scan signature");
+
+    auto arguments = options;
+    arguments.additional_arguments.emplace_back("/Zc:preprocessor-");
+    expect(
+        baseline != mqb::BuildSignature::for_module_scan(
+            source,
+            mqb::TranslationUnitKind::source,
+            toolchain,
+            arguments),
+        "raw scan-visible compiler arguments should participate in module-scan signature");
+
+    auto runtime = options;
+    runtime.runtime_library = mqb::RuntimeLibrary::mt;
+    expect(
+        baseline == mqb::BuildSignature::for_module_scan(
+            source,
+            mqb::TranslationUnitKind::source,
+            toolchain,
+            runtime),
+        "runtime library policy should not invalidate P1689 topology identity");
+
+    auto ltcg = options;
+    ltcg.link_time_code_generation = true;
+    expect(
+        baseline == mqb::BuildSignature::for_module_scan(
+            source,
+            mqb::TranslationUnitKind::source,
+            toolchain,
+            ltcg),
+        "LTCG policy should not invalidate P1689 topology identity");
+
+    const mqb::ModuleScanEvidence evidence{
+        .signature = baseline,
+        .source = snapshot(source, 10),
+        .output = snapshot(".mqb/scan/main.json", 20),
+        .dependencies = {
+            snapshot("include/app.hpp", 11),
+            snapshot("include/config.hpp", 12),
+        },
+    };
+    const std::vector<mqb::FileSnapshot> dependencies = evidence.dependencies;
+
+    expect(
+        mqb::ModuleScanEvidenceValidator::reusable(
+            evidence,
+            baseline,
+            evidence.source,
+            evidence.output,
+            dependencies),
+        "exact sealed scan evidence should be reusable");
+
+    auto newer_source = evidence.source;
+    newer_source.modified = time_at(21);
+    expect(
+        !mqb::ModuleScanEvidenceValidator::reusable(
+            evidence,
+            baseline,
+            newer_source,
+            evidence.output,
+            dependencies),
+        "source snapshot change should invalidate sealed scan evidence");
+
+    auto changed_output = evidence.output;
+    changed_output.modified = time_at(22);
+    expect(
+        !mqb::ModuleScanEvidenceValidator::reusable(
+            evidence,
+            baseline,
+            evidence.source,
+            changed_output,
+            dependencies),
+        "P1689 artifact replacement should invalidate sealed scan evidence");
+
+    auto changed_dependencies = dependencies;
+    changed_dependencies[0].modified = time_at(30);
+    expect(
+        !mqb::ModuleScanEvidenceValidator::reusable(
+            evidence,
+            baseline,
+            evidence.source,
+            evidence.output,
+            changed_dependencies),
+        "textual dependency mutation should invalidate sealed scan evidence");
+
+    auto missing_dependency = dependencies;
+    missing_dependency[1].exists = false;
+    expect(
+        !mqb::ModuleScanEvidenceValidator::reusable(
+            evidence,
+            baseline,
+            evidence.source,
+            evidence.output,
+            missing_dependency),
+        "deleted textual dependency should invalidate sealed scan evidence");
+
+    expect(
+        !mqb::ModuleScanEvidenceValidator::reusable(
+            evidence,
+            mqb::BuildSignature::for_module_scan(
+                source,
+                mqb::TranslationUnitKind::source,
+                changed_toolchain,
+                options),
+            evidence.source,
+            evidence.output,
+            dependencies),
+        "scan recipe change should invalidate sealed scan evidence");
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+    std::cout << "mqb_module_scan_cache_tests passed\n";
+    return 0;
+}

--- a/cpp/tests/core/cache/module_scan_cache_tests.cpp
+++ b/cpp/tests/core/cache/module_scan_cache_tests.cpp
@@ -1,7 +1,9 @@
+#include <algorithm>
 #include <chrono>
 #include <filesystem>
 #include <iostream>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include "mqb/core/BuildSignature.hpp"

--- a/cpp/tests/orchestration/modules/module_target_coordinator_tests.cpp
+++ b/cpp/tests/orchestration/modules/module_target_coordinator_tests.cpp
@@ -4,7 +4,6 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
-#include <mutex>
 #include <string>
 #include <string_view>
 #include <thread>
@@ -21,37 +20,350 @@
 #include "mqb/process/Process.hpp"
 
 namespace {
+
 namespace fs = std::filesystem;
-int failures=0;
-void expect(bool condition,std::string_view message){if(!condition){++failures;std::cerr<<"FAIL: "<<message<<'\n';}}
-class TemporaryDirectory{public:TemporaryDirectory(){const auto t=std::chrono::steady_clock::now().time_since_epoch().count();path_=fs::temp_directory_path()/("mqb-module-target-test-"+std::to_string(t));fs::create_directories(path_);}~TemporaryDirectory(){std::error_code e;fs::remove_all(path_,e);}const fs::path& path()const noexcept{return path_;}private:fs::path path_;};
-void write_text(const fs::path& path,std::string_view text){fs::create_directories(path.parent_path());std::ofstream f{path,std::ios::binary|std::ios::trunc};f.write(text.data(),static_cast<std::streamsize>(text.size()));}
-std::string path_to_utf8(const fs::path& path){const auto b=path.lexically_normal().generic_u8string();return {reinterpret_cast<const char*>(b.data()),b.size()};}
-std::string json_escape(std::string_view value){std::string e;for(char ch:value){switch(ch){case '\\':e+="\\\\";break;case '"':e+="\\\"";break;case '\n':e+="\\n";break;case '\r':e+="\\r";break;case '\t':e+="\\t";break;default:e.push_back(ch);}}return e;}
-class ToolchainLikeRunner final:public mqb::process::ProcessRunner{
-public:fs::path linker;std::atomic<int> scan_calls{0},compile_calls{0},link_calls{0};std::atomic<bool> emit_two_scan_rules{false};
-std::expected<mqb::process::ProcessResult,mqb::process::ProcessError> run(const mqb::process::ProcessSpec& spec)override{if(spec.executable==linker)return run_link(spec);for(const auto& a:spec.arguments)if(a=="/scanDependencies")return run_scan(spec);return run_compile(spec);}
+int failures = 0;
+
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+class TemporaryDirectory {
+public:
+    TemporaryDirectory() {
+        const auto tick = std::chrono::steady_clock::now().time_since_epoch().count();
+        path_ = fs::temp_directory_path()
+            / ("mqb-module-target-test-" + std::to_string(tick));
+        fs::create_directories(path_);
+    }
+
+    ~TemporaryDirectory() {
+        std::error_code ignored;
+        fs::remove_all(path_, ignored);
+    }
+
+    [[nodiscard]] const fs::path& path() const noexcept {
+        return path_;
+    }
+
 private:
-std::expected<mqb::process::ProcessResult,mqb::process::ProcessError> run_scan(const mqb::process::ProcessSpec& spec){++scan_calls;fs::path output,source;for(std::size_t i=0;i<spec.arguments.size();++i)if(spec.arguments[i]=="/scanDependencies"&&i+1<spec.arguments.size())output=fs::path{spec.arguments[i+1]};if(!spec.arguments.empty())source=fs::path{spec.arguments.back()};const bool iface=source.extension()==".ixx";std::string rule=iface?R"json({"provides":[{"logical-name":"math"}]})json":R"json({"requires":[{"logical-name":"math"}]})json";std::string json="{\"version\":1,\"revision\":0,\"rules\":["+rule;if(emit_two_scan_rules.load())json+=",{}";json+="]}";write_text(output,json);return mqb::process::ProcessResult{.exit_code=0};}
-std::expected<mqb::process::ProcessResult,mqb::process::ProcessError> run_compile(const mqb::process::ProcessSpec& spec){++compile_calls;fs::path source,object,deps,ifc;for(std::size_t i=0;i<spec.arguments.size();++i){const auto& a=spec.arguments[i];if(a.starts_with("/Fo"))object=fs::path{a.substr(3)};else if(a=="/sourceDependencies"&&i+1<spec.arguments.size())deps=fs::path{spec.arguments[++i]};else if(a=="/ifcOutput"&&i+1<spec.arguments.size())ifc=fs::path{spec.arguments[++i]};}if(!spec.arguments.empty())source=fs::path{spec.arguments.back()};write_text(object,"fake object");if(!ifc.empty())write_text(ifc,"fake ifc");const std::string metadata="{\"Data\":{\"Source\":\""+json_escape(path_to_utf8(source))+"\",\"Includes\":[]}}";write_text(deps,metadata);return mqb::process::ProcessResult{.exit_code=0};}
-std::expected<mqb::process::ProcessResult,mqb::process::ProcessError> run_link(const mqb::process::ProcessSpec& spec){++link_calls;fs::path output;for(const auto& a:spec.arguments){constexpr std::string_view p="/OUT:";if(a.starts_with(p)){output=fs::path{a.substr(p.size())};break;}}write_text(output,"fake executable");return mqb::process::ProcessResult{.exit_code=0};}
+    fs::path path_;
 };
+
+void write_text(const fs::path& path, const std::string_view text) {
+    fs::create_directories(path.parent_path());
+    std::ofstream stream{path, std::ios::binary | std::ios::trunc};
+    stream.write(text.data(), static_cast<std::streamsize>(text.size()));
+}
+
+[[nodiscard]] std::string path_to_utf8(const fs::path& path) {
+    const auto bytes = path.lexically_normal().generic_u8string();
+    return std::string{
+        reinterpret_cast<const char*>(bytes.data()),
+        bytes.size()};
+}
+
+[[nodiscard]] std::string json_escape(const std::string_view value) {
+    std::string escaped;
+    for (const char ch : value) {
+        switch (ch) {
+        case '\\':
+            escaped += "\\\\";
+            break;
+        case '"':
+            escaped += "\\\"";
+            break;
+        case '\n':
+            escaped += "\\n";
+            break;
+        case '\r':
+            escaped += "\\r";
+            break;
+        case '\t':
+            escaped += "\\t";
+            break;
+        default:
+            escaped.push_back(ch);
+            break;
+        }
+    }
+    return escaped;
+}
+
+class ToolchainLikeRunner final : public mqb::process::ProcessRunner {
+public:
+    fs::path linker;
+    std::atomic<int> scan_calls{0};
+    std::atomic<int> compile_calls{0};
+    std::atomic<int> link_calls{0};
+    std::atomic<bool> emit_two_scan_rules{false};
+
+    std::expected<mqb::process::ProcessResult, mqb::process::ProcessError>
+    run(const mqb::process::ProcessSpec& spec) override {
+        if (spec.executable == linker) {
+            return run_link(spec);
+        }
+        for (const auto& argument : spec.arguments) {
+            if (argument == "/scanDependencies") {
+                return run_scan(spec);
+            }
+        }
+        return run_compile(spec);
+    }
+
+private:
+    std::expected<mqb::process::ProcessResult, mqb::process::ProcessError>
+    run_scan(const mqb::process::ProcessSpec& spec) {
+        ++scan_calls;
+
+        fs::path output;
+        for (std::size_t index = 0; index < spec.arguments.size(); ++index) {
+            if (spec.arguments[index] == "/scanDependencies"
+                && index + 1 < spec.arguments.size()) {
+                output = fs::path{spec.arguments[index + 1]};
+                break;
+            }
+        }
+
+        const fs::path source = spec.arguments.empty()
+            ? fs::path{}
+            : fs::path{spec.arguments.back()};
+        const bool module_interface = source.extension() == ".ixx";
+        const std::string rule = module_interface
+            ? R"json({"provides":[{"logical-name":"math"}]})json"
+            : R"json({"requires":[{"logical-name":"math"}]})json";
+
+        std::string json = "{\"version\":1,\"revision\":0,\"rules\":[" + rule;
+        if (emit_two_scan_rules.load()) {
+            json += ",{}";
+        }
+        json += "]}";
+        write_text(output, json);
+        return mqb::process::ProcessResult{.exit_code = 0};
+    }
+
+    std::expected<mqb::process::ProcessResult, mqb::process::ProcessError>
+    run_compile(const mqb::process::ProcessSpec& spec) {
+        ++compile_calls;
+
+        fs::path source;
+        fs::path object;
+        fs::path dependencies;
+        fs::path module_interface;
+        for (std::size_t index = 0; index < spec.arguments.size(); ++index) {
+            const auto& argument = spec.arguments[index];
+            if (argument.starts_with("/Fo")) {
+                object = fs::path{argument.substr(3)};
+            } else if (argument == "/sourceDependencies"
+                       && index + 1 < spec.arguments.size()) {
+                dependencies = fs::path{spec.arguments[++index]};
+            } else if (argument == "/ifcOutput"
+                       && index + 1 < spec.arguments.size()) {
+                module_interface = fs::path{spec.arguments[++index]};
+            }
+        }
+        if (!spec.arguments.empty()) {
+            source = fs::path{spec.arguments.back()};
+        }
+
+        write_text(object, "fake object");
+        if (!module_interface.empty()) {
+            write_text(module_interface, "fake ifc");
+        }
+        const std::string metadata =
+            "{\"Data\":{\"Source\":\""
+            + json_escape(path_to_utf8(source))
+            + "\",\"Includes\":[]}}";
+        write_text(dependencies, metadata);
+        return mqb::process::ProcessResult{.exit_code = 0};
+    }
+
+    std::expected<mqb::process::ProcessResult, mqb::process::ProcessError>
+    run_link(const mqb::process::ProcessSpec& spec) {
+        ++link_calls;
+
+        fs::path output;
+        for (const auto& argument : spec.arguments) {
+            constexpr std::string_view prefix = "/OUT:";
+            if (argument.starts_with(prefix)) {
+                output = fs::path{argument.substr(prefix.size())};
+                break;
+            }
+        }
+        write_text(output, "fake executable");
+        return mqb::process::ProcessResult{.exit_code = 0};
+    }
+};
+
 } // namespace
 
-int main(){
-TemporaryDirectory fixture;const fs::path root=fixture.path(),module_source=root/"modules/math.ixx",consumer_source=root/"src/main.cpp";write_text(module_source,"export module math;\n");write_text(consumer_source,"import math;\nint main(){return 0;}\n");
-auto layout=mqb::ProjectArtifactLayout::create(root);expect(layout.has_value(),"layout");if(!layout)return 1;auto module_artifacts=layout->for_source(module_source),consumer_artifacts=layout->for_source(consumer_source),target_artifacts=layout->for_target("module-app");expect(module_artifacts&&consumer_artifacts&&target_artifacts,"artifacts");if(!module_artifacts||!consumer_artifacts||!target_artifacts)return 1;
-const fs::path fake_compiler=root/"toolchain/cl.exe",fake_linker=root/"toolchain/link.exe",fake_librarian=root/"toolchain/lib.exe";write_text(fake_compiler,"fake compiler");write_text(fake_linker,"fake linker");write_text(fake_librarian,"fake librarian");
-mqb::msvc::MsvcToolchain toolchain{.identity={.compiler=fake_compiler,.version="19.51.test",.binary_stamp="fake-compiler-stamp"},.linker=fake_linker,.librarian=fake_librarian,.vc_tools_root=fake_compiler.parent_path(),.source=mqb::msvc::ToolchainSource::visual_studio};
-ToolchainLikeRunner runner;runner.linker=fake_linker;mqb::msvc::MsvcModuleDependencyScanner scanner{toolchain,runner};mqb::msvc::MsvcCompileExecutor executor{toolchain,runner};mqb::orchestration::MsvcIncrementalCompileCoordinator incremental_compile{toolchain,executor};mqb::orchestration::MsvcModuleCompileCoordinator module_compile{incremental_compile};mqb::msvc::MsvcLinker linker{toolchain,runner};mqb::orchestration::MsvcIncrementalLinkCoordinator incremental_link{toolchain,linker};mqb::orchestration::MsvcModuleTargetCoordinator target{scanner,module_compile,incremental_link};
-mqb::orchestration::IncrementalModuleTargetRequest request;request.sources={{.source=consumer_source,.artifacts=*consumer_artifacts,.kind=mqb::TranslationUnitKind::source},{.source=module_source,.artifacts=*module_artifacts,.kind=mqb::TranslationUnitKind::module_interface}};request.target=*target_artifacts;request.compiler_options.standard=mqb::CppStandard::latest;request.link_options.architecture=mqb::Architecture::x64;request.link_options.subsystem=mqb::LinkSubsystem::console;request.working_directory=root;request.max_parallel_scans=2;request.max_parallel_compiles=2;
-const auto cold=target.run(request);expect(cold.has_value(),"cold module target should succeed");if(!cold)return 1;expect(cold->scans.size()==2&&cold->scans[0].source==consumer_source&&cold->scans[1].source==module_source,"scan ordering");expect(!cold->scans[0].result.reused&&!cold->scans[1].result.reused,"cold scans must launch compiler");expect(cold->plan.compile_levels.size()==2,"two compile levels");expect(cold->compiles.any_compiled&&cold->link.linked,"cold compile/link");expect(runner.scan_calls.load()==2&&runner.compile_calls.load()==2&&runner.link_calls.load()==1,"cold process counts");
-const auto warm=target.run(request);expect(warm.has_value(),"warm target should succeed");if(!warm)return 1;expect(!warm->compiles.any_compiled&&!warm->link.linked,"warm compile/link cache reuse");expect(warm->scans.size()==2&&warm->scans[0].result.reused&&warm->scans[1].result.reused,"warm P1689 scans should reuse sealed evidence");expect(runner.scan_calls.load()==2,"warm target should launch zero additional scans");expect(runner.compile_calls.load()==2&&runner.link_calls.load()==1,"warm target should launch zero compiles/links");
-// Force an observable source timestamp change; only the consumer scan should miss.
-std::this_thread::sleep_for(std::chrono::milliseconds{20});write_text(consumer_source,"import math;\nint main(){return 0;} // changed\n");
-const auto changed=target.run(request);expect(changed.has_value(),"changed consumer should rebuild");if(!changed)return 1;expect(!changed->scans[0].result.reused&&changed->scans[1].result.reused,"source mutation should rescan only changed TU");expect(runner.scan_calls.load()==3,"one changed source should add exactly one raw scan");expect(runner.compile_calls.load()==3,"changed consumer should add exactly one compile");
-const auto warm_again=target.run(request);expect(warm_again.has_value(),"re-sealed warm target should succeed");if(!warm_again)return 1;expect(warm_again->scans[0].result.reused&&warm_again->scans[1].result.reused&&runner.scan_calls.load()==3,"successful rebuild should re-seal scan evidence");
-// Remove one seal so malformed raw scanner output still exercises fail-closed cardinality validation.
-std::error_code ignored;fs::remove(consumer_artifacts->compile_cache,ignored);runner.emit_two_scan_rules=true;const int compiles_before=runner.compile_calls.load(),links_before=runner.link_calls.load();const auto invalid=target.run(request);expect(!invalid&&invalid.error().code==mqb::orchestration::IncrementalModuleTargetErrorCode::invalid_scan_result,"multi-rule raw scan should fail closed");expect(runner.compile_calls.load()==compiles_before&&runner.link_calls.load()==links_before,"invalid scan should stop before compile/link");
-if(failures){std::cerr<<failures<<" test(s) failed\n";return 1;}std::cout<<"mqb_module_target_coordinator_tests passed\n";return 0;
+int main() {
+    TemporaryDirectory fixture;
+    const fs::path root = fixture.path();
+    const fs::path module_source = root / "modules/math.ixx";
+    const fs::path consumer_source = root / "src/main.cpp";
+    write_text(module_source, "export module math;\n");
+    write_text(consumer_source, "import math;\nint main(){return 0;}\n");
+
+    auto layout = mqb::ProjectArtifactLayout::create(root);
+    expect(layout.has_value(), "project artifact layout should be created");
+    if (!layout) return 1;
+
+    auto module_artifacts = layout->for_source(module_source);
+    auto consumer_artifacts = layout->for_source(consumer_source);
+    auto target_artifacts = layout->for_target("module-app");
+    expect(
+        module_artifacts && consumer_artifacts && target_artifacts,
+        "module target artifacts should be assigned");
+    if (!module_artifacts || !consumer_artifacts || !target_artifacts) return 1;
+
+    const fs::path fake_compiler = root / "toolchain/cl.exe";
+    const fs::path fake_linker = root / "toolchain/link.exe";
+    const fs::path fake_librarian = root / "toolchain/lib.exe";
+    write_text(fake_compiler, "fake compiler");
+    write_text(fake_linker, "fake linker");
+    write_text(fake_librarian, "fake librarian");
+
+    mqb::msvc::MsvcToolchain toolchain{
+        .identity = {
+            .compiler = fake_compiler,
+            .version = "19.51.test",
+            .binary_stamp = "fake-compiler-stamp",
+        },
+        .linker = fake_linker,
+        .librarian = fake_librarian,
+        .vc_tools_root = fake_compiler.parent_path(),
+        .source = mqb::msvc::ToolchainSource::visual_studio,
+    };
+
+    ToolchainLikeRunner runner;
+    runner.linker = fake_linker;
+    mqb::msvc::MsvcModuleDependencyScanner scanner{toolchain, runner};
+    mqb::msvc::MsvcCompileExecutor executor{toolchain, runner};
+    mqb::orchestration::MsvcIncrementalCompileCoordinator incremental_compile{
+        toolchain,
+        executor};
+    mqb::orchestration::MsvcModuleCompileCoordinator module_compile{
+        incremental_compile};
+    mqb::msvc::MsvcLinker linker{toolchain, runner};
+    mqb::orchestration::MsvcIncrementalLinkCoordinator incremental_link{
+        toolchain,
+        linker};
+    mqb::orchestration::MsvcModuleTargetCoordinator target{
+        scanner,
+        module_compile,
+        incremental_link};
+
+    mqb::orchestration::IncrementalModuleTargetRequest request;
+    request.sources = {
+        {
+            .source = consumer_source,
+            .artifacts = *consumer_artifacts,
+            .kind = mqb::TranslationUnitKind::source,
+        },
+        {
+            .source = module_source,
+            .artifacts = *module_artifacts,
+            .kind = mqb::TranslationUnitKind::module_interface,
+        },
+    };
+    request.target = *target_artifacts;
+    request.compiler_options.standard = mqb::CppStandard::latest;
+    request.link_options.architecture = mqb::Architecture::x64;
+    request.link_options.subsystem = mqb::LinkSubsystem::console;
+    request.working_directory = root;
+    request.max_parallel_scans = 2;
+    request.max_parallel_compiles = 2;
+
+    const auto cold = target.run(request);
+    expect(cold.has_value(), "cold module target should succeed");
+    if (!cold) return 1;
+    expect(
+        cold->scans.size() == 2
+            && cold->scans[0].source == consumer_source
+            && cold->scans[1].source == module_source,
+        "public scan ordering should preserve request order");
+    expect(
+        !cold->scans[0].result.reused && !cold->scans[1].result.reused,
+        "cold scans must launch the scanner");
+    expect(cold->plan.compile_levels.size() == 2,
+           "consumer/provider graph should have two compile levels");
+    expect(cold->compiles.any_compiled && cold->link.linked,
+           "cold module target should compile and link");
+    expect(
+        runner.scan_calls.load() == 2
+            && runner.compile_calls.load() == 2
+            && runner.link_calls.load() == 1,
+        "cold module target should launch exactly two scans, two compiles, and one link");
+
+    const auto warm = target.run(request);
+    expect(warm.has_value(), "warm module target should succeed");
+    if (!warm) return 1;
+    expect(!warm->compiles.any_compiled && !warm->link.linked,
+           "warm module target should reuse compile/link caches");
+    expect(
+        warm->scans.size() == 2
+            && warm->scans[0].result.reused
+            && warm->scans[1].result.reused,
+        "warm P1689 scans should reuse sealed evidence");
+    expect(runner.scan_calls.load() == 2,
+           "warm module target should launch zero additional scan processes");
+    expect(
+        runner.compile_calls.load() == 2 && runner.link_calls.load() == 1,
+        "warm module target should launch zero additional compile/link processes");
+
+    // Force an observable source timestamp change. Only the consumer topology
+    // should miss the scan cache; the unchanged provider remains reusable.
+    std::this_thread::sleep_for(std::chrono::milliseconds{20});
+    write_text(
+        consumer_source,
+        "import math;\nint main(){return 0;} // changed\n");
+
+    const auto changed = target.run(request);
+    expect(changed.has_value(), "changed consumer should rebuild successfully");
+    if (!changed) return 1;
+    expect(
+        !changed->scans[0].result.reused && changed->scans[1].result.reused,
+        "source mutation should rescan only the changed translation unit");
+    expect(runner.scan_calls.load() == 3,
+           "one changed source should add exactly one raw scan");
+    expect(runner.compile_calls.load() == 3,
+           "changed consumer should add exactly one compile");
+
+    const auto warm_again = target.run(request);
+    expect(warm_again.has_value(), "re-sealed warm target should succeed");
+    if (!warm_again) return 1;
+    expect(
+        warm_again->scans[0].result.reused
+            && warm_again->scans[1].result.reused
+            && runner.scan_calls.load() == 3,
+        "successful rebuild should re-seal scan evidence for the next warm build");
+
+    // Remove one seal so malformed raw scanner output still exercises the
+    // authoritative cardinality validation rather than cached P1689 metadata.
+    std::error_code ignored;
+    fs::remove(consumer_artifacts->compile_cache, ignored);
+    runner.emit_two_scan_rules = true;
+    const int compiles_before = runner.compile_calls.load();
+    const int links_before = runner.link_calls.load();
+    const auto invalid = target.run(request);
+    expect(
+        !invalid
+            && invalid.error().code
+                == mqb::orchestration::IncrementalModuleTargetErrorCode::invalid_scan_result,
+        "multi-rule raw scan should fail closed");
+    expect(
+        runner.compile_calls.load() == compiles_before
+            && runner.link_calls.load() == links_before,
+        "invalid scan should stop before compile/link");
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+    std::cout << "mqb_module_target_coordinator_tests passed\n";
+    return 0;
 }

--- a/cpp/tests/orchestration/modules/module_target_coordinator_tests.cpp
+++ b/cpp/tests/orchestration/modules/module_target_coordinator_tests.cpp
@@ -7,6 +7,7 @@
 #include <mutex>
 #include <string>
 #include <string_view>
+#include <thread>
 #include <vector>
 
 #include "mqb/core/ProjectArtifactLayout.hpp"
@@ -20,290 +21,37 @@
 #include "mqb/process/Process.hpp"
 
 namespace {
-
 namespace fs = std::filesystem;
-int failures = 0;
-
-void expect(const bool condition, const std::string_view message) {
-    if (!condition) {
-        ++failures;
-        std::cerr << "FAIL: " << message << '\n';
-    }
-}
-
-class TemporaryDirectory {
-public:
-    TemporaryDirectory() {
-        const auto tick = std::chrono::steady_clock::now().time_since_epoch().count();
-        path_ = fs::temp_directory_path() / ("mqb-module-target-test-" + std::to_string(tick));
-        fs::create_directories(path_);
-    }
-
-    ~TemporaryDirectory() {
-        std::error_code ignored;
-        fs::remove_all(path_, ignored);
-    }
-
-    [[nodiscard]] const fs::path& path() const noexcept { return path_; }
-
+int failures=0;
+void expect(bool condition,std::string_view message){if(!condition){++failures;std::cerr<<"FAIL: "<<message<<'\n';}}
+class TemporaryDirectory{public:TemporaryDirectory(){const auto t=std::chrono::steady_clock::now().time_since_epoch().count();path_=fs::temp_directory_path()/("mqb-module-target-test-"+std::to_string(t));fs::create_directories(path_);}~TemporaryDirectory(){std::error_code e;fs::remove_all(path_,e);}const fs::path& path()const noexcept{return path_;}private:fs::path path_;};
+void write_text(const fs::path& path,std::string_view text){fs::create_directories(path.parent_path());std::ofstream f{path,std::ios::binary|std::ios::trunc};f.write(text.data(),static_cast<std::streamsize>(text.size()));}
+std::string path_to_utf8(const fs::path& path){const auto b=path.lexically_normal().generic_u8string();return {reinterpret_cast<const char*>(b.data()),b.size()};}
+std::string json_escape(std::string_view value){std::string e;for(char ch:value){switch(ch){case '\\':e+="\\\\";break;case '"':e+="\\\"";break;case '\n':e+="\\n";break;case '\r':e+="\\r";break;case '\t':e+="\\t";break;default:e.push_back(ch);}}return e;}
+class ToolchainLikeRunner final:public mqb::process::ProcessRunner{
+public:fs::path linker;std::atomic<int> scan_calls{0},compile_calls{0},link_calls{0};std::atomic<bool> emit_two_scan_rules{false};
+std::expected<mqb::process::ProcessResult,mqb::process::ProcessError> run(const mqb::process::ProcessSpec& spec)override{if(spec.executable==linker)return run_link(spec);for(const auto& a:spec.arguments)if(a=="/scanDependencies")return run_scan(spec);return run_compile(spec);}
 private:
-    fs::path path_;
+std::expected<mqb::process::ProcessResult,mqb::process::ProcessError> run_scan(const mqb::process::ProcessSpec& spec){++scan_calls;fs::path output,source;for(std::size_t i=0;i<spec.arguments.size();++i)if(spec.arguments[i]=="/scanDependencies"&&i+1<spec.arguments.size())output=fs::path{spec.arguments[i+1]};if(!spec.arguments.empty())source=fs::path{spec.arguments.back()};const bool iface=source.extension()==".ixx";std::string rule=iface?R"json({"provides":[{"logical-name":"math"}]})json":R"json({"requires":[{"logical-name":"math"}]})json";std::string json="{\"version\":1,\"revision\":0,\"rules\":["+rule;if(emit_two_scan_rules.load())json+=",{}";json+="]}";write_text(output,json);return mqb::process::ProcessResult{.exit_code=0};}
+std::expected<mqb::process::ProcessResult,mqb::process::ProcessError> run_compile(const mqb::process::ProcessSpec& spec){++compile_calls;fs::path source,object,deps,ifc;for(std::size_t i=0;i<spec.arguments.size();++i){const auto& a=spec.arguments[i];if(a.starts_with("/Fo"))object=fs::path{a.substr(3)};else if(a=="/sourceDependencies"&&i+1<spec.arguments.size())deps=fs::path{spec.arguments[++i]};else if(a=="/ifcOutput"&&i+1<spec.arguments.size())ifc=fs::path{spec.arguments[++i]};}if(!spec.arguments.empty())source=fs::path{spec.arguments.back()};write_text(object,"fake object");if(!ifc.empty())write_text(ifc,"fake ifc");const std::string metadata="{\"Data\":{\"Source\":\""+json_escape(path_to_utf8(source))+"\",\"Includes\":[]}}";write_text(deps,metadata);return mqb::process::ProcessResult{.exit_code=0};}
+std::expected<mqb::process::ProcessResult,mqb::process::ProcessError> run_link(const mqb::process::ProcessSpec& spec){++link_calls;fs::path output;for(const auto& a:spec.arguments){constexpr std::string_view p="/OUT:";if(a.starts_with(p)){output=fs::path{a.substr(p.size())};break;}}write_text(output,"fake executable");return mqb::process::ProcessResult{.exit_code=0};}
 };
-
-void write_text(const fs::path& path, const std::string_view text) {
-    fs::create_directories(path.parent_path());
-    std::ofstream file{path, std::ios::binary | std::ios::trunc};
-    file.write(text.data(), static_cast<std::streamsize>(text.size()));
-}
-
-[[nodiscard]] std::string path_to_utf8(const fs::path& path) {
-    const auto bytes = path.lexically_normal().generic_u8string();
-    return std::string{
-        reinterpret_cast<const char*>(bytes.data()),
-        bytes.size()};
-}
-
-[[nodiscard]] std::string json_escape(const std::string_view value) {
-    std::string escaped;
-    for (const char ch : value) {
-        switch (ch) {
-        case '\\': escaped += "\\\\"; break;
-        case '"': escaped += "\\\""; break;
-        case '\n': escaped += "\\n"; break;
-        case '\r': escaped += "\\r"; break;
-        case '\t': escaped += "\\t"; break;
-        default: escaped.push_back(ch); break;
-        }
-    }
-    return escaped;
-}
-
-class ToolchainLikeRunner final : public mqb::process::ProcessRunner {
-public:
-    fs::path linker;
-    std::atomic<int> scan_calls{0};
-    std::atomic<int> compile_calls{0};
-    std::atomic<int> link_calls{0};
-    std::atomic<bool> emit_two_scan_rules{false};
-
-    std::expected<mqb::process::ProcessResult, mqb::process::ProcessError>
-    run(const mqb::process::ProcessSpec& spec) override {
-        if (spec.executable == linker) {
-            return run_link(spec);
-        }
-        for (const auto& argument : spec.arguments) {
-            if (argument == "/scanDependencies") {
-                return run_scan(spec);
-            }
-        }
-        return run_compile(spec);
-    }
-
-private:
-    std::expected<mqb::process::ProcessResult, mqb::process::ProcessError>
-    run_scan(const mqb::process::ProcessSpec& spec) {
-        ++scan_calls;
-        fs::path output;
-        fs::path source;
-        for (std::size_t index = 0; index < spec.arguments.size(); ++index) {
-            if (spec.arguments[index] == "/scanDependencies"
-                && index + 1 < spec.arguments.size()) {
-                output = fs::path{spec.arguments[index + 1]};
-            }
-        }
-        if (!spec.arguments.empty()) {
-            source = fs::path{spec.arguments.back()};
-        }
-
-        const bool module_interface = source.extension() == ".ixx";
-        std::string rule = module_interface
-            ? R"json({"provides":[{"logical-name":"math"}]})json"
-            : R"json({"requires":[{"logical-name":"math"}]})json";
-        std::string json = "{\"version\":1,\"revision\":0,\"rules\":[" + rule;
-        if (emit_two_scan_rules.load()) {
-            json += ",{}";
-        }
-        json += "]}";
-        write_text(output, json);
-        return mqb::process::ProcessResult{.exit_code = 0};
-    }
-
-    std::expected<mqb::process::ProcessResult, mqb::process::ProcessError>
-    run_compile(const mqb::process::ProcessSpec& spec) {
-        ++compile_calls;
-        fs::path source;
-        fs::path object;
-        fs::path dependencies;
-        fs::path interface_file;
-        for (std::size_t index = 0; index < spec.arguments.size(); ++index) {
-            const auto& argument = spec.arguments[index];
-            if (argument.starts_with("/Fo")) {
-                object = fs::path{argument.substr(3)};
-            } else if (argument == "/sourceDependencies" && index + 1 < spec.arguments.size()) {
-                dependencies = fs::path{spec.arguments[++index]};
-            } else if (argument == "/ifcOutput" && index + 1 < spec.arguments.size()) {
-                interface_file = fs::path{spec.arguments[++index]};
-            }
-        }
-        if (!spec.arguments.empty()) {
-            source = fs::path{spec.arguments.back()};
-        }
-
-        write_text(object, "fake object");
-        if (!interface_file.empty()) {
-            write_text(interface_file, "fake ifc");
-        }
-        const std::string metadata =
-            "{\"Data\":{\"Source\":\""
-            + json_escape(path_to_utf8(source))
-            + "\",\"Includes\":[]}}";
-        write_text(dependencies, metadata);
-        return mqb::process::ProcessResult{.exit_code = 0};
-    }
-
-    std::expected<mqb::process::ProcessResult, mqb::process::ProcessError>
-    run_link(const mqb::process::ProcessSpec& spec) {
-        ++link_calls;
-        fs::path output;
-        for (const auto& argument : spec.arguments) {
-            constexpr std::string_view prefix = "/OUT:";
-            if (argument.starts_with(prefix)) {
-                output = fs::path{argument.substr(prefix.size())};
-                break;
-            }
-        }
-        write_text(output, "fake executable");
-        return mqb::process::ProcessResult{.exit_code = 0};
-    }
-};
-
 } // namespace
 
-int main() {
-    TemporaryDirectory fixture;
-    const fs::path root = fixture.path();
-    const fs::path module_source = root / "modules" / "math.ixx";
-    const fs::path consumer_source = root / "src" / "main.cpp";
-    write_text(module_source, "export module math;\n");
-    write_text(consumer_source, "import math;\nint main() { return 0; }\n");
-
-    auto layout = mqb::ProjectArtifactLayout::create(root);
-    expect(layout.has_value(), "module target fixture should create artifact layout");
-    if (!layout) return 1;
-    auto module_artifacts = layout->for_source(module_source);
-    auto consumer_artifacts = layout->for_source(consumer_source);
-    auto target_artifacts = layout->for_target("module-app");
-    expect(module_artifacts && consumer_artifacts && target_artifacts,
-           "module target fixture should map all source and target artifacts");
-    if (!module_artifacts || !consumer_artifacts || !target_artifacts) return 1;
-
-    const fs::path fake_compiler = root / "toolchain" / "cl.exe";
-    const fs::path fake_linker = root / "toolchain" / "link.exe";
-    const fs::path fake_librarian = root / "toolchain" / "lib.exe";
-    write_text(fake_compiler, "fake compiler binary");
-    write_text(fake_linker, "fake linker binary");
-    write_text(fake_librarian, "fake librarian binary");
-
-    mqb::msvc::MsvcToolchain toolchain{
-        .identity = mqb::ToolchainIdentity{
-            .compiler = fake_compiler,
-            .version = "19.51.test",
-            .binary_stamp = "fake-compiler-stamp",
-        },
-        .linker = fake_linker,
-        .librarian = fake_librarian,
-        .vc_tools_root = fake_compiler.parent_path(),
-        .source = mqb::msvc::ToolchainSource::visual_studio,
-    };
-
-    ToolchainLikeRunner runner;
-    runner.linker = fake_linker;
-    mqb::msvc::MsvcModuleDependencyScanner scanner{toolchain, runner};
-    mqb::msvc::MsvcCompileExecutor executor{toolchain, runner};
-    mqb::orchestration::MsvcIncrementalCompileCoordinator incremental_compile{
-        toolchain,
-        executor};
-    mqb::orchestration::MsvcModuleCompileCoordinator module_compile{incremental_compile};
-    mqb::msvc::MsvcLinker linker{toolchain, runner};
-    mqb::orchestration::MsvcIncrementalLinkCoordinator incremental_link{toolchain, linker};
-    mqb::orchestration::MsvcModuleTargetCoordinator target{
-        scanner,
-        module_compile,
-        incremental_link};
-
-    mqb::orchestration::IncrementalModuleTargetRequest request;
-    request.sources = {
-        mqb::orchestration::ModuleCompileSourceRequest{
-            .source = consumer_source,
-            .artifacts = *consumer_artifacts,
-            .kind = mqb::TranslationUnitKind::source,
-        },
-        mqb::orchestration::ModuleCompileSourceRequest{
-            .source = module_source,
-            .artifacts = *module_artifacts,
-            .kind = mqb::TranslationUnitKind::module_interface,
-        },
-    };
-    request.target = *target_artifacts;
-    request.compiler_options.standard = mqb::CppStandard::latest;
-    request.link_options.architecture = mqb::Architecture::x64;
-    request.link_options.subsystem = mqb::LinkSubsystem::console;
-    request.working_directory = root;
-    request.max_parallel_scans = 2;
-    request.max_parallel_compiles = 2;
-
-    const auto cold = target.run(request);
-    expect(cold.has_value(), "cold module target should scan, graph, compile and link successfully");
-    if (!cold) return 1;
-    expect(cold->scans.size() == 2
-               && cold->scans[0].source == consumer_source
-               && cold->scans[1].source == module_source,
-           "module target scan results should preserve request source order");
-    expect(cold->plan.compile_levels.size() == 2,
-           "scanned provider and consumer should form two compile levels");
-    expect(cold->plan.resolved_dependencies.size() == 1
-               && cold->plan.resolved_dependencies.front().logical_name == "math"
-               && cold->plan.resolved_dependencies.front().provider_source == module_source
-               && cold->plan.resolved_dependencies.front().consumer_source == consumer_source,
-           "module target should retain graph-selected math provider mapping");
-    expect(cold->compiles.any_compiled,
-           "cold module target should report compile work");
-    expect(cold->link.linked,
-           "cold module target should execute the link action");
-    expect(runner.scan_calls.load() == 2
-               && runner.compile_calls.load() == 2
-               && runner.link_calls.load() == 1,
-           "cold module target should run two scans, two compiles and one link");
-
-    const auto warm = target.run(request);
-    expect(warm.has_value(), "warm module target should validate successfully");
-    if (!warm) return 1;
-    expect(!warm->compiles.any_compiled,
-           "warm module target should reuse both compile caches");
-    expect(!warm->link.linked,
-           "warm module target should reuse link cache");
-    expect(runner.scan_calls.load() == 4,
-           "topology scanning is intentionally repeated on the warm target build");
-    expect(runner.compile_calls.load() == 2 && runner.link_calls.load() == 1,
-           "warm module target should run zero compiles and zero links");
-
-    runner.emit_two_scan_rules = true;
-    const int compile_calls_before_invalid_scan = runner.compile_calls.load();
-    const int link_calls_before_invalid_scan = runner.link_calls.load();
-    const auto invalid = target.run(request);
-    expect(!invalid
-               && invalid.error().code
-                   == mqb::orchestration::IncrementalModuleTargetErrorCode::invalid_scan_result,
-           "multi-rule output from a one-source scan should fail closed");
-    expect(runner.compile_calls.load() == compile_calls_before_invalid_scan
-               && runner.link_calls.load() == link_calls_before_invalid_scan,
-           "invalid scan cardinality should stop before compile and link");
-
-    if (failures != 0) {
-        std::cerr << failures << " test(s) failed\n";
-        return 1;
-    }
-
-    std::cout << "mqb_module_target_coordinator_tests passed\n";
-    return 0;
+int main(){
+TemporaryDirectory fixture;const fs::path root=fixture.path(),module_source=root/"modules/math.ixx",consumer_source=root/"src/main.cpp";write_text(module_source,"export module math;\n");write_text(consumer_source,"import math;\nint main(){return 0;}\n");
+auto layout=mqb::ProjectArtifactLayout::create(root);expect(layout.has_value(),"layout");if(!layout)return 1;auto module_artifacts=layout->for_source(module_source),consumer_artifacts=layout->for_source(consumer_source),target_artifacts=layout->for_target("module-app");expect(module_artifacts&&consumer_artifacts&&target_artifacts,"artifacts");if(!module_artifacts||!consumer_artifacts||!target_artifacts)return 1;
+const fs::path fake_compiler=root/"toolchain/cl.exe",fake_linker=root/"toolchain/link.exe",fake_librarian=root/"toolchain/lib.exe";write_text(fake_compiler,"fake compiler");write_text(fake_linker,"fake linker");write_text(fake_librarian,"fake librarian");
+mqb::msvc::MsvcToolchain toolchain{.identity={.compiler=fake_compiler,.version="19.51.test",.binary_stamp="fake-compiler-stamp"},.linker=fake_linker,.librarian=fake_librarian,.vc_tools_root=fake_compiler.parent_path(),.source=mqb::msvc::ToolchainSource::visual_studio};
+ToolchainLikeRunner runner;runner.linker=fake_linker;mqb::msvc::MsvcModuleDependencyScanner scanner{toolchain,runner};mqb::msvc::MsvcCompileExecutor executor{toolchain,runner};mqb::orchestration::MsvcIncrementalCompileCoordinator incremental_compile{toolchain,executor};mqb::orchestration::MsvcModuleCompileCoordinator module_compile{incremental_compile};mqb::msvc::MsvcLinker linker{toolchain,runner};mqb::orchestration::MsvcIncrementalLinkCoordinator incremental_link{toolchain,linker};mqb::orchestration::MsvcModuleTargetCoordinator target{scanner,module_compile,incremental_link};
+mqb::orchestration::IncrementalModuleTargetRequest request;request.sources={{.source=consumer_source,.artifacts=*consumer_artifacts,.kind=mqb::TranslationUnitKind::source},{.source=module_source,.artifacts=*module_artifacts,.kind=mqb::TranslationUnitKind::module_interface}};request.target=*target_artifacts;request.compiler_options.standard=mqb::CppStandard::latest;request.link_options.architecture=mqb::Architecture::x64;request.link_options.subsystem=mqb::LinkSubsystem::console;request.working_directory=root;request.max_parallel_scans=2;request.max_parallel_compiles=2;
+const auto cold=target.run(request);expect(cold.has_value(),"cold module target should succeed");if(!cold)return 1;expect(cold->scans.size()==2&&cold->scans[0].source==consumer_source&&cold->scans[1].source==module_source,"scan ordering");expect(!cold->scans[0].result.reused&&!cold->scans[1].result.reused,"cold scans must launch compiler");expect(cold->plan.compile_levels.size()==2,"two compile levels");expect(cold->compiles.any_compiled&&cold->link.linked,"cold compile/link");expect(runner.scan_calls.load()==2&&runner.compile_calls.load()==2&&runner.link_calls.load()==1,"cold process counts");
+const auto warm=target.run(request);expect(warm.has_value(),"warm target should succeed");if(!warm)return 1;expect(!warm->compiles.any_compiled&&!warm->link.linked,"warm compile/link cache reuse");expect(warm->scans.size()==2&&warm->scans[0].result.reused&&warm->scans[1].result.reused,"warm P1689 scans should reuse sealed evidence");expect(runner.scan_calls.load()==2,"warm target should launch zero additional scans");expect(runner.compile_calls.load()==2&&runner.link_calls.load()==1,"warm target should launch zero compiles/links");
+// Force an observable source timestamp change; only the consumer scan should miss.
+std::this_thread::sleep_for(std::chrono::milliseconds{20});write_text(consumer_source,"import math;\nint main(){return 0;} // changed\n");
+const auto changed=target.run(request);expect(changed.has_value(),"changed consumer should rebuild");if(!changed)return 1;expect(!changed->scans[0].result.reused&&changed->scans[1].result.reused,"source mutation should rescan only changed TU");expect(runner.scan_calls.load()==3,"one changed source should add exactly one raw scan");expect(runner.compile_calls.load()==3,"changed consumer should add exactly one compile");
+const auto warm_again=target.run(request);expect(warm_again.has_value(),"re-sealed warm target should succeed");if(!warm_again)return 1;expect(warm_again->scans[0].result.reused&&warm_again->scans[1].result.reused&&runner.scan_calls.load()==3,"successful rebuild should re-seal scan evidence");
+// Remove one seal so malformed raw scanner output still exercises fail-closed cardinality validation.
+std::error_code ignored;fs::remove(consumer_artifacts->compile_cache,ignored);runner.emit_two_scan_rules=true;const int compiles_before=runner.compile_calls.load(),links_before=runner.link_calls.load();const auto invalid=target.run(request);expect(!invalid&&invalid.error().code==mqb::orchestration::IncrementalModuleTargetErrorCode::invalid_scan_result,"multi-rule raw scan should fail closed");expect(runner.compile_calls.load()==compiles_before&&runner.link_calls.load()==links_before,"invalid scan should stop before compile/link");
+if(failures){std::cerr<<failures<<" test(s) failed\n";return 1;}std::cout<<"mqb_module_target_coordinator_tests passed\n";return 0;
 }

--- a/cpp/tests/orchestration/scheduling/bounded_work_scheduler_tests.cpp
+++ b/cpp/tests/orchestration/scheduling/bounded_work_scheduler_tests.cpp
@@ -168,6 +168,8 @@ int main() {
         std::barrier gate{static_cast<std::ptrdiff_t>(concurrent_workers)};
         std::atomic<int> active{0};
         std::atomic<int> maximum_active{0};
+        std::atomic<bool> caller_participated{false};
+        const auto caller_thread = std::this_thread::get_id();
         std::vector<std::atomic<bool>> seen(5);
         for (auto& value : seen) value.store(false, std::memory_order_relaxed);
 
@@ -175,6 +177,9 @@ int main() {
             seen.size(),
             concurrent_workers,
             [&](const std::size_t index) {
+                if (std::this_thread::get_id() == caller_thread) {
+                    caller_participated.store(true, std::memory_order_relaxed);
+                }
                 seen[index].store(true, std::memory_order_relaxed);
                 const int now_active = active.fetch_add(1, std::memory_order_relaxed) + 1;
                 update_max(maximum_active, now_active);
@@ -192,8 +197,10 @@ int main() {
             expect(concurrent->started_count == seen.size(),
                    "successful concurrent scheduling should start every item");
         }
+        expect(caller_participated.load(std::memory_order_relaxed),
+               "multi-worker scheduling should use the caller as one logical worker");
         expect(maximum_active.load(std::memory_order_relaxed) == 3,
-               "three workers should be observably active at the same time");
+               "three logical workers should be observably active at the same time");
         for (std::size_t index = 0; index < seen.size(); ++index) {
             expect(seen[index].load(std::memory_order_relaxed),
                    "every successful work index should run exactly once");

--- a/docs/PARALLELISM.md
+++ b/docs/PARALLELISM.md
@@ -42,7 +42,7 @@ workers = min(hardware budget, ready work items)
 - named-module compile 会**逐 dependency level**按该层 ready width 重新解析；
 - header unit / toolchain-owned module provider 进入对应 ready level 后使用同一策略。
 
-PR8 不加入诸如“只用 75% 核心”之类经验常数。内存压力、机器负载、TU 成本估计等资源自适应属于后续 throughput 阶段。
+MQB 不加入诸如“只用 75% 核心”之类经验常数。内存压力、机器瞬时负载和 TU 成本预测只有在能够形成稳定、可验证的资源模型时才应进入 scheduler，而不会依据 hosted-runner 偶然数据硬编码。
 
 ### `fixed(N)`
 
@@ -53,6 +53,42 @@ workers = min(N, ready work items)
 ```
 
 硬件线程数不会把用户明确指定的 `N` 再改写成另一策略。最终是否适合该机器由用户负责选择。
+
+## Caller-participating scheduler
+
+当解析出的 `worker_count > 1` 时，MQB 将**调用 scheduler 的当前线程本身算作一个 logical worker**，只额外创建 `worker_count - 1` 个后台线程：
+
+```text
+logical workers = caller + background workers
+background threads created = worker_count - 1
+```
+
+这不会改变并发上限、任务索引分配、stop/exception 语义或 public `worker_count`，但会确定性消除每次 parallel dispatch 的一个线程创建/销毁。对 named-module graph 来说，每个 dependency level 都能获得这项收益。
+
+单 worker 仍使用原有 inline fast path，不创建后台线程。
+
+## Warm P1689 scan reuse
+
+Named Modules / Header Unit pipeline 的 compile/link warm cache hit 还不足以构成真正 no-op：如果每次都重新启动 `cl.exe /scanDependencies`，module topology 仍有固定进程成本。
+
+MQB 因此把可复用的 P1689 topology evidence **封存在成功 compile 的现有 compile cache 中**，而不是创建第二套独立 scan-cache artifact。compile cache v3 可选保存：
+
+- scan recipe signature；
+- source 的精确文件时间快照；
+- P1689 `.scan` artifact 的精确快照；
+- 成功 `/sourceDependencies` 得到的 textual include dependency 快照。
+
+只有成功 compile 才能 seal 这份 evidence。若 source/header 在 scan 之后、compile 完成之前已经变化，则该次 compile cache 不写入 scan evidence。
+
+下一次 module scan 只有在 signature、source、`.scan` 和全部 textual dependency snapshot **全部精确匹配**时才能复用旧 P1689；任何 cache 读取失败、snapshot 失败、metadata 损坏或 P1689 parse 失败都会 fail-open 到正常 raw scan，而不会让性能缓存成为新的构建失败面。
+
+工具链提供的 `std` / `std.compat` module provider 与项目源码共用同一套 scan-reuse 规则。
+
+### Cache wire compatibility
+
+新写入的 compile cache 是 v3。历史 v2 cache 仍可读取，只是没有 scan evidence，因此第一次 module build 会正常重新 scan；后续成功 compile 才会获得 warm scan reuse。v1 继续按原策略拒绝。
+
+scan evidence 使用 native `file_time_type` tick count 原样持久化，不做跨 epoch 的纳秒换算，避免范围溢出或精度损失。
 
 ## 单一并行所有权
 
@@ -78,6 +114,8 @@ MQB workers × cl.exe /MP workers
 
 只要源码、依赖、工具链和构建配方不变，改变 jobs policy 后仍应保持 warm cache hit。
 
+P1689 scan signature 是独立的 topology recipe identity，只包含会影响 scan 的输入；runtime library 与 LTCG 等不进入 scan identity。
+
 ## C++ API 兼容性
 
 原有 request 字段名保持不变，例如：
@@ -99,11 +137,13 @@ MQB workers × cl.exe /MP workers
 
 ## 测试契约
 
-PR8 使用结构性测试而不是 hosted-runner 毫秒阈值：
+结构性正确性测试不使用 hosted-runner 毫秒阈值：
 
 - resolver 可注入 hardware concurrency，验证 unknown / hardware-limited / work-limited / fixed ceiling；
-- numeric C++ API compatibility 和 fixed(0) fail-closed 被锁定；
-- CLI parser 覆盖四种 `auto` 写法；
-- ordinary 四 TU E2E 在 fixed → auto 后必须全部 compile/link cache hit；
-- `import std` P1689 module E2E 在 fixed → auto 后必须保持 consumer/provider/link warm reuse；
+- multi-worker barrier test 验证 caller 实际参与，同时 observed concurrency 仍严格等于 logical worker 上限；
+- scan signature test 锁定 topology-affecting 与非 scan 输入边界；
+- scan evidence test 锁定 source/header/P1689 artifact 任一 snapshot 变化必失效；
+- compile-cache v3 round-trip 与 v2 compatibility 被直接验证；
+- module coordinator 验证 cold scan、warm zero-scan、单 source mutation 精确 rescan、成功 rebuild 后重新 seal；
+- ordinary 与 `import std` E2E 继续验证 jobs policy 不污染 compile/link cache；
 - Debug/Release self-host、完整 native test graph 和 Release package validation 仍是最终合并门。

--- a/docs/PARALLELISM_EN.md
+++ b/docs/PARALLELISM_EN.md
@@ -42,7 +42,7 @@ Consequently:
 - named-module compilation resolves **per dependency level** against that level's ready width;
 - header units and toolchain-owned module providers use the same policy when they enter a ready level.
 
-PR8 deliberately avoids arbitrary heuristics such as “use 75% of cores”. Memory pressure, machine load, and TU-cost-aware scheduling belong to later throughput work.
+MQB does not hard-code arbitrary heuristics such as “use 75% of cores”. Memory pressure, instantaneous machine load, and TU-cost prediction should enter the scheduler only when they can be represented by a stable, testable resource model rather than hosted-runner accident.
 
 ### `fixed(N)`
 
@@ -53,6 +53,42 @@ workers = min(N, ready work items)
 ```
 
 Hardware concurrency does not silently rewrite an explicitly selected fixed policy. The user owns the decision to choose an appropriate explicit ceiling for the machine.
+
+## Caller-participating scheduler
+
+When the resolved `worker_count` is greater than one, MQB counts the thread that called the scheduler as one logical worker and creates only `worker_count - 1` background threads:
+
+```text
+logical workers = caller + background workers
+background threads created = worker_count - 1
+```
+
+This does not change the concurrency ceiling, item assignment, stop/exception behavior, or public `worker_count`. It deterministically removes one thread creation/destruction from every parallel dispatch, including every dependency level in a named-module graph.
+
+The one-worker path remains the existing inline fast path and creates no background thread.
+
+## Warm P1689 scan reuse
+
+A warm compile/link cache hit is not a true no-op for the Named Modules / Header Unit pipeline if every invocation still launches `cl.exe /scanDependencies` to rediscover unchanged topology.
+
+MQB therefore seals reusable P1689 topology evidence **inside the existing compile cache after a successful compile**, rather than creating a second independent scan-cache artifact. Compile-cache v3 may store:
+
+- a scan-recipe signature;
+- the exact source file-time snapshot;
+- the exact P1689 `.scan` artifact snapshot;
+- textual include dependency snapshots obtained from the successful `/sourceDependencies` metadata.
+
+Only a successful compile can seal this evidence. If the source or one of its textual headers changes after the scan but before the compile completes, the compile cache is still usable for its normal purpose but no scan evidence is sealed.
+
+A later module scan is reusable only when the signature, source, `.scan`, and every textual dependency snapshot match exactly. Any cache load failure, snapshot failure, malformed metadata, or P1689 parse failure fails open to the normal raw scan; the optimization never becomes a new build-failure surface.
+
+Toolchain-owned `std` / `std.compat` module providers use the same scan-reuse path as project sources.
+
+### Cache wire compatibility
+
+New compile caches are written as v3. Historical v2 entries remain readable but contain no scan evidence, so the first module build performs a normal scan and a later successful compile can seal the new evidence. v1 remains unsupported as before.
+
+Scan evidence persists the native `file_time_type` tick count exactly instead of converting across epochs to nanoseconds, avoiding range overflow and precision loss.
 
 ## One owner of compile parallelism
 
@@ -78,6 +114,8 @@ Switching from `-j 1` to `-j auto`, or from `-j 4` to `-j 2`, does not change:
 
 If source, dependencies, toolchain, and build recipe are unchanged, changing only the jobs policy must remain a warm cache hit.
 
+The P1689 scan signature is a separate topology-recipe identity and contains only inputs that can affect scanning; runtime-library and LTCG policy do not participate in scan identity.
+
 ## C++ API compatibility
 
 Existing request field names remain unchanged, for example:
@@ -99,11 +137,13 @@ New code may be explicit:
 
 ## Validation contract
 
-PR8 uses structural tests instead of hosted-runner timing thresholds:
+Structural correctness tests do not use hosted-runner millisecond thresholds:
 
 - the resolver accepts injected hardware concurrency and tests unknown, hardware-limited, work-limited, and fixed-ceiling cases;
-- numeric C++ API compatibility and fixed(0) fail-closed behavior are locked;
-- the CLI parser covers all four `auto` spellings;
-- the ordinary four-TU E2E must preserve every compile/link cache hit after fixed → auto;
-- the `import std` P1689 module E2E must preserve provider/consumer/link warm reuse after fixed → auto;
+- a multi-worker barrier test proves the caller participates while observed concurrency still equals the logical worker ceiling;
+- scan-signature tests lock topology-affecting inputs and intentionally excluded non-scan inputs;
+- scan-evidence tests require any source/header/P1689 artifact snapshot change to invalidate reuse;
+- compile-cache v3 round-trip and v2 compatibility are directly tested;
+- the module coordinator verifies cold scans, warm zero-scan reuse, precise rescan after one source mutation, and resealing after a successful rebuild;
+- ordinary and `import std` E2E continue proving jobs policy does not contaminate compile/link cache identity;
 - Debug/Release self-host, the complete native test graph, and Release package validation remain the final merge gates.

--- a/tests/native/assert_cpp_layout.ps1
+++ b/tests/native/assert_cpp_layout.ps1
@@ -192,7 +192,8 @@ Assert-LeafLayout -Root (Join-Path $srcRoot 'core') -LeafFiles $coreLeafFiles
 Assert-LeafLayout -Root (Join-Path $testsRoot 'core') -LeafFiles ([ordered]@{
     'cache' = @(
         'compile_cache_file_tests.cpp', 'compile_cache_tests.cpp',
-        'link_cache_file_tests.cpp', 'link_state_tests.cpp'
+        'link_cache_file_tests.cpp', 'link_state_tests.cpp',
+        'module_scan_cache_tests.cpp'
     )
     'model' = @(
         'build_request_tests.cpp', 'build_signature_tests.cpp',

--- a/tests/native/run_native_tests.ps1
+++ b/tests/native/run_native_tests.ps1
@@ -84,8 +84,8 @@ if ($includeDirs.Count -eq 0) { throw 'Native test config has no include_dirs.' 
 $allTestFiles = @(Get-ChildItem -LiteralPath $cppRoot -Recurse -File -Filter '*_tests.cpp' |
     Where-Object { $_.FullName -notmatch '[\\/]\.mqb[\\/]' } |
     Sort-Object FullName)
-if ($allTestFiles.Count -ne 71) {
-    throw "Native test manifest drift: expected 71 *_tests.cpp files, found $($allTestFiles.Count)."
+if ($allTestFiles.Count -ne 72) {
+    throw "Native test manifest drift: expected 72 *_tests.cpp files, found $($allTestFiles.Count)."
 }
 
 function Get-TestRelativePath {
@@ -121,7 +121,7 @@ $testWeightOverrides = [ordered]@{
 $relativeTestPaths = @($allTestFiles | ForEach-Object { Get-TestRelativePath -File $_ })
 foreach ($weightedPath in $testWeightOverrides.Keys) {
     if ($weightedPath -notin $relativeTestPaths) {
-        throw "Native test weight override is stale or missing from the 71-test manifest: $weightedPath"
+        throw "Native test weight override is stale or missing from the 72-test manifest: $weightedPath"
     }
 }
 


### PR DESCRIPTION
## Summary

Completes PR 9, the final MQB productization round: Advanced Throughput.

This round deliberately avoids timing-dependent or machine-specific heuristics. Instead it removes two deterministic sources of overhead while preserving existing build/cache correctness contracts:

1. parallel dispatch now uses the caller as one logical worker, removing one background thread creation/destruction per parallel batch;
2. warm Named Modules / Header Unit builds can reuse P1689 topology sealed by a prior successful compile, removing redundant `cl.exe /scanDependencies` processes when the exact scan evidence is unchanged.

## Caller-participating scheduler

- preserve the existing logical `worker_count` contract and concurrency ceiling
- preserve monotonic work claiming, stop behavior, callback exception behavior, and the single-worker inline fast path
- for `worker_count > 1`, execute with `caller + (worker_count - 1) background threads`
- benefit ordinary/static compile batches and every named-module dependency level without changing cache or artifact identity
- add barrier-backed tests proving the caller participates while observed concurrency remains exactly the requested logical worker bound

## Sealed P1689 warm-scan reuse

A compile/link cache hit is not a true warm no-op for the module pipeline if every invocation still launches `cl.exe /scanDependencies`. PR9 removes that fixed process cost without introducing an independent scan-cache artifact.

The existing compile cache becomes the transaction boundary: only a successful compile may seal `ModuleScanEvidence` containing:

- a dedicated P1689 scan-recipe signature;
- the exact source snapshot;
- the exact `.scan` P1689 artifact snapshot;
- exact textual include snapshots read from the successful `/sourceDependencies` metadata.

The scan signature includes source/TU kind, compiler identity, configuration, architecture, language mode, defines, include search order, and scan-visible raw compiler arguments. Runtime-library, LTCG, PCH bindings, and graph-selected IFC references intentionally do not enter P1689 topology identity.

Evidence is not sealed if the source or a textual dependency is newer than the P1689 output, preventing a scan/compile race from blessing stale topology.

On the next build, reuse requires an exact signature and exact source/P1689/dependency snapshots. Cache-load, snapshot, evidence-validation, file-read, or P1689-parse failure falls back to a normal raw scan rather than becoming a new build failure surface.

Project sources and toolchain-owned `std` / `std.compat` providers use the same reuse path.

## Compile cache v3

- new compile caches are written as v3 with optional `ModuleScanEvidence`
- historical v2 compile caches remain readable and conservatively contain no scan evidence
- v1 remains unsupported as before
- scan snapshots persist the native `file_time_type` tick count exactly rather than converting across epochs to nanoseconds
- no new project artifact identity or second cache sidecar is introduced

## Behavior coverage

The native graph is now 72 tests. New/expanded coverage proves:

- caller participation with the exact existing worker ceiling
- deterministic scan-signature sensitivity boundaries
- source/header/P1689 snapshot changes invalidate scan reuse
- compile-cache v3 evidence round-trip
- compile-cache v2 backward compatibility
- cold module target: two raw scans / two compiles / one link
- warm module target: zero additional scan/compile/link processes
- changing one consumer source rescans and recompiles only that source while the unchanged provider scan remains reusable
- a successful rebuild reseals evidence for the next warm build
- malformed raw P1689 output still fails closed before compile/link
- existing jobs policy remains execution-only and does not alter compile/link cache identity

## Deliberate non-goals

PR9 does not add arbitrary memory-pressure percentages, dynamic CPU-load thresholds, or hosted-runner-derived TU cost constants. Those would require a separately testable resource model; they are not necessary to obtain the deterministic throughput wins delivered here.

Toolchain-environment persistence is also deliberately excluded: blindly persisting the captured VS environment could retain inherited process secrets. Any future persistent toolchain cache must use an explicit allowlisted/delta model rather than serializing the ambient environment.

## Validation

Exact validated head: `be2ca3cbb64077a84fca30fcd5418e42b0b4202f`

Native C++ #269 / run `31813139239`:
- Debug candidate self-build: success
- 67-TU shared native-test product: success
- 72-test graph, 4/4 Debug shards: success
- final Native C++ gate: success

Native Release #233 / run `31813139262`:
- Stage 0 Release self-build + 67-TU shared product: success
- 72-test graph, 4/4 Release shards: success
- Stage 1 stable self-host: success
- runtime-only package staging: success
- exact packaged-artifact validation: success
- validated artifact upload: success
- `publish-release`: skipped as expected for a PR

The Chinese and English parallelism documents are updated with the caller-participation, sealed P1689 reuse, v3/v2 cache compatibility, and validation contracts.