### PR TITLE
feat: close productization parameter and performance gaps

### DIFF
--- a/cpp/include/mqb/msvc/MsvcParameterCapabilities.hpp
+++ b/cpp/include/mqb/msvc/MsvcParameterCapabilities.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <string_view>
+
+#include "mqb/msvc/MsvcParameterEngine.hpp"
+
+namespace mqb::msvc {
+
+enum class ParameterLifecycle {
+    active,
+    deprecated,
+    removed,
+    indeterminate,
+};
+
+struct ParameterCapability {
+    ParameterLifecycle lifecycle{ParameterLifecycle::active};
+    std::string_view guidance;
+};
+
+class MsvcParameterCapabilities {
+public:
+    [[nodiscard]] static ParameterCapability inspect(
+        ParameterTool tool,
+        std::string_view argument,
+        std::string_view vc_tools_version) noexcept;
+
+    [[nodiscard]] static bool is_visual_studio_2026_or_later(
+        std::string_view vc_tools_version) noexcept;
+};
+
+[[nodiscard]] std::string_view to_string(ParameterLifecycle lifecycle) noexcept;
+
+} // namespace mqb::msvc

--- a/cpp/mqb.json
+++ b/cpp/mqb.json
@@ -44,6 +44,7 @@
       "src/msvc/linker/MsvcLinker.cpp",
       "src/msvc/modules/MsvcModuleDependencyScanner.cpp",
       "src/msvc/compiler/MsvcSourceDependenciesReader.cpp",
+      "src/msvc/parameters/MsvcParameterCapabilities.cpp",
       "src/msvc/parameters/MsvcParameterEngine.cpp",
       "src/msvc/parameters/MsvcParameterRegistry.cpp",
       "src/msvc/toolchain/MsvcToolchainLocator.cpp",

--- a/cpp/src/app/Application.cpp
+++ b/cpp/src/app/Application.cpp
@@ -23,6 +23,7 @@
 #include "mqb/discovery/SourceDiscovery.hpp"
 #include "mqb/msvc/MsvcCompileExecutor.hpp"
 #include "mqb/msvc/MsvcLinker.hpp"
+#include "mqb/msvc/MsvcParameterCapabilities.hpp"
 #include "mqb/msvc/MsvcToolchainLocator.hpp"
 #include "mqb/orchestration/MsvcIncrementalCompileCoordinator.hpp"
 #include "mqb/orchestration/MsvcIncrementalLinkCoordinator.hpp"
@@ -82,6 +83,43 @@ void add_portable_root_if_missing(
         message += diagnostics::path_text(path);
     }
     return message;
+}
+
+[[nodiscard]] bool validate_parameter_capabilities(
+    const mqb::msvc::ParameterTool tool,
+    const std::vector<std::string>& arguments,
+    const std::string_view vc_tools_version) {
+    for (const auto& argument : arguments) {
+        const auto capability = mqb::msvc::MsvcParameterCapabilities::inspect(
+            tool,
+            argument,
+            vc_tools_version);
+        if (capability.lifecycle == mqb::msvc::ParameterLifecycle::active) {
+            continue;
+        }
+
+        std::string message = "MSVC ";
+        message += mqb::msvc::to_string(tool);
+        message += " option '";
+        message += argument;
+        message += "' is ";
+        message += mqb::msvc::to_string(capability.lifecycle);
+        message += " for toolset ";
+        message += vc_tools_version;
+        if (!capability.guidance.empty()) {
+            message += ": ";
+            message += capability.guidance;
+        }
+
+        if (capability.lifecycle == mqb::msvc::ParameterLifecycle::deprecated) {
+            diagnostics::print_warning(message);
+            continue;
+        }
+
+        diagnostics::print_error(message);
+        return false;
+    }
+    return true;
 }
 
 void print_jobs(const mqb::orchestration::ParallelismPolicy policy) {
@@ -268,6 +306,17 @@ int Application::run(const std::span<const std::string_view> arguments) {
             toolchain.error().message,
             toolchain.error().path));
         return 3;
+    }
+
+    if (!validate_parameter_capabilities(
+            mqb::msvc::ParameterTool::compiler,
+            options.compiler_arguments,
+            toolchain->identity.version)
+        || !validate_parameter_capabilities(
+            mqb::msvc::ParameterTool::linker,
+            options.linker_arguments,
+            toolchain->identity.version)) {
+        return 2;
     }
 
     mqb::CompilerOptions compiler_options;

--- a/cpp/src/msvc/parameters/MsvcParameterCapabilities.cpp
+++ b/cpp/src/msvc/parameters/MsvcParameterCapabilities.cpp
@@ -1,0 +1,122 @@
+#include "mqb/msvc/MsvcParameterCapabilities.hpp"
+
+#include <cctype>
+#include <string>
+#include <string_view>
+
+namespace mqb::msvc {
+namespace {
+
+struct ParsedVersion {
+    int major{};
+    int minor{};
+    bool valid{};
+};
+
+[[nodiscard]] ParsedVersion parse_version(const std::string_view version) noexcept {
+    ParsedVersion parsed;
+    std::size_t index = 0;
+
+    const auto read_component = [&](int& value) mutable {
+        if (index >= version.size() || !std::isdigit(static_cast<unsigned char>(version[index]))) {
+            return false;
+        }
+        value = 0;
+        while (index < version.size()
+               && std::isdigit(static_cast<unsigned char>(version[index]))) {
+            value = (value * 10) + (version[index] - '0');
+            ++index;
+        }
+        return true;
+    };
+
+    if (!read_component(parsed.major)) return parsed;
+    if (index >= version.size() || version[index] != '.') return parsed;
+    ++index;
+    if (!read_component(parsed.minor)) return parsed;
+    parsed.valid = true;
+    return parsed;
+}
+
+[[nodiscard]] std::string upper_ascii(const std::string_view value) {
+    std::string result{value};
+    for (char& ch : result) {
+        ch = static_cast<char>(std::toupper(static_cast<unsigned char>(ch)));
+    }
+    return result;
+}
+
+[[nodiscard]] std::string_view option_body(const std::string_view argument) noexcept {
+    if (argument.size() >= 2 && (argument.front() == '/' || argument.front() == '-')) {
+        return argument.substr(1);
+    }
+    return {};
+}
+
+[[nodiscard]] ParameterCapability conditional_capability(
+    const bool version_known,
+    const bool changed,
+    const ParameterLifecycle changed_lifecycle,
+    const std::string_view guidance) noexcept {
+    if (!version_known) {
+        return ParameterCapability{
+            .lifecycle = ParameterLifecycle::indeterminate,
+            .guidance = "MQB cannot determine this option's lifecycle because the MSVC tools version is not parseable",
+        };
+    }
+    return ParameterCapability{
+        .lifecycle = changed ? changed_lifecycle : ParameterLifecycle::active,
+        .guidance = changed ? guidance : std::string_view{},
+    };
+}
+
+} // namespace
+
+bool MsvcParameterCapabilities::is_visual_studio_2026_or_later(
+    const std::string_view vc_tools_version) noexcept {
+    const ParsedVersion version = parse_version(vc_tools_version);
+    if (!version.valid) return false;
+    if (version.major != 14) return version.major > 14;
+    return version.minor >= 50;
+}
+
+ParameterCapability MsvcParameterCapabilities::inspect(
+    const ParameterTool tool,
+    const std::string_view argument,
+    const std::string_view vc_tools_version) noexcept {
+    const ParsedVersion parsed = parse_version(vc_tools_version);
+    const bool version_known = parsed.valid;
+    const bool vs2026_or_later = version_known
+        && (parsed.major > 14 || (parsed.major == 14 && parsed.minor >= 50));
+    const std::string_view body = option_body(argument);
+
+    if (tool == ParameterTool::compiler && body == "await") {
+        return conditional_capability(
+            version_known,
+            vs2026_or_later,
+            ParameterLifecycle::deprecated,
+            "/await is deprecated starting with Visual Studio 2026; prefer standard C++20 coroutines or /await:strict for earlier language modes");
+    }
+
+    if (tool == ParameterTool::linker && upper_ascii(body) == "DEBUG:FASTLINK") {
+        return conditional_capability(
+            version_known,
+            vs2026_or_later,
+            ParameterLifecycle::removed,
+            "/DEBUG:FASTLINK is removed starting with Visual Studio 2026; use /DEBUG:FULL");
+    }
+
+    return ParameterCapability{};
+}
+
+std::string_view to_string(const ParameterLifecycle lifecycle) noexcept {
+    switch (lifecycle) {
+    case ParameterLifecycle::active: return "active";
+    case ParameterLifecycle::deprecated: return "deprecated";
+    case ParameterLifecycle::removed: return "removed";
+    case ParameterLifecycle::indeterminate: return "indeterminate";
+    }
+    return "unknown";
+}
+
+} // namespace mqb::msvc

--- a/cpp/src/msvc/parameters/MsvcParameterCapabilities.cpp
+++ b/cpp/src/msvc/parameters/MsvcParameterCapabilities.cpp
@@ -17,7 +17,7 @@ struct ParsedVersion {
     ParsedVersion parsed;
     std::size_t index = 0;
 
-    const auto read_component = [&](int& value) mutable {
+    auto read_component = [&](int& value) {
         if (index >= version.size() || !std::isdigit(static_cast<unsigned char>(version[index]))) {
             return false;
         }

--- a/cpp/src/msvc/parameters/MsvcParameterRegistry.cpp
+++ b/cpp/src/msvc/parameters/MsvcParameterRegistry.cpp
@@ -148,7 +148,9 @@ ParameterClassification classify_linker_parameter(const std::string_view argumen
         return classified(ParameterTool::linker, ParameterOwnership::mqb_owned, "/" + body, "MQB owns target identity, primary link artifacts, or structured library search inputs");
     }
 
-    if (body == "DEBUG:FASTLINK") return linker_unsupported(body, "/DEBUG:FASTLINK is removed from current Visual Studio toolchains; use /DEBUG:FULL");
+    if (body == "DEBUG:FASTLINK") {
+        return classified(ParameterTool::linker, ParameterOwnership::passthrough, "/DEBUG:FASTLINK", "availability is toolchain-version conditional and is validated after MSVC discovery");
+    }
     if (body == "LTCG:INCREMENTAL" || body == "LTCG:NOSTATUS" || body == "LTCG:STATUS") return linker_unsupported(body, "current MQB LTCG policy is boolean and cannot preserve this /LTCG mode yet");
     if (body == "DRIVER" || body.starts_with("DRIVER:")) return linker_unsupported(body, "kernel-driver target shape requires a first-class MQB target policy");
     if (body == "KERNEL") return linker_unsupported(body, "kernel-mode linking is coupled to compiler policy that MQB does not model yet");

--- a/cpp/tests/msvc/parameters/msvc_parameter_capabilities_tests.cpp
+++ b/cpp/tests/msvc/parameters/msvc_parameter_capabilities_tests.cpp
@@ -1,0 +1,75 @@
+#include <iostream>
+#include <string_view>
+
+#include "mqb/msvc/MsvcParameterCapabilities.hpp"
+
+namespace {
+
+int failures = 0;
+
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+} // namespace
+
+int main() {
+    using mqb::msvc::MsvcParameterCapabilities;
+    using mqb::msvc::ParameterLifecycle;
+    using mqb::msvc::ParameterTool;
+
+    expect(!MsvcParameterCapabilities::is_visual_studio_2026_or_later("14.44.35207"),
+           "v143-era 14.44 toolsets must remain pre-VS2026");
+    expect(MsvcParameterCapabilities::is_visual_studio_2026_or_later("14.50.35717"),
+           "14.50 is the VS2026/v145 lifecycle boundary");
+    expect(MsvcParameterCapabilities::is_visual_studio_2026_or_later("14.51.36100"),
+           "14.51 must remain VS2026-or-later");
+    expect(!MsvcParameterCapabilities::is_visual_studio_2026_or_later("unknown"),
+           "unparseable versions must not be guessed as VS2026");
+
+    expect(MsvcParameterCapabilities::inspect(
+               ParameterTool::compiler, "/await", "14.44.35207").lifecycle
+               == ParameterLifecycle::active,
+           "/await remains active before VS2026");
+    expect(MsvcParameterCapabilities::inspect(
+               ParameterTool::compiler, "/await", "14.50.35717").lifecycle
+               == ParameterLifecycle::deprecated,
+           "/await is deprecated starting with VS2026");
+    expect(MsvcParameterCapabilities::inspect(
+               ParameterTool::compiler, "/await:strict", "14.51.36100").lifecycle
+               == ParameterLifecycle::active,
+           "/await:strict is not part of the /await deprecation rule");
+    expect(MsvcParameterCapabilities::inspect(
+               ParameterTool::compiler, "/await", "unknown").lifecycle
+               == ParameterLifecycle::indeterminate,
+           "conditional compiler lifecycle must fail closed on unknown toolset versions");
+
+    expect(MsvcParameterCapabilities::inspect(
+               ParameterTool::linker, "/DEBUG:FASTLINK", "14.44.35207").lifecycle
+               == ParameterLifecycle::active,
+           "/DEBUG:FASTLINK remains available on pre-VS2026 toolsets");
+    expect(MsvcParameterCapabilities::inspect(
+               ParameterTool::linker, "/debug:fastlink", "14.50.35717").lifecycle
+               == ParameterLifecycle::removed,
+           "/DEBUG:FASTLINK is removed starting with VS2026");
+    expect(MsvcParameterCapabilities::inspect(
+               ParameterTool::linker, "/DEBUG:FASTLINK", "unknown").lifecycle
+               == ParameterLifecycle::indeterminate,
+           "conditional linker lifecycle must fail closed on unknown toolset versions");
+
+    expect(MsvcParameterCapabilities::inspect(
+               ParameterTool::compiler, "/W4", "unknown").lifecycle
+               == ParameterLifecycle::active,
+           "non-conditional options do not depend on toolset version parsing");
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+
+    std::cout << "mqb_parameter_capabilities_tests passed\n";
+    return 0;
+}

--- a/cpp/tests/msvc/parameters/msvc_parameter_engine_tests.cpp
+++ b/cpp/tests/msvc/parameters/msvc_parameter_engine_tests.cpp
@@ -193,8 +193,15 @@ int main() {
            "linker registry should be case-insensitive");
     expect(MsvcParameterEngine::classify(ParameterTool::linker, "/OUT:escape.exe").ownership == ParameterOwnership::mqb_owned,
            "/OUT should remain MQB-owned linker routing");
-    expect(MsvcParameterEngine::classify(ParameterTool::linker, "/DEBUG:FASTLINK").ownership == ParameterOwnership::unsupported,
-           "removed /DEBUG:FASTLINK should be rejected explicitly");
+    expect(MsvcParameterEngine::classify(ParameterTool::linker, "/DEBUG:FASTLINK").ownership == ParameterOwnership::passthrough,
+           "/DEBUG:FASTLINK ownership is passthrough while toolchain lifecycle admission is deferred");
+    {
+        const std::vector<std::string> arguments{"/DEBUG:FASTLINK"};
+        auto routed = MsvcParameterEngine::route_linker(arguments);
+        expect(routed.has_value() && routed->passthrough.size() == 1
+                   && routed->passthrough.front() == "/DEBUG:FASTLINK",
+               "toolchain-conditional linker options must survive semantic routing for late admission");
+    }
 
     {
         const std::vector<std::string> arguments{"/STACK:8388608", "/DEBUG:FULL", "/machine:x86", "/subsystem:windows", "/ltcg"};

--- a/docs/MSVC_PARAMETER_ENGINE.md
+++ b/docs/MSVC_PARAMETER_ENGINE.md
@@ -8,19 +8,36 @@ MQB does not try to rename every MSVC switch into a second property system. Inst
 |---|---|---|---|
 | A — MQB-owned structural | Changes target/TU shape, primary artifacts, dependency metadata, or graph topology owned by MQB | `/Fo`, `/OUT`, `/ifcOutput`, `/sourceDependencies`, `/scanDependencies` | Reject user/raw ownership escape with an explanation |
 | B — Semantic typed | Already represented by the MQB build model | `/std:`, `/MD`/`/MT`, `/GL`, `/MACHINE`, `/SUBSYSTEM`, `/LTCG` | Normalize into typed policy before project-option resolution |
-| C — Safe passthrough | Does not invalidate MQB's structural ownership and can remain an ordinary MSVC argv element | `/W4`, `/WX`, `/fp:fast`, `/arch:AVX2`, `/favor:AMD64`, `/STACK` | Preserve spelling/order verbatim; existing signatures/cache identity include it |
-| D — Unsupported / deprecated / conflicting | Changes an unmodeled pipeline, hides inputs, is obsolete, or conflicts with another semantic value | `/MP`, PCH `/Y*`, `@response`, removed `/DEBUG:FASTLINK` | Fail closed before invoking MSVC |
+| C — Safe/conditional passthrough | Does not invalidate MQB structural ownership and can remain an ordinary MSVC argv element | `/W4`, `/WX`, `/fp:fast`, `/arch:AVX2`, `/favor:AMD64`, `/STACK`, version-conditional `/DEBUG:FASTLINK` | Preserve spelling/order verbatim; existing signatures/cache identity include it, then apply toolchain lifecycle admission where required |
+| D — Unsupported / conflicting | Changes an unmodeled pipeline, hides inputs, is unconditionally obsolete, or conflicts with another semantic value | `/MP`, raw PCH `/Y*`, `@response` | Fail closed before invoking MSVC |
 
 `unsupported` is not the same as `unregistered`. A current official option may intentionally be unsupported, but it still has an explicit registry entry and rationale. `unregistered` means the registry has no classification and is a coverage failure for the current reference snapshot.
+
+Ownership and availability are deliberately separate. An option can be structurally safe for MQB to pass through while only existing on part of the supported MSVC toolset range. Those options survive semantic routing and are admitted after MQB discovers the actual toolchain.
+
+## Toolchain lifecycle admission
+
+`ToolchainIdentity.version` records the discovered `VCToolsVersion` (for example `14.44.x` or `14.50.x`). `MsvcParameterCapabilities` uses that real toolset identity after discovery instead of baking a single forever-current answer into the ownership registry.
+
+The initial lifecycle rules are:
+
+- `14.50+` is treated as the Visual Studio 2026 / v145 boundary;
+- compiler `/await` is accepted on older toolsets and accepted with an MQB deprecation warning on `14.50+`; `/await:strict` is not included in that rule;
+- linker `/DEBUG:FASTLINK` is accepted on pre-`14.50` toolsets and rejected before `link.exe` on `14.50+`, with guidance to use `/DEBUG:FULL`;
+- an unparseable toolset version fails closed only for an option whose lifecycle actually depends on the version; ordinary options such as `/W4` remain unaffected.
+
+This two-stage design preserves the existing early config/profile/CLI normalization and precedence model while still making final option admission a property of the toolchain that will execute it.
 
 ## Layering and precedence
 
 Native parameters are normalized inside the layer that supplied them:
 
 1. `mqb.json` typed fields and `compiler_args` / `linker_args` are normalized together.
-2. CLI typed options and `--compiler-arg` / `--linker-arg` are normalized together.
-3. Conflicting typed/native values inside one layer are errors.
-4. The existing project resolver then applies `CLI > mqb.json > built-in defaults`.
+2. A selected profile is normalized as its own overlay.
+3. CLI typed options and native/raw arguments are normalized together.
+4. Conflicting typed/native values inside one layer are errors.
+5. The project resolver then applies `built-ins < base mqb.json < selected profile < CLI`.
+6. After MSVC discovery, remaining raw arguments pass toolchain lifecycle admission.
 
 This prevents argv ordering from becoming a second precedence system. A CLI semantic option can still override a project semantic option, while contradictory values inside the same source are diagnosed instead of relying on MSVC's last-option-wins behavior.
 
@@ -30,21 +47,24 @@ Compiler option names are treated with compiler spelling/case semantics. Linker 
 
 MQB compiles one TU per `cl.exe /c` invocation and owns concurrency, so `/MP` is rejected in favor of `-j/--jobs`. Compiler `/F` is also rejected: it asks `cl.exe` to control linker stack size, but MQB owns a separate `link.exe` invocation; use linker `/STACK` instead.
 
-PCH switches are deliberately reserved for the later first-class PCH pipeline. Response files are rejected because they can hide options and input files from ownership, cache, and dependency classification.
+Raw PCH switches remain reserved for MQB's first-class PCH pipeline. Response files are rejected because they can hide options and input files from ownership, cache, and dependency classification.
 
 File-bearing linker modes that introduce untracked graph inputs or secondary outputs fail closed until the corresponding artifacts are modeled. `/WHOLEARCHIVE:<library>` is a narrow exception: it may pass through when the same library is also declared through MQB's structured library inputs, which keeps freshness tracking authoritative.
 
-## Coverage gate
+## Coverage gates
 
-`cpp/tests/msvc/parameters/msvc_parameter_engine_tests.cpp` is the executable coverage matrix. It contains representative argv for every option family in the current Microsoft references used by this registry and requires each family to resolve to A, B, C, or D rather than `unregistered`.
+`cpp/tests/msvc/parameters/msvc_parameter_engine_tests.cpp` is the executable ownership coverage matrix. It contains representative argv for every option family in the current Microsoft references used by the registry and requires each family to resolve to A, B, C, or D rather than `unregistered`.
 
-Reference snapshot for this PR:
+`cpp/tests/msvc/parameters/msvc_parameter_capabilities_tests.cpp` independently locks toolset lifecycle boundaries so ownership coverage cannot silently collapse back into one static, version-agnostic answer.
 
-- Microsoft C/C++ compiler options, alphabetical reference, metadata date **2026-05-25**
-- Microsoft LINK options reference current at implementation time
-- Microsoft LIB overview/options reference current at implementation time
+Reference snapshot lineage:
 
-The registry implementation lives under `cpp/src/msvc/parameters/`; the public routing API remains under the stable `cpp/include/mqb/msvc/` facade.
+- Microsoft C/C++ compiler options alphabetical reference metadata date: **2026-05-25**;
+- Microsoft LINK options reference current at the original registry implementation;
+- Microsoft LIB overview/options reference current at the original registry implementation;
+- lifecycle updates are modeled against the discovered `VCToolsVersion`, beginning with the Visual Studio 2026 / v145 (`14.50+`) transition.
+
+The registry/capability implementation lives under `cpp/src/msvc/parameters/`; the public APIs remain under the stable `cpp/include/mqb/msvc/` facade.
 
 ## Current typed-model limits
 
@@ -53,18 +73,8 @@ The engine intentionally fails closed where MQB cannot preserve semantics yet:
 - target architecture: typed x86/x64 only;
 - subsystem: typed console/windows only;
 - LTCG: boolean on/off policy; specialized `/LTCG:*` modes are not silently collapsed;
-- PCH: reserved for first-class PCH artifacts and producer/consumer dependencies;
 - CLR/Windows Runtime/kernel/driver/ARM64EC target modes: no first-class MQB target model yet;
 - PGO and other file-producing/file-consuming modes: rejected until their artifacts participate in freshness/cache identity;
 - response files: rejected until MQB can expand and classify their contents safely.
 
-## Next stage
-
-This PR deliberately keeps the existing raw entry points. The next CLI stage can route native tokens such as:
-
-```powershell
-mqb main.cpp /W4 /arch:AVX2 /fp:fast
-mqb main.cpp /O2 /W4 /link /STACK:8388608 /DEBUG:FULL
-```
-
-through the same engine without duplicating parameter semantics inside the CLI parser.
+The parameter engine therefore has two independent correctness questions for every native argument: **who owns the semantics?** and, where necessary, **does this exact toolset still provide the option?**

--- a/docs/PERFORMANCE_GOVERNANCE.md
+++ b/docs/PERFORMANCE_GOVERNANCE.md
@@ -1,0 +1,46 @@
+# MQB Performance Governance
+
+Performance work in MQB is measured against the existing `--timings=json` instrumentation. Hosted-runner wall-clock time is deliberately **not** a correctness gate, but a performance PR must still provide reproducible before/after evidence.
+
+## Required review evidence
+
+For a PR whose primary claim is lower build latency or higher throughput:
+
+1. benchmark a baseline MQB executable built from the PR base;
+2. benchmark the candidate executable from the PR head on the same machine;
+3. use the same iteration count for both executables;
+4. report at least the standard scenarios emitted by `tests/native/benchmark_mqb.ps1`:
+   - `cold`
+   - `no-op`
+   - `single-tu`
+   - `public-header`
+   - `build-run`
+   - `link-only`
+   - `modules-cold`
+   - `modules-no-op`
+5. attach or quote the comparison JSON/table in the PR description or review evidence;
+6. explain any material regression in a core scenario rather than hiding it behind the scenario being optimized.
+
+The canonical comparison command is:
+
+```powershell
+./tests/native/compare_mqb_benchmarks.ps1 `
+  -BaselineMqbPath ./baseline/mqb.exe `
+  -CandidateMqbPath ./candidate/mqb.exe `
+  -Iterations 5 `
+  -OutputPath ./benchmark-comparison.json
+```
+
+`delta_pct < 0` means the candidate is faster. The raw baseline and candidate benchmark records are embedded in the comparison JSON so phase timings and cache hit/miss counts remain auditable.
+
+## What is and is not gated
+
+Correctness CI continues to gate cache freshness, missing-output repair, scheduling bounds, dependency behavior, self-hosting, packaging, and native tests.
+
+Performance evidence is a **review gate**, not a hosted-runner timing threshold. CI machine load, VM placement, antivirus activity, and unrelated system noise make fixed millisecond or percentage thresholds brittle. A reviewer should evaluate repeated medians and the relevant phase/cache evidence instead.
+
+Structural performance tests remain useful when they prove deterministic properties such as “warm module builds launch zero dependency-scan processes” or “one logical worker creates no background thread.” They complement, but do not replace, before/after benchmark evidence for a `perf:` change.
+
+## Benchmark evolution
+
+When a new optimization targets a scenario not represented by the standard harness, add a deterministic fixture/scenario to `benchmark_mqb.ps1` and make the comparator consume it automatically. Do not remove an existing core scenario merely because a new optimization does not improve it.

--- a/tests/native/assert_cpp_layout.ps1
+++ b/tests/native/assert_cpp_layout.ps1
@@ -219,6 +219,7 @@ $msvcLeafFiles = [ordered]@{
     'linker' = @('MsvcLibraryResolver.cpp', 'MsvcLinker.cpp')
     'modules' = @('MsvcModuleDependencyScanner.cpp')
     'parameters' = @(
+        'MsvcParameterCapabilities.cpp',
         'MsvcParameterEngine.cpp',
         'MsvcParameterRegistry.cpp',
         'MsvcParameterRegistry.hpp'
@@ -246,7 +247,7 @@ Assert-LeafLayout -Root (Join-Path $testsRoot 'msvc') -LeafFiles ([ordered]@{
         'module_dependency_scanner_integration_tests.cpp',
         'module_dependency_scanner_tests.cpp'
     )
-    'parameters' = @('msvc_parameter_engine_tests.cpp')
+    'parameters' = @('msvc_parameter_capabilities_tests.cpp', 'msvc_parameter_engine_tests.cpp')
     'toolchain' = @('portable_tests.cpp', 'visual_studio_tests.cpp')
 })
 

--- a/tests/native/compare_mqb_benchmarks.ps1
+++ b/tests/native/compare_mqb_benchmarks.ps1
@@ -1,0 +1,119 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$BaselineMqbPath,
+    [Parameter(Mandatory = $true)][string]$CandidateMqbPath,
+    [ValidateRange(1, 20)][int]$Iterations = 5,
+    [string]$OutputPath
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+function Get-FullPath {
+    param([Parameter(Mandatory = $true)][string]$Path)
+    return [System.IO.Path]::GetFullPath($Path)
+}
+
+$BaselineMqbPath = Get-FullPath $BaselineMqbPath
+$CandidateMqbPath = Get-FullPath $CandidateMqbPath
+foreach ($path in @($BaselineMqbPath, $CandidateMqbPath)) {
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+        throw "MQB executable not found: $path"
+    }
+}
+if (-not [string]::IsNullOrWhiteSpace($OutputPath)) {
+    $OutputPath = Get-FullPath $OutputPath
+}
+
+$benchmarkScript = Join-Path $PSScriptRoot 'benchmark_mqb.ps1'
+if (-not (Test-Path -LiteralPath $benchmarkScript -PathType Leaf)) {
+    throw "Benchmark harness not found: $benchmarkScript"
+}
+
+$tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("mqb-benchmark-compare-" + [Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $tempRoot | Out-Null
+$baselineJson = Join-Path $tempRoot 'baseline.json'
+$candidateJson = Join-Path $tempRoot 'candidate.json'
+
+try {
+    Write-Host '=== Baseline MQB benchmark ==='
+    & $benchmarkScript -MqbPath $BaselineMqbPath -Iterations $Iterations -OutputPath $baselineJson
+    if ($LASTEXITCODE -notin @(0, $null)) {
+        throw "Baseline benchmark failed with exit code $LASTEXITCODE"
+    }
+
+    Write-Host "`n=== Candidate MQB benchmark ==="
+    & $benchmarkScript -MqbPath $CandidateMqbPath -Iterations $Iterations -OutputPath $candidateJson
+    if ($LASTEXITCODE -notin @(0, $null)) {
+        throw "Candidate benchmark failed with exit code $LASTEXITCODE"
+    }
+
+    $baseline = Get-Content -LiteralPath $baselineJson -Raw | ConvertFrom-Json
+    $candidate = Get-Content -LiteralPath $candidateJson -Raw | ConvertFrom-Json
+
+    $candidateByScenario = @{}
+    foreach ($row in @($candidate.summary)) {
+        $candidateByScenario[[string]$row.scenario] = $row
+    }
+
+    $comparison = @(
+        foreach ($baselineRow in @($baseline.summary)) {
+            $scenario = [string]$baselineRow.scenario
+            if (-not $candidateByScenario.ContainsKey($scenario)) {
+                throw "Candidate benchmark is missing scenario '$scenario'"
+            }
+            $candidateRow = $candidateByScenario[$scenario]
+            $baselineMedian = [double]$baselineRow.median_total_ms
+            $candidateMedian = [double]$candidateRow.median_total_ms
+            $deltaMs = $candidateMedian - $baselineMedian
+            $deltaPct = if ($baselineMedian -eq 0.0) {
+                $null
+            }
+            else {
+                ($deltaMs / $baselineMedian) * 100.0
+            }
+
+            [PSCustomObject]@{
+                scenario = $scenario
+                baseline_median_ms = [Math]::Round($baselineMedian, 3)
+                candidate_median_ms = [Math]::Round($candidateMedian, 3)
+                delta_ms = [Math]::Round($deltaMs, 3)
+                delta_pct = if ($null -eq $deltaPct) { $null } else { [Math]::Round($deltaPct, 2) }
+            }
+        }
+    )
+
+    $extraCandidateScenarios = @(
+        $candidateByScenario.Keys | Where-Object {
+            $_ -notin @($baseline.summary | ForEach-Object { [string]$_.scenario })
+        }
+    )
+    if ($extraCandidateScenarios.Count -ne 0) {
+        throw "Candidate benchmark has scenarios absent from baseline: $($extraCandidateScenarios -join ', ')"
+    }
+
+    Write-Host "`n=== Median wall-clock comparison ==="
+    $comparison | Sort-Object scenario | Format-Table -AutoSize
+    Write-Host 'Negative delta means the candidate is faster. Timings are review evidence, not CI pass/fail thresholds.'
+
+    if (-not [string]::IsNullOrWhiteSpace($OutputPath)) {
+        $parent = Split-Path -Parent $OutputPath
+        if (-not [string]::IsNullOrWhiteSpace($parent)) {
+            New-Item -ItemType Directory -Path $parent -Force | Out-Null
+        }
+        [PSCustomObject]@{
+            schema_version = 1
+            generated_utc = [DateTime]::UtcNow.ToString('o')
+            iterations = $Iterations
+            baseline_mqb = $BaselineMqbPath
+            candidate_mqb = $CandidateMqbPath
+            comparison = @($comparison | Sort-Object scenario)
+            baseline = $baseline
+            candidate = $candidate
+        } | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath $OutputPath -Encoding utf8
+        Write-Host "Benchmark comparison JSON: $OutputPath"
+    }
+}
+finally {
+    Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/tests/native/run_native_tests.ps1
+++ b/tests/native/run_native_tests.ps1
@@ -84,8 +84,8 @@ if ($includeDirs.Count -eq 0) { throw 'Native test config has no include_dirs.' 
 $allTestFiles = @(Get-ChildItem -LiteralPath $cppRoot -Recurse -File -Filter '*_tests.cpp' |
     Where-Object { $_.FullName -notmatch '[\\/]\.mqb[\\/]' } |
     Sort-Object FullName)
-if ($allTestFiles.Count -ne 72) {
-    throw "Native test manifest drift: expected 72 *_tests.cpp files, found $($allTestFiles.Count)."
+if ($allTestFiles.Count -ne 73) {
+    throw "Native test manifest drift: expected 73 *_tests.cpp files, found $($allTestFiles.Count)."
 }
 
 function Get-TestRelativePath {
@@ -121,7 +121,7 @@ $testWeightOverrides = [ordered]@{
 $relativeTestPaths = @($allTestFiles | ForEach-Object { Get-TestRelativePath -File $_ })
 foreach ($weightedPath in $testWeightOverrides.Keys) {
     if ($weightedPath -notin $relativeTestPaths) {
-        throw "Native test weight override is stale or missing from the 72-test manifest: $weightedPath"
+        throw "Native test weight override is stale or missing from the 73-test manifest: $weightedPath"
     }
 }
 


### PR DESCRIPTION
## Summary

Starts the Productization Closure round identified after auditing PRs #79-#87.

This tranche closes two concrete gaps without weakening the existing ownership/cache model:

- split MSVC parameter **ownership** from toolchain-version **lifecycle/admission**;
- restore a reproducible **before/after performance review contract** on top of the existing `--timings=json` benchmark harness.

## Toolchain-aware parameter capabilities

`ToolchainIdentity.version` already carries the discovered `VCToolsVersion`. MQB now uses it after toolchain discovery for options whose lifecycle varies across supported MSVC releases.

Initial rules:

- `14.50+` is the Visual Studio 2026 / v145 lifecycle boundary;
- `/await` remains accepted on older toolsets and emits an MQB deprecation warning on `14.50+`; `/await:strict` is unaffected;
- `/DEBUG:FASTLINK` remains structurally safe passthrough for pre-14.50 toolsets but is rejected before `link.exe` on `14.50+` with `/DEBUG:FULL` guidance;
- unparseable toolset versions fail closed only for arguments whose lifecycle actually depends on the version.

This deliberately preserves early `mqb.json/profile/CLI` semantic normalization and precedence. Ownership routing happens before project resolution; lifecycle admission happens only after the actual MSVC toolchain is known.

## Coverage

- add `MsvcParameterCapabilities` public facade + implementation;
- add dedicated lifecycle-boundary tests;
- update `/DEBUG:FASTLINK` parameter-engine coverage to prove it survives early routing for late admission;
- register the new production TU in self-host discovery;
- update the strict responsibility layout;
- advance the native graph from 72 to 73 tests.

## Performance governance

Add `tests/native/compare_mqb_benchmarks.ps1` to run the existing benchmark harness against a base executable and candidate executable with the same iteration count, then emit median baseline/candidate/delta data plus the underlying raw records.

`docs/PERFORMANCE_GOVERNANCE.md` makes this a review-evidence contract for future `perf:` work. Timings remain observational review evidence rather than brittle hosted-runner pass/fail thresholds.

## Scope boundary

The true persistent warm/no-op fingerprint path and resource-aware adaptive scheduling remain independent follow-up changes. Keeping them separate lets this parameter/lifecycle correction be validated and merged without mixing cache-graph risk into the same review.

## Exact validation

Exact validated head: `e2415ca2c0f7d04dd053e082ccf24a7c9794630f`.

### Native C++ #271 — success

- current Debug MQB self-build: success
- shared Debug native-test product library: success
- 73-test graph, 4/4 Debug shards: success
- final Native C++ gate: success

### Native Release #234 — success

- Stage 0 Release MQB self-build: success
- shared Release native-test product library: success
- 73-test graph, 4/4 Release shards: success
- Stage 1 stable self-host: success
- runtime-only release package staging: success
- exact packaged-artifact validation: success
- validated package upload: success
- publish-release remains skipped as expected for a pull request

No unresolved review threads are present.