### PR TITLE
feat: track MSVC linker stub inputs

### DIFF
--- a/cpp/include/mqb/msvc/MsvcParameterEngine.hpp
+++ b/cpp/include/mqb/msvc/MsvcParameterEngine.hpp
@@ -82,6 +82,7 @@ struct LinkerParameterRouting {
 enum class LinkerFileInputKind {
     module_definition,
     function_order,
+    msdos_stub,
 };
 
 struct LinkerFileInput {
@@ -216,6 +217,25 @@ public:
             }
             return path.lexically_normal();
         };
+        const auto replace_last_wins_input = [](
+            std::vector<LinkerFileInput>& inputs,
+            const LinkerFileInputKind kind,
+            std::filesystem::path path) {
+            const auto existing = std::find_if(
+                inputs.begin(),
+                inputs.end(),
+                [kind](const LinkerFileInput& input) {
+                    return input.kind == kind;
+                });
+            if (existing == inputs.end()) {
+                inputs.push_back(LinkerFileInput{
+                    .kind = kind,
+                    .path = std::move(path),
+                });
+            } else {
+                existing->path = std::move(path);
+            }
+        };
 
         LinkerFileInputRouting result;
         result.passthrough.reserve(validated->passthrough.size());
@@ -273,24 +293,38 @@ public:
 
                 const std::filesystem::path path = resolve_path(
                     body.substr(order_prefix.size()));
-                const auto existing = std::find_if(
-                    result.inputs.begin(),
-                    result.inputs.end(),
-                    [](const LinkerFileInput& input) {
-                        return input.kind == LinkerFileInputKind::function_order;
-                    });
-                if (existing == result.inputs.end()) {
-                    result.inputs.push_back(LinkerFileInput{
-                        .kind = LinkerFileInputKind::function_order,
-                        .path = path,
-                    });
-                } else {
-                    existing->path = path;
-                }
+                replace_last_wins_input(
+                    result.inputs,
+                    LinkerFileInputKind::function_order,
+                    path);
                 result.requires_full_link = true;
                 result.passthrough.push_back(
                     path_base
                         ? argument.substr(0, 1 + order_prefix.size()) + path_text(path)
+                        : argument);
+                continue;
+            }
+
+            if (starts_with_ascii_ci(body, "STUB:")) {
+                constexpr std::string_view stub_prefix = "STUB:";
+                if (body.size() == stub_prefix.size()) {
+                    return std::unexpected(ParameterError{
+                        .code = ParameterErrorCode::invalid_value,
+                        .tool = ParameterTool::linker,
+                        .argument = argument,
+                        .message = "MSVC linker /STUB requires an MS-DOS .exe file path",
+                    });
+                }
+
+                const std::filesystem::path path = resolve_path(
+                    body.substr(stub_prefix.size()));
+                replace_last_wins_input(
+                    result.inputs,
+                    LinkerFileInputKind::msdos_stub,
+                    path);
+                result.passthrough.push_back(
+                    path_base
+                        ? argument.substr(0, 1 + stub_prefix.size()) + path_text(path)
                         : argument);
                 continue;
             }

--- a/cpp/src/app/project/ProjectSetup.cpp
+++ b/cpp/src/app/project/ProjectSetup.cpp
@@ -58,9 +58,11 @@ template <typename T>
         if (existing.kind != input.kind) {
             continue;
         }
-        if (input.kind == mqb::msvc::LinkerFileInputKind::function_order) {
-            // LINK's /ORDER contract is last-wins, including across config,
-            // profile, and CLI layers. Keep only the effective freshness input.
+        if (input.kind == mqb::msvc::LinkerFileInputKind::function_order
+            || input.kind == mqb::msvc::LinkerFileInputKind::msdos_stub) {
+            // LINK option processing is last-wins for /ORDER and /STUB,
+            // including across config, profile, and CLI layers. Keep only the
+            // effective file as non-owning freshness evidence.
             existing = std::move(input);
             return {};
         }
@@ -251,8 +253,8 @@ prepare_project(
     std::vector<fs::path> native_include_directories;
     // This app-layer vector exists only while resolving config/profile/CLI so
     // duplicate /DEF inputs fail closed while last-wins file inputs such as
-    // /ORDER retain only the effective layer value. Runtime freshness evidence
-    // is re-observed from final linker argv by the incremental linker.
+    // /ORDER and /STUB retain only the effective layer value. Runtime freshness
+    // evidence is re-observed from final linker argv by the incremental linker.
     std::vector<mqb::msvc::LinkerFileInput> native_linker_file_inputs;
     if (project_config) {
         auto normalized = normalize_native_parameters(

--- a/cpp/src/msvc/parameters/MsvcParameterRegistry.cpp
+++ b/cpp/src/msvc/parameters/MsvcParameterRegistry.cpp
@@ -170,7 +170,7 @@ ParameterClassification classify_linker_parameter(const std::string_view argumen
 
     static constexpr std::array graph_input_prefix{
         "ASSEMBLYLINKRESOURCE:"sv, "ASSEMBLYMODULE:"sv, "ASSEMBLYRESOURCE:"sv, "DEFAULTLIB:"sv, "KEYFILE:"sv, "MANIFESTINPUT:"sv,
-        "NATVIS:"sv, "SOURCELINK:"sv, "SPD:"sv, "SPDEMBED:"sv, "SPDIN:"sv, "STUB:"sv, "WINMDKEYFILE:"sv,
+        "NATVIS:"sv, "SOURCELINK:"sv, "SPD:"sv, "SPDEMBED:"sv, "SPDIN:"sv, "WINMDKEYFILE:"sv,
     };
     static constexpr std::array graph_output_prefix{"IDLOUT:"sv, "MANIFESTFILE:"sv, "PDBSTRIPPED:"sv, "PGD:"sv, "TLBOUT:"sv, "WINMDFILE:"sv};
     if (starts_with_any(std::string_view{body}, graph_input_prefix)) return linker_unsupported(body, "option introduces a file input that is not yet represented in MQB's link freshness graph");
@@ -196,7 +196,7 @@ ParameterClassification classify_linker_parameter(const std::string_view argumen
         "DEPENDENTLOADFLAG:"sv, "DYNAMICBASE:"sv, "ENTRY:"sv, "EXPORT:"sv, "FILEALIGN:"sv, "FIXED:"sv, "FORCE:"sv, "GUARD:"sv,
         "HEAP:"sv, "HIGHENTROPYVA:"sv, "IGNORE:"sv, "INCLUDE:"sv, "LARGEADDRESSAWARE:"sv, "LINKREPRO:"sv, "LINKREPROFULLPATHRSP:"sv,
         "LINKREPROTARGET:"sv, "MANIFEST:"sv, "MANIFESTDEPENDENCY:"sv, "MANIFESTUAC:"sv, "MAP:"sv, "MAPINFO:"sv, "MERGE:"sv,
-        "NODEFAULTLIB:"sv, "NXCOMPAT:"sv, "OPT:"sv, "ORDER:"sv, "PDBALTPATH:"sv, "SAFESEH:"sv, "SECTION:"sv, "STACK:"sv, "SWAPRUN:"sv,
+        "NODEFAULTLIB:"sv, "NXCOMPAT:"sv, "OPT:"sv, "ORDER:"sv, "PDBALTPATH:"sv, "SAFESEH:"sv, "SECTION:"sv, "STACK:"sv, "STUB:"sv, "SWAPRUN:"sv,
         "TIMESTAMP:"sv, "TLBID:"sv, "TSAWARE:"sv, "VERSION:"sv, "WHOLEARCHIVE:"sv,
     };
     if (contains_exact(std::string_view{body}, passthrough_exact) || starts_with_any(std::string_view{body}, passthrough_prefix)) {
@@ -207,7 +207,9 @@ ParameterClassification classify_linker_parameter(const std::string_view argumen
                     ? "module-definition input is preserved in linker argv and tracked through MQB's generic link file-input freshness graph"
                     : body.starts_with("ORDER:")
                         ? "function-order input is preserved in linker argv, tracked through MQB's generic link file-input freshness graph, and requires non-incremental linking when LINK runs"
-                        : "validated linker option is preserved verbatim in link identity");
+                        : body.starts_with("STUB:")
+                            ? "MS-DOS stub executable is preserved in linker argv and tracked through MQB's generic link file-input freshness graph"
+                            : "validated linker option is preserved verbatim in link identity");
     }
     return unregistered(ParameterTool::linker, body);
 }

--- a/cpp/tests/e2e/mqb_stub_linker_e2e_tests.cpp
+++ b/cpp/tests/e2e/mqb_stub_linker_e2e_tests.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <array>
 #include <chrono>
 #include <cstdint>

--- a/cpp/tests/e2e/mqb_stub_linker_e2e_tests.cpp
+++ b/cpp/tests/e2e/mqb_stub_linker_e2e_tests.cpp
@@ -236,6 +236,137 @@ int main(int argc, char* argv[]) {
     expect(contains_stub_marker(output, 0x43),
            "relinked executable should contain the mutated effective DOS stub");
 
+    // Prove layer-relative normalization and LINK's general last-option-wins
+    // behavior across project configuration and CLI overlays.
+    const fs::path project = tree.root / "layered-project";
+    const fs::path child = project / "child";
+    fs::create_directories(child);
+    write_text(project / "main.cpp", "int main() { return 0; }\n");
+    write_dos_stub(project / "config-stub.exe", 0x51);
+    write_dos_stub(child / "cli-stub.exe", 0x52);
+    write_text(project / "mqb.json", R"json({
+  "version": 1,
+  "build": {
+    "entry": "main.cpp",
+    "type": "exe",
+    "runtime": "MT",
+    "output": "layered",
+    "linker_args": ["/STUB:config-stub.exe"]
+  },
+  "discovery": {
+    "enabled": false
+  }
+}
+)json");
+
+    const fs::path layered_output = project / ".mqb" / "bin" / "layered.exe";
+    auto config_build = run_mqb(
+        runner,
+        mqb_executable,
+        child,
+        {"build", "--env", "vs"});
+    expect(config_build.has_value(), "config-relative /STUB build should launch from child directory");
+    if (config_build) {
+        if (config_build->exit_code != 0) dump_failure(*config_build);
+        expect(config_build->exit_code == 0,
+               "mqb.json /STUB should resolve relative to project root");
+    }
+    expect(contains_stub_marker(layered_output, 0x51),
+           "project-root-relative config /STUB should be attached to output");
+
+    const std::vector<std::string> layered_cli_arguments{
+        "build",
+        "--env", "vs",
+        "/link",
+        "/STUB:cli-stub.exe",
+    };
+    auto cli_override = run_mqb(
+        runner,
+        mqb_executable,
+        child,
+        layered_cli_arguments);
+    expect(cli_override.has_value(), "CLI /STUB overlay should launch from child directory");
+    if (cli_override) {
+        if (cli_override->exit_code != 0) dump_failure(*cli_override);
+        expect(cli_override->exit_code == 0,
+               "CLI /STUB should override config /STUB according to LINK last-option semantics");
+        expect(cli_override->stdout_text.find("[link] layered.exe") != std::string::npos,
+               "changing the effective /STUB option across layers should relink");
+    }
+    expect(!contains_stub_marker(layered_output, 0x51),
+           "config /STUB should be overridden by later CLI /STUB");
+    expect(contains_stub_marker(layered_output, 0x52),
+           "CLI-relative /STUB should resolve from invocation directory and reach output");
+
+    auto layered_warm = run_mqb(
+        runner,
+        mqb_executable,
+        child,
+        layered_cli_arguments);
+    expect(layered_warm.has_value(), "layered warm /STUB invocation should launch");
+    if (layered_warm) {
+        if (layered_warm->exit_code != 0) dump_failure(*layered_warm);
+        expect(layered_warm->exit_code == 0, "layered warm /STUB build should succeed");
+        expect(contains_line(layered_warm->stdout_text, "[up-to-date] layered.exe"),
+               "unchanged effective CLI /STUB should reuse link cache");
+        expect(layered_warm->stdout_text.find("[link] layered.exe") == std::string::npos,
+               "unchanged layered /STUB build should remain zero-LINK");
+    }
+
+    time_error.clear();
+    const auto layered_output_time = fs::last_write_time(layered_output, time_error);
+    expect(!time_error, "layered stub fixture should read output timestamp");
+    write_dos_stub(project / "config-stub.exe", 0x53);
+    if (!time_error) {
+        fs::last_write_time(
+            project / "config-stub.exe",
+            layered_output_time + std::chrono::seconds{2},
+            time_error);
+    }
+    expect(!time_error, "layered fixture should advance overridden config stub timestamp");
+    auto shadowed_config_changed = run_mqb(
+        runner,
+        mqb_executable,
+        child,
+        layered_cli_arguments);
+    expect(shadowed_config_changed.has_value(), "shadowed config-stub mutation should launch");
+    if (shadowed_config_changed) {
+        if (shadowed_config_changed->exit_code != 0) dump_failure(*shadowed_config_changed);
+        expect(shadowed_config_changed->exit_code == 0,
+               "changing overridden config /STUB should remain successful");
+        expect(contains_line(shadowed_config_changed->stdout_text, "[up-to-date] layered.exe"),
+               "overridden config /STUB content must not enter effective freshness");
+        expect(shadowed_config_changed->stdout_text.find("[link] layered.exe") == std::string::npos,
+               "overridden config /STUB mutation must not create false relink");
+    }
+
+    write_dos_stub(child / "cli-stub.exe", 0x54);
+    time_error.clear();
+    fs::last_write_time(
+        child / "cli-stub.exe",
+        layered_output_time + std::chrono::seconds{3},
+        time_error);
+    expect(!time_error, "layered fixture should advance effective CLI stub timestamp");
+    auto effective_cli_changed = run_mqb(
+        runner,
+        mqb_executable,
+        child,
+        layered_cli_arguments);
+    expect(effective_cli_changed.has_value(), "effective CLI-stub mutation should launch");
+    if (effective_cli_changed) {
+        if (effective_cli_changed->exit_code != 0) dump_failure(*effective_cli_changed);
+        expect(effective_cli_changed->exit_code == 0,
+               "changing effective CLI /STUB should relink successfully");
+        expect(contains_line(effective_cli_changed->stdout_text, "[up-to-date] main.cpp"),
+               "layered stub-only mutation must not recompile source TU");
+        expect(effective_cli_changed->stdout_text.find("[link] layered.exe") != std::string::npos,
+               "effective CLI /STUB mutation must invalidate link freshness");
+    }
+    expect(!contains_stub_marker(layered_output, 0x52),
+           "layered relink should remove previous effective CLI stub marker");
+    expect(contains_stub_marker(layered_output, 0x54),
+           "layered relink should contain mutated effective CLI stub marker");
+
     auto invalid = run_mqb(
         runner,
         mqb_executable,

--- a/cpp/tests/e2e/mqb_stub_linker_e2e_tests.cpp
+++ b/cpp/tests/e2e/mqb_stub_linker_e2e_tests.cpp
@@ -1,0 +1,256 @@
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <expected>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+#include "mqb/platform/windows/WindowsProcessRunner.hpp"
+#include "mqb/process/Process.hpp"
+
+namespace {
+
+namespace fs = std::filesystem;
+int failures = 0;
+
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+void write_text(const fs::path& path, const std::string_view text) {
+    fs::create_directories(path.parent_path());
+    std::ofstream stream{path, std::ios::binary | std::ios::trunc};
+    stream << text;
+}
+
+// Produce a minimal MZ executable whose DOS program exits with `marker` as its
+// return code. /STUB requires a valid MS-DOS .exe; keeping the fixture in this
+// test avoids depending on an external binary or SDK sample.
+void write_dos_stub(const fs::path& path, const std::uint8_t marker) {
+    std::array<std::uint8_t, 69> bytes{};
+    const auto put_u16 = [&bytes](const std::size_t offset, const std::uint16_t value) {
+        bytes[offset] = static_cast<std::uint8_t>(value & 0xffu);
+        bytes[offset + 1] = static_cast<std::uint8_t>((value >> 8u) & 0xffu);
+    };
+
+    put_u16(0x00, 0x5a4d); // e_magic = MZ
+    put_u16(0x02, static_cast<std::uint16_t>(bytes.size())); // bytes in final page
+    put_u16(0x04, 1); // pages in file
+    put_u16(0x06, 0); // relocations
+    put_u16(0x08, 4); // 64-byte header
+    put_u16(0x0a, 0); // min extra paragraphs
+    put_u16(0x0c, 0xffff); // max extra paragraphs
+    put_u16(0x0e, 0); // initial SS
+    put_u16(0x10, 0x0100); // initial SP
+    put_u16(0x12, 0); // checksum
+    put_u16(0x14, 0); // initial IP
+    put_u16(0x16, 0); // initial CS
+    put_u16(0x18, 0x0040); // relocation table offset
+    put_u16(0x1a, 0); // overlay number
+
+    // mov ax, 4cXXh ; int 21h
+    bytes[64] = 0xb8;
+    bytes[65] = marker;
+    bytes[66] = 0x4c;
+    bytes[67] = 0xcd;
+    bytes[68] = 0x21;
+
+    fs::create_directories(path.parent_path());
+    std::ofstream stream{path, std::ios::binary | std::ios::trunc};
+    stream.write(
+        reinterpret_cast<const char*>(bytes.data()),
+        static_cast<std::streamsize>(bytes.size()));
+}
+
+[[nodiscard]] bool contains_stub_marker(const fs::path& executable, const std::uint8_t marker) {
+    std::ifstream stream{executable, std::ios::binary};
+    const std::vector<std::uint8_t> bytes{
+        std::istreambuf_iterator<char>{stream},
+        std::istreambuf_iterator<char>{}};
+    const std::array<std::uint8_t, 5> program{0xb8, marker, 0x4c, 0xcd, 0x21};
+    return std::search(bytes.begin(), bytes.end(), program.begin(), program.end()) != bytes.end();
+}
+
+void dump_failure(const mqb::process::ProcessResult& result) {
+    std::cerr << "exit: " << result.exit_code << '\n'
+              << "stdout:\n" << result.stdout_text << '\n'
+              << "stderr:\n" << result.stderr_text << '\n';
+}
+
+[[nodiscard]] bool contains_line(std::string_view output, std::string_view expected) {
+    std::size_t begin = 0;
+    while (begin <= output.size()) {
+        const std::size_t newline = output.find('\n', begin);
+        const std::size_t end = newline == std::string_view::npos ? output.size() : newline;
+        std::string_view line = output.substr(begin, end - begin);
+        if (!line.empty() && line.back() == '\r') line.remove_suffix(1);
+        if (line == expected) return true;
+        if (newline == std::string_view::npos) break;
+        begin = newline + 1;
+    }
+    return false;
+}
+
+struct TempTree {
+    fs::path root;
+    ~TempTree() {
+        std::error_code ignored;
+        fs::remove_all(root, ignored);
+    }
+};
+
+[[nodiscard]] std::expected<mqb::process::ProcessResult, std::string> run_mqb(
+    mqb::platform::windows::WindowsProcessRunner& runner,
+    const fs::path& mqb,
+    const fs::path& root,
+    std::vector<std::string> arguments) {
+    mqb::process::ProcessSpec spec;
+    spec.executable = mqb;
+    spec.arguments = std::move(arguments);
+    spec.working_directory = root;
+    spec.capture_stdout = true;
+    spec.capture_stderr = true;
+    auto result = runner.run(spec);
+    if (!result) return std::unexpected("failed to launch mqb: " + result.error().message);
+    return std::move(*result);
+}
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+    if (argc != 2) {
+        std::cerr << "usage: mqb_stub_linker_e2e_tests <mqb-executable>\n";
+        return 2;
+    }
+
+    const fs::path mqb_executable{argv[1]};
+    const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
+    TempTree tree{
+        .root = fs::temp_directory_path() / ("mqb_stub_linker_e2e_" + std::to_string(unique)),
+    };
+    fs::create_directories(tree.root);
+    mqb::platform::windows::WindowsProcessRunner runner;
+
+    write_text(tree.root / "main.cpp", "int main() { return 0; }\n");
+    const fs::path overridden_stub = tree.root / "overridden.exe";
+    const fs::path effective_stub = tree.root / "effective.exe";
+    write_dos_stub(overridden_stub, 0x31);
+    write_dos_stub(effective_stub, 0x42);
+
+    const std::vector<std::string> build_arguments{
+        "main.cpp",
+        "--no-discover",
+        "--env", "vs",
+        "--runtime", "MT",
+        "-o", "stubbed",
+        "/link",
+        "/STUB:overridden.exe",
+        "/STUB:effective.exe",
+    };
+    const fs::path output = tree.root / ".mqb" / "bin" / "stubbed.exe";
+
+    auto cold = run_mqb(runner, mqb_executable, tree.root, build_arguments);
+    expect(cold.has_value(), "cold /STUB invocation should launch");
+    if (cold) {
+        if (cold->exit_code != 0) dump_failure(*cold);
+        expect(cold->exit_code == 0, "cold /STUB target should build successfully");
+        expect(cold->stdout_text.find("[compile] main.cpp") != std::string::npos,
+               "cold /STUB target should compile its TU");
+        expect(cold->stdout_text.find("[link] stubbed.exe") != std::string::npos,
+               "cold /STUB target should invoke LINK");
+    }
+    expect(fs::is_regular_file(output), "cold /STUB target should create executable output");
+    expect(!contains_stub_marker(output, 0x31),
+           "an overridden earlier /STUB input should not define the final DOS stub");
+    expect(contains_stub_marker(output, 0x42),
+           "the last /STUB input should be attached to the linked executable");
+
+    auto warm = run_mqb(runner, mqb_executable, tree.root, build_arguments);
+    expect(warm.has_value(), "warm /STUB invocation should launch");
+    if (warm) {
+        if (warm->exit_code != 0) dump_failure(*warm);
+        expect(warm->exit_code == 0, "warm /STUB target should succeed");
+        expect(contains_line(warm->stdout_text, "[up-to-date] main.cpp"),
+               "unchanged /STUB target should reuse compile cache");
+        expect(contains_line(warm->stdout_text, "[up-to-date] stubbed.exe"),
+               "unchanged effective /STUB should reuse link cache");
+        expect(warm->stdout_text.find("[link] stubbed.exe") == std::string::npos,
+               "unchanged /STUB target should remain a zero-LINK no-op");
+    }
+
+    std::error_code time_error;
+    const auto output_time = fs::last_write_time(output, time_error);
+    expect(!time_error, "stub fixture should read linked output timestamp");
+
+    write_dos_stub(overridden_stub, 0x32);
+    if (!time_error) {
+        fs::last_write_time(
+            overridden_stub,
+            output_time + std::chrono::seconds{2},
+            time_error);
+    }
+    expect(!time_error, "stub fixture should advance overridden stub timestamp");
+    auto overridden_changed = run_mqb(runner, mqb_executable, tree.root, build_arguments);
+    expect(overridden_changed.has_value(), "overridden-stub mutation invocation should launch");
+    if (overridden_changed) {
+        if (overridden_changed->exit_code != 0) dump_failure(*overridden_changed);
+        expect(overridden_changed->exit_code == 0,
+               "changing an overridden /STUB input should remain a successful no-op");
+        expect(contains_line(overridden_changed->stdout_text, "[up-to-date] stubbed.exe"),
+               "only the last effective /STUB file should participate in link freshness");
+        expect(overridden_changed->stdout_text.find("[link] stubbed.exe") == std::string::npos,
+               "changing an overridden /STUB file must not cause a false relink");
+    }
+
+    write_dos_stub(effective_stub, 0x43);
+    time_error.clear();
+    fs::last_write_time(
+        effective_stub,
+        output_time + std::chrono::seconds{3},
+        time_error);
+    expect(!time_error, "stub fixture should advance effective stub timestamp");
+    auto effective_changed = run_mqb(runner, mqb_executable, tree.root, build_arguments);
+    expect(effective_changed.has_value(), "effective-stub mutation invocation should launch");
+    if (effective_changed) {
+        if (effective_changed->exit_code != 0) dump_failure(*effective_changed);
+        expect(effective_changed->exit_code == 0,
+               "changing the effective /STUB input should relink successfully");
+        expect(contains_line(effective_changed->stdout_text, "[up-to-date] main.cpp"),
+               "stub-only mutation must not recompile the source TU");
+        expect(effective_changed->stdout_text.find("[link] stubbed.exe") != std::string::npos,
+               "effective /STUB mutation must invalidate link freshness");
+    }
+    expect(!contains_stub_marker(output, 0x42),
+           "relinked executable should no longer contain the previous effective stub marker");
+    expect(contains_stub_marker(output, 0x43),
+           "relinked executable should contain the mutated effective DOS stub");
+
+    auto invalid = run_mqb(
+        runner,
+        mqb_executable,
+        tree.root,
+        {"main.cpp", "--no-discover", "--env", "vs", "/link", "/STUB:"});
+    expect(invalid.has_value(), "empty /STUB validation invocation should launch");
+    if (invalid) {
+        expect(invalid->exit_code != 0, "empty /STUB must fail before LINK.exe");
+        expect(invalid->stderr_text.find("/STUB requires an MS-DOS .exe file path") != std::string::npos,
+               "empty /STUB should report its required file operand");
+    }
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+    std::cout << "mqb_stub_linker_e2e_tests passed\n";
+    return 0;
+}

--- a/docs/MSVC_PARAMETER_ENGINE.md
+++ b/docs/MSVC_PARAMETER_ENGINE.md
@@ -8,7 +8,7 @@ MQB does not try to rename every MSVC switch into a second property system. Inst
 |---|---|---|---|
 | A — MQB-owned structural | Changes target/TU shape, primary artifacts, dependency metadata, or graph topology owned by MQB | `/Fo`, `/OUT`, `/ifcOutput`, `/ifcMap`, `/sourceDependencies`, `/scanDependencies` | Reject user/raw ownership escape with an explanation |
 | B — Semantic typed | Already represented by the MQB build model | `/std:`, `/MD`/`/MT`, `/GL`, `/MACHINE`, `/SUBSYSTEM`, `/LTCG` | Normalize into typed policy before project-option resolution |
-| C — Safe/conditional passthrough | Does not invalidate MQB structural ownership and can remain an ordinary MSVC argv element | `/W4`, `/WX`, `/fp:fast`, `/arch:AVX2`, `/favor:AMD64`, `/I`, `/D`, `/U`, `/external:I`, `/FI`, `/DEF`, `/ORDER`, `/STACK`, version-conditional `/DEBUG:FASTLINK` | Preserve native argv ownership/order; existing signatures/cache identity include it, expose non-owning graph/execution evidence where required, then apply toolchain lifecycle admission where required |
+| C — Safe/conditional passthrough | Does not invalidate MQB structural ownership and can remain an ordinary MSVC argv element | `/W4`, `/WX`, `/fp:fast`, `/arch:AVX2`, `/favor:AMD64`, `/I`, `/D`, `/U`, `/external:I`, `/FI`, `/DEF`, `/ORDER`, `/STUB`, `/STACK`, version-conditional `/DEBUG:FASTLINK` | Preserve native argv ownership/order; existing signatures/cache identity include it, expose non-owning graph/execution evidence where required, then apply toolchain lifecycle admission where required |
 | D — Unsupported / conflicting | Changes an unmodeled pipeline, hides inputs, introduces untracked files/artifacts, is unconditionally obsolete, or conflicts with another semantic value | `/MP`, raw PCH `/Y*`, `/FU`, `/analyze`, `/experimental:log`, `@response` | Fail closed before invoking MSVC |
 
 `unsupported` is not the same as `unregistered`. A current official option may intentionally be unsupported, but it still has an explicit registry entry and rationale. `unregistered` means the registry has no classification and is a coverage failure for the current reference snapshot.
@@ -20,6 +20,8 @@ Class C passthrough does not mean MQB must remain blind to every effect of an op
 Native linker `/DEF:<file>` follows the same evidence-without-ownership model. The raw LINK argument remains authoritative, but MQB resolves a relative definition-file payload inside the layer that supplied it and records the resolved file as a generic linker freshness input. Config/profile paths are based at project root; CLI paths are based at the invocation directory. The argument keeps its original argv position. Because LINK accepts one module-definition file for an invocation, a second effective `/DEF` is rejected before `link.exe` rather than relying on argv ordering.
 
 Native linker `/ORDER:@<file>` is also graph-aware, with an additional execution constraint. Every raw `/ORDER` stays in argv, while MQB tracks only the **last** order file as the effective freshness input because LINK applies the last `/ORDER` option. Config/profile/CLI-relative order-file paths are normalized inside the supplying layer. An unchanged warm build may still skip LINK completely; however, whenever an actual link is required while an effective `/ORDER` exists, MQB forces the final linker recipe to `/INCREMENTAL:NO` because `/ORDER` is incompatible with incremental linking. A later raw `/INCREMENTAL` cannot override that safety policy because MQB emits its authoritative full-link switch after raw linker arguments.
+
+Native linker `/STUB:<file>` uses the generic freshness model without an always-full-link rule. Every raw `/STUB` remains in argv, while MQB tracks only the **last** effective MS-DOS executable as freshness evidence. Relative stub paths are normalized inside the supplying config/profile/CLI layer. An unchanged effective stub reuses the ordinary warm link cache; changing, removing, or re-resolving the effective stub invalidates generic linker-file freshness. Earlier overridden stub files are deliberately not tracked as effective freshness inputs, so changing one does not create a false relink.
 
 ## Native argv token shape
 
@@ -58,7 +60,7 @@ Native parameters are normalized inside the layer that supplied them:
 1. `mqb.json` typed fields and `compiler_args` / `linker_args` are normalized together.
 2. A selected profile is normalized as its own overlay.
 3. CLI typed options and native/raw arguments are normalized together.
-4. Conflicting typed/native values inside one layer are errors; tracked file inputs obey their LINK semantics across effective layers (`/DEF` is single-instance, `/ORDER` is last-wins).
+4. Conflicting typed/native values inside one layer are errors; tracked file inputs obey their LINK semantics across effective layers (`/DEF` is single-instance, `/ORDER` and `/STUB` are last-wins).
 5. The project resolver then applies `built-ins < base mqb.json < selected profile < CLI`.
 6. After MSVC discovery, remaining raw arguments pass toolchain lifecycle admission.
 
@@ -82,7 +84,9 @@ MSVC code-analysis execution is also fail-closed for now. `/analyze` can create 
 
 `/ORDER:@<file>` reuses the generic linker-file freshness path but has stronger execution semantics. MQB preserves all raw `/ORDER` arguments because LINK owns their order-sensitive last-wins behavior, while the cache tracks only the last effective order file. Missing/changed effective order files invalidate reuse through ordinary `file_inputs` evidence. In addition, the presence of an effective `/ORDER` sets execution-only `requires_full_link` evidence. The warm no-op path still returns before invoking LINK, but any real Debug link—whether caused by an object change, explicit rebuild, linker-option change, or order-file freshness—ends with MQB's authoritative `/INCREMENTAL:NO`. This avoids relying on LINK to diagnose and override an incompatible raw `/INCREMENTAL` request.
 
-Other file-bearing linker modes that introduce graph inputs or secondary outputs remain fail closed until their corresponding semantics are modeled. `/NATVIS`, `/SOURCELINK`, manifest/signing inputs, PGO inputs/outputs, and similar options are **not** implicitly admitted just because generic `file_inputs` exists; options that affect PDB/manifest/signing artifacts may need additional output modeling before promotion. `/WHOLEARCHIVE:<library>` remains a narrow separate exception: it may pass through when the same library is also declared through MQB's structured library inputs, which keeps freshness tracking authoritative.
+`/STUB:<file>` also reuses LinkCache v4 `file_inputs`, but it does not permanently force non-incremental linking. MQB preserves every raw `/STUB` argument while tracking only the last effective MS-DOS executable input. Unchanged input state keeps the zero-LINK warm path intact. A missing, changed, or re-resolved effective stub produces ordinary `file_inputs_changed` evidence; the existing Debug one-shot full-link safety for linker-file changes then prevents stale incremental state from surviving a stub-only mutation without turning every future `/STUB` link into a full link. Because only the last effective stub is tracked, mutating an earlier overridden stub does not create a false freshness invalidation.
+
+Other file-bearing linker modes beyond promoted `/DEF`, `/ORDER`, and `/STUB` that introduce graph inputs or secondary outputs remain fail closed until their corresponding semantics are modeled. `/NATVIS`, `/SOURCELINK`, manifest/signing inputs, PGO inputs/outputs, and similar options are **not** implicitly admitted just because generic `file_inputs` exists; options that affect PDB/manifest/signing artifacts may need additional output modeling before promotion. `/WHOLEARCHIVE:<library>` remains a narrow separate exception: it may pass through when the same library is also declared through MQB's structured library inputs, which keeps freshness tracking authoritative.
 
 ## Coverage gates
 
@@ -93,6 +97,8 @@ Other file-bearing linker modes that introduce graph inputs or secondary outputs
 `cpp/tests/orchestration/incremental/incremental_link_coordinator_tests.cpp` locks `/ORDER` execution semantics: repeated order options preserve raw argv but track only the last effective file, malformed `/ORDER` fails before LINK, warm no-op skips LINK, effective order-file mutation invalidates freshness, and every actual `/ORDER` link appends authoritative `/INCREMENTAL:NO` after raw linker arguments.
 
 `cpp/tests/e2e/mqb_dll_target_e2e_tests.cpp` proves the real `/DEF` pipeline on Windows/MSVC: a cold DLL exposes the first `.def` export, an unchanged build is a link-cache hit, a definition-file-only mutation leaves the TU up-to-date but relinks the DLL, and the resulting export table removes the old symbol and exposes the replacement. The fixture also verifies project-root-relative `mqb.json` `/DEF` normalization from a child invocation directory and rejects a second CLI `/DEF` before LINK.
+
+`cpp/tests/e2e/mqb_stub_linker_e2e_tests.cpp` proves the real `/STUB` pipeline on Windows/MSVC. The fixture creates valid DOS MZ executables itself, passes two raw `/STUB` arguments, and verifies that the final PE contains the DOS program from the last effective stub rather than the overridden one. It then proves an unchanged build is a zero-LINK cache hit, mutating only the overridden stub does not cause a false relink, mutating only the effective stub leaves the source TU up-to-date but relinks the executable and replaces the embedded DOS program, and empty `/STUB:` fails before LINK.
 
 `cpp/tests/app/cli/mqb_native_msvc_cli_e2e_tests.cpp` independently verifies the CLI boundary and native execution path: fixed operands stay in ordered compiler argv, attached forms do not consume the next source, and graph-aware native options such as `/FI` retain their split operand and rebuild behavior under the real candidate MQB/MSVC pipeline.
 
@@ -117,7 +123,7 @@ The engine intentionally fails closed where MQB cannot preserve semantics yet:
 - CLR/Windows Runtime/kernel/driver/ARM64EC target modes: no first-class MQB target model yet;
 - raw forced metadata `/FU`: rejected until its dependency input participates in freshness identity;
 - code-analysis and diagnostic-log artifact modes (`/analyze`, `/experimental:log`): rejected until their inputs/outputs participate in artifact/freshness identity; `/analyze-` remains a safe disable switch;
-- file-bearing LINK options other than promoted `/DEF`, promoted `/ORDER`, and separately constrained `/WHOLEARCHIVE`: rejected until their inputs/outputs can be represented without weakening cache or artifact correctness;
+- file-bearing LINK options other than promoted `/DEF`, promoted `/ORDER`, promoted `/STUB`, and separately constrained `/WHOLEARCHIVE`: rejected until their inputs/outputs can be represented without weakening cache or artifact correctness;
 - PGO and other file-producing/file-consuming modes: rejected until their artifacts participate in freshness/cache identity;
 - response files: rejected until MQB can expand and classify their contents safely.
 

--- a/tests/native/run_native_tests.ps1
+++ b/tests/native/run_native_tests.ps1
@@ -84,8 +84,8 @@ if ($includeDirs.Count -eq 0) { throw 'Native test config has no include_dirs.' 
 $allTestFiles = @(Get-ChildItem -LiteralPath $cppRoot -Recurse -File -Filter '*_tests.cpp' |
     Where-Object { $_.FullName -notmatch '[\\/]\.mqb[\\/]' } |
     Sort-Object FullName)
-if ($allTestFiles.Count -ne 74) {
-    throw "Native test manifest drift: expected 74 *_tests.cpp files, found $($allTestFiles.Count)."
+if ($allTestFiles.Count -ne 75) {
+    throw "Native test manifest drift: expected 75 *_tests.cpp files, found $($allTestFiles.Count)."
 }
 
 function Get-TestRelativePath {
@@ -112,6 +112,7 @@ $testWeightOverrides = [ordered]@{
     'tests/e2e/mqb_dll_target_e2e_tests.cpp' = 3
     'tests/e2e/mqb_parallel_cli_e2e_tests.cpp' = 3
     'tests/e2e/mqb_project_config_e2e_tests.cpp' = 3
+    'tests/e2e/mqb_stub_linker_e2e_tests.cpp' = 3
     'tests/e2e/mqb_c_source_e2e_tests.cpp' = 2
     # This test also requires building the process_echo_helper executable once
     # on whichever shard owns it, so account for that extra compile/link work.
@@ -121,7 +122,7 @@ $testWeightOverrides = [ordered]@{
 $relativeTestPaths = @($allTestFiles | ForEach-Object { Get-TestRelativePath -File $_ })
 foreach ($weightedPath in $testWeightOverrides.Keys) {
     if ($weightedPath -notin $relativeTestPaths) {
-        throw "Native test weight override is stale or missing from the 74-test manifest: $weightedPath"
+        throw "Native test weight override is stale or missing from the 75-test manifest: $weightedPath"
     }
 }
 


### PR DESCRIPTION
## Summary

Promote native MSVC LINK `/STUB:<file>` from graph-input fail-closed handling onto MQB's generic LinkCache v4 file-input freshness path.

`/STUB` supplies an MS-DOS executable that LINK attaches to the Win32 image. The raw linker argv remains authoritative; MQB additionally observes the effective stub file as non-owning freshness evidence so stub-only changes cannot be hidden behind a warm link cache.

## Semantics

- `/STUB:<file>` becomes validated linker passthrough.
- empty `/STUB:` fails before LINK.exe with a dedicated parameter error.
- relative stub paths are normalized in the layer that supplied them:
  - `mqb.json` / profile: project root
  - CLI: invocation directory
- raw argv order remains authoritative.
- repeated `/STUB` arguments remain in raw argv while generic freshness tracks only the final effective stub input.
- config/profile/CLI layering follows the same last-effective-input model.
- `/DEF` remains single-instance/fail-closed and `/ORDER` retains its stronger `requires_full_link` execution policy.

## Incremental behavior

No new cache format or linker execution flag is introduced.

- unchanged effective stub => ordinary warm no-op link-cache reuse;
- mutation/path change/missing effective stub => existing LinkCache v4 `file_inputs_changed` evidence invalidates reuse;
- that evidence feeds MQB's existing one-shot Debug full-link safety policy, so a stub-only mutation cannot reuse stale incremental-link state;
- changing an overridden earlier `/STUB` file does not create false freshness invalidation.

## Real Windows/MSVC E2E

`cpp/tests/e2e/mqb_stub_linker_e2e_tests.cpp` creates valid DOS MZ executables in the fixture itself instead of relying on an external binary and drives the candidate MQB plus real LINK.exe through:

1. two raw `/STUB` values; the final executable contains the DOS program from the last effective stub and not the overridden one;
2. an unchanged warm build; source and executable are up-to-date with zero LINK invocation;
3. mutation of only the overridden stub; build remains a zero-LINK no-op;
4. mutation of only the effective stub; source TU stays up-to-date, LINK runs, and the resulting executable contains the new DOS stub program;
5. `mqb.json` `/STUB` is resolved from project root even when invoked from a child directory;
6. a later CLI `/STUB` is resolved from the invocation directory and wins across config/CLI layers;
7. changing the shadowed config stub does not relink, while changing the effective CLI stub does;
8. empty `/STUB:` fails before LINK.exe.

The native test manifest moves from 74 to **75** tests and keeps deterministic weighted sharding balanced.

## Scope

Base: `12c224eeb4a2dec2647b20480af77a261bd5ab6d` (main after #98; post-merge Native C++ #348 is green).

Final exact head: `db85b7329e55186e5b88801f027ec04621bf7cb3`.

Final diff is limited to the parameter/file-input model, project-layer last-effective-input handling, registry admission, one focused real Windows/MSVC E2E, the native test manifest, and the parameter-engine documentation. `/NATVIS`, `/SOURCELINK`, manifest/signing inputs, PGO inputs/outputs, and other unmodeled file-bearing LINK options remain fail-closed.

## Final validation

- **Native C++ #351:** candidate Debug self-build, shared 75-test product, all 4/4 Debug shards, and Native C++ gate are green.
- Debug outer 2/4 explicitly reports `mqb_stub_linker_e2e_tests passed` on the final merge-ref, including the added layered path/last-wins/freshness scenarios.
- **Native Release #303:** Stage 0 + shared product and all 4/4 Release shards are green.
- Release Stage 1 self-host, runtime-only package staging, exact packaged-artifact validation, and artifact upload are green.
- PR-only `publish-release` and Performance Evidence #78 are skipped by design.
- No review threads or submitted review blockers remain.
