### PR TITLE
perf: add persistent source discovery fast path

### DIFF
--- a/.github/workflows/performance-evidence.yml
+++ b/.github/workflows/performance-evidence.yml
@@ -1,0 +1,129 @@
+name: Performance Evidence
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+
+concurrency:
+  group: performance-evidence-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  compare:
+    name: Compare base and candidate
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.pull_request.title, 'perf:')
+    runs-on: windows-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    env:
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - name: Checkout candidate
+        uses: actions/checkout@v7
+        with:
+          path: candidate
+
+      - name: Checkout exact PR base
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: baseline
+
+      - name: Checkout baseline for manual run
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v7
+        with:
+          ref: main
+          path: baseline
+
+      - name: Acquire one pinned historical MQB seed
+        id: seed
+        shell: pwsh
+        run: |
+          $candidateRoot = Join-Path $env:GITHUB_WORKSPACE 'candidate'
+          $seed = & (Join-Path $candidateRoot 'tests/native/acquire_seed.ps1') `
+            -RepoRoot $candidateRoot `
+            -OutputRoot (Join-Path $env:GITHUB_WORKSPACE 'performance-seed')
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          "path=$seed" >> $env:GITHUB_OUTPUT
+
+      - name: Build exact baseline Release MQB
+        shell: pwsh
+        run: |
+          $root = Join-Path $env:GITHUB_WORKSPACE 'baseline'
+          $version = (Get-Content -LiteralPath (Join-Path $root 'VERSION') -Raw).Trim()
+          $output = Join-Path $env:GITHUB_WORKSPACE 'performance-out/baseline/mqb.exe'
+          $mqb = & (Join-Path $root 'tests/native/build_mqb.ps1') `
+            -BuilderMqbPath '${{ steps.seed.outputs.path }}' `
+            -RepoRoot $root `
+            -Version $version `
+            -Configuration Release `
+            -Clean `
+            -OutputPath $output
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          if (-not (Test-Path -LiteralPath $mqb -PathType Leaf)) {
+            throw "Baseline Release MQB missing: $mqb"
+          }
+
+      - name: Build candidate Release MQB
+        shell: pwsh
+        run: |
+          $root = Join-Path $env:GITHUB_WORKSPACE 'candidate'
+          $version = (Get-Content -LiteralPath (Join-Path $root 'VERSION') -Raw).Trim()
+          $output = Join-Path $env:GITHUB_WORKSPACE 'performance-out/candidate/mqb.exe'
+          $mqb = & (Join-Path $root 'tests/native/build_mqb.ps1') `
+            -BuilderMqbPath '${{ steps.seed.outputs.path }}' `
+            -RepoRoot $root `
+            -Version $version `
+            -Configuration Release `
+            -Clean `
+            -OutputPath $output
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          if (-not (Test-Path -LiteralPath $mqb -PathType Leaf)) {
+            throw "Candidate Release MQB missing: $mqb"
+          }
+
+      - name: Compare benchmark medians on the same runner
+        shell: pwsh
+        run: |
+          $candidateRoot = Join-Path $env:GITHUB_WORKSPACE 'candidate'
+          $baselineMqb = Join-Path $env:GITHUB_WORKSPACE 'performance-out/baseline/mqb.exe'
+          $candidateMqb = Join-Path $env:GITHUB_WORKSPACE 'performance-out/candidate/mqb.exe'
+          $comparison = Join-Path $env:GITHUB_WORKSPACE 'performance-out/benchmark-comparison.json'
+          & (Join-Path $candidateRoot 'tests/native/compare_mqb_benchmarks.ps1') `
+            -BaselineMqbPath $baselineMqb `
+            -CandidateMqbPath $candidateMqb `
+            -Iterations 5 `
+            -OutputPath $comparison
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Publish comparison summary
+        shell: pwsh
+        run: |
+          $comparisonPath = Join-Path $env:GITHUB_WORKSPACE 'performance-out/benchmark-comparison.json'
+          $report = Get-Content -LiteralPath $comparisonPath -Raw | ConvertFrom-Json
+          $lines = [System.Collections.Generic.List[string]]::new()
+          $lines.Add('## MQB performance evidence')
+          $lines.Add('')
+          $lines.Add('Negative deltas mean the candidate is faster. These values are review evidence, not correctness thresholds.')
+          $lines.Add('')
+          $lines.Add('| Scenario | Base total ms | Candidate total ms | Total Δ% | Base discovery ms | Candidate discovery ms | Discovery Δ% |')
+          $lines.Add('|---|---:|---:|---:|---:|---:|---:|')
+          foreach ($row in @($report.comparison)) {
+            $totalDelta = if ($null -eq $row.total_delta_pct) { 'n/a' } else { [string]$row.total_delta_pct }
+            $discoveryDelta = if ($null -eq $row.discovery_delta_pct) { 'n/a' } else { [string]$row.discovery_delta_pct }
+            $lines.Add("| $($row.scenario) | $($row.baseline_total_ms) | $($row.candidate_total_ms) | $totalDelta | $($row.baseline_discovery_ms) | $($row.candidate_discovery_ms) | $discoveryDelta |")
+          }
+          $lines | Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Encoding utf8
+
+      - name: Upload benchmark evidence
+        uses: actions/upload-artifact@v7
+        with:
+          name: mqb-performance-evidence
+          path: performance-out/benchmark-comparison.json
+          if-no-files-found: error
+          retention-days: 30

--- a/cpp/include/mqb/discovery/SourceDiscovery.hpp
+++ b/cpp/include/mqb/discovery/SourceDiscovery.hpp
@@ -3,6 +3,7 @@
 #include <cstddef>
 #include <expected>
 #include <filesystem>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -38,6 +39,9 @@ struct Request {
     std::vector<std::filesystem::path> excluded_directories;
     std::vector<std::filesystem::path> extra_sources;
     std::vector<std::filesystem::path> excluded_sources;
+    // Optional performance-only state. Cache load/validation/write failures
+    // always fall back to ordinary discovery and never become build failures.
+    std::optional<std::filesystem::path> cache_file;
 };
 
 struct Result {
@@ -48,6 +52,9 @@ struct Result {
     // that requires the P1689/module pipeline, even if discovery found no local
     // interface provider (for example `import external.module;`).
     bool requires_module_pipeline{false};
+    // True only when the result was restored from validated persistent
+    // discovery evidence without recursively re-indexing/re-reading sources.
+    bool reused{false};
 };
 
 class SourceDiscovery {

--- a/cpp/include/mqb/discovery/SourceDiscovery.hpp
+++ b/cpp/include/mqb/discovery/SourceDiscovery.hpp
@@ -39,8 +39,10 @@ struct Request {
     std::vector<std::filesystem::path> excluded_directories;
     std::vector<std::filesystem::path> extra_sources;
     std::vector<std::filesystem::path> excluded_sources;
-    // Optional performance-only state. Cache load/validation/write failures
-    // always fall back to ordinary discovery and never become build failures.
+    // Performance-only persistent state. The default cache lives under the
+    // discovery root's .mqb/cache/discovery directory. Callers may disable it
+    // or override the file path. Cache failures always fall back to discovery.
+    bool persistent_cache{true};
     std::optional<std::filesystem::path> cache_file;
 };
 

--- a/cpp/mqb.json
+++ b/cpp/mqb.json
@@ -69,6 +69,7 @@
       "src/core/model/TranslationUnitClassifier.cpp",
       "src/discovery/analysis/ModuleSyntax.cpp",
       "src/discovery/analysis/SourceTextAnalysis.cpp",
+      "src/discovery/cache/DiscoveryCache.cpp",
       "src/discovery/indexing/SourceIndex.cpp",
       "src/discovery/selection/SourceSelectionGraph.cpp",
       "src/discovery/SourceDiscovery.cpp",

--- a/cpp/src/discovery/SourceDiscovery.cpp
+++ b/cpp/src/discovery/SourceDiscovery.cpp
@@ -87,11 +87,16 @@ using detail::path_key;
 }
 
 [[nodiscard]] std::optional<fs::path> prepare_cache_file(
-    const std::optional<fs::path>& requested) {
-    if (!requested || requested->empty()) return std::nullopt;
+    const bool enabled,
+    const std::optional<fs::path>& requested,
+    const fs::path& root) {
+    if (!enabled) return std::nullopt;
     try {
+        const fs::path candidate = requested && !requested->empty()
+            ? *requested
+            : root / ".mqb" / "cache" / "discovery" / "source-discovery.mqbcache";
         std::error_code error_code;
-        fs::path absolute = fs::absolute(*requested, error_code).lexically_normal();
+        fs::path absolute = fs::absolute(candidate, error_code).lexically_normal();
         if (error_code) return std::nullopt;
         return absolute;
     } catch (...) {
@@ -210,7 +215,10 @@ SourceDiscovery::discover(const Request& request) {
         .extra_sources = extra_sources,
         .excluded_sources = excluded_sources,
     };
-    const std::optional<fs::path> cache_file = prepare_cache_file(request.cache_file);
+    const std::optional<fs::path> cache_file = prepare_cache_file(
+        request.persistent_cache,
+        request.cache_file,
+        root);
     if (cache_file) {
         if (auto cached = detail::try_reuse_discovery_cache(*cache_file, cache_identity)) {
             return std::move(*cached);

--- a/cpp/src/discovery/SourceDiscovery.cpp
+++ b/cpp/src/discovery/SourceDiscovery.cpp
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "mqb/core/TranslationUnitClassifier.hpp"
+#include "cache/DiscoveryCache.hpp"
 #include "indexing/DiscoveryPath.hpp"
 #include "indexing/SourceIndex.hpp"
 #include "selection/SourceSelectionGraph.hpp"
@@ -70,6 +71,44 @@ using detail::path_key;
     return absolute;
 }
 
+[[nodiscard]] std::vector<fs::path> normalize_include_directories(
+    const std::vector<fs::path>& requested) {
+    std::vector<fs::path> result;
+    result.reserve(requested.size());
+    std::error_code error_code;
+    for (const auto& directory : requested) {
+        fs::path absolute = fs::absolute(directory, error_code).lexically_normal();
+        if (!error_code) {
+            result.push_back(std::move(absolute));
+        }
+        error_code.clear();
+    }
+    return result;
+}
+
+[[nodiscard]] std::optional<fs::path> prepare_cache_file(
+    const std::optional<fs::path>& requested) {
+    if (!requested || requested->empty()) return std::nullopt;
+    try {
+        std::error_code error_code;
+        fs::path absolute = fs::absolute(*requested, error_code).lexically_normal();
+        if (error_code) return std::nullopt;
+        return absolute;
+    } catch (...) {
+        return std::nullopt;
+    }
+}
+
+void stabilize_cache_parent_best_effort(const fs::path& cache_file) noexcept {
+    try {
+        if (cache_file.parent_path().empty()) return;
+        std::error_code error_code;
+        fs::create_directories(cache_file.parent_path(), error_code);
+    } catch (...) {
+        return;
+    }
+}
+
 } // namespace
 
 std::expected<Result, Error>
@@ -114,7 +153,9 @@ SourceDiscovery::discover(const Request& request) {
         }
     }
 
+    std::vector<fs::path> excluded_sources;
     std::unordered_set<std::string> excluded_source_keys;
+    excluded_sources.reserve(request.excluded_sources.size());
     for (const auto& requested : request.excluded_sources) {
         auto source = normalize_source_correction(requested, root, "discovery excluded source");
         if (!source) {
@@ -126,11 +167,14 @@ SourceDiscovery::discover(const Request& request) {
                 *source,
                 "discovery excluded source must not be the entry translation unit"));
         }
-        excluded_source_keys.insert(path_key(*source));
+        if (excluded_source_keys.insert(path_key(*source)).second) {
+            excluded_sources.push_back(std::move(*source));
+        }
     }
 
     std::vector<fs::path> extra_sources;
     std::unordered_set<std::string> extra_source_keys;
+    extra_sources.reserve(request.extra_sources.size());
     for (const auto& requested : request.extra_sources) {
         auto source = normalize_source_correction(requested, root, "discovery extra source");
         if (!source) {
@@ -152,21 +196,44 @@ SourceDiscovery::discover(const Request& request) {
             }
         }
         if (*source != entry && extra_source_keys.insert(key).second) {
-            auto analysis = detail::read_source_analysis(*source, false);
-            if (!analysis) {
-                return std::unexpected(failure(
-                    ErrorCode::invalid_correction,
-                    *source,
-                    analysis.error()));
-            }
-            if (classify_translation_unit_path(*source) == TranslationUnitKind::source
-                && analysis->defines_main) {
-                return std::unexpected(failure(
-                    ErrorCode::invalid_correction,
-                    *source,
-                    "discovery extra source must not define another main()"));
-            }
             extra_sources.push_back(std::move(*source));
+        }
+    }
+
+    std::vector<fs::path> include_directories =
+        normalize_include_directories(request.include_directories);
+    const detail::DiscoveryRequestIdentity cache_identity{
+        .project_root = root,
+        .entry = entry,
+        .include_directories = include_directories,
+        .excluded_directories = excluded_directories,
+        .extra_sources = extra_sources,
+        .excluded_sources = excluded_sources,
+    };
+    const std::optional<fs::path> cache_file = prepare_cache_file(request.cache_file);
+    if (cache_file) {
+        if (auto cached = detail::try_reuse_discovery_cache(*cache_file, cache_identity)) {
+            return std::move(*cached);
+        }
+        // Stabilize creation of the .mqb/cache hierarchy before directory
+        // freshness evidence is captured by a full discovery pass.
+        stabilize_cache_parent_best_effort(*cache_file);
+    }
+
+    for (const auto& source : extra_sources) {
+        auto analysis = detail::read_source_analysis(source, false);
+        if (!analysis) {
+            return std::unexpected(failure(
+                ErrorCode::invalid_correction,
+                source,
+                analysis.error()));
+        }
+        if (classify_translation_unit_path(source) == TranslationUnitKind::source
+            && analysis->defines_main) {
+            return std::unexpected(failure(
+                ErrorCode::invalid_correction,
+                source,
+                "discovery extra source must not define another main()"));
         }
     }
 
@@ -187,16 +254,6 @@ SourceDiscovery::discover(const Request& request) {
             "source discovery entry was not indexed"));
     }
 
-    std::vector<fs::path> include_directories;
-    include_directories.reserve(request.include_directories.size());
-    for (const auto& directory : request.include_directories) {
-        fs::path absolute = fs::absolute(directory, error_code).lexically_normal();
-        if (!error_code) {
-            include_directories.push_back(std::move(absolute));
-        }
-        error_code.clear();
-    }
-
     const auto selection = detail::select_source_closure(
         indexed->files,
         indexed->index_by_path,
@@ -208,8 +265,12 @@ SourceDiscovery::discover(const Request& request) {
         result.sources.push_back(indexed->files[index].path);
     }
 
+    bool extras_are_indexed = true;
     for (const auto& source : extra_sources) {
         const std::string key = path_key(source);
+        if (!indexed->index_by_path.contains(key)) {
+            extras_are_indexed = false;
+        }
         const auto duplicate = std::find_if(
             result.sources.begin(),
             result.sources.end(),
@@ -244,6 +305,20 @@ SourceDiscovery::discover(const Request& request) {
             ErrorCode::invalid_entry,
             entry,
             "source discovery did not retain the entry translation unit"));
+    }
+
+    if (cache_file
+        && indexed->cacheable
+        && extras_are_indexed
+        && result.warnings.empty()) {
+        detail::save_discovery_cache_best_effort(
+            *cache_file,
+            detail::DiscoveryCacheRecord{
+                .request = cache_identity,
+                .result = result,
+                .files = indexed->file_snapshots,
+                .directories = indexed->directory_snapshots,
+            });
     }
     return result;
 }

--- a/cpp/src/discovery/cache/DiscoveryCache.cpp
+++ b/cpp/src/discovery/cache/DiscoveryCache.cpp
@@ -288,6 +288,21 @@ private:
     };
 }
 
+[[nodiscard]] bool record_semantics_valid(
+    const DiscoveryCacheRecord& record,
+    const DiscoveryRequestIdentity& request) noexcept {
+    if (record.request != request
+        || record.result.sources.empty()
+        || record.result.sources.front().lexically_normal() != request.entry.lexically_normal()
+        || record.result.indexed_files != record.files.size()
+        || record.directories.empty()
+        || record.directories.front().path.lexically_normal()
+            != request.project_root.lexically_normal()) {
+        return false;
+    }
+    return true;
+}
+
 [[nodiscard]] bool snapshot_matches(
     const FileSnapshot& snapshot,
     const bool directory) noexcept {
@@ -343,7 +358,9 @@ std::optional<Result> try_reuse_discovery_cache(
     const DiscoveryRequestIdentity& request) noexcept {
     try {
         auto record = load_record(cache_file);
-        if (!record || record->request != request || !evidence_matches(*record)) {
+        if (!record
+            || !record_semantics_valid(*record, request)
+            || !evidence_matches(*record)) {
             return std::nullopt;
         }
         return std::move(record->result);

--- a/cpp/src/discovery/cache/DiscoveryCache.cpp
+++ b/cpp/src/discovery/cache/DiscoveryCache.cpp
@@ -1,0 +1,407 @@
+#include "DiscoveryCache.hpp"
+
+#include <array>
+#include <bit>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <limits>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace mqb::discovery::detail {
+namespace {
+
+namespace fs = std::filesystem;
+using FileTimeRep = fs::file_time_type::duration::rep;
+static_assert(std::is_integral_v<FileTimeRep> && sizeof(FileTimeRep) <= sizeof(std::int64_t));
+
+constexpr std::array<std::uint8_t, 8> magic{
+    'M', 'Q', 'B', 'D', 'I', 'S', 'C', '1'};
+constexpr std::uint32_t format_version = 1;
+constexpr std::size_t max_cache_file_size = 64u * 1024u * 1024u;
+constexpr std::uint32_t max_string_size = 4u * 1024u * 1024u;
+constexpr std::uint32_t max_path_count = 250000u;
+
+[[nodiscard]] std::string path_to_utf8(const fs::path& path) {
+    const auto bytes = path.lexically_normal().generic_u8string();
+    return std::string{
+        reinterpret_cast<const char*>(bytes.data()),
+        bytes.size()};
+}
+
+[[nodiscard]] fs::path path_from_utf8(const std::string_view value) {
+    std::u8string bytes;
+    bytes.assign(
+        reinterpret_cast<const char8_t*>(value.data()),
+        reinterpret_cast<const char8_t*>(value.data() + value.size()));
+    return fs::path{bytes}.lexically_normal();
+}
+
+[[nodiscard]] std::int64_t timestamp_to_i64(const fs::file_time_type value) noexcept {
+    return static_cast<std::int64_t>(value.time_since_epoch().count());
+}
+
+[[nodiscard]] fs::file_time_type timestamp_from_i64(const std::int64_t value) noexcept {
+    return fs::file_time_type{
+        fs::file_time_type::duration{static_cast<FileTimeRep>(value)}};
+}
+
+class BinaryWriter {
+public:
+    void write_u8(const std::uint8_t value) { bytes_.push_back(value); }
+
+    void write_u32(const std::uint32_t value) {
+        for (std::uint32_t shift = 0; shift < 32u; shift += 8u) {
+            write_u8(static_cast<std::uint8_t>((value >> shift) & 0xffu));
+        }
+    }
+
+    void write_u64(const std::uint64_t value) {
+        for (std::uint32_t shift = 0; shift < 64u; shift += 8u) {
+            write_u8(static_cast<std::uint8_t>((value >> shift) & 0xffu));
+        }
+    }
+
+    void write_i64(const std::int64_t value) {
+        write_u64(std::bit_cast<std::uint64_t>(value));
+    }
+
+    void write_bytes(const std::span<const std::uint8_t> bytes) {
+        bytes_.insert(bytes_.end(), bytes.begin(), bytes.end());
+    }
+
+    [[nodiscard]] bool write_string(const std::string_view value) {
+        if (value.size() > max_string_size
+            || value.size() > std::numeric_limits<std::uint32_t>::max()) {
+            return false;
+        }
+        write_u32(static_cast<std::uint32_t>(value.size()));
+        bytes_.insert(bytes_.end(), value.begin(), value.end());
+        return true;
+    }
+
+    [[nodiscard]] bool write_path(const fs::path& path) {
+        return write_string(path_to_utf8(path));
+    }
+
+    [[nodiscard]] const std::vector<std::uint8_t>& bytes() const noexcept {
+        return bytes_;
+    }
+
+private:
+    std::vector<std::uint8_t> bytes_;
+};
+
+class BinaryReader {
+public:
+    explicit BinaryReader(const std::span<const std::uint8_t> bytes)
+        : bytes_(bytes) {}
+
+    [[nodiscard]] bool at_end() const noexcept { return offset_ == bytes_.size(); }
+
+    [[nodiscard]] std::optional<std::uint8_t> read_u8() {
+        if (offset_ >= bytes_.size()) return std::nullopt;
+        return bytes_[offset_++];
+    }
+
+    [[nodiscard]] std::optional<std::uint32_t> read_u32() {
+        std::uint32_t value = 0;
+        for (std::uint32_t shift = 0; shift < 32u; shift += 8u) {
+            auto byte = read_u8();
+            if (!byte) return std::nullopt;
+            value |= static_cast<std::uint32_t>(*byte) << shift;
+        }
+        return value;
+    }
+
+    [[nodiscard]] std::optional<std::uint64_t> read_u64() {
+        std::uint64_t value = 0;
+        for (std::uint32_t shift = 0; shift < 64u; shift += 8u) {
+            auto byte = read_u8();
+            if (!byte) return std::nullopt;
+            value |= static_cast<std::uint64_t>(*byte) << shift;
+        }
+        return value;
+    }
+
+    [[nodiscard]] std::optional<std::int64_t> read_i64() {
+        auto value = read_u64();
+        if (!value) return std::nullopt;
+        return std::bit_cast<std::int64_t>(*value);
+    }
+
+    [[nodiscard]] std::optional<std::string> read_string() {
+        auto length = read_u32();
+        if (!length || *length > max_string_size) return std::nullopt;
+        if (static_cast<std::size_t>(*length) > bytes_.size() - offset_) return std::nullopt;
+        const char* begin = reinterpret_cast<const char*>(bytes_.data() + offset_);
+        std::string value{begin, begin + *length};
+        offset_ += *length;
+        return value;
+    }
+
+    [[nodiscard]] std::optional<fs::path> read_path() {
+        auto value = read_string();
+        if (!value) return std::nullopt;
+        return path_from_utf8(*value);
+    }
+
+private:
+    std::span<const std::uint8_t> bytes_;
+    std::size_t offset_{};
+};
+
+[[nodiscard]] bool write_paths(BinaryWriter& writer, const std::vector<fs::path>& paths) {
+    if (paths.size() > max_path_count) return false;
+    writer.write_u32(static_cast<std::uint32_t>(paths.size()));
+    for (const auto& path : paths) {
+        if (!writer.write_path(path)) return false;
+    }
+    return true;
+}
+
+[[nodiscard]] std::optional<std::vector<fs::path>> read_paths(BinaryReader& reader) {
+    auto count = reader.read_u32();
+    if (!count || *count > max_path_count) return std::nullopt;
+    std::vector<fs::path> paths;
+    paths.reserve(*count);
+    for (std::uint32_t index = 0; index < *count; ++index) {
+        auto path = reader.read_path();
+        if (!path) return std::nullopt;
+        paths.push_back(std::move(*path));
+    }
+    return paths;
+}
+
+[[nodiscard]] bool write_snapshots(
+    BinaryWriter& writer,
+    const std::vector<FileSnapshot>& snapshots) {
+    if (snapshots.size() > max_path_count) return false;
+    writer.write_u32(static_cast<std::uint32_t>(snapshots.size()));
+    for (const auto& snapshot : snapshots) {
+        if (!snapshot.exists || !writer.write_path(snapshot.path)) return false;
+        writer.write_i64(timestamp_to_i64(snapshot.modified));
+    }
+    return true;
+}
+
+[[nodiscard]] std::optional<std::vector<FileSnapshot>> read_snapshots(BinaryReader& reader) {
+    auto count = reader.read_u32();
+    if (!count || *count > max_path_count) return std::nullopt;
+    std::vector<FileSnapshot> snapshots;
+    snapshots.reserve(*count);
+    for (std::uint32_t index = 0; index < *count; ++index) {
+        auto path = reader.read_path();
+        auto modified = reader.read_i64();
+        if (!path || !modified) return std::nullopt;
+        snapshots.push_back(FileSnapshot{
+            .path = std::move(*path),
+            .exists = true,
+            .modified = timestamp_from_i64(*modified),
+        });
+    }
+    return snapshots;
+}
+
+[[nodiscard]] std::optional<std::vector<std::uint8_t>> serialize(
+    const DiscoveryCacheRecord& record) {
+    BinaryWriter writer;
+    writer.write_bytes(magic);
+    writer.write_u32(format_version);
+
+    if (!writer.write_path(record.request.project_root)
+        || !writer.write_path(record.request.entry)
+        || !write_paths(writer, record.request.include_directories)
+        || !write_paths(writer, record.request.excluded_directories)
+        || !write_paths(writer, record.request.extra_sources)
+        || !write_paths(writer, record.request.excluded_sources)
+        || !write_paths(writer, record.result.sources)) {
+        return std::nullopt;
+    }
+    writer.write_u64(static_cast<std::uint64_t>(record.result.indexed_files));
+    writer.write_u8(record.result.requires_module_pipeline ? 1u : 0u);
+    if (!write_snapshots(writer, record.files)
+        || !write_snapshots(writer, record.directories)) {
+        return std::nullopt;
+    }
+    return writer.bytes();
+}
+
+[[nodiscard]] std::optional<DiscoveryCacheRecord> deserialize(
+    const std::span<const std::uint8_t> bytes) {
+    BinaryReader reader{bytes};
+    for (const std::uint8_t expected : magic) {
+        auto actual = reader.read_u8();
+        if (!actual || *actual != expected) return std::nullopt;
+    }
+    auto version = reader.read_u32();
+    if (!version || *version != format_version) return std::nullopt;
+
+    auto project_root = reader.read_path();
+    auto entry = reader.read_path();
+    auto include_directories = read_paths(reader);
+    auto excluded_directories = read_paths(reader);
+    auto extra_sources = read_paths(reader);
+    auto excluded_sources = read_paths(reader);
+    auto sources = read_paths(reader);
+    auto indexed_files = reader.read_u64();
+    auto requires_module_pipeline = reader.read_u8();
+    auto files = read_snapshots(reader);
+    auto directories = read_snapshots(reader);
+    if (!project_root || !entry || !include_directories || !excluded_directories
+        || !extra_sources || !excluded_sources || !sources || !indexed_files
+        || !requires_module_pipeline || *requires_module_pipeline > 1u
+        || !files || !directories || !reader.at_end()) {
+        return std::nullopt;
+    }
+    if (*indexed_files > std::numeric_limits<std::size_t>::max()) {
+        return std::nullopt;
+    }
+
+    Result result;
+    result.sources = std::move(*sources);
+    result.indexed_files = static_cast<std::size_t>(*indexed_files);
+    result.requires_module_pipeline = *requires_module_pipeline != 0;
+    result.reused = true;
+
+    return DiscoveryCacheRecord{
+        .request = DiscoveryRequestIdentity{
+            .project_root = std::move(*project_root),
+            .entry = std::move(*entry),
+            .include_directories = std::move(*include_directories),
+            .excluded_directories = std::move(*excluded_directories),
+            .extra_sources = std::move(*extra_sources),
+            .excluded_sources = std::move(*excluded_sources),
+        },
+        .result = std::move(result),
+        .files = std::move(*files),
+        .directories = std::move(*directories),
+    };
+}
+
+[[nodiscard]] bool snapshot_matches(
+    const FileSnapshot& snapshot,
+    const bool directory) noexcept {
+    std::error_code error_code;
+    const auto status = fs::status(snapshot.path, error_code);
+    if (error_code) return false;
+    if (directory ? !fs::is_directory(status) : !fs::is_regular_file(status)) {
+        return false;
+    }
+    const auto modified = fs::last_write_time(snapshot.path, error_code);
+    return !error_code && modified == snapshot.modified;
+}
+
+[[nodiscard]] bool evidence_matches(const DiscoveryCacheRecord& record) noexcept {
+    for (const auto& snapshot : record.files) {
+        if (!snapshot_matches(snapshot, false)) return false;
+    }
+    for (const auto& snapshot : record.directories) {
+        if (!snapshot_matches(snapshot, true)) return false;
+    }
+    return true;
+}
+
+[[nodiscard]] fs::path temporary_path_for(const fs::path& file) {
+    const auto tick = std::chrono::steady_clock::now().time_since_epoch().count();
+    fs::path temporary = file;
+    temporary += ".tmp." + std::to_string(tick);
+    return temporary;
+}
+
+[[nodiscard]] std::optional<DiscoveryCacheRecord> load_record(const fs::path& file) {
+    std::error_code error_code;
+    if (!fs::is_regular_file(file, error_code) || error_code) return std::nullopt;
+    const auto size = fs::file_size(file, error_code);
+    if (error_code || size > max_cache_file_size) return std::nullopt;
+
+    std::ifstream stream{file, std::ios::binary};
+    if (!stream) return std::nullopt;
+    std::vector<std::uint8_t> bytes(static_cast<std::size_t>(size));
+    if (!bytes.empty()) {
+        stream.read(
+            reinterpret_cast<char*>(bytes.data()),
+            static_cast<std::streamsize>(bytes.size()));
+    }
+    if (!stream && !bytes.empty()) return std::nullopt;
+    return deserialize(bytes);
+}
+
+} // namespace
+
+std::optional<Result> try_reuse_discovery_cache(
+    const fs::path& cache_file,
+    const DiscoveryRequestIdentity& request) noexcept {
+    try {
+        auto record = load_record(cache_file);
+        if (!record || record->request != request || !evidence_matches(*record)) {
+            return std::nullopt;
+        }
+        return std::move(record->result);
+    } catch (...) {
+        return std::nullopt;
+    }
+}
+
+void save_discovery_cache_best_effort(
+    const fs::path& cache_file,
+    const DiscoveryCacheRecord& record) noexcept {
+    try {
+        auto bytes = serialize(record);
+        if (!bytes) return;
+
+        std::error_code error_code;
+        if (!cache_file.parent_path().empty()) {
+            fs::create_directories(cache_file.parent_path(), error_code);
+            if (error_code) return;
+        }
+
+        const fs::path temporary = temporary_path_for(cache_file);
+        {
+            std::ofstream stream{temporary, std::ios::binary | std::ios::trunc};
+            if (!stream) return;
+            if (!bytes->empty()) {
+                stream.write(
+                    reinterpret_cast<const char*>(bytes->data()),
+                    static_cast<std::streamsize>(bytes->size()));
+            }
+            stream.flush();
+            if (!stream) {
+                stream.close();
+                fs::remove(temporary, error_code);
+                return;
+            }
+        }
+
+        error_code.clear();
+        if (fs::exists(cache_file, error_code) && !error_code) {
+            fs::remove(cache_file, error_code);
+            if (error_code) {
+                fs::remove(temporary, error_code);
+                return;
+            }
+        } else if (error_code) {
+            fs::remove(temporary, error_code);
+            return;
+        }
+
+        fs::rename(temporary, cache_file, error_code);
+        if (error_code) {
+            std::error_code ignored;
+            fs::remove(temporary, ignored);
+        }
+    } catch (...) {
+        return;
+    }
+}
+
+} // namespace mqb::discovery::detail

--- a/cpp/src/discovery/cache/DiscoveryCache.hpp
+++ b/cpp/src/discovery/cache/DiscoveryCache.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <filesystem>
+#include <optional>
+#include <vector>
+
+#include "mqb/core/FileSnapshot.hpp"
+#include "mqb/discovery/SourceDiscovery.hpp"
+
+namespace mqb::discovery::detail {
+
+struct DiscoveryRequestIdentity {
+    std::filesystem::path project_root;
+    std::filesystem::path entry;
+    std::vector<std::filesystem::path> include_directories;
+    std::vector<std::filesystem::path> excluded_directories;
+    std::vector<std::filesystem::path> extra_sources;
+    std::vector<std::filesystem::path> excluded_sources;
+
+    bool operator==(const DiscoveryRequestIdentity&) const = default;
+};
+
+struct DiscoveryCacheRecord {
+    DiscoveryRequestIdentity request;
+    Result result;
+    std::vector<FileSnapshot> files;
+    std::vector<FileSnapshot> directories;
+};
+
+[[nodiscard]] std::optional<Result> try_reuse_discovery_cache(
+    const std::filesystem::path& cache_file,
+    const DiscoveryRequestIdentity& request) noexcept;
+
+void save_discovery_cache_best_effort(
+    const std::filesystem::path& cache_file,
+    const DiscoveryCacheRecord& record) noexcept;
+
+} // namespace mqb::discovery::detail

--- a/cpp/src/discovery/indexing/SourceIndex.cpp
+++ b/cpp/src/discovery/indexing/SourceIndex.cpp
@@ -2,6 +2,7 @@
 
 #include <fstream>
 #include <iterator>
+#include <optional>
 #include <string>
 #include <system_error>
 #include <utility>
@@ -40,6 +41,39 @@ read_text(const fs::path& path) {
     return text;
 }
 
+[[nodiscard]] std::optional<FileSnapshot> snapshot_path(
+    const fs::path& path,
+    const bool directory) {
+    std::error_code error_code;
+    const auto status = fs::status(path, error_code);
+    if (error_code) return std::nullopt;
+    if (directory ? !fs::is_directory(status) : !fs::is_regular_file(status)) {
+        return std::nullopt;
+    }
+    const auto modified = fs::last_write_time(path, error_code);
+    if (error_code) return std::nullopt;
+    return FileSnapshot{
+        .path = path.lexically_normal(),
+        .exists = true,
+        .modified = modified,
+    };
+}
+
+void seal_snapshots(
+    std::vector<FileSnapshot>& snapshots,
+    const bool directory,
+    bool& cacheable) {
+    if (!cacheable) return;
+    for (auto& snapshot : snapshots) {
+        auto current = snapshot_path(snapshot.path, directory);
+        if (!current || current->modified != snapshot.modified) {
+            cacheable = false;
+            return;
+        }
+        snapshot = std::move(*current);
+    }
+}
+
 } // namespace
 
 std::expected<SourceTextAnalysis, std::string>
@@ -57,6 +91,12 @@ std::expected<SourceIndex, Error> build_source_index(
     const fs::path& root,
     const std::unordered_set<std::string>& excluded_directory_keys) {
     SourceIndex result;
+    if (auto root_snapshot = snapshot_path(root, true)) {
+        result.directory_snapshots.push_back(std::move(*root_snapshot));
+    } else {
+        result.cacheable = false;
+    }
+
     std::error_code error_code;
     fs::recursive_directory_iterator iterator{
         root,
@@ -83,9 +123,21 @@ std::expected<SourceIndex, Error> build_source_index(
         if (item.is_directory(error_code)) {
             const bool configured_excluded = !error_code
                 && excluded_directory_keys.contains(path_key(item.path()));
-            if (!error_code
-                && (default_excluded_directory(item.path()) || configured_excluded)) {
+            const bool excluded = !error_code
+                && (default_excluded_directory(item.path()) || configured_excluded);
+            if (excluded) {
                 iterator.disable_recursion_pending();
+            } else if (!error_code) {
+                fs::path absolute = fs::absolute(item.path(), error_code).lexically_normal();
+                if (!error_code) {
+                    if (auto snapshot = snapshot_path(absolute, true)) {
+                        result.directory_snapshots.push_back(std::move(*snapshot));
+                    } else {
+                        result.cacheable = false;
+                    }
+                } else {
+                    result.cacheable = false;
+                }
             }
             error_code.clear();
             continue;
@@ -100,8 +152,15 @@ std::expected<SourceIndex, Error> build_source_index(
         record.path = fs::absolute(item.path(), error_code).lexically_normal();
         if (error_code) {
             error_code.clear();
+            result.cacheable = false;
             continue;
         }
+        if (auto snapshot = snapshot_path(record.path, false)) {
+            result.file_snapshots.push_back(std::move(*snapshot));
+        } else {
+            result.cacheable = false;
+        }
+
         record.translation_unit_kind = classify_translation_unit_path(record.path);
         record.kind = record.translation_unit_kind
             ? IndexedFileKind::translation_unit
@@ -118,6 +177,7 @@ std::expected<SourceIndex, Error> build_source_index(
                 && record.translation_unit_kind == TranslationUnitKind::source
                 && analysis->defines_main;
         } else {
+            result.cacheable = false;
             result.warnings.push_back(Warning{
                 .code = WarningCode::file_read_failed,
                 .path = record.path,
@@ -130,6 +190,8 @@ std::expected<SourceIndex, Error> build_source_index(
         result.files.push_back(std::move(record));
     }
 
+    seal_snapshots(result.file_snapshots, false, result.cacheable);
+    seal_snapshots(result.directory_snapshots, true, result.cacheable);
     return result;
 }
 

--- a/cpp/src/discovery/indexing/SourceIndex.hpp
+++ b/cpp/src/discovery/indexing/SourceIndex.hpp
@@ -9,6 +9,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "mqb/core/FileSnapshot.hpp"
 #include "mqb/core/TranslationUnit.hpp"
 #include "mqb/discovery/ModuleSyntax.hpp"
 #include "mqb/discovery/SourceDiscovery.hpp"
@@ -34,6 +35,9 @@ struct SourceIndex {
     std::vector<IndexedFile> files;
     std::unordered_map<std::string, std::size_t> index_by_path;
     std::vector<Warning> warnings;
+    std::vector<FileSnapshot> file_snapshots;
+    std::vector<FileSnapshot> directory_snapshots;
+    bool cacheable{true};
 };
 
 [[nodiscard]] std::expected<SourceTextAnalysis, std::string>

--- a/cpp/tests/discovery/source_discovery_cache_tests.cpp
+++ b/cpp/tests/discovery/source_discovery_cache_tests.cpp
@@ -1,0 +1,187 @@
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <string_view>
+#include <system_error>
+
+#include "mqb/discovery/SourceDiscovery.hpp"
+
+namespace {
+
+namespace fs = std::filesystem;
+int failures = 0;
+
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+void write_text(const fs::path& path, const std::string_view text) {
+    fs::create_directories(path.parent_path());
+    std::ofstream stream{path, std::ios::binary | std::ios::trunc};
+    stream << text;
+}
+
+void force_newer_timestamp(const fs::path& path) {
+    std::error_code error_code;
+    const auto current = fs::last_write_time(path, error_code);
+    if (!error_code) {
+        fs::last_write_time(path, current + std::chrono::seconds{2}, error_code);
+    }
+}
+
+[[nodiscard]] bool contains_source(
+    const std::vector<fs::path>& sources,
+    const fs::path& source) {
+    const fs::path normalized = source.lexically_normal();
+    for (const auto& candidate : sources) {
+        if (candidate.lexically_normal() == normalized) return true;
+    }
+    return false;
+}
+
+struct TempTree {
+    fs::path root;
+    ~TempTree() {
+        std::error_code ignored;
+        fs::remove_all(root, ignored);
+    }
+};
+
+} // namespace
+
+int main() {
+    const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
+    TempTree tree{
+        .root = fs::temp_directory_path()
+            / ("mqb_source_discovery_cache_" + std::to_string(unique)),
+    };
+    fs::create_directories(tree.root / "src");
+
+    const fs::path entry = tree.root / "main.cpp";
+    const fs::path header = tree.root / "src" / "value.hpp";
+    const fs::path implementation = tree.root / "src" / "value.cpp";
+    write_text(
+        entry,
+        "#include \"src/value.hpp\"\n"
+        "int main() { return value(); }\n");
+    write_text(header, "#pragma once\nint value();\n");
+    write_text(
+        implementation,
+        "#include \"value.hpp\"\n"
+        "int value() { return 0; }\n");
+
+    const mqb::discovery::Request request{
+        .project_root = tree.root,
+        .entry = entry,
+        .include_directories = {},
+    };
+    const fs::path default_cache =
+        tree.root / ".mqb" / "cache" / "discovery" / "source-discovery.mqbcache";
+
+    const auto cold = mqb::discovery::SourceDiscovery::discover(request);
+    expect(cold.has_value(), "cold discovery should succeed");
+    if (cold) {
+        expect(!cold->reused, "cold discovery must not report persistent reuse");
+        expect(contains_source(cold->sources, implementation),
+               "cold discovery should select the implementation source");
+    }
+    expect(fs::is_regular_file(default_cache),
+           "successful cacheable discovery should persist project-local evidence");
+
+    const auto warm = mqb::discovery::SourceDiscovery::discover(request);
+    expect(warm.has_value(), "warm discovery should succeed");
+    if (warm && cold) {
+        expect(warm->reused, "unchanged discovery should reuse persistent evidence");
+        expect(warm->sources == cold->sources,
+               "persistent discovery reuse must preserve exact source ordering");
+        expect(warm->indexed_files == cold->indexed_files,
+               "persistent discovery reuse must preserve indexed-file accounting");
+    }
+
+    write_text(header, "#pragma once\nint value();\n// changed\n");
+    force_newer_timestamp(header);
+    const auto header_changed = mqb::discovery::SourceDiscovery::discover(request);
+    expect(header_changed.has_value(), "header mutation discovery should succeed");
+    if (header_changed) {
+        expect(!header_changed->reused,
+               "indexed header timestamp changes must invalidate discovery reuse");
+    }
+    const auto resealed_after_header = mqb::discovery::SourceDiscovery::discover(request);
+    expect(resealed_after_header.has_value() && resealed_after_header->reused,
+           "successful header-triggered rediscovery should reseal warm evidence");
+
+    const fs::path new_source = tree.root / "src" / "unrelated.cpp";
+    write_text(new_source, "int unrelated() { return 7; }\n");
+    force_newer_timestamp(tree.root / "src");
+    const auto file_added = mqb::discovery::SourceDiscovery::discover(request);
+    expect(file_added.has_value(), "discovery after adding a source should succeed");
+    if (file_added) {
+        expect(!file_added->reused,
+               "parent directory changes must invalidate reuse when indexed files are added");
+        expect(file_added->indexed_files == 4,
+               "new translation unit should enter the fresh source index");
+        expect(!contains_source(file_added->sources, new_source),
+               "unrelated added source should not change selected closure");
+    }
+
+    std::error_code error_code;
+    fs::remove(new_source, error_code);
+    force_newer_timestamp(tree.root / "src");
+    const auto file_removed = mqb::discovery::SourceDiscovery::discover(request);
+    expect(file_removed.has_value(), "discovery after removing a source should succeed");
+    if (file_removed) {
+        expect(!file_removed->reused,
+               "parent directory changes must invalidate reuse when indexed files are removed");
+        expect(file_removed->indexed_files == 3,
+               "removed translation unit must leave the fresh source index");
+    }
+
+    const fs::path include_root = tree.root / "include";
+    fs::create_directories(include_root);
+    mqb::discovery::Request changed_request = request;
+    changed_request.include_directories.push_back(include_root);
+    const auto request_changed = mqb::discovery::SourceDiscovery::discover(changed_request);
+    expect(request_changed.has_value(), "discovery with changed request identity should succeed");
+    if (request_changed) {
+        expect(!request_changed->reused,
+               "include search order changes must invalidate discovery request identity");
+    }
+
+    write_text(default_cache, "not a valid MQB discovery cache");
+    const auto corrupt_cache = mqb::discovery::SourceDiscovery::discover(request);
+    expect(corrupt_cache.has_value(), "corrupt discovery cache must fall back to full discovery");
+    if (corrupt_cache) {
+        expect(!corrupt_cache->reused,
+               "corrupt cache fallback must not be mislabeled as a cache hit");
+        expect(contains_source(corrupt_cache->sources, implementation),
+               "corrupt cache fallback must preserve discovery correctness");
+    }
+    const auto repaired_cache = mqb::discovery::SourceDiscovery::discover(request);
+    expect(repaired_cache.has_value() && repaired_cache->reused,
+           "full fallback after corrupt cache should repair evidence for the next invocation");
+
+    mqb::discovery::Request uncached = request;
+    uncached.persistent_cache = false;
+    const auto disabled_first = mqb::discovery::SourceDiscovery::discover(uncached);
+    const auto disabled_second = mqb::discovery::SourceDiscovery::discover(uncached);
+    expect(disabled_first.has_value() && disabled_second.has_value(),
+           "explicitly uncached discovery should still succeed");
+    if (disabled_first && disabled_second) {
+        expect(!disabled_first->reused && !disabled_second->reused,
+               "persistent_cache=false must force ordinary discovery on every call");
+        expect(disabled_first->sources == disabled_second->sources,
+               "disabling persistent state must not change discovery semantics");
+    }
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+    std::cout << "mqb_source_discovery_cache_tests passed\n";
+    return 0;
+}

--- a/docs/PERFORMANCE_GOVERNANCE.md
+++ b/docs/PERFORMANCE_GOVERNANCE.md
@@ -6,7 +6,7 @@ Performance work in MQB is measured against the existing `--timings=json` instru
 
 For a PR whose primary claim is lower build latency or higher throughput:
 
-1. benchmark a baseline MQB executable built from the PR base;
+1. benchmark a baseline MQB executable built from the exact PR base;
 2. benchmark the candidate executable from the PR head on the same machine;
 3. use the same iteration count for both executables;
 4. report at least the standard scenarios emitted by `tests/native/benchmark_mqb.ps1`:
@@ -16,12 +16,15 @@ For a PR whose primary claim is lower build latency or higher throughput:
    - `public-header`
    - `build-run`
    - `link-only`
+   - `discovery-cold`
+   - `discovery-no-op`
+   - `discovery-header`
    - `modules-cold`
    - `modules-no-op`
 5. attach or quote the comparison JSON/table in the PR description or review evidence;
 6. explain any material regression in a core scenario rather than hiding it behind the scenario being optimized.
 
-The canonical comparison command is:
+The canonical local comparison command is:
 
 ```powershell
 ./tests/native/compare_mqb_benchmarks.ps1 `
@@ -31,7 +34,24 @@ The canonical comparison command is:
   -OutputPath ./benchmark-comparison.json
 ```
 
-`delta_pct < 0` means the candidate is faster. The raw baseline and candidate benchmark records are embedded in the comparison JSON so phase timings and cache hit/miss counts remain auditable.
+Negative deltas mean the candidate is faster. The raw baseline and candidate benchmark records are embedded in the comparison JSON so phase timings and cache hit/miss counts remain auditable.
+
+## Automated PR evidence
+
+`.github/workflows/performance-evidence.yml` runs automatically for pull requests whose title starts with `perf:` and can also be invoked manually.
+
+The workflow:
+
+- checks out the candidate and the exact `pull_request.base.sha` into separate working trees;
+- acquires one pinned historical MQB seed;
+- independently builds Release MQB binaries from the base and candidate with each tree's own self-build script and manifest contract;
+- runs both benchmark suites serially on the same Windows runner with the same iteration count;
+- emits the comparison table into the GitHub Actions job summary;
+- uploads `benchmark-comparison.json` as a retained review artifact.
+
+The base is deliberately the immutable PR base SHA rather than the moving branch name. This makes the recorded performance comparison reproducible for that PR head even if `main` advances later.
+
+Running base first and candidate second may still introduce some operating-system cache/order bias. The measurements therefore remain review evidence rather than a numerical merge threshold. For a close or surprising result, reviewers should rerun the workflow or reproduce locally and examine phase-level timings instead of treating one percentage as absolute truth.
 
 ## What is and is not gated
 

--- a/docs/WARM_FAST_PATH.md
+++ b/docs/WARM_FAST_PATH.md
@@ -1,0 +1,81 @@
+# Persistent Warm Fast Path
+
+MQB's compile/link/archive caches already avoid repeated tool invocations, but a fully warm build can still spend time recursively indexing a project and rereading source/header text before those downstream caches are consulted. The persistent source-discovery cache removes that repeated front-half work without weakening discovery correctness.
+
+## Scope
+
+Smart source discovery persists one best-effort record per discovery root at:
+
+```text
+<discovery-root>/.mqb/cache/discovery/source-discovery.mqbcache
+```
+
+The public `SourceDiscovery::Request` enables persistent state by default. Direct callers may set `persistent_cache = false` or supply an explicit `cache_file`.
+
+This state is performance-only. Cache read, parse, validation, or write failures never create a build failure; MQB falls back to the ordinary recursive discovery path.
+
+## What is sealed
+
+A successful cacheable discovery records:
+
+- normalized discovery request identity:
+  - project/discovery root;
+  - entry translation unit;
+  - include search order;
+  - excluded directories;
+  - explicitly included extra sources;
+  - excluded sources;
+- the selected translation-unit list and ordering;
+- the indexed-file count;
+- whether the selected closure requires the Modules/P1689 pipeline;
+- exact `file_time_type` snapshots for every indexed C/C++ source/header;
+- exact directory snapshots for the discovery root and every recursively visited non-excluded directory.
+
+File evidence catches content changes. Directory evidence catches file additions, removals, and renames even when no previously indexed file changed.
+
+## Race-safe sealing
+
+Discovery captures freshness evidence while building the source index, then rechecks every captured file and directory snapshot before the record is eligible for persistence.
+
+If a source/header or traversed directory changes during discovery, that pass remains valid for the current invocation but is not blessed as reusable persistent evidence. The next invocation performs ordinary discovery again.
+
+Warnings caused by unreadable indexed files also prevent sealing. Explicit extra sources must be present in the index before the result can be cached.
+
+## Warm reuse
+
+On a later invocation MQB first performs the inexpensive request/path validation required to preserve existing diagnostics. It then loads the persistent record before reading extra-source text or recursively enumerating/analyzing the project.
+
+Reuse requires:
+
+1. exact normalized request identity;
+2. every indexed file still exists as a regular file with the exact recorded timestamp;
+3. every recorded directory still exists as a directory with the exact recorded timestamp;
+4. a valid versioned cache record.
+
+Any mismatch becomes a normal cache miss.
+
+The `.mqb` state directory is already excluded from smart discovery, so writing or replacing the discovery-cache file cannot invalidate the project directory evidence it protects.
+
+## Cache format
+
+The current binary format is version 1 (`MQBDISC1`). It is bounded when parsing (file size, string size, and path/snapshot counts), rejects malformed or trailing data, stores paths in normalized generic UTF-8 form, and persists native `file_time_type` tick counts exactly.
+
+The format is intentionally private. An incompatible future version should be treated as a cache miss rather than migrated at the cost of build correctness.
+
+## Validation and performance evidence
+
+`source_discovery_cache_tests.cpp` covers cold/warm reuse, header invalidation, source addition/removal through directory evidence, request-identity changes, corrupt-cache fallback/repair, and explicit cache disablement.
+
+The native benchmark harness includes:
+
+- `discovery-cold` — first smart-discovery/build invocation;
+- `discovery-no-op` — unchanged warm invocation where persistent evidence should avoid recursive indexing/text analysis;
+- `discovery-header` — a header mutation that must invalidate persistent evidence.
+
+`compare_mqb_benchmarks.ps1` reports both total-wall-clock and discovery-phase medians/deltas for every scenario. These measurements are review evidence rather than hosted-runner correctness thresholds.
+
+## Deliberate limits
+
+The first implementation stores one discovery request/result per discovery root. Alternating multiple entry/request identities may therefore replace the prior record and cause extra cache misses, but never stale reuse. A future multi-key cache can improve that workload without changing the freshness contract.
+
+This milestone does not persist MSVC environment/toolchain discovery and does not bypass project configuration parsing. Those are separate fast-path layers with different invalidation and security boundaries.

--- a/tests/native/assert_cpp_layout.ps1
+++ b/tests/native/assert_cpp_layout.ps1
@@ -174,6 +174,7 @@ Assert-ExactFiles -Root $discoveryTestsRoot -Expected @(
     'c_source_discovery_tests.cpp',
     'module_source_discovery_tests.cpp',
     'module_syntax_tests.cpp',
+    'source_discovery_cache_tests.cpp',
     'source_discovery_corrections_tests.cpp',
     'source_discovery_tests.cpp'
 )

--- a/tests/native/assert_cpp_layout.ps1
+++ b/tests/native/assert_cpp_layout.ps1
@@ -150,13 +150,14 @@ Assert-LeafLayout -Root (Join-Path $testsRoot 'config') -LeafFiles ([ordered]@{
 })
 
 # Source discovery. The public facade remains at the discovery root while
-# source-text analysis, filesystem indexing, and graph selection own separate
-# private leaves. Module syntax is lexical analysis, not traversal policy.
+# text analysis, persistent freshness state, indexing, and graph selection own
+# separate private leaves. Module syntax is lexical analysis, not traversal policy.
 $discoveryRoot = Join-Path $srcRoot 'discovery'
-Assert-DirectDirectories -Root $discoveryRoot -Allowed @('analysis', 'indexing', 'selection')
+Assert-DirectDirectories -Root $discoveryRoot -Allowed @('analysis', 'cache', 'indexing', 'selection')
 Assert-ExactFiles -Root $discoveryRoot -Expected @('SourceDiscovery.cpp')
 $discoveryLeafFiles = [ordered]@{
     'analysis' = @('ModuleSyntax.cpp', 'SourceTextAnalysis.cpp', 'SourceTextAnalysis.hpp')
+    'cache' = @('DiscoveryCache.cpp', 'DiscoveryCache.hpp')
     'indexing' = @('DiscoveryPath.hpp', 'SourceIndex.cpp', 'SourceIndex.hpp')
     'selection' = @('SourceSelectionGraph.cpp', 'SourceSelectionGraph.hpp')
 }

--- a/tests/native/benchmark_mqb.ps1
+++ b/tests/native/benchmark_mqb.ps1
@@ -71,6 +71,17 @@ function Invoke-TimedMqb {
     }
 }
 
+function Get-Median {
+    param([Parameter(Mandatory = $true)][double[]]$Values)
+
+    $sorted = @($Values | Sort-Object)
+    $middle = [int][Math]::Floor($sorted.Count / 2)
+    if (($sorted.Count % 2) -eq 0) {
+        return ($sorted[$middle - 1] + $sorted[$middle]) / 2.0
+    }
+    return $sorted[$middle]
+}
+
 $results = [System.Collections.Generic.List[object]]::new()
 $benchmarkRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("mqb-benchmark-" + [Guid]::NewGuid().ToString('N'))
 New-Item -ItemType Directory -Path $benchmarkRoot | Out-Null
@@ -107,6 +118,31 @@ int main() { return helper_value() == shared_value() + 2 ? 0 : 1; }
         $results.Add((Invoke-TimedMqb -Scenario 'build-run' -Iteration $iteration -WorkingDirectory $ordinaryRoot -Arguments ($ordinaryArgs + @('--run'))))
         $results.Add((Invoke-TimedMqb -Scenario 'link-only' -Iteration $iteration -WorkingDirectory $ordinaryRoot -Arguments ($ordinaryArgs + @('--linker-arg', '/MAP'))))
 
+        # Dedicated smart-discovery fixture. Only the entry TU is passed to MQB;
+        # helper.cpp must be found through the shared local header graph. The
+        # warm sample therefore isolates the cost of repeated filesystem
+        # enumeration/source-text analysis that persistent discovery can avoid.
+        $discoveryRoot = Join-Path $benchmarkRoot "discovery-$iteration"
+        New-Item -ItemType Directory -Path (Join-Path $discoveryRoot 'src') -Force | Out-Null
+        Set-Content -LiteralPath (Join-Path $discoveryRoot 'src/common.hpp') -Encoding utf8 -Value @'
+#pragma once
+int helper_value();
+'@
+        Set-Content -LiteralPath (Join-Path $discoveryRoot 'src/helper.cpp') -Encoding utf8 -Value @'
+#include "common.hpp"
+int helper_value() { return 42; }
+'@
+        Set-Content -LiteralPath (Join-Path $discoveryRoot 'main.cpp') -Encoding utf8 -Value @'
+#include "src/common.hpp"
+int main() { return helper_value() == 42 ? 0 : 1; }
+'@
+        $discoveryArgs = @('main.cpp', '--output', 'discovery_bench')
+        $results.Add((Invoke-TimedMqb -Scenario 'discovery-cold' -Iteration $iteration -WorkingDirectory $discoveryRoot -Arguments $discoveryArgs))
+        $results.Add((Invoke-TimedMqb -Scenario 'discovery-no-op' -Iteration $iteration -WorkingDirectory $discoveryRoot -Arguments $discoveryArgs))
+
+        Add-Content -LiteralPath (Join-Path $discoveryRoot 'src/common.hpp') -Encoding utf8 -Value "// discovery invalidation $iteration"
+        $results.Add((Invoke-TimedMqb -Scenario 'discovery-header' -Iteration $iteration -WorkingDirectory $discoveryRoot -Arguments $discoveryArgs))
+
         $moduleRoot = Join-Path $benchmarkRoot "modules-$iteration"
         New-Item -ItemType Directory -Path $moduleRoot | Out-Null
         Set-Content -LiteralPath (Join-Path $moduleRoot 'bench_math.ixx') -Encoding utf8 -Value @'
@@ -134,18 +170,13 @@ $summary = @(
         Group-Object scenario |
         ForEach-Object {
             $group = @($_.Group)
-            $sortedTotals = @($group.total_ms | Sort-Object)
-            $middle = [int][Math]::Floor($sortedTotals.Count / 2)
-            $median = if (($sortedTotals.Count % 2) -eq 0) {
-                ($sortedTotals[$middle - 1] + $sortedTotals[$middle]) / 2.0
-            }
-            else {
-                $sortedTotals[$middle]
-            }
+            $medianTotal = Get-Median -Values @($group.total_ms)
+            $medianDiscovery = Get-Median -Values @($group.discovery_ms)
             [PSCustomObject]@{
                 scenario = $_.Name
                 samples = $group.Count
-                median_total_ms = [Math]::Round($median, 3)
+                median_total_ms = [Math]::Round($medianTotal, 3)
+                median_discovery_ms = [Math]::Round($medianDiscovery, 3)
                 min_total_ms = [Math]::Round((($group.total_ms | Measure-Object -Minimum).Minimum), 3)
                 max_total_ms = [Math]::Round((($group.total_ms | Measure-Object -Maximum).Maximum), 3)
             }
@@ -162,7 +193,7 @@ if (-not [string]::IsNullOrWhiteSpace($OutputPath)) {
         New-Item -ItemType Directory -Path $parent -Force | Out-Null
     }
     [PSCustomObject]@{
-        schema_version = 1
+        schema_version = 2
         generated_utc = [DateTime]::UtcNow.ToString('o')
         mqb = $MqbPath
         iterations = $Iterations

--- a/tests/native/compare_mqb_benchmarks.ps1
+++ b/tests/native/compare_mqb_benchmarks.ps1
@@ -14,6 +14,15 @@ function Get-FullPath {
     return [System.IO.Path]::GetFullPath($Path)
 }
 
+function Get-DeltaPercent {
+    param(
+        [Parameter(Mandatory = $true)][double]$Baseline,
+        [Parameter(Mandatory = $true)][double]$Candidate
+    )
+    if ($Baseline -eq 0.0) { return $null }
+    return (($Candidate - $Baseline) / $Baseline) * 100.0
+}
+
 $BaselineMqbPath = Get-FullPath $BaselineMqbPath
 $CandidateMqbPath = Get-FullPath $CandidateMqbPath
 foreach ($path in @($BaselineMqbPath, $CandidateMqbPath)) {
@@ -63,22 +72,23 @@ try {
                 throw "Candidate benchmark is missing scenario '$scenario'"
             }
             $candidateRow = $candidateByScenario[$scenario]
-            $baselineMedian = [double]$baselineRow.median_total_ms
-            $candidateMedian = [double]$candidateRow.median_total_ms
-            $deltaMs = $candidateMedian - $baselineMedian
-            $deltaPct = if ($baselineMedian -eq 0.0) {
-                $null
-            }
-            else {
-                ($deltaMs / $baselineMedian) * 100.0
-            }
+            $baselineTotal = [double]$baselineRow.median_total_ms
+            $candidateTotal = [double]$candidateRow.median_total_ms
+            $baselineDiscovery = [double]$baselineRow.median_discovery_ms
+            $candidateDiscovery = [double]$candidateRow.median_discovery_ms
+            $totalDeltaPct = Get-DeltaPercent -Baseline $baselineTotal -Candidate $candidateTotal
+            $discoveryDeltaPct = Get-DeltaPercent -Baseline $baselineDiscovery -Candidate $candidateDiscovery
 
             [PSCustomObject]@{
                 scenario = $scenario
-                baseline_median_ms = [Math]::Round($baselineMedian, 3)
-                candidate_median_ms = [Math]::Round($candidateMedian, 3)
-                delta_ms = [Math]::Round($deltaMs, 3)
-                delta_pct = if ($null -eq $deltaPct) { $null } else { [Math]::Round($deltaPct, 2) }
+                baseline_total_ms = [Math]::Round($baselineTotal, 3)
+                candidate_total_ms = [Math]::Round($candidateTotal, 3)
+                total_delta_ms = [Math]::Round(($candidateTotal - $baselineTotal), 3)
+                total_delta_pct = if ($null -eq $totalDeltaPct) { $null } else { [Math]::Round($totalDeltaPct, 2) }
+                baseline_discovery_ms = [Math]::Round($baselineDiscovery, 3)
+                candidate_discovery_ms = [Math]::Round($candidateDiscovery, 3)
+                discovery_delta_ms = [Math]::Round(($candidateDiscovery - $baselineDiscovery), 3)
+                discovery_delta_pct = if ($null -eq $discoveryDeltaPct) { $null } else { [Math]::Round($discoveryDeltaPct, 2) }
             }
         }
     )
@@ -94,7 +104,7 @@ try {
 
     Write-Host "`n=== Median wall-clock comparison ==="
     $comparison | Sort-Object scenario | Format-Table -AutoSize
-    Write-Host 'Negative delta means the candidate is faster. Timings are review evidence, not CI pass/fail thresholds.'
+    Write-Host 'Negative deltas mean the candidate is faster. Timings are review evidence, not CI pass/fail thresholds.'
 
     if (-not [string]::IsNullOrWhiteSpace($OutputPath)) {
         $parent = Split-Path -Parent $OutputPath
@@ -102,7 +112,7 @@ try {
             New-Item -ItemType Directory -Path $parent -Force | Out-Null
         }
         [PSCustomObject]@{
-            schema_version = 1
+            schema_version = 2
             generated_utc = [DateTime]::UtcNow.ToString('o')
             iterations = $Iterations
             baseline_mqb = $BaselineMqbPath

--- a/tests/native/run_native_tests.ps1
+++ b/tests/native/run_native_tests.ps1
@@ -84,8 +84,8 @@ if ($includeDirs.Count -eq 0) { throw 'Native test config has no include_dirs.' 
 $allTestFiles = @(Get-ChildItem -LiteralPath $cppRoot -Recurse -File -Filter '*_tests.cpp' |
     Where-Object { $_.FullName -notmatch '[\\/]\.mqb[\\/]' } |
     Sort-Object FullName)
-if ($allTestFiles.Count -ne 73) {
-    throw "Native test manifest drift: expected 73 *_tests.cpp files, found $($allTestFiles.Count)."
+if ($allTestFiles.Count -ne 74) {
+    throw "Native test manifest drift: expected 74 *_tests.cpp files, found $($allTestFiles.Count)."
 }
 
 function Get-TestRelativePath {
@@ -121,7 +121,7 @@ $testWeightOverrides = [ordered]@{
 $relativeTestPaths = @($allTestFiles | ForEach-Object { Get-TestRelativePath -File $_ })
 foreach ($weightedPath in $testWeightOverrides.Keys) {
     if ($weightedPath -notin $relativeTestPaths) {
-        throw "Native test weight override is stale or missing from the 73-test manifest: $weightedPath"
+        throw "Native test weight override is stale or missing from the 74-test manifest: $weightedPath"
     }
 }
 


### PR DESCRIPTION
## Summary

Completes the largest remaining PR7 debt from the productization audit: a fully warm smart-discovery invocation can now reuse persistent, validated source-graph evidence instead of recursively enumerating the project and rereading/analyzing every indexed C/C++ source/header before downstream compile/link caches are consulted.

## Persistent discovery evidence

A cacheable successful discovery seals:

- normalized request identity: discovery root, entry, include search order, excluded directories/sources, extra sources;
- selected source list/order and indexed-file count;
- Modules/P1689 pipeline requirement;
- exact native `file_time_type` snapshots for every indexed C/C++ source/header;
- exact snapshots for the discovery root and every recursively visited non-excluded directory.

The default private cache is:

```text
<discovery-root>/.mqb/cache/discovery/source-discovery.mqbcache
```

Direct `SourceDiscovery` callers may disable persistent state or override the cache file.

## Correctness boundary

Warm reuse requires exact request identity plus unchanged file and directory evidence. This deliberately covers two different invalidation classes:

- source/header content changes invalidate through file snapshots;
- source/header additions, deletions, and renames invalidate through parent-directory snapshots even when every previously indexed file is unchanged.

The full discovery pass rechecks captured file/directory snapshots before sealing. If the tree changes while discovery is running, that invocation may complete normally but its evidence is not persisted as reusable.

Unreadable indexed-file warnings also prevent sealing. Cache load, parse, structural validation, freshness validation, and write failures are performance-only misses and never introduce a new build failure surface.

The private binary cache is bounded/versioned (`MQBDISC1`) and stores native file timestamp ticks exactly.

## Warm path

On a candidate hit MQB still performs the inexpensive path/config correction validation needed to preserve existing diagnostics, but attempts persistent reuse **before** reading extra-source text and before recursive filesystem indexing/source-text analysis.

The `.mqb` state directory is already excluded from smart discovery, so updating the cache itself does not invalidate the project evidence.

## Behavior coverage

Add a dedicated discovery-cache contract test covering:

- cold -> warm reuse;
- exact source-order/index-count preservation;
- header mutation invalidation + reseal;
- source addition/removal invalidation via directory evidence;
- request-identity changes;
- corrupt-cache fallback and repair;
- explicit persistent-cache disablement.

The native graph advances from 73 to **74 tests** and the strict responsibility layout adds a dedicated `src/discovery/cache` leaf.

## Performance governance

Extend the benchmark harness with:

- `discovery-cold`
- `discovery-no-op`
- `discovery-header`

The fixture passes only the entry TU so smart discovery must actually resolve a helper through the local-header graph. Benchmark summaries expose `median_discovery_ms`, and the comparator reports both total and discovery-phase deltas.

This PR also adds `.github/workflows/performance-evidence.yml`. For `perf:` pull requests it checks out the candidate plus the immutable `pull_request.base.sha`, builds both Release MQB binaries from source using one pinned historical seed, runs a five-iteration benchmark comparison serially on the same Windows runner, publishes the table to the Actions summary, and uploads `benchmark-comparison.json` as `mqb-performance-evidence`.

Performance evidence remains review-oriented rather than a brittle hosted-runner timing threshold.

## Deliberate limits

The first persistent format stores one request/result per discovery root. Alternating entry/request identities may replace the previous record and cause extra misses, never stale reuse.

This PR does not persist Visual Studio environment/toolchain probing and does not add resource-aware scheduling; those remain separate invalidation/resource models.

## Exact validation

Exact validated head: `1df330f15951836230ecafb4210d8aedea321272`.

### Native C++ #275 — success

- current Debug MQB self-build: success
- shared Debug native-test product library: success
- 74-test graph, 4/4 Debug shards: success
- final Native C++ gate: success

### Native Release #237 — success

- Stage 0 Release MQB self-build: success
- shared Release native-test product library: success
- 74-test graph, 4/4 Release shards: success
- Stage 1 stable self-host: success
- runtime-only release package staging: success
- exact packaged-artifact validation: success
- validated package upload: success
- `publish-release`: skipped as expected for a pull request

### Performance Evidence #2 — success

- exact PR base and candidate checked out separately: success
- one pinned historical MQB seed used for both builds: success
- baseline Release MQB built from the exact PR base: success
- candidate Release MQB built from the PR head: success
- five-iteration same-runner benchmark comparison: success
- GitHub Actions summary published: success
- `mqb-performance-evidence` / `benchmark-comparison.json` artifact uploaded: success

No unresolved review threads are present.