### PR TITLE
perf: reuse validated Visual Studio toolchain discovery

### DIFF
--- a/cpp/include/mqb/msvc/MsvcToolchainLocator.hpp
+++ b/cpp/include/mqb/msvc/MsvcToolchainLocator.hpp
@@ -35,6 +35,10 @@ struct DiscoveryOptions {
     std::vector<std::filesystem::path> portable_roots;
     std::optional<std::filesystem::path> vswhere_path;
     std::optional<std::filesystem::path> cmd_path;
+    // Visual Studio discovery only. nullopt uses MQB's user-local cache under
+    // LOCALAPPDATA; an explicitly empty path disables persistent reuse. Custom
+    // vswhere/cmd overrides also disable reuse so explicit discovery remains authoritative.
+    std::optional<std::filesystem::path> cache_file;
 };
 
 struct MsvcToolchain {
@@ -49,6 +53,9 @@ struct MsvcToolchain {
     StandardLibraryModuleSources standard_library_modules;
     ToolchainSource source{ToolchainSource::visual_studio};
     std::vector<process::EnvironmentVariable> environment;
+    // True only when validated persistent Visual Studio discovery evidence was
+    // reused without invoking vswhere/cmd/vcvarsall for this call.
+    bool reused{false};
 };
 
 enum class ToolchainErrorCode {

--- a/cpp/src/msvc/toolchain/MsvcToolchainLocator.cpp
+++ b/cpp/src/msvc/toolchain/MsvcToolchainLocator.cpp
@@ -1,35 +1,487 @@
 #include "mqb/msvc/MsvcToolchainLocator.hpp"
 
+#include <algorithm>
+#include <chrono>
+#include <cctype>
+#include <cstdint>
 #include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <optional>
 #include <string>
+#include <string_view>
 #include <system_error>
+#include <utility>
+#include <vector>
 
 #include "PortableToolchainDiscovery.hpp"
 #include "ToolchainDiscoveryPrimitives.hpp"
 #include "VisualStudioToolchainDiscovery.hpp"
 
 namespace mqb::msvc {
+namespace {
 
 namespace fs = std::filesystem;
+using process::EnvironmentVariable;
+
+constexpr std::string_view cache_magic = "MQB_TOOLCHAIN_CACHE_V5";
+constexpr std::uintmax_t max_cache_size = 1024u * 1024u;
+constexpr std::size_t max_cache_entries = 64u;
+constexpr std::size_t max_cache_string = 256u * 1024u;
+constexpr auto max_cache_age = std::chrono::minutes{30};
+
+struct CacheRecord {
+    std::string target_architecture;
+    std::string host_architecture;
+    int preference{};
+    fs::path vc_tools_root;
+    std::string binary_stamp;
+    std::vector<EnvironmentVariable> environment;
+    std::vector<fs::path> path_prefixes;
+};
+
+struct ToolPaths {
+    fs::path compiler;
+    fs::path linker;
+    fs::path librarian;
+};
+
+[[nodiscard]] fs::path stable_path(fs::path path) {
+    path = path.lexically_normal();
+    while (path.filename().empty() && path.has_parent_path()) {
+        const fs::path parent = path.parent_path();
+        if (parent.empty() || parent == path) break;
+        path = parent;
+    }
+    return path;
+}
+
+[[nodiscard]] int preference_value(const ToolchainPreference preference) noexcept {
+    switch (preference) {
+    case ToolchainPreference::automatic: return 0;
+    case ToolchainPreference::visual_studio: return 1;
+    case ToolchainPreference::portable: return 2;
+    }
+    return -1;
+}
+
+[[nodiscard]] std::string_view preference_name(const ToolchainPreference preference) noexcept {
+    switch (preference) {
+    case ToolchainPreference::automatic: return "auto";
+    case ToolchainPreference::visual_studio: return "vs";
+    case ToolchainPreference::portable: return "portable";
+    }
+    return "unknown";
+}
+
+[[nodiscard]] std::string lower_ascii(std::string value) {
+    std::transform(value.begin(), value.end(), value.begin(), [](const unsigned char ch) {
+        return static_cast<char>(std::tolower(ch));
+    });
+    return value;
+}
+
+[[nodiscard]] std::string normalized_path_text(const fs::path& path) {
+    return lower_ascii(detail::path_to_utf8(stable_path(path)));
+}
+
+[[nodiscard]] bool cache_key_matches(const CacheRecord& record, const DiscoveryOptions& options) {
+    return record.target_architecture == detail::architecture_name(options.target_architecture)
+        && record.host_architecture == detail::architecture_name(options.host_architecture)
+        && record.preference == preference_value(options.preference);
+}
+
+[[nodiscard]] std::optional<fs::path> effective_cache_file(const DiscoveryOptions& options) {
+    if (options.vswhere_path || options.cmd_path) return std::nullopt;
+    if (options.cache_file) {
+        if (options.cache_file->empty()) return std::nullopt;
+        return stable_path(*options.cache_file);
+    }
+    const auto local_app_data = detail::environment_path("LOCALAPPDATA");
+    if (!local_app_data || local_app_data->empty()) return std::nullopt;
+    const std::string filename =
+        "msvc-" + std::string{preference_name(options.preference)} + "-"
+        + detail::architecture_name(options.host_architecture) + "-"
+        + detail::architecture_name(options.target_architecture) + ".mqbcache";
+    return stable_path(*local_app_data / "MQB" / "cache" / "toolchain" / filename);
+}
+
+[[nodiscard]] bool environment_name_equal(const std::string_view left, const std::string_view right) {
+    if (left.size() != right.size()) return false;
+    for (std::size_t index = 0; index < left.size(); ++index) {
+        if (std::tolower(static_cast<unsigned char>(left[index]))
+            != std::tolower(static_cast<unsigned char>(right[index]))) return false;
+    }
+    return true;
+}
+
+[[nodiscard]] bool cacheable_environment_name(const std::string_view name) {
+    constexpr std::string_view names[]{
+        "INCLUDE", "LIB", "VCToolsInstallDir", "WindowsSdkDir",
+        "WindowsSDKVersion", "UniversalCRTSdkDir", "UCRTVersion",
+    };
+    for (const auto candidate : names) {
+        if (environment_name_equal(name, candidate)) return true;
+    }
+    return false;
+}
+
+[[nodiscard]] const EnvironmentVariable* find_environment(
+    const std::vector<EnvironmentVariable>& environment,
+    const std::string_view name) {
+    const auto found = std::find_if(environment.begin(), environment.end(), [&](const EnvironmentVariable& variable) {
+        return environment_name_equal(variable.name, name);
+    });
+    return found == environment.end() ? nullptr : &*found;
+}
+
+[[nodiscard]] fs::path visual_studio_root(const fs::path& vc_tools_root) {
+    fs::path root = stable_path(vc_tools_root);
+    for (int level = 0; level < 4 && root.has_parent_path(); ++level) root = root.parent_path();
+    return stable_path(std::move(root));
+}
+
+[[nodiscard]] bool path_inside_root(const fs::path& root, const fs::path& candidate) {
+    std::error_code error_code;
+    const fs::path absolute_root = stable_path(fs::absolute(root, error_code));
+    if (error_code) return false;
+    const fs::path absolute_candidate = stable_path(fs::absolute(candidate, error_code));
+    if (error_code) return false;
+    std::string root_text = normalized_path_text(absolute_root);
+    const std::string candidate_text = normalized_path_text(absolute_candidate);
+    if (candidate_text == root_text) return true;
+    if (!root_text.empty() && root_text.back() != '/') root_text.push_back('/');
+    return candidate_text.starts_with(root_text);
+}
+
+void append_unique_existing_root(std::vector<fs::path>& roots, fs::path root) {
+    std::error_code error_code;
+    root = stable_path(std::move(root));
+    if (!fs::is_directory(root, error_code) || error_code) return;
+    const auto duplicate = std::find_if(roots.begin(), roots.end(), [&](const fs::path& existing) {
+        return normalized_path_text(existing) == normalized_path_text(root);
+    });
+    if (duplicate == roots.end()) roots.push_back(std::move(root));
+}
+
+[[nodiscard]] std::vector<fs::path> trusted_roots(
+    const std::vector<EnvironmentVariable>& environment,
+    const fs::path& vc_tools_root) {
+    std::vector<fs::path> roots;
+    append_unique_existing_root(roots, visual_studio_root(vc_tools_root));
+    for (const auto name : {"WindowsSdkDir", "UniversalCRTSdkDir"}) {
+        if (const auto* variable = find_environment(environment, name);
+            variable != nullptr && !variable->value.empty()) {
+            append_unique_existing_root(roots, detail::path_from_utf8(variable->value));
+        }
+    }
+    if (const auto system_root = detail::environment_path("SystemRoot")) append_unique_existing_root(roots, *system_root);
+    return roots;
+}
+
+[[nodiscard]] bool path_inside_any_root(const std::vector<fs::path>& roots, const fs::path& candidate) {
+    return std::any_of(roots.begin(), roots.end(), [&](const fs::path& root) {
+        return path_inside_root(root, candidate);
+    });
+}
+
+[[nodiscard]] std::vector<std::string_view> split_semicolon(const std::string& value) {
+    std::vector<std::string_view> parts;
+    std::size_t begin = 0;
+    while (begin <= value.size()) {
+        const std::size_t end = value.find(';', begin);
+        const std::size_t count = end == std::string::npos ? value.size() - begin : end - begin;
+        if (count != 0) parts.push_back(std::string_view{value}.substr(begin, count));
+        if (end == std::string::npos) break;
+        begin = end + 1;
+    }
+    return parts;
+}
+
+[[nodiscard]] bool trusted_directory_list(const std::string& value, const std::vector<fs::path>& roots) {
+    const auto parts = split_semicolon(value);
+    if (parts.empty()) return false;
+    for (const auto part : parts) {
+        fs::path directory = stable_path(detail::path_from_utf8(part));
+        std::error_code error_code;
+        if (!fs::is_directory(directory, error_code) || error_code || !path_inside_any_root(roots, directory)) return false;
+    }
+    return true;
+}
+
+[[nodiscard]] std::vector<EnvironmentVariable> cacheable_environment(const MsvcToolchain& toolchain) {
+    std::vector<EnvironmentVariable> result;
+    for (const auto& variable : toolchain.environment) {
+        if (cacheable_environment_name(variable.name)) result.push_back(variable);
+    }
+    return result;
+}
+
+[[nodiscard]] bool environment_is_cacheable(
+    const std::vector<EnvironmentVariable>& environment,
+    const fs::path& vc_tools_root) {
+    const auto* include = find_environment(environment, "INCLUDE");
+    const auto* lib = find_environment(environment, "LIB");
+    const auto* tools = find_environment(environment, "VCToolsInstallDir");
+    if (include == nullptr || lib == nullptr || tools == nullptr
+        || include->value.empty() || lib->value.empty() || tools->value.empty()) return false;
+    if (normalized_path_text(detail::path_from_utf8(tools->value)) != normalized_path_text(vc_tools_root)) return false;
+    const auto roots = trusted_roots(environment, vc_tools_root);
+    return !roots.empty() && trusted_directory_list(include->value, roots) && trusted_directory_list(lib->value, roots);
+}
+
+[[nodiscard]] std::vector<fs::path> trusted_path_prefixes(const MsvcToolchain& toolchain) {
+    const auto* path = find_environment(toolchain.environment, "PATH");
+    if (path == nullptr || path->value.empty()) return {};
+    const auto roots = trusted_roots(toolchain.environment, toolchain.vc_tools_root);
+    std::vector<fs::path> result;
+    for (const auto part : split_semicolon(path->value)) {
+        fs::path directory = stable_path(detail::path_from_utf8(part));
+        std::error_code error_code;
+        if (!fs::is_directory(directory, error_code) || error_code || !path_inside_any_root(roots, directory)) continue;
+        const auto duplicate = std::find_if(result.begin(), result.end(), [&](const fs::path& existing) {
+            return normalized_path_text(existing) == normalized_path_text(directory);
+        });
+        if (duplicate == result.end()) result.push_back(std::move(directory));
+    }
+    return result;
+}
+
+[[nodiscard]] std::string joined_path(const std::vector<fs::path>& prefixes) {
+    std::string value;
+    for (const auto& prefix : prefixes) {
+        if (!value.empty()) value.push_back(';');
+        value += detail::path_to_utf8(prefix);
+    }
+    if (const auto inherited = detail::environment_value("PATH"); inherited && !inherited->empty()) {
+        if (!value.empty()) value.push_back(';');
+        value += *inherited;
+    }
+    return value;
+}
+
+[[nodiscard]] ToolPaths tool_paths(const fs::path& vc_tools_root, const DiscoveryOptions& options) {
+    const fs::path directory = stable_path(vc_tools_root) / "bin"
+        / detail::host_directory(options.host_architecture)
+        / detail::architecture_name(options.target_architecture);
+    return ToolPaths{
+        .compiler = stable_path(directory / "cl.exe"),
+        .linker = stable_path(directory / "link.exe"),
+        .librarian = stable_path(directory / "lib.exe"),
+    };
+}
+
+[[nodiscard]] bool write_quoted(std::ostream& stream, const std::string_view label, const std::string& value) {
+    if (value.size() > max_cache_string) return false;
+    stream << label << ' ' << std::quoted(value) << '\n';
+    return static_cast<bool>(stream);
+}
+
+[[nodiscard]] bool read_quoted(std::istream& stream, const std::string_view expected_label, std::string& value) {
+    std::string label;
+    if (!(stream >> label >> std::quoted(value))) return false;
+    return label == expected_label && value.size() <= max_cache_string;
+}
+
+[[nodiscard]] bool write_record(std::ostream& stream, const CacheRecord& record) {
+    stream << cache_magic << '\n';
+    if (!write_quoted(stream, "target", record.target_architecture)
+        || !write_quoted(stream, "host", record.host_architecture)) return false;
+    stream << "preference " << record.preference << '\n';
+    if (!write_quoted(stream, "vc_tools_root", detail::path_to_utf8(record.vc_tools_root))
+        || !write_quoted(stream, "binary_stamp", record.binary_stamp)) return false;
+    if (record.environment.size() > max_cache_entries) return false;
+    stream << "environment " << record.environment.size() << '\n';
+    for (const auto& variable : record.environment) {
+        if (!write_quoted(stream, "env_name", variable.name) || !write_quoted(stream, "env_value", variable.value)) return false;
+    }
+    if (record.path_prefixes.size() > max_cache_entries) return false;
+    stream << "path_prefixes " << record.path_prefixes.size() << '\n';
+    for (const auto& prefix : record.path_prefixes) {
+        if (!write_quoted(stream, "path_prefix", detail::path_to_utf8(prefix))) return false;
+    }
+    return static_cast<bool>(stream);
+}
+
+[[nodiscard]] std::optional<std::size_t> read_count(std::istream& stream, const std::string_view expected_label) {
+    std::string label;
+    std::size_t count{};
+    if (!(stream >> label >> count) || label != expected_label || count > max_cache_entries) return std::nullopt;
+    return count;
+}
+
+[[nodiscard]] std::optional<CacheRecord> read_record(std::istream& stream) {
+    std::string magic;
+    if (!std::getline(stream, magic) || magic != cache_magic) return std::nullopt;
+    CacheRecord record;
+    if (!read_quoted(stream, "target", record.target_architecture) || !read_quoted(stream, "host", record.host_architecture)) return std::nullopt;
+    std::string preference_label;
+    if (!(stream >> preference_label >> record.preference) || preference_label != "preference") return std::nullopt;
+    std::string root;
+    if (!read_quoted(stream, "vc_tools_root", root) || !read_quoted(stream, "binary_stamp", record.binary_stamp)) return std::nullopt;
+    record.vc_tools_root = stable_path(detail::path_from_utf8(root));
+    const auto environment_count = read_count(stream, "environment");
+    if (!environment_count) return std::nullopt;
+    for (std::size_t index = 0; index < *environment_count; ++index) {
+        EnvironmentVariable variable;
+        if (!read_quoted(stream, "env_name", variable.name)
+            || !read_quoted(stream, "env_value", variable.value)
+            || !cacheable_environment_name(variable.name)) return std::nullopt;
+        record.environment.push_back(std::move(variable));
+    }
+    const auto path_count = read_count(stream, "path_prefixes");
+    if (!path_count) return std::nullopt;
+    for (std::size_t index = 0; index < *path_count; ++index) {
+        std::string value;
+        if (!read_quoted(stream, "path_prefix", value)) return std::nullopt;
+        record.path_prefixes.push_back(stable_path(detail::path_from_utf8(value)));
+    }
+    stream >> std::ws;
+    if (!stream.eof()) return std::nullopt;
+    return record;
+}
+
+[[nodiscard]] std::optional<MsvcToolchain> try_reuse_visual_studio_cache(
+    const fs::path& cache_file,
+    const DiscoveryOptions& options) {
+    try {
+        std::error_code error_code;
+        if (!fs::is_regular_file(cache_file, error_code) || error_code) return std::nullopt;
+        const auto size = fs::file_size(cache_file, error_code);
+        if (error_code || size > max_cache_size) return std::nullopt;
+        const auto modified = fs::last_write_time(cache_file, error_code);
+        if (error_code) return std::nullopt;
+        const auto now = fs::file_time_type::clock::now();
+        if (modified > now || now - modified > max_cache_age) return std::nullopt;
+        std::ifstream stream{cache_file, std::ios::binary};
+        if (!stream) return std::nullopt;
+        auto record = read_record(stream);
+        if (!record || !cache_key_matches(*record, options) || record->binary_stamp.empty()) return std::nullopt;
+        if (!fs::is_directory(record->vc_tools_root, error_code) || error_code) return std::nullopt;
+        const auto latest_tools = detail::latest_directory(record->vc_tools_root.parent_path());
+        if (!latest_tools || normalized_path_text(*latest_tools) != normalized_path_text(record->vc_tools_root)) return std::nullopt;
+        const ToolPaths paths = tool_paths(record->vc_tools_root, options);
+        for (const auto& file : {paths.compiler, paths.linker, paths.librarian}) {
+            error_code.clear();
+            if (!fs::is_regular_file(file, error_code) || error_code) return std::nullopt;
+        }
+        auto stamp = detail::binary_stamp(paths.compiler);
+        if (!stamp || *stamp != record->binary_stamp) return std::nullopt;
+        if (!environment_is_cacheable(record->environment, record->vc_tools_root)) return std::nullopt;
+        const auto roots = trusted_roots(record->environment, record->vc_tools_root);
+        if (record->path_prefixes.empty()) return std::nullopt;
+        for (const auto& prefix : record->path_prefixes) {
+            error_code.clear();
+            if (!fs::is_directory(prefix, error_code) || error_code || !path_inside_any_root(roots, prefix)) return std::nullopt;
+        }
+        std::vector<EnvironmentVariable> environment = std::move(record->environment);
+        environment.push_back(EnvironmentVariable{.name = "PATH", .value = joined_path(record->path_prefixes)});
+        return MsvcToolchain{
+            .identity = ToolchainIdentity{
+                .compiler = paths.compiler,
+                .version = detail::path_to_utf8(record->vc_tools_root.filename()),
+                .binary_stamp = std::move(record->binary_stamp),
+            },
+            .linker = paths.linker,
+            .librarian = paths.librarian,
+            .vc_tools_root = record->vc_tools_root,
+            .standard_library_modules = detail::discover_standard_library_modules(record->vc_tools_root),
+            .source = ToolchainSource::visual_studio,
+            .environment = std::move(environment),
+            .reused = true,
+        };
+    } catch (...) {
+        return std::nullopt;
+    }
+}
+
+void save_visual_studio_cache_best_effort(
+    const fs::path& cache_file,
+    const DiscoveryOptions& options,
+    const MsvcToolchain& toolchain) noexcept {
+    try {
+        if (toolchain.source != ToolchainSource::visual_studio || toolchain.reused) return;
+        const fs::path root = stable_path(toolchain.vc_tools_root);
+        const ToolPaths expected = tool_paths(root, options);
+        if (normalized_path_text(expected.compiler) != normalized_path_text(toolchain.identity.compiler)
+            || normalized_path_text(expected.linker) != normalized_path_text(toolchain.linker)
+            || normalized_path_text(expected.librarian) != normalized_path_text(toolchain.librarian)) return;
+        std::vector<EnvironmentVariable> environment = cacheable_environment(toolchain);
+        std::vector<fs::path> path_prefixes = trusted_path_prefixes(toolchain);
+        if (!environment_is_cacheable(environment, root) || path_prefixes.empty()) return;
+        const CacheRecord record{
+            .target_architecture = detail::architecture_name(options.target_architecture),
+            .host_architecture = detail::architecture_name(options.host_architecture),
+            .preference = preference_value(options.preference),
+            .vc_tools_root = root,
+            .binary_stamp = toolchain.identity.binary_stamp,
+            .environment = std::move(environment),
+            .path_prefixes = std::move(path_prefixes),
+        };
+        std::error_code error_code;
+        if (!cache_file.parent_path().empty()) {
+            fs::create_directories(cache_file.parent_path(), error_code);
+            if (error_code) return;
+        }
+        fs::path temporary = cache_file;
+        temporary += ".tmp." + std::to_string(std::chrono::steady_clock::now().time_since_epoch().count());
+        {
+            std::ofstream stream{temporary, std::ios::binary | std::ios::trunc};
+            if (!stream || !write_record(stream, record)) {
+                stream.close();
+                fs::remove(temporary, error_code);
+                return;
+            }
+            stream.flush();
+            if (!stream) {
+                stream.close();
+                fs::remove(temporary, error_code);
+                return;
+            }
+        }
+        error_code.clear();
+        if (fs::exists(cache_file, error_code) && !error_code) {
+            fs::remove(cache_file, error_code);
+            if (error_code) {
+                fs::remove(temporary, error_code);
+                return;
+            }
+        } else if (error_code) {
+            fs::remove(temporary, error_code);
+            return;
+        }
+        fs::rename(temporary, cache_file, error_code);
+        if (error_code) {
+            std::error_code ignored;
+            fs::remove(temporary, ignored);
+        }
+    } catch (...) {
+        return;
+    }
+}
+
+} // namespace
 
 std::expected<MsvcToolchain, ToolchainError>
 MsvcToolchainLocator::discover(const DiscoveryOptions& options) const {
     if (options.preference != ToolchainPreference::visual_studio) {
         for (const auto& portable_root : options.portable_roots) {
             std::error_code error_code;
-            if (fs::is_directory(portable_root, error_code)) {
-                return detail::discover_portable_toolchain(portable_root, options);
-            }
+            if (fs::is_directory(portable_root, error_code)) return detail::discover_portable_toolchain(portable_root, options);
         }
-
         if (options.preference == ToolchainPreference::portable) {
             return std::unexpected(detail::toolchain_failure(
                 ToolchainErrorCode::toolchain_not_found,
                 "portable toolchain was requested but no portable_msvc root exists"));
         }
     }
-
-    return detail::discover_visual_studio_toolchain(runner_, options);
+    const auto cache_file = effective_cache_file(options);
+    if (cache_file) {
+        if (auto cached = try_reuse_visual_studio_cache(*cache_file, options)) return std::move(*cached);
+    }
+    auto discovered = detail::discover_visual_studio_toolchain(runner_, options);
+    if (discovered && cache_file) save_visual_studio_cache_best_effort(*cache_file, options, *discovered);
+    return discovered;
 }
 
 } // namespace mqb::msvc

--- a/cpp/src/msvc/toolchain/MsvcToolchainLocator.cpp
+++ b/cpp/src/msvc/toolchain/MsvcToolchainLocator.cpp
@@ -24,7 +24,7 @@ namespace {
 namespace fs = std::filesystem;
 using process::EnvironmentVariable;
 
-constexpr std::string_view cache_magic = "MQB_TOOLCHAIN_CACHE_V5";
+constexpr std::string_view cache_magic = "MQB_TOOLCHAIN_CACHE_V6";
 constexpr std::uintmax_t max_cache_size = 1024u * 1024u;
 constexpr std::size_t max_cache_entries = 64u;
 constexpr std::size_t max_cache_string = 256u * 1024u;
@@ -117,8 +117,8 @@ struct ToolPaths {
 
 [[nodiscard]] bool cacheable_environment_name(const std::string_view name) {
     constexpr std::string_view names[]{
-        "INCLUDE", "LIB", "VCToolsInstallDir", "WindowsSdkDir",
-        "WindowsSDKVersion", "UniversalCRTSdkDir", "UCRTVersion",
+        "INCLUDE", "LIB", "LIBPATH", "VCToolsInstallDir", "WindowsSdkDir",
+        "WindowsSDKVersion", "UniversalCRTSdkDir", "UCRTVersion", "NETFXSDKDir",
     };
     for (const auto candidate : names) {
         if (environment_name_equal(name, candidate)) return true;
@@ -169,7 +169,7 @@ void append_unique_existing_root(std::vector<fs::path>& roots, fs::path root) {
     const fs::path& vc_tools_root) {
     std::vector<fs::path> roots;
     append_unique_existing_root(roots, visual_studio_root(vc_tools_root));
-    for (const auto name : {"WindowsSdkDir", "UniversalCRTSdkDir"}) {
+    for (const auto name : {"WindowsSdkDir", "UniversalCRTSdkDir", "NETFXSDKDir"}) {
         if (const auto* variable = find_environment(environment, name);
             variable != nullptr && !variable->value.empty()) {
             append_unique_existing_root(roots, detail::path_from_utf8(variable->value));
@@ -222,12 +222,16 @@ void append_unique_existing_root(std::vector<fs::path>& roots, fs::path root) {
     const fs::path& vc_tools_root) {
     const auto* include = find_environment(environment, "INCLUDE");
     const auto* lib = find_environment(environment, "LIB");
+    const auto* lib_path = find_environment(environment, "LIBPATH");
     const auto* tools = find_environment(environment, "VCToolsInstallDir");
-    if (include == nullptr || lib == nullptr || tools == nullptr
-        || include->value.empty() || lib->value.empty() || tools->value.empty()) return false;
+    if (include == nullptr || lib == nullptr || lib_path == nullptr || tools == nullptr
+        || include->value.empty() || lib->value.empty() || lib_path->value.empty() || tools->value.empty()) return false;
     if (normalized_path_text(detail::path_from_utf8(tools->value)) != normalized_path_text(vc_tools_root)) return false;
     const auto roots = trusted_roots(environment, vc_tools_root);
-    return !roots.empty() && trusted_directory_list(include->value, roots) && trusted_directory_list(lib->value, roots);
+    return !roots.empty()
+        && trusted_directory_list(include->value, roots)
+        && trusted_directory_list(lib->value, roots)
+        && trusted_directory_list(lib_path->value, roots);
 }
 
 [[nodiscard]] std::vector<fs::path> trusted_path_prefixes(const MsvcToolchain& toolchain) {

--- a/cpp/tests/msvc/toolchain/visual_studio_tests.cpp
+++ b/cpp/tests/msvc/toolchain/visual_studio_tests.cpp
@@ -120,6 +120,8 @@ int main() {
                "vcvars environment should contain INCLUDE");
         expect(has_environment_variable(*result, "LIB"),
                "vcvars environment should contain LIB");
+        expect(has_environment_variable(*result, "LIBPATH"),
+               "vcvars environment should contain LIBPATH");
         expect(has_environment_variable(*result, "VCToolsInstallDir"),
                "vcvars environment should expose VCToolsInstallDir");
 
@@ -154,6 +156,12 @@ int main() {
                    "cache hit should reconstruct the same linker path");
             expect(cached->librarian == result->librarian,
                    "cache hit should reconstruct the same librarian path");
+
+            const auto* cold_lib_path = find_environment_variable(*result, "LIBPATH");
+            const auto* cached_lib_path = find_environment_variable(*cached, "LIBPATH");
+            expect(cold_lib_path != nullptr && cached_lib_path != nullptr
+                       && cached_lib_path->value == cold_lib_path->value,
+                   "cache hit should preserve vcvars LIBPATH exactly");
 
             const auto* cached_path = find_environment_variable(*cached, "PATH");
             const char* current_path = std::getenv("PATH");

--- a/cpp/tests/msvc/toolchain/visual_studio_tests.cpp
+++ b/cpp/tests/msvc/toolchain/visual_studio_tests.cpp
@@ -1,7 +1,11 @@
 #include <algorithm>
+#include <chrono>
 #include <cctype>
+#include <cstdlib>
 #include <filesystem>
+#include <fstream>
 #include <iostream>
+#include <iterator>
 #include <string>
 #include <string_view>
 
@@ -9,6 +13,8 @@
 #include "mqb/platform/windows/WindowsProcessRunner.hpp"
 
 namespace {
+
+namespace fs = std::filesystem;
 
 int failures = 0;
 
@@ -30,38 +36,79 @@ void expect(const bool condition, const std::string_view message) {
     return left == right;
 }
 
-[[nodiscard]] bool has_environment_variable(
+[[nodiscard]] const mqb::process::EnvironmentVariable* find_environment_variable(
     const mqb::msvc::MsvcToolchain& toolchain,
     const std::string_view name) {
-    return std::any_of(
+    const auto found = std::find_if(
         toolchain.environment.begin(),
         toolchain.environment.end(),
         [name](const mqb::process::EnvironmentVariable& variable) {
             return equals_ignore_case(variable.name, std::string{name});
         });
+    return found == toolchain.environment.end() ? nullptr : &*found;
+}
+
+[[nodiscard]] bool has_environment_variable(
+    const mqb::msvc::MsvcToolchain& toolchain,
+    const std::string_view name) {
+    return find_environment_variable(toolchain, name) != nullptr;
+}
+
+class RejectingRunner final : public mqb::process::ProcessRunner {
+public:
+    [[nodiscard]] std::expected<mqb::process::ProcessResult, mqb::process::ProcessError>
+    run(const mqb::process::ProcessSpec&) override {
+        ++calls;
+        return std::unexpected(mqb::process::ProcessError{
+            .code = mqb::process::ProcessErrorCode::launch_failed,
+            .message = "toolchain cache miss attempted a subprocess",
+        });
+    }
+
+    std::size_t calls{};
+};
+
+[[nodiscard]] fs::path unique_cache_file() {
+    return fs::temp_directory_path()
+        / ("mqb-vs-toolchain-cache-test-"
+           + std::to_string(std::chrono::steady_clock::now().time_since_epoch().count())
+           + ".mqbcache");
 }
 
 } // namespace
 
 int main() {
-    mqb::platform::windows::WindowsProcessRunner runner;
-    mqb::msvc::MsvcToolchainLocator locator{runner};
+    const fs::path cache_file = unique_cache_file();
+    std::error_code cleanup_error;
+    fs::remove(cache_file, cleanup_error);
+
+    constexpr const char* secret_name = "MQB_TOOLCHAIN_CACHE_TEST_SECRET";
+    constexpr const char* secret_value = "mqb-cache-must-not-persist-this-value";
+    const char* inherited_secret = std::getenv(secret_name);
+    const std::string original_secret = inherited_secret == nullptr ? std::string{} : std::string{inherited_secret};
+    const bool had_original_secret = inherited_secret != nullptr;
+    _putenv_s(secret_name, secret_value);
 
     mqb::msvc::DiscoveryOptions options;
     options.preference = mqb::msvc::ToolchainPreference::visual_studio;
     options.target_architecture = mqb::Architecture::x64;
     options.host_architecture = mqb::Architecture::x64;
+    options.cache_file = cache_file;
 
+    mqb::platform::windows::WindowsProcessRunner runner;
+    mqb::msvc::MsvcToolchainLocator locator{runner};
     const auto result = locator.discover(options);
     expect(result.has_value(), "Visual Studio toolchain should be discoverable on the Windows CI image");
     if (result) {
         expect(result->source == mqb::msvc::ToolchainSource::visual_studio,
                "forced VS discovery should preserve toolchain provenance");
-        expect(std::filesystem::is_regular_file(result->identity.compiler),
+        expect(!result->reused,
+               "cold Visual Studio discovery should not report persistent cache reuse");
+        expect(fs::is_regular_file(result->identity.compiler),
                "discovered cl.exe should exist");
-        expect(std::filesystem::is_regular_file(result->linker),
+        expect(fs::is_regular_file(result->linker),
                "discovered link.exe should exist");
-        expect(std::filesystem::is_regular_file(result->librarian),
+        expect(fs::is_regular_file(result->librarian),
                "discovered lib.exe should exist");
         expect(!result->identity.version.empty(),
                "discovered compiler should expose the VC tools version");
@@ -75,6 +122,57 @@ int main() {
                "vcvars environment should contain LIB");
         expect(has_environment_variable(*result, "VCToolsInstallDir"),
                "vcvars environment should expose VCToolsInstallDir");
+
+        expect(fs::is_regular_file(cache_file),
+               "cold Visual Studio discovery should persist validated cache evidence");
+        std::ifstream cache_stream{cache_file, std::ios::binary};
+        const std::string cache_text{
+            std::istreambuf_iterator<char>{cache_stream},
+            std::istreambuf_iterator<char>{}};
+        expect(cache_text.find(secret_name) == std::string::npos,
+               "toolchain cache must not persist unrelated inherited environment names");
+        expect(cache_text.find(secret_value) == std::string::npos,
+               "toolchain cache must not persist unrelated inherited environment values");
+
+        RejectingRunner rejecting_runner;
+        mqb::msvc::MsvcToolchainLocator cached_locator{rejecting_runner};
+        const auto cached = cached_locator.discover(options);
+        expect(cached.has_value(),
+               "validated Visual Studio cache should be reusable without subprocesses");
+        expect(rejecting_runner.calls == 0,
+               "Visual Studio cache hit must skip vswhere/cmd/vcvarsall subprocesses");
+        if (cached) {
+            expect(cached->reused,
+                   "validated Visual Studio cache hit should report reuse");
+            expect(cached->identity.compiler == result->identity.compiler,
+                   "cache hit should preserve compiler identity path");
+            expect(cached->identity.version == result->identity.version,
+                   "cache hit should preserve VC tools version");
+            expect(cached->identity.binary_stamp == result->identity.binary_stamp,
+                   "cache hit should preserve compiler binary stamp");
+            expect(cached->linker == result->linker,
+                   "cache hit should reconstruct the same linker path");
+            expect(cached->librarian == result->librarian,
+                   "cache hit should reconstruct the same librarian path");
+
+            const auto* cached_path = find_environment_variable(*cached, "PATH");
+            const char* current_path = std::getenv("PATH");
+            expect(cached_path != nullptr && current_path != nullptr
+                       && cached_path->value.find(current_path) != std::string::npos,
+                   "cache hit should append the current process PATH");
+        }
+
+        {
+            std::ofstream corrupt{cache_file, std::ios::binary | std::ios::trunc};
+            corrupt << "not-an-mqb-toolchain-cache\n";
+        }
+        RejectingRunner fallback_runner;
+        mqb::msvc::MsvcToolchainLocator fallback_locator{fallback_runner};
+        const auto fallback = fallback_locator.discover(options);
+        expect(!fallback.has_value(),
+               "corrupt cache evidence should fall back to ordinary discovery");
+        expect(fallback_runner.calls != 0,
+               "corrupt cache evidence must not suppress ordinary discovery");
     } else {
         std::cerr << "toolchain discovery error: " << result.error().message << '\n';
         if (!result.error().path.empty()) {
@@ -85,6 +183,13 @@ int main() {
                       << " native=" << result.error().process_error->native_code << '\n';
         }
     }
+
+    if (had_original_secret) {
+        _putenv_s(secret_name, original_secret.c_str());
+    } else {
+        _putenv_s(secret_name, "");
+    }
+    fs::remove(cache_file, cleanup_error);
 
     if (failures != 0) {
         std::cerr << failures << " test(s) failed\n";

--- a/cpp/tests/msvc/toolchain/visual_studio_tests.cpp
+++ b/cpp/tests/msvc/toolchain/visual_studio_tests.cpp
@@ -131,6 +131,7 @@ int main() {
         const std::string cache_text{
             std::istreambuf_iterator<char>{cache_stream},
             std::istreambuf_iterator<char>{}};
+        cache_stream.close();
         expect(cache_text.find(secret_name) == std::string::npos,
                "toolchain cache must not persist unrelated inherited environment names");
         expect(cache_text.find(secret_value) == std::string::npos,


### PR DESCRIPTION
## Summary

Add a safe persistent fast path for repeated Visual Studio toolchain discovery without persisting the full `vcvarsall && set` environment.

- reuse validated VS toolchain evidence instead of rerunning `vswhere + vcvarsall` on every invocation
- default to user-local cache state under `%LOCALAPPDATA%/MQB/cache/toolchain`
- keep automatic portable-toolchain precedence ahead of VS cache reuse
- use a 30-minute hard TTL and require the cached VC Tools directory to remain the newest toolset inside that VS installation
- persist only the VC Tools root, the `cl.exe` binary stamp, host/target/preference key, a minimal MSVC environment allowlist, and trusted PATH prefixes
- deterministically reconstruct `cl.exe`, `link.exe`, and `lib.exe` from the validated VC Tools root plus host/target architecture instead of trusting executable paths serialized into cache
- persist `INCLUDE`, `LIB`, `LIBPATH`, `VCToolsInstallDir`, Windows SDK/UCRT evidence, and `NETFXSDKDir`; never serialize the full inherited environment
- require cached `INCLUDE`, `LIB`, and `LIBPATH` directories to exist and remain inside trusted Visual Studio / Windows SDK / UCRT / .NET FX SDK / current SystemRoot roots; unsupported custom paths therefore disable reuse instead of changing build semantics
- persist PATH entries only under those trusted roots, then append the *current* process PATH on every hit
- explicit `vswhere` / `cmd` discovery overrides disable persistent reuse so explicit discovery remains authoritative
- treat missing, corrupt, stale, custom-environment, or otherwise invalid evidence as an ordinary cache miss and fall back to normal discovery
- expose `MsvcToolchain::reused` as structural cache evidence

## Selection and correctness boundary

Automatic selection semantics remain unchanged. Existing portable roots are checked before the VS cache; forced portable discovery never consults the VS cache. Portable-root paths are deliberately not serialized into the user-local VS cache.

A V6 cache hit requires matching host/target/preference, no explicit discovery override, a fresh record, an existing/latest VC Tools root, expected `bin/Host*/{target}/cl.exe|link.exe|lib.exe` files, an unchanged compiler binary stamp, a matching `VCToolsInstallDir`, trusted `INCLUDE` / `LIB` / `LIBPATH` evidence, and trusted PATH prefixes. Any failed check causes ordinary Visual Studio discovery.

`LIBPATH` is part of the cached parity contract rather than falling through to the invoking shell: warm discovery must reproduce the captured vcvars `LIBPATH` exactly. This preserves metadata-search behavior while still rebuilding PATH from trusted toolchain prefixes plus the current process PATH.

## Security / cache evidence

The existing VS discovery captures the entire post-`vcvarsall` environment. This PR never writes that environment wholesale to disk. The cache uses an explicit allowlist and cannot serialize unrelated inherited environment keys.

`visual_studio_tests.cpp` locks the fast path directly with an isolated temporary cache file:

- cold discovery must write cache evidence and report `reused=false`;
- an unrelated secret-like inherited environment name/value must not appear in the cache file;
- a second discovery uses a `ProcessRunner` that rejects every subprocess and must still succeed with `reused=true` and **zero runner calls**, proving `vswhere/cmd/vcvarsall` were skipped;
- reconstructed PATH must contain the current process PATH rather than freezing the cold invocation's inherited PATH;
- compiler identity and linker/librarian paths must match the cold discovery result;
- warm `LIBPATH` must exactly equal cold vcvars `LIBPATH`;
- corrupt evidence must miss and attempt ordinary discovery rather than being trusted.

The exact-head Debug matrix ran this test successfully on the hosted Windows Server 2025 / VS 2026 image (`mqb_msvc_visual_studio_tests passed`).

## Performance evidence

Performance Evidence #49 compares exact PR base `0c6ecc91d4dad5e3ab04b6dfbfcd94b6e4cadb33` against exact candidate `ac6917fb017c107347023c5bd310d5fc0f4d32cd` on the same Windows runner, 5 iterations per scenario.

The important repeated-invocation medians are:

| Scenario | Base total ms | Candidate total ms | Δ |
|---|---:|---:|---:|
| `no-op` | 1559.172 | 4.328 | -99.72% |
| `discovery-no-op` | 1555.161 | 4.888 | -99.69% |
| `modules-no-op` | 1566.414 | 5.052 | -99.68% |
| `build-run` | 1566.800 | 15.723 | -99.00% |
| `link-only` | 1602.949 | 54.296 | -96.61% |

The benchmark scenario named `cold` is project-build-cache cold, not first-ever toolchain-discovery cold. Its median drops from 1677.692 ms to 113.081 ms because the candidate process is reusing already validated VS toolchain evidence. The performance claim of this PR is therefore specifically repeated MQB invocation latency, not a faster first-ever Visual Studio discovery.

The existing timing schema is unchanged. The dedicated cache E2E independently proves that the eliminated work is `vswhere/cmd/vcvarsall`, rather than compile/link correctness being bypassed.

## Scope

The diff is limited to:

- `cpp/include/mqb/msvc/MsvcToolchainLocator.hpp`
- `cpp/src/msvc/toolchain/MsvcToolchainLocator.cpp`
- `cpp/tests/msvc/toolchain/visual_studio_tests.cpp`

No compile/link/archive cache identity, CLI parameter semantics, project-resolution semantics, or Application timing schema is changed.

## Validation

Current exact head: `ac6917fb017c107347023c5bd310d5fc0f4d32cd`.

- Native C++ #322: **green** — Debug build, shared product library, all 4 outer shards / 8 subshards, and final gate passed.
- Native Release #280: **green** — Stage 0 build, shared product library, exact-head 4/4 Release outer shards on the successful rerun, Stage-1 self-host, runtime-only package validation, installer lifecycle, and artifact upload all passed. The first attempt had one isolated `mqb_static_library_e2e_tests` runtime-behavior failure after the test had already observed source recompilation, archive rebuild, and consumer relink; the same exact head rerun produced `mqb_static_library_e2e_tests passed`, so no unrelated product-code change was made for the non-stable failure.
- Performance Evidence #49: **green**, with the repeated-invocation medians above.

All exact-head gates required by this PR are green.