### PR TITLE
fix: fail closed on untracked compiler PDB debug modes

### DIFF
--- a/cpp/src/msvc/parameters/MsvcParameterRegistry.cpp
+++ b/cpp/src/msvc/parameters/MsvcParameterRegistry.cpp
@@ -104,6 +104,9 @@ ParameterClassification classify_compiler_parameter(const std::string_view argum
     if (body == "FA" || body.starts_with("Fa") || body.starts_with("FR") || body.starts_with("Fr") || body.starts_with("Ft") || body.starts_with("Fx") || body == "doc" || body.starts_with("doc:")) {
         return compiler_unsupported(body, "option creates a secondary output artifact that is not yet represented in MQB's cache/artifact graph");
     }
+    if (body == "Zi" || body == "ZI") {
+        return compiler_unsupported(body, "compiler Program Database debug information creates a .pdb artifact that is not yet represented in MQB's compile cache/artifact graph; use /Z7 until compiler PDB output becomes first-class");
+    }
     if (body == "arm64EC") return compiler_unsupported(body, "MQB's current Architecture model supports x86/x64 only; ARM64EC requires a first-class toolchain/ABI policy");
     if (body == "kernel") return compiler_unsupported(body, "kernel-mode compilation is coupled to linker target policy that MQB does not model yet");
     if (body == "ZW") return compiler_unsupported(body, "Windows Runtime compilation changes the target pipeline and is not modeled by MQB");
@@ -129,7 +132,7 @@ ParameterClassification classify_compiler_parameter(const std::string_view argum
         "QIntel-jcc-erratum"sv, "Qsafe_fp_loads"sv, "Qspectre-load"sv, "Qspectre-load-cf"sv, "sdl"sv, "sdl-"sv, "showIncludes"sv,
         "translateInclude"sv, "u"sv, "utf-8"sv, "validate-charset"sv, "vlen"sv, "vmb"sv, "vmg"sv, "vmm"sv, "vms"sv, "vmv"sv,
         "volatileMetadata"sv, "w"sv, "W0"sv, "W1"sv, "W2"sv, "W3"sv, "W4"sv, "Wall"sv, "WL"sv, "WX"sv, "WX-"sv, "X"sv,
-        "Z7"sv, "Za"sv, "Zf"sv, "ZI"sv, "Zi"sv, "Zl"sv,
+        "Z7"sv, "Za"sv, "Zf"sv, "Zl"sv,
     };
     static constexpr std::array passthrough_prefix{
         "AI"sv, "arch"sv, "await"sv, "cgthreads"sv, "constexpr:"sv, "D"sv, "diagnostics"sv, "EH"sv,

--- a/tests/native/verify_msvc_parameter_inventory.ps1
+++ b/tests/native/verify_msvc_parameter_inventory.ps1
@@ -172,6 +172,9 @@ $source.Add('expect(mqb::msvc::ParameterTool::compiler,"/Zc:trigraphs",mqb::msvc
 $source.Add('expect(mqb::msvc::ParameterTool::compiler,"/std:c11",mqb::msvc::ParameterOwnership::passthrough);')
 $source.Add('expect(mqb::msvc::ParameterTool::compiler,"/std:c17",mqb::msvc::ParameterOwnership::passthrough);')
 $source.Add('expect(mqb::msvc::ParameterTool::compiler,"/std:clatest",mqb::msvc::ParameterOwnership::passthrough);')
+$source.Add('expect(mqb::msvc::ParameterTool::compiler,"/Z7",mqb::msvc::ParameterOwnership::passthrough);')
+$source.Add('expect(mqb::msvc::ParameterTool::compiler,"/Zi",mqb::msvc::ParameterOwnership::unsupported);')
+$source.Add('expect(mqb::msvc::ParameterTool::compiler,"/ZI",mqb::msvc::ParameterOwnership::unsupported);')
 $source.Add('if(failures){std::cerr<<failures<<" exact MSVC inventory failure(s)\n";return 1;} return 0;}')
 $source | Set-Content -LiteralPath $sourcePath -Encoding utf8
 


### PR DESCRIPTION
## Summary

Closes the second post-#103 productization final-audit blocker: `/Zi` and `/ZI` were classified as safe compiler passthrough even though they create compiler Program Database output that MQB does not model as a compile artifact.

## Problem

MQB emits `/Z7` by default and then appends raw compiler arguments. A user-supplied `/Zi` or `/ZI` could therefore replace the embedded-CodeView policy and make `cl.exe` create a compiler PDB. `/Fd` is already MQB-owned, so that PDB had no first-class path/artifact/freshness ownership in MQB. This breaks the Class C requirement that admitted passthrough be safe with respect to MQB's cache/artifact graph.

## Fix

- keep `/Z7` as safe passthrough;
- classify `/Zi` and `/ZI` as explicit unsupported/Class D until compiler PDB output is first-class;
- emit a diagnostic explaining that the `.pdb` artifact is not represented and recommending `/Z7` for the current model;
- retain `/Zi` and `/ZI` in the exact official inventory as registered options, so this is a safety correction rather than a coverage reduction.

## Regression contract

The exact 444-entry MSVC inventory gate now pins:

- `/Z7` -> `passthrough`
- `/Zi` -> `unsupported`
- `/ZI` -> `unsupported`

This prevents a future registry refactor from silently re-admitting compiler PDB modes without adding the corresponding artifact ownership.

## Exact validation

Exact validated head: `f8676fba1fa4412a92e7b52f196159de97f6e82a`.

- Native C++ #375: **success**
  - current Debug self-build: success
  - ambient MSVC option isolation regression: success
  - shared Debug native-test product library: success
  - exact 444-entry MSVC inventory, including `/Z7`/`/Zi`/`/ZI` ownership assertions: success
  - 4/4 Debug shards + final gate: success
- Native Release #321: **success**
  - Stage 0 Release self-build: success
  - shared Release product library: success
  - 4/4 Release shards: success
  - stable self-host: success
  - runtime-only package staging/validation/upload: success
- Performance Evidence #105: skipped as expected for a correctness `fix:` PR.

## Scope

This PR deliberately does not introduce a first-class compiler-PDB feature. That requires explicit `.pdb` artifact layout, `/Fd` routing, cache output validation, concurrency semantics, and missing-output repair and should be reviewed as a separate feature rather than smuggled into a correctness closure.