### PR TITLE
fix: force full relink after library input changes

### DIFF
--- a/cpp/include/mqb/core/LinkCache.hpp
+++ b/cpp/include/mqb/core/LinkCache.hpp
@@ -24,6 +24,10 @@ struct LinkCacheEntry {
 
 struct LinkCacheValidation {
     std::vector<BuildReason> reasons;
+    // Runtime execution evidence only; this does not participate in cache
+    // identity. MSVC incremental linking can otherwise reuse stale archive
+    // members when a .lib is rebuilt inside the linker timestamp granularity.
+    bool library_inputs_changed{false};
 
     [[nodiscard]] bool reusable() const noexcept {
         return reasons.empty();

--- a/cpp/include/mqb/msvc/MsvcLinker.hpp
+++ b/cpp/include/mqb/msvc/MsvcLinker.hpp
@@ -19,6 +19,10 @@ struct LinkInvocation {
     std::vector<std::filesystem::path> libraries;
     LinkOptions options;
     std::filesystem::path working_directory;
+    // Use a non-incremental linker pass when resolved library inputs changed.
+    // This avoids stale archive-member reuse inside MSVC's .ilk state while
+    // preserving ordinary Debug incremental linking for object-only changes.
+    bool force_full_link{false};
 };
 
 enum class LinkerErrorCode {

--- a/cpp/src/core/cache/LinkCache.cpp
+++ b/cpp/src/core/cache/LinkCache.cpp
@@ -64,22 +64,26 @@ void add_reason(std::vector<BuildReason>& reasons, const BuildReason reason) {
     return find_snapshot(snapshots, path);
 }
 
-void validate_freshness(
+[[nodiscard]] bool validate_freshness(
     const std::span<const std::filesystem::path> inputs,
     const std::span<const FileSnapshot> snapshots,
     const FileSnapshot& output_snapshot,
     std::vector<BuildReason>& reasons) {
+    bool changed = false;
     for (std::size_t index = 0; index < inputs.size(); ++index) {
         const auto& input = inputs[index];
         const auto* snapshot = aligned_snapshot_or_find(snapshots, input, index);
         if (snapshot == nullptr || !snapshot->exists) {
             add_reason(reasons, BuildReason::link_inputs_changed);
+            changed = true;
             continue;
         }
         if (output_snapshot.exists && snapshot->modified > output_snapshot.modified) {
             add_reason(reasons, BuildReason::link_inputs_changed);
+            changed = true;
         }
     }
+    return changed;
 }
 
 void validate_side_outputs(
@@ -167,6 +171,10 @@ LinkCacheValidation LinkCacheValidator::validate(
         add_reason(result.reasons, BuildReason::missing_cache_entry);
         if (!output_snapshot.exists) {
             add_reason(result.reasons, BuildReason::missing_output);
+        } else if (!current_libraries.empty()) {
+            // Existing incremental-link state cannot be proven to match the
+            // currently resolved libraries when link metadata is missing.
+            result.library_inputs_changed = true;
         }
         return result;
     }
@@ -182,6 +190,9 @@ LinkCacheValidation LinkCacheValidator::validate(
     const bool inputs_match = object_inputs_match && library_inputs_match;
     if (!inputs_match) {
         add_reason(result.reasons, BuildReason::link_inputs_changed);
+    }
+    if (!library_inputs_match) {
+        result.library_inputs_changed = true;
     }
 
     const auto current_signature = BuildSignature::for_link(
@@ -203,8 +214,18 @@ LinkCacheValidation LinkCacheValidator::validate(
     }
     validate_side_outputs(cached.side_outputs, side_output_snapshots, result.reasons);
 
-    validate_freshness(current_objects, object_snapshots, output_snapshot, result.reasons);
-    validate_freshness(current_libraries, library_snapshots, output_snapshot, result.reasons);
+    (void)validate_freshness(
+        current_objects,
+        object_snapshots,
+        output_snapshot,
+        result.reasons);
+    if (validate_freshness(
+            current_libraries,
+            library_snapshots,
+            output_snapshot,
+            result.reasons)) {
+        result.library_inputs_changed = true;
+    }
 
     return result;
 }

--- a/cpp/src/msvc/linker/MsvcLinker.cpp
+++ b/cpp/src/msvc/linker/MsvcLinker.cpp
@@ -146,7 +146,7 @@ MsvcLinker::build_arguments(const LinkInvocation& invocation) {
 
     std::vector<std::string> arguments;
     arguments.reserve(
-        15
+        16
         + invocation.objects.size()
         + invocation.options.library_directories.size()
         + invocation.libraries.size()
@@ -155,10 +155,12 @@ MsvcLinker::build_arguments(const LinkInvocation& invocation) {
     arguments.emplace_back("/NOLOGO");
     if (invocation.options.configuration == BuildConfiguration::debug) {
         arguments.emplace_back("/DEBUG");
-        arguments.emplace_back(
-            invocation.options.link_time_code_generation || invocation.force_full_link
-                ? "/INCREMENTAL:NO"
-                : "/INCREMENTAL");
+        if (!invocation.force_full_link) {
+            arguments.emplace_back(
+                invocation.options.link_time_code_generation
+                    ? "/INCREMENTAL:NO"
+                    : "/INCREMENTAL");
+        }
     } else {
         arguments.emplace_back("/INCREMENTAL:NO");
         arguments.emplace_back("/OPT:REF");
@@ -183,6 +185,13 @@ MsvcLinker::build_arguments(const LinkInvocation& invocation) {
                 "additional linker argument must not be empty"));
         }
         arguments.push_back(argument);
+    }
+
+    // A library-change full link is MQB execution policy rather than a user
+    // linker preference. Emit it after raw flags so stale .ilk state cannot be
+    // re-enabled by a passthrough /INCREMENTAL argument.
+    if (invocation.force_full_link) {
+        arguments.emplace_back("/INCREMENTAL:NO");
     }
 
     // Typed LTCG is downstream structured policy and therefore follows raw

--- a/cpp/src/msvc/linker/MsvcLinker.cpp
+++ b/cpp/src/msvc/linker/MsvcLinker.cpp
@@ -156,7 +156,7 @@ MsvcLinker::build_arguments(const LinkInvocation& invocation) {
     if (invocation.options.configuration == BuildConfiguration::debug) {
         arguments.emplace_back("/DEBUG");
         arguments.emplace_back(
-            invocation.options.link_time_code_generation
+            invocation.options.link_time_code_generation || invocation.force_full_link
                 ? "/INCREMENTAL:NO"
                 : "/INCREMENTAL");
     } else {

--- a/cpp/src/orchestration/incremental/MsvcIncrementalLinkCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalLinkCoordinator.cpp
@@ -207,6 +207,7 @@ MsvcIncrementalLinkCoordinator::run(const IncrementalLinkRequest& request) const
         .libraries = action->libraries,
         .options = request.options,
         .working_directory = request.working_directory.value_or(fs::path{}),
+        .force_full_link = result.validation.library_inputs_changed,
     };
     auto linked = linker_.link(invocation);
     if (!linked) {

--- a/cpp/tests/core/cache/link_state_tests.cpp
+++ b/cpp/tests/core/cache/link_state_tests.cpp
@@ -107,6 +107,8 @@ int main() {
         object_snapshots,
         library_snapshots);
     expect(warm.reusable(), "matching object and library inputs should be reusable");
+    expect(!warm.library_inputs_changed,
+           "warm link should not report changed library execution evidence");
 
     auto unordered_object_snapshots = object_snapshots;
     std::reverse(unordered_object_snapshots.begin(), unordered_object_snapshots.end());
@@ -122,6 +124,8 @@ int main() {
         library_snapshots);
     expect(unordered_warm.reusable(),
            "unordered snapshot callers should retain path-based fallback compatibility");
+    expect(!unordered_warm.library_inputs_changed,
+           "unordered warm snapshots should not synthesize library-change evidence");
 
     const auto cold = mqb::LinkCacheValidator::validate(
         objects,
@@ -137,6 +141,21 @@ int main() {
            "cold link should report missing cache entry");
     expect(has_reason(cold, mqb::BuildReason::missing_output),
            "cold link should report missing output");
+    expect(!cold.library_inputs_changed,
+           "brand-new output has no incremental-link state that needs invalidating");
+
+    const auto lost_metadata = mqb::LinkCacheValidator::validate(
+        objects,
+        libraries,
+        output,
+        linker,
+        options,
+        std::nullopt,
+        output_snapshot,
+        object_snapshots,
+        library_snapshots);
+    expect(lost_metadata.library_inputs_changed,
+           "existing output with missing link metadata must distrust incremental library state");
 
     auto newer_objects = object_snapshots;
     newer_objects[1].modified = base_time + std::chrono::seconds{1};
@@ -152,6 +171,8 @@ int main() {
         library_snapshots);
     expect(has_reason(object_changed, mqb::BuildReason::link_inputs_changed),
            "object newer than executable should invalidate link cache");
+    expect(!object_changed.library_inputs_changed,
+           "object-only changes must preserve ordinary Debug incremental linking");
 
     auto newer_libraries = library_snapshots;
     newer_libraries[0].modified = base_time + std::chrono::seconds{1};
@@ -167,6 +188,8 @@ int main() {
         newer_libraries);
     expect(has_reason(library_changed, mqb::BuildReason::link_inputs_changed),
            "resolved library newer than executable should invalidate link cache");
+    expect(library_changed.library_inputs_changed,
+           "newer resolved library must force a full Debug relink");
 
     const auto library_missing = mqb::LinkCacheValidator::validate(
         objects,
@@ -182,6 +205,8 @@ int main() {
         });
     expect(has_reason(library_missing, mqb::BuildReason::link_inputs_changed),
            "missing resolved library should invalidate link cache");
+    expect(library_missing.library_inputs_changed,
+           "missing resolved library must invalidate incremental-link library state");
 
     const auto library_resolution_changed = mqb::LinkCacheValidator::validate(
         objects,
@@ -197,6 +222,8 @@ int main() {
         });
     expect(has_reason(library_resolution_changed, mqb::BuildReason::link_inputs_changed),
            "changed resolved library path should invalidate link cache");
+    expect(library_resolution_changed.library_inputs_changed,
+           "changed resolved library path must force a full Debug relink");
 
     const auto forced = mqb::LinkCacheValidator::validate(
         objects,
@@ -211,6 +238,8 @@ int main() {
         true);
     expect(has_reason(forced, mqb::BuildReason::explicit_rebuild),
            "fresh compile result must be able to force relink independent of timestamps");
+    expect(!forced.library_inputs_changed,
+           "generic explicit relink must not be mislabeled as a library mutation");
 
     auto other_linker = linker;
     other_linker.binary_stamp = "link-stamp-b";
@@ -226,6 +255,8 @@ int main() {
         library_snapshots);
     expect(has_reason(linker_changed, mqb::BuildReason::toolchain_changed),
            "linker identity change should invalidate link cache");
+    expect(!linker_changed.library_inputs_changed,
+           "toolchain-only changes should not be classified as library changes");
 
     const auto options_changed = mqb::LinkCacheValidator::validate(
         objects,
@@ -239,6 +270,8 @@ int main() {
         library_snapshots);
     expect(has_reason(options_changed, mqb::BuildReason::linker_options_changed),
            "link option change should invalidate link cache");
+    expect(!options_changed.library_inputs_changed,
+           "linker-option changes should not be classified as library changes");
 
     const mqb::LinkPlanItem plan_item{
         .objects = objects,

--- a/cpp/tests/msvc/linker/linker_arguments_tests.cpp
+++ b/cpp/tests/msvc/linker/linker_arguments_tests.cpp
@@ -65,6 +65,7 @@ int main() {
 
     auto changed_library = invocation;
     changed_library.force_full_link = true;
+    changed_library.options.additional_arguments.push_back("/INCREMENTAL");
     const auto changed_library_result = mqb::msvc::MsvcLinker::build_arguments(changed_library);
     expect(changed_library_result.has_value(),
            "library-change full-link invocation should produce argv");
@@ -73,8 +74,14 @@ int main() {
                "full library relink should retain Debug information");
         expect(contains(*changed_library_result, "/INCREMENTAL:NO"),
                "changed library inputs must disable MSVC incremental linking");
-        expect(!contains(*changed_library_result, "/INCREMENTAL"),
-               "changed library inputs must not retain incremental .ilk reuse");
+        const auto raw_incremental = std::find(
+            changed_library_result->begin(), changed_library_result->end(), "/INCREMENTAL");
+        const auto forced_full = std::find(
+            changed_library_result->begin(), changed_library_result->end(), "/INCREMENTAL:NO");
+        expect(raw_incremental != changed_library_result->end()
+                   && forced_full != changed_library_result->end()
+                   && raw_incremental < forced_full,
+               "MQB full-link safety policy must override a raw /INCREMENTAL argument");
     }
 
     auto ltcg = invocation;

--- a/cpp/tests/msvc/linker/linker_arguments_tests.cpp
+++ b/cpp/tests/msvc/linker/linker_arguments_tests.cpp
@@ -45,6 +45,8 @@ int main() {
         expect(contains(*result, "/NOLOGO"), "link should suppress banner");
         expect(contains(*result, "/DEBUG"), "debug link should emit /DEBUG");
         expect(contains(*result, "/INCREMENTAL"), "debug link should be incremental");
+        expect(!contains(*result, "/INCREMENTAL:NO"),
+               "ordinary debug link should not disable incremental linking");
         expect(!contains(*result, "/LTCG"), "default link recipe should preserve non-LTCG behavior");
         expect(contains(*result, "/LIBPATH:vendor libs"), "library path should stay one argv element");
         expect(contains(*result, "C:/sdk libs/user32.lib"),
@@ -59,6 +61,20 @@ int main() {
         const auto planned_out = std::find(result->begin(), result->end(), "/OUT:bin/my app.exe");
         expect(raw_out != result->end() && planned_out != result->end() && raw_out < planned_out,
                "planned output must override a conflicting raw /OUT");
+    }
+
+    auto changed_library = invocation;
+    changed_library.force_full_link = true;
+    const auto changed_library_result = mqb::msvc::MsvcLinker::build_arguments(changed_library);
+    expect(changed_library_result.has_value(),
+           "library-change full-link invocation should produce argv");
+    if (changed_library_result) {
+        expect(contains(*changed_library_result, "/DEBUG"),
+               "full library relink should retain Debug information");
+        expect(contains(*changed_library_result, "/INCREMENTAL:NO"),
+               "changed library inputs must disable MSVC incremental linking");
+        expect(!contains(*changed_library_result, "/INCREMENTAL"),
+               "changed library inputs must not retain incremental .ilk reuse");
     }
 
     auto ltcg = invocation;


### PR DESCRIPTION
## Summary

Fix a Debug incremental-link correctness regression exposed by the Visual Studio discovery fast path merged in #93.

After #93 reduced repeated toolchain setup from ~1.56 s to a few milliseconds, static-library mutation/relink sequences began occurring inside a much tighter time window. MQB correctly detected the changed source, rebuilt the object, rebuilt the `.lib`, and invoked `link.exe`, but MSVC `/INCREMENTAL` could still reuse stale archive-member state from the existing `.ilk`, leaving the executable with old library behavior.

This PR keeps ordinary Debug incremental linking and disables it only when resolved library inputs are known to have changed.

## Main regression evidence

Merged main `e7040093167a47cd8092116b54f54af73f9b0c66` / Native C++ #323 showed two independent failures:

- `mqb_static_library_e2e_tests.cpp`: `consumer should observe mutated static-library behavior`
- `mqb_cli_e2e_tests.cpp`: `library-only relink must update executable behavior` and `partial rebuild must preserve current static library behavior`

In these failures MQB had already recompiled/rearchived and emitted `[link]`; the stale behavior remained after `link.exe` ran. A similar Release-run occurrence appeared during #93 validation, which first looked non-deterministic before the main Debug matrix reproduced the same static-library pattern in two separate E2Es.

## Fix

- extend `LinkCacheValidation` with runtime-only `library_inputs_changed` evidence; it does **not** participate in cache identity or serialization
- set that evidence when resolved library paths differ, a resolved library is missing/newer than output, or an existing library-linked output has lost link-cache metadata
- object-only freshness changes do not set the library flag
- pass the flag through `MsvcIncrementalLinkCoordinator` as `LinkInvocation::force_full_link`
- ordinary Debug links still emit `/INCREMENTAL`
- library-change Debug links emit an authoritative `/INCREMENTAL:NO`
- the forced full-link switch is emitted after raw linker arguments, so passthrough raw `/INCREMENTAL` cannot re-enable stale `.ilk` reuse
- Release behavior remains `/INCREMENTAL:NO`
- LTCG behavior remains full-link as before

## Why not sleep or disable incremental linking globally?

No timestamp delay is introduced, and Debug incremental linking is not globally disabled. The fix is tied to structural link-cache evidence already produced by MQB. Object-only rebuilds retain the existing incremental-link fast path.

## Tests

Low-level regression coverage locks both boundaries:

- `link_state_tests.cpp`: warm/object-only state stays incremental; newer/missing/re-resolved libraries and missing metadata on an existing library-linked output produce library-change evidence; generic explicit/toolchain/options changes do not
- `linker_arguments_tests.cpp`: ordinary Debug emits `/INCREMENTAL`; `force_full_link` emits final `/INCREMENTAL:NO`; a raw `/INCREMENTAL` appears before MQB's final authoritative `/INCREMENTAL:NO`

The existing static-library/CLI E2Es are the end-to-end success criteria; no sleeps are added to them.

## Scope

Current exact head: `5a496dc6942dd8b778ee632da300fd74f99cf7d1`.

Changed files are limited to link-cache runtime validation, linker invocation policy, the incremental link coordinator, and their tests. Performance Evidence #53 skipped as expected for this `fix:` PR.

## Validation

- **Native C++ #326:** exact-head full Debug matrix 4/4 + gate green.
- The two exact failures from main #323 are explicitly green on the hotfix:
  - `mqb_static_library_e2e_tests passed`
  - `mqb_cli_e2e_tests passed`
- **Native Release #283:** Stage 0 + shared library, all 4/4 Release shards, self-host, exact runtime-only package validation, and artifact upload are green.
- PR-only release publication is skipped by design.
