### PR TITLE
perf: enforce benchmark evidence contract

### DIFF
--- a/.github/workflows/performance-evidence.yml
+++ b/.github/workflows/performance-evidence.yml
@@ -2,7 +2,7 @@ name: Performance Evidence
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, edited]
   workflow_dispatch:
 
 concurrency:
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   compare:
     name: Compare base and candidate
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.pull_request.title, 'perf:')
+    if: github.event_name == 'workflow_dispatch' || (startsWith(github.event.pull_request.title, 'perf:') && (github.event.action != 'edited' || github.event.changes.title.from != null))
     runs-on: windows-latest
     timeout-minutes: 30
     permissions:

--- a/docs/PERFORMANCE_GOVERNANCE.md
+++ b/docs/PERFORMANCE_GOVERNANCE.md
@@ -6,10 +6,11 @@ Performance work in MQB is measured against the existing `--timings=json` instru
 
 For a PR whose primary claim is lower build latency or higher throughput:
 
-1. benchmark a baseline MQB executable built from the exact PR base;
-2. benchmark the candidate executable from the PR head on the same machine;
-3. use the same iteration count for both executables;
-4. report at least the standard scenarios emitted by `tests/native/benchmark_mqb.ps1`:
+1. use a `perf:` pull-request title so the repository's automated performance-evidence contract is activated;
+2. benchmark a baseline MQB executable built from the exact PR base;
+3. benchmark the candidate executable from the PR head on the same machine;
+4. use the same iteration count for both executables;
+5. report at least the standard scenarios emitted by `tests/native/benchmark_mqb.ps1`:
    - `cold`
    - `no-op`
    - `single-tu`
@@ -21,8 +22,8 @@ For a PR whose primary claim is lower build latency or higher throughput:
    - `discovery-header`
    - `modules-cold`
    - `modules-no-op`
-5. attach or quote the comparison JSON/table in the PR description or review evidence;
-6. explain any material regression in a core scenario rather than hiding it behind the scenario being optimized.
+6. attach or quote the comparison JSON/table in the PR description or review evidence;
+7. explain any material regression in a core scenario rather than hiding it behind the scenario being optimized.
 
 The canonical local comparison command is:
 
@@ -36,16 +37,22 @@ The canonical local comparison command is:
 
 Negative deltas mean the candidate is faster. The raw baseline and candidate benchmark records are embedded in the comparison JSON so phase timings and cache hit/miss counts remain auditable.
 
+`compare_mqb_benchmarks.ps1` fails closed if either benchmark report weakens the standard evidence contract. Every required scenario must be present exactly once in the summary, must report the requested sample count, and must contain one raw sample for every requested iteration. Additional scenarios are allowed, but deleting or silently skipping a standard scenario cannot produce a successful comparison.
+
 ## Automated PR evidence
 
-`.github/workflows/performance-evidence.yml` runs automatically for pull requests whose title starts with `perf:` and can also be invoked manually.
+`.github/workflows/performance-evidence.yml` runs automatically for pull requests whose title starts with `perf:` and can also be invoked manually. Performance claims therefore use the `perf:` title prefix as the machine-readable boundary between ordinary correctness CI and mandatory benchmark evidence.
 
 The workflow:
 
+- reacts to opening, synchronization, reopening, ready-for-review transitions, and title edits;
+- when an existing PR is retitled to `perf:`, starts performance evidence without requiring a new code push;
+- ignores unrelated body-only edits so they do not rerun the expensive benchmark suite;
 - checks out the candidate and the exact `pull_request.base.sha` into separate working trees;
 - acquires one pinned historical MQB seed;
 - independently builds Release MQB binaries from the base and candidate with each tree's own self-build script and manifest contract;
 - runs both benchmark suites serially on the same Windows runner with the same iteration count;
+- validates the mandatory standard-scenario/sample contract before producing comparison output;
 - emits the comparison table into the GitHub Actions job summary;
 - uploads `benchmark-comparison.json` as a retained review artifact.
 
@@ -63,4 +70,4 @@ Structural performance tests remain useful when they prove deterministic propert
 
 ## Benchmark evolution
 
-When a new optimization targets a scenario not represented by the standard harness, add a deterministic fixture/scenario to `benchmark_mqb.ps1` and make the comparator consume it automatically. Do not remove an existing core scenario merely because a new optimization does not improve it.
+When a new optimization targets a scenario not represented by the standard harness, add a deterministic fixture/scenario to `benchmark_mqb.ps1` and make the comparator consume it automatically. Additional scenarios may extend the evidence set, but the standard scenarios are an append-only compatibility floor: do not remove an existing core scenario merely because a new optimization does not improve it.

--- a/tests/native/compare_mqb_benchmarks.ps1
+++ b/tests/native/compare_mqb_benchmarks.ps1
@@ -9,6 +9,20 @@ param(
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version 2.0
 
+$RequiredScenarios = @(
+    'cold',
+    'no-op',
+    'single-tu',
+    'public-header',
+    'build-run',
+    'link-only',
+    'discovery-cold',
+    'discovery-no-op',
+    'discovery-header',
+    'modules-cold',
+    'modules-no-op'
+)
+
 function Get-FullPath {
     param([Parameter(Mandatory = $true)][string]$Path)
     return [System.IO.Path]::GetFullPath($Path)
@@ -21,6 +35,65 @@ function Get-DeltaPercent {
     )
     if ($Baseline -eq 0.0) { return $null }
     return (($Candidate - $Baseline) / $Baseline) * 100.0
+}
+
+function Assert-BenchmarkContract {
+    param(
+        [Parameter(Mandatory = $true)][string]$Label,
+        [Parameter(Mandatory = $true)]$Report,
+        [Parameter(Mandatory = $true)][int]$ExpectedIterations
+    )
+
+    if ([int]$Report.schema_version -lt 2) {
+        throw "$Label benchmark schema is too old: expected schema_version >= 2, got $($Report.schema_version)"
+    }
+    if ([int]$Report.iterations -ne $ExpectedIterations) {
+        throw "$Label benchmark iteration contract mismatch: expected $ExpectedIterations, got $($Report.iterations)"
+    }
+
+    $summaryRows = @($Report.summary)
+    $sampleRows = @($Report.samples)
+    if ($summaryRows.Count -eq 0) {
+        throw "$Label benchmark produced no summary rows"
+    }
+
+    $summaryByScenario = @{}
+    foreach ($row in $summaryRows) {
+        $scenario = [string]$row.scenario
+        if ([string]::IsNullOrWhiteSpace($scenario)) {
+            throw "$Label benchmark contains a summary row with an empty scenario name"
+        }
+        if ($summaryByScenario.ContainsKey($scenario)) {
+            throw "$Label benchmark contains duplicate summary scenario '$scenario'"
+        }
+        $summaryByScenario[$scenario] = $row
+    }
+
+    foreach ($scenario in $RequiredScenarios) {
+        if (-not $summaryByScenario.ContainsKey($scenario)) {
+            throw "$Label benchmark is missing required scenario '$scenario'"
+        }
+
+        $summarySamples = [int]$summaryByScenario[$scenario].samples
+        if ($summarySamples -ne $ExpectedIterations) {
+            throw "$Label benchmark scenario '$scenario' summary has $summarySamples samples; expected $ExpectedIterations"
+        }
+
+        $rawSamples = @($sampleRows | Where-Object { [string]$_.scenario -eq $scenario })
+        if ($rawSamples.Count -ne $ExpectedIterations) {
+            throw "$Label benchmark scenario '$scenario' has $($rawSamples.Count) raw samples; expected $ExpectedIterations"
+        }
+
+        $iterationsSeen = @($rawSamples | ForEach-Object { [int]$_.iteration } | Sort-Object -Unique)
+        if ($iterationsSeen.Count -ne $ExpectedIterations) {
+            throw "$Label benchmark scenario '$scenario' does not contain one distinct sample for every iteration"
+        }
+        for ($iteration = 1; $iteration -le $ExpectedIterations; ++$iteration) {
+            if ($iteration -notin $iterationsSeen) {
+                throw "$Label benchmark scenario '$scenario' is missing iteration $iteration"
+            }
+        }
+    }
 }
 
 $BaselineMqbPath = Get-FullPath $BaselineMqbPath
@@ -59,6 +132,9 @@ try {
 
     $baseline = Get-Content -LiteralPath $baselineJson -Raw | ConvertFrom-Json
     $candidate = Get-Content -LiteralPath $candidateJson -Raw | ConvertFrom-Json
+
+    Assert-BenchmarkContract -Label 'Baseline' -Report $baseline -ExpectedIterations $Iterations
+    Assert-BenchmarkContract -Label 'Candidate' -Report $candidate -ExpectedIterations $Iterations
 
     $candidateByScenario = @{}
     foreach ($row in @($candidate.summary)) {
@@ -115,6 +191,7 @@ try {
             schema_version = 2
             generated_utc = [DateTime]::UtcNow.ToString('o')
             iterations = $Iterations
+            required_scenarios = $RequiredScenarios
             baseline_mqb = $BaselineMqbPath
             candidate_mqb = $CandidateMqbPath
             comparison = @($comparison | Sort-Object scenario)


### PR DESCRIPTION
## Summary

Close the remaining PR #79 performance-governance gap by making MQB's standard benchmark evidence a machine-enforced contract rather than documentation-only guidance.

## Root cause

The current `Performance Evidence` workflow already compares an exact PR base with the candidate on the same Windows runner, but both executables are driven by the candidate branch's benchmark harness. If a future performance change accidentally removes a standard benchmark scenario from that harness, both reports can omit it and the base/candidate comparator can still succeed.

The workflow also did not react to pull-request title edits, so an existing PR retitled to `perf:` would not start performance evidence until another synchronize/reopen/ready event occurred.

## Changes

- define the mandatory standard benchmark scenario set in `compare_mqb_benchmarks.ps1`;
- fail closed if either baseline or candidate report:
  - uses an obsolete benchmark schema;
  - reports a different iteration count;
  - omits a required scenario;
  - duplicates a summary scenario;
  - reports the wrong summary sample count;
  - lacks exactly one raw sample for every requested iteration;
- preserve extensibility: extra scenarios remain allowed as long as base and candidate expose the same set;
- include `required_scenarios` in comparison JSON for auditability;
- trigger `Performance Evidence` on PR title edits so retitling an existing PR to `perf:` starts evidence without a code push;
- avoid rerunning the expensive benchmark job for body-only edits;
- make the `perf:` title prefix an explicit part of the documented performance-review contract.

## Scope

Base: `7e51244b9fa418216759508e1d8f8d9fcec6b924`.

Final exact head: `6828563bc98cc17968f140a195e4c87ab3850949`.

The diff is intentionally limited to:

- `tests/native/compare_mqb_benchmarks.ps1`
- `.github/workflows/performance-evidence.yml`
- `docs/PERFORMANCE_GOVERNANCE.md`

No production C++ code, build/cache identity, benchmark fixture behavior, or timing threshold is changed.

## Final validation

- **Performance Evidence #85: success.**
  - exact PR base and candidate built independently on the same Windows runner;
  - the strengthened comparator accepted all **11 required scenarios**;
  - every required scenario contains exactly **5 summary samples and 5 distinct raw iterations** for both base and candidate;
  - comparison JSON includes the new `required_scenarios` audit field;
  - comparison summary and retained `mqb-performance-evidence` artifact were produced successfully.
- **Native C++ #358: success.**
  - candidate Debug self-build and shared test product succeeded;
  - all 4/4 Debug shards succeeded;
  - final Native C++ gate succeeded.
- **Native Release #308: success.**
  - Stage 0 Release build and shared test product succeeded;
  - all 4/4 Release shards succeeded;
  - stable self-host succeeded;
  - runtime-only package staging, exact packaged-artifact validation, and package upload succeeded.
- No review threads are open.

Because this PR changes only benchmark/governance scripts and documentation, not the MQB production executable, observed timing deltas are runner/order noise rather than a product performance claim. For example, the 5-sample no-op median moved from 4.177 ms to 6.507 ms (+2.330 ms), while modules-cold moved from 209.942 ms to 194.840 ms (-7.19%). The purpose of this PR is to make such evidence mandatory and structurally complete, not to claim a latency improvement.