### PR TITLE
fix: isolate MSVC invocations from ambient option variables

### DIFF
--- a/.github/workflows/native-ci.yml
+++ b/.github/workflows/native-ci.yml
@@ -90,8 +90,8 @@ jobs:
 
           $modules = Join-Path $fixture 'modules'
           New-Item -ItemType Directory -Path $modules -Force | Out-Null
-          Set-Content -LiteralPath (Join-Path $modules 'math.ixx') -Encoding utf8 -Value 'export module math; export int answer() { return 42; }'
-          Set-Content -LiteralPath (Join-Path $modules 'main.cpp') -Encoding utf8 -Value 'import math; int main() { return answer() == 42 ? 0 : 1; }'
+          Set-Content -LiteralPath (Join-Path $modules 'math.ixx') -Encoding utf8 -Value @('export module math;', 'export int answer() { return 42; }')
+          Set-Content -LiteralPath (Join-Path $modules 'main.cpp') -Encoding utf8 -Value @('import math;', 'int main() { return answer() == 42 ? 0 : 1; }')
           Push-Location $modules
           try {
             & $mqb run main.cpp math.ixx --no-discover

--- a/.github/workflows/native-ci.yml
+++ b/.github/workflows/native-ci.yml
@@ -60,6 +60,48 @@ jobs:
             throw "Debug MQB build output missing: $mqb"
           }
 
+      - name: Verify ambient MSVC option isolation
+        shell: pwsh
+        env:
+          CL: /FI_mqb_ambient_cl_should_never_exist_.hpp
+          _CL_: /Fo_mqb_ambient_cl_should_never_exist_.obj
+          LINK: /DEF:_mqb_ambient_link_should_never_exist_.def
+          _LINK_: /OUT:_mqb_ambient_link_should_never_exist_.exe
+        run: |
+          $mqb = (Resolve-Path -LiteralPath 'native-out/debug/mqb.exe').Path
+          $fixture = Join-Path $PWD 'native-out/ambient-msvc-option-isolation'
+          if (Test-Path -LiteralPath $fixture) {
+            Remove-Item -LiteralPath $fixture -Recurse -Force
+          }
+          New-Item -ItemType Directory -Path $fixture -Force | Out-Null
+
+          $ordinary = Join-Path $fixture 'ordinary'
+          New-Item -ItemType Directory -Path $ordinary -Force | Out-Null
+          Set-Content -LiteralPath (Join-Path $ordinary 'main.cpp') -Encoding utf8 -Value 'int main() { return 0; }'
+          Push-Location $ordinary
+          try {
+            & $mqb run main.cpp --no-discover
+            if ($LASTEXITCODE -ne 0) {
+              throw "ordinary build/run observed ambient CL/_CL_/LINK/_LINK_ options"
+            }
+          } finally {
+            Pop-Location
+          }
+
+          $modules = Join-Path $fixture 'modules'
+          New-Item -ItemType Directory -Path $modules -Force | Out-Null
+          Set-Content -LiteralPath (Join-Path $modules 'math.ixx') -Encoding utf8 -Value 'export module math; export int answer() { return 42; }'
+          Set-Content -LiteralPath (Join-Path $modules 'main.cpp') -Encoding utf8 -Value 'import math; int main() { return answer() == 42 ? 0 : 1; }'
+          Push-Location $modules
+          try {
+            & $mqb run main.cpp math.ixx --no-discover
+            if ($LASTEXITCODE -ne 0) {
+              throw "module scan/build/run observed ambient CL/_CL_/LINK/_LINK_ options"
+            }
+          } finally {
+            Pop-Location
+          }
+
       - name: Build shared Debug native-test product library
         shell: pwsh
         run: |

--- a/cpp/src/msvc/compiler/CompilerExecution.cpp
+++ b/cpp/src/msvc/compiler/CompilerExecution.cpp
@@ -23,6 +23,16 @@ namespace fs = std::filesystem;
     });
 }
 
+void suppress_ambient_compiler_options(
+    std::vector<process::EnvironmentVariable>& environment) {
+    // cl.exe prepends CL and appends _CL_ to its explicit argv. Those hidden
+    // arguments would bypass MQB's Parameter Engine, structured ownership, and
+    // compile identity. Empty overrides preserve the inherited vcvars environment
+    // while making the explicit MQB argv the complete compiler option surface.
+    environment.push_back(process::EnvironmentVariable{"CL", {}});
+    environment.push_back(process::EnvironmentVariable{"_CL_", {}});
+}
+
 [[nodiscard]] std::expected<process::ProcessResult, CompilerError> run_compiler(
     const MsvcToolchain& toolchain,
     process::ProcessRunner& runner,
@@ -37,6 +47,7 @@ namespace fs = std::filesystem;
         .capture_stdout = true,
         .capture_stderr = true,
     };
+    suppress_ambient_compiler_options(spec.environment);
     auto result = runner.run(spec);
     if (!result) {
         return std::unexpected(CompilerError{

--- a/cpp/src/msvc/linker/MsvcLinker.cpp
+++ b/cpp/src/msvc/linker/MsvcLinker.cpp
@@ -54,6 +54,16 @@ namespace fs = std::filesystem;
     return {};
 }
 
+void suppress_ambient_linker_options(
+    std::vector<process::EnvironmentVariable>& environment) {
+    // link.exe prepends LINK and appends _LINK_ to its explicit argv. Hidden
+    // arguments could otherwise bypass MQB-owned /OUT, target policy, tracked
+    // linker inputs, and link identity. Preserve LIB/PATH/vcvars state while
+    // making the explicit MQB argv authoritative.
+    environment.push_back(process::EnvironmentVariable{"LINK", {}});
+    environment.push_back(process::EnvironmentVariable{"_LINK_", {}});
+}
+
 } // namespace
 
 std::expected<LinkerIdentity, LinkerError>
@@ -232,6 +242,7 @@ MsvcLinker::link(const LinkInvocation& invocation) const {
     spec.arguments = std::move(*arguments);
     spec.working_directory = invocation.working_directory;
     spec.environment = toolchain_.environment;
+    suppress_ambient_linker_options(spec.environment);
     spec.inherit_environment = true;
     spec.capture_stdout = true;
     spec.capture_stderr = true;

--- a/cpp/src/msvc/modules/MsvcModuleDependencyScanner.cpp
+++ b/cpp/src/msvc/modules/MsvcModuleDependencyScanner.cpp
@@ -62,6 +62,15 @@ void append_configuration_macro(
     }
 }
 
+void suppress_ambient_compiler_options(
+    std::vector<process::EnvironmentVariable>& environment) {
+    // P1689 scans are compiler invocations too. They must observe the same
+    // explicit option surface as real compiles or hidden CL/_CL_ arguments can
+    // change topology without changing MQB's module-scan identity.
+    environment.push_back(process::EnvironmentVariable{"CL", {}});
+    environment.push_back(process::EnvironmentVariable{"_CL_", {}});
+}
+
 [[nodiscard]] std::expected<void, ModuleScanError> prepare_output(
     const fs::path& output) {
     const fs::path parent = output.parent_path();
@@ -202,6 +211,7 @@ MsvcModuleDependencyScanner::scan(const ModuleScanInvocation& invocation) const 
     spec.arguments = std::move(*arguments);
     spec.working_directory = invocation.working_directory;
     spec.environment = toolchain_.environment;
+    suppress_ambient_compiler_options(spec.environment);
     spec.inherit_environment = true;
     spec.capture_stdout = true;
     spec.capture_stderr = true;


### PR DESCRIPTION
## Summary

Closes the first P0 finding from the post-#103 productization final audit: MSVC's `CL` / `_CL_` and `LINK` / `_LINK_` environment variables could inject hidden compiler/linker options outside MQB's Parameter Engine, structured ownership, and cache identity.

## Root cause

MQB intentionally inherits the Visual Studio/vcvars environment for tool execution, but `cl.exe` and `link.exe` also interpret special environment variables as implicit command-line arguments. Because those arguments were not routed by MQB, they could bypass Class A ownership (for example `/Fo` or `/OUT`) and make actual execution differ from the build/cache identity.

## Fix

- preserve inherited vcvars state such as `PATH`, `INCLUDE`, and `LIB`;
- explicitly override `CL` and `_CL_` to empty for every MQB compiler launch;
- apply the same isolation to P1689 `/scanDependencies` compiler launches, so hidden options cannot change module topology outside module-scan identity;
- explicitly override `LINK` and `_LINK_` to empty for every MQB linker launch.

The override is applied at the final `ProcessSpec` boundary, after the discovered toolchain environment, so even a toolchain environment containing these names cannot reintroduce hidden options.

## Regression gate

Native C++ CI poisons all four variables with options that would break or redirect the build if they reached MSVC:

- `CL=/FI...missing...hpp`
- `_CL_=/Fo...obj`
- `LINK=/DEF:...missing...def`
- `_LINK_=/OUT:...exe`

The gate runs both an ordinary build/run and a C++ Modules build/run. This covers normal compile, module dependency scan/module compile, and final link with real Windows/MSVC processes.

## Exact validation

Exact validated head: `19dc69c7204bb1e9f8859ac7696b2a856e438605`.

- Native C++ #373: **success**
  - current Debug self-build: success
  - ambient MSVC option isolation gate: success
  - shared Debug native-test product library: success
  - exact 444-entry MSVC parameter inventory: success
  - 4/4 Debug shards + final gate: success
- Native Release #320: **success**
  - Stage 0 Release self-build: success
  - shared Release test product library: success
  - 4/4 Release shards: success
  - stable self-host: success
  - runtime-only package staging/validation/upload: success
- Performance Evidence #102: skipped as expected for a correctness `fix:` PR.

The first CI attempt correctly exposed a malformed one-line module fixture (`C7586`); the fixture alone was corrected to put the module declaration on its own physical line. Product code was unchanged by that correction, and the exact replacement head above is fully green.

## Scope

This PR deliberately does not change explicit MQB/native arguments, cache signatures, or normal vcvars environment inheritance. It addresses only the ambient hidden-option bypass. The next final-audit item is the `/Zi` / `/ZI` compiler-PDB ownership gap.