### PR TITLE
fix: track LINK PDB, manifest, and map outputs

### DIFF
--- a/.github/workflows/native-ci.yml
+++ b/.github/workflows/native-ci.yml
@@ -102,6 +102,14 @@ jobs:
             Pop-Location
           }
 
+      - name: Verify linker side-output repair
+        shell: pwsh
+        run: |
+          & (Join-Path $PWD 'tests/native/verify_link_side_output_repair.ps1') `
+            -MqbPath (Join-Path $PWD 'native-out/debug/mqb.exe') `
+            -RepoRoot $PWD
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
       - name: Build shared Debug native-test product library
         shell: pwsh
         run: |

--- a/cpp/include/mqb/msvc/MsvcLinker.hpp
+++ b/cpp/include/mqb/msvc/MsvcLinker.hpp
@@ -61,6 +61,22 @@ public:
     [[nodiscard]] static std::filesystem::path
     manifest_file_path(const std::filesystem::path& output);
 
+    // Evaluate final LINK output semantics after MQB's configuration defaults
+    // and raw user linker options are applied in command-line order.
+    [[nodiscard]] static bool
+    program_database_enabled(const LinkOptions& options) noexcept;
+
+    [[nodiscard]] static bool
+    external_manifest_enabled(const LinkOptions& options) noexcept;
+
+    // Correctness-bearing deterministic side outputs. Missing files from this
+    // set invalidate the link cache. Recoverable performance state such as .ilk
+    // is deliberately excluded.
+    [[nodiscard]] static std::vector<std::filesystem::path>
+    required_side_output_paths(
+        const std::filesystem::path& output,
+        const LinkOptions& options);
+
     [[nodiscard]] static std::expected<std::vector<std::string>, LinkerError>
     build_arguments(const LinkInvocation& invocation);
 

--- a/cpp/include/mqb/msvc/MsvcLinker.hpp
+++ b/cpp/include/mqb/msvc/MsvcLinker.hpp
@@ -61,6 +61,12 @@ public:
     [[nodiscard]] static std::filesystem::path
     manifest_file_path(const std::filesystem::path& output);
 
+    [[nodiscard]] static std::optional<std::filesystem::path>
+    map_file_path(
+        const std::filesystem::path& output,
+        const LinkOptions& options,
+        const std::filesystem::path& working_directory = {});
+
     // Evaluate final LINK output semantics after MQB's configuration defaults
     // and raw user linker options are applied in command-line order.
     [[nodiscard]] static bool
@@ -69,13 +75,14 @@ public:
     [[nodiscard]] static bool
     external_manifest_enabled(const LinkOptions& options);
 
-    // Correctness-bearing deterministic side outputs. Missing files from this
-    // set invalidate the link cache. Recoverable performance state such as .ilk
-    // is deliberately excluded.
+    // Deterministic LINK side outputs derivable from configuration/raw policy.
+    // The coordinator distinguishes explicitly requested outputs (for example
+    // /MAP) from conditionally emitted outputs such as PDB/manifest files.
     [[nodiscard]] static std::vector<std::filesystem::path>
     required_side_output_paths(
         const std::filesystem::path& output,
-        const LinkOptions& options);
+        const LinkOptions& options,
+        const std::filesystem::path& working_directory = {});
 
     [[nodiscard]] static std::expected<std::vector<std::string>, LinkerError>
     build_arguments(const LinkInvocation& invocation);

--- a/cpp/include/mqb/msvc/MsvcLinker.hpp
+++ b/cpp/include/mqb/msvc/MsvcLinker.hpp
@@ -64,10 +64,10 @@ public:
     // Evaluate final LINK output semantics after MQB's configuration defaults
     // and raw user linker options are applied in command-line order.
     [[nodiscard]] static bool
-    program_database_enabled(const LinkOptions& options) noexcept;
+    program_database_enabled(const LinkOptions& options);
 
     [[nodiscard]] static bool
-    external_manifest_enabled(const LinkOptions& options) noexcept;
+    external_manifest_enabled(const LinkOptions& options);
 
     // Correctness-bearing deterministic side outputs. Missing files from this
     // set invalidate the link cache. Recoverable performance state such as .ilk

--- a/cpp/include/mqb/msvc/MsvcLinker.hpp
+++ b/cpp/include/mqb/msvc/MsvcLinker.hpp
@@ -55,6 +55,12 @@ public:
     [[nodiscard]] static std::filesystem::path
     export_file_path(const std::filesystem::path& output);
 
+    [[nodiscard]] static std::filesystem::path
+    program_database_path(const std::filesystem::path& output);
+
+    [[nodiscard]] static std::filesystem::path
+    manifest_file_path(const std::filesystem::path& output);
+
     [[nodiscard]] static std::expected<std::vector<std::string>, LinkerError>
     build_arguments(const LinkInvocation& invocation);
 

--- a/cpp/src/msvc/linker/MsvcLinker.cpp
+++ b/cpp/src/msvc/linker/MsvcLinker.cpp
@@ -30,6 +30,14 @@ namespace fs = std::filesystem;
         bytes.size()};
 }
 
+[[nodiscard]] fs::path path_from_utf8(const std::string_view value) {
+    std::u8string bytes;
+    bytes.assign(
+        reinterpret_cast<const char8_t*>(value.data()),
+        reinterpret_cast<const char8_t*>(value.data() + value.size()));
+    return fs::path{bytes};
+}
+
 [[nodiscard]] std::string architecture_argument(const Architecture architecture) {
     return architecture == Architecture::x86 ? "/MACHINE:X86" : "/MACHINE:X64";
 }
@@ -141,6 +149,44 @@ fs::path MsvcLinker::manifest_file_path(const fs::path& output) {
     return manifest;
 }
 
+std::optional<fs::path> MsvcLinker::map_file_path(
+    const fs::path& output,
+    const LinkOptions& options,
+    const fs::path& working_directory) {
+    std::optional<fs::path> map_file;
+    for (const auto& argument : options.additional_arguments) {
+        if (argument.size() < 2 || (argument.front() != '/' && argument.front() != '-')) {
+            continue;
+        }
+        const std::string_view raw_body{argument.data() + 1, argument.size() - 1};
+        const std::string body = linker_option_body_upper(argument);
+        if (body == "MAP") {
+            fs::path default_map = output;
+            default_map.replace_extension(".map");
+            map_file = std::move(default_map);
+            continue;
+        }
+        if (!body.starts_with("MAP:")) {
+            continue;
+        }
+
+        const std::string_view value = raw_body.substr(std::string_view{"MAP:"}.size());
+        if (value.empty()) {
+            fs::path default_map = output;
+            default_map.replace_extension(".map");
+            map_file = std::move(default_map);
+            continue;
+        }
+
+        fs::path explicit_map = path_from_utf8(value);
+        if (explicit_map.is_relative() && !working_directory.empty()) {
+            explicit_map = working_directory / explicit_map;
+        }
+        map_file = explicit_map.lexically_normal();
+    }
+    return map_file;
+}
+
 bool MsvcLinker::program_database_enabled(const LinkOptions& options) {
     bool enabled = options.configuration == BuildConfiguration::debug;
     for (const auto& argument : options.additional_arguments) {
@@ -173,11 +219,15 @@ bool MsvcLinker::external_manifest_enabled(const LinkOptions& options) {
 
 std::vector<fs::path> MsvcLinker::required_side_output_paths(
     const fs::path& output,
-    const LinkOptions& options) {
+    const LinkOptions& options,
+    const fs::path& working_directory) {
     std::vector<fs::path> paths;
-    paths.reserve(1);
+    paths.reserve(2);
     if (program_database_enabled(options)) {
         paths.push_back(program_database_path(output));
+    }
+    if (auto map_file = map_file_path(output, options, working_directory)) {
+        paths.push_back(std::move(*map_file));
     }
     return paths;
 }

--- a/cpp/src/msvc/linker/MsvcLinker.cpp
+++ b/cpp/src/msvc/linker/MsvcLinker.cpp
@@ -117,6 +117,18 @@ fs::path MsvcLinker::export_file_path(const fs::path& output) {
     return export_file;
 }
 
+fs::path MsvcLinker::program_database_path(const fs::path& output) {
+    fs::path program_database = output;
+    program_database.replace_extension(".pdb");
+    return program_database;
+}
+
+fs::path MsvcLinker::manifest_file_path(const fs::path& output) {
+    fs::path manifest = output;
+    manifest += ".manifest";
+    return manifest;
+}
+
 std::expected<std::vector<std::string>, LinkerError>
 MsvcLinker::build_arguments(const LinkInvocation& invocation) {
     if (invocation.options.target_kind == TargetKind::static_library) {
@@ -156,7 +168,7 @@ MsvcLinker::build_arguments(const LinkInvocation& invocation) {
 
     std::vector<std::string> arguments;
     arguments.reserve(
-        16
+        17
         + invocation.objects.size()
         + invocation.options.library_directories.size()
         + invocation.libraries.size()
@@ -209,6 +221,11 @@ MsvcLinker::build_arguments(const LinkInvocation& invocation) {
     if (invocation.options.link_time_code_generation) {
         arguments.emplace_back("/LTCG");
     }
+
+    // /PDB is an MQB-owned side artifact. Emit its stable location after raw
+    // flags so every effective /DEBUG mode writes to the path represented by
+    // the link cache. LINK ignores /PDB when the effective mode is /DEBUG:NONE.
+    arguments.push_back("/PDB:" + path_to_utf8(program_database_path(invocation.output)));
 
     // Structured routing is emitted after raw flags so the BuildPlan owns the
     // final target identity even if a user supplied a conflicting raw switch.

--- a/cpp/src/msvc/linker/MsvcLinker.cpp
+++ b/cpp/src/msvc/linker/MsvcLinker.cpp
@@ -271,7 +271,7 @@ MsvcLinker::build_arguments(const LinkInvocation& invocation) {
 
     std::vector<std::string> arguments;
     arguments.reserve(
-        17
+        18
         + invocation.objects.size()
         + invocation.options.library_directories.size()
         + invocation.libraries.size()
@@ -312,10 +312,16 @@ MsvcLinker::build_arguments(const LinkInvocation& invocation) {
         arguments.push_back(argument);
     }
 
-    // A library-change full link is MQB execution policy rather than a user
-    // linker preference. Emit it after raw flags so stale .ilk state cannot be
-    // re-enabled by a passthrough /INCREMENTAL argument.
-    if (invocation.force_full_link) {
+    // Library/file-input changes already require a full link to avoid stale
+    // .ilk state. A requested mapfile also needs a full LINK pass whenever a
+    // link action runs: LINK can otherwise report success for an unchanged
+    // incremental image without recreating a deleted .map file. Emit the final
+    // execution policy after raw flags so user /INCREMENTAL cannot override it.
+    if (invocation.force_full_link
+        || map_file_path(
+            invocation.output,
+            invocation.options,
+            invocation.working_directory)) {
         arguments.emplace_back("/INCREMENTAL:NO");
     }
 

--- a/cpp/src/msvc/linker/MsvcLinker.cpp
+++ b/cpp/src/msvc/linker/MsvcLinker.cpp
@@ -1,5 +1,6 @@
 #include "mqb/msvc/MsvcLinker.hpp"
 
+#include <cctype>
 #include <filesystem>
 #include <string>
 #include <string_view>
@@ -62,6 +63,17 @@ void suppress_ambient_linker_options(
     // making the explicit MQB argv authoritative.
     environment.push_back(process::EnvironmentVariable{"LINK", {}});
     environment.push_back(process::EnvironmentVariable{"_LINK_", {}});
+}
+
+[[nodiscard]] std::string linker_option_body_upper(const std::string_view argument) {
+    if (argument.size() < 2 || (argument.front() != '/' && argument.front() != '-')) {
+        return {};
+    }
+    std::string body{argument.substr(1)};
+    for (char& character : body) {
+        character = static_cast<char>(std::toupper(static_cast<unsigned char>(character)));
+    }
+    return body;
 }
 
 } // namespace
@@ -127,6 +139,48 @@ fs::path MsvcLinker::manifest_file_path(const fs::path& output) {
     fs::path manifest = output;
     manifest += ".manifest";
     return manifest;
+}
+
+bool MsvcLinker::program_database_enabled(const LinkOptions& options) noexcept {
+    bool enabled = options.configuration == BuildConfiguration::debug;
+    for (const auto& argument : options.additional_arguments) {
+        const std::string body = linker_option_body_upper(argument);
+        if (body == "DEBUG" || body == "DEBUG:FULL" || body == "DEBUG:FASTLINK") {
+            enabled = true;
+        } else if (body == "DEBUG:NONE") {
+            enabled = false;
+        }
+    }
+    return enabled;
+}
+
+bool MsvcLinker::external_manifest_enabled(const LinkOptions& options) noexcept {
+    // LINK's command-line default is an external manifest. Only the explicit
+    // disabled or embedded forms remove that standalone output.
+    bool enabled = true;
+    for (const auto& argument : options.additional_arguments) {
+        const std::string body = linker_option_body_upper(argument);
+        if (body == "MANIFEST") {
+            enabled = true;
+        } else if (body == "MANIFEST:NO" || body.starts_with("MANIFEST:EMBED")) {
+            enabled = false;
+        }
+    }
+    return enabled;
+}
+
+std::vector<fs::path> MsvcLinker::required_side_output_paths(
+    const fs::path& output,
+    const LinkOptions& options) {
+    std::vector<fs::path> paths;
+    paths.reserve(2);
+    if (program_database_enabled(options)) {
+        paths.push_back(program_database_path(output));
+    }
+    if (external_manifest_enabled(options)) {
+        paths.push_back(manifest_file_path(output));
+    }
+    return paths;
 }
 
 std::expected<std::vector<std::string>, LinkerError>
@@ -222,10 +276,12 @@ MsvcLinker::build_arguments(const LinkInvocation& invocation) {
         arguments.emplace_back("/LTCG");
     }
 
-    // /PDB is an MQB-owned side artifact. Emit its stable location after raw
-    // flags so every effective /DEBUG mode writes to the path represented by
-    // the link cache. LINK ignores /PDB when the effective mode is /DEBUG:NONE.
-    arguments.push_back("/PDB:" + path_to_utf8(program_database_path(invocation.output)));
+    // When debug information is effective, make the linker PDB an MQB-owned
+    // deterministic side artifact. The explicit path follows raw flags so a
+    // user cannot redirect it outside the cache/artifact graph.
+    if (program_database_enabled(invocation.options)) {
+        arguments.push_back("/PDB:" + path_to_utf8(program_database_path(invocation.output)));
+    }
 
     // Structured routing is emitted after raw flags so the BuildPlan owns the
     // final target identity even if a user supplied a conflicting raw switch.

--- a/cpp/src/msvc/linker/MsvcLinker.cpp
+++ b/cpp/src/msvc/linker/MsvcLinker.cpp
@@ -155,8 +155,10 @@ bool MsvcLinker::program_database_enabled(const LinkOptions& options) {
 }
 
 bool MsvcLinker::external_manifest_enabled(const LinkOptions& options) {
-    // LINK's command-line default is an external manifest. Only the explicit
-    // disabled or embedded forms remove that standalone output.
+    // LINK's command-line default allows an external manifest, but whether a
+    // standalone file is emitted depends on the effective manifest content.
+    // This function only models whether external emission is allowed; the
+    // coordinator observes whether LINK actually produced the optional file.
     bool enabled = true;
     for (const auto& argument : options.additional_arguments) {
         const std::string body = linker_option_body_upper(argument);
@@ -173,12 +175,9 @@ std::vector<fs::path> MsvcLinker::required_side_output_paths(
     const fs::path& output,
     const LinkOptions& options) {
     std::vector<fs::path> paths;
-    paths.reserve(2);
+    paths.reserve(1);
     if (program_database_enabled(options)) {
         paths.push_back(program_database_path(output));
-    }
-    if (external_manifest_enabled(options)) {
-        paths.push_back(manifest_file_path(output));
     }
     return paths;
 }

--- a/cpp/src/msvc/linker/MsvcLinker.cpp
+++ b/cpp/src/msvc/linker/MsvcLinker.cpp
@@ -141,7 +141,7 @@ fs::path MsvcLinker::manifest_file_path(const fs::path& output) {
     return manifest;
 }
 
-bool MsvcLinker::program_database_enabled(const LinkOptions& options) noexcept {
+bool MsvcLinker::program_database_enabled(const LinkOptions& options) {
     bool enabled = options.configuration == BuildConfiguration::debug;
     for (const auto& argument : options.additional_arguments) {
         const std::string body = linker_option_body_upper(argument);
@@ -154,7 +154,7 @@ bool MsvcLinker::program_database_enabled(const LinkOptions& options) noexcept {
     return enabled;
 }
 
-bool MsvcLinker::external_manifest_enabled(const LinkOptions& options) noexcept {
+bool MsvcLinker::external_manifest_enabled(const LinkOptions& options) {
     // LINK's command-line default is an external manifest. Only the explicit
     // disabled or embedded forms remove that standalone output.
     bool enabled = true;

--- a/cpp/src/msvc/parameters/MsvcParameterRegistry.cpp
+++ b/cpp/src/msvc/parameters/MsvcParameterRegistry.cpp
@@ -190,11 +190,14 @@ ParameterClassification classify_linker_parameter(const std::string_view argumen
 
     static constexpr std::array unsupported_pgo_exact{"FASTGENPROFILE"sv, "GENPROFILE"sv, "SPGO"sv, "USEPROFILE"sv};
     if (contains_exact(std::string_view{body}, unsupported_pgo_exact)) return linker_unsupported(body, "profile-guided optimization artifacts are not yet represented in MQB's build graph");
+    if (body == "MAP" || body.starts_with("MAP:")) {
+        return linker_unsupported(body, "mapfile output is not yet represented in MQB's link cache/artifact graph");
+    }
 
     static constexpr std::array passthrough_exact{
         "?"sv, "ALLOWBIND"sv, "ALLOWISOLATION"sv, "APPCONTAINER"sv, "ASSEMBLYDEBUG"sv, "CETCOMPAT"sv, "DEBUG"sv, "DEBUG:FULL"sv, "DEBUG:NONE"sv,
         "DELAYSIGN"sv, "DYNAMICBASE"sv, "DYNAMICDEOPT"sv, "FIXED"sv, "FORCE"sv, "FUNCTIONPADMIN"sv, "HIGHENTROPYVA"sv, "IGNOREIDL"sv,
-        "INCREMENTAL"sv, "INCREMENTAL:NO"sv, "INFERASANLIBS"sv, "INTEGRITYCHECK"sv, "LARGEADDRESSAWARE"sv, "MAP"sv, "MANIFEST"sv,
+        "INCREMENTAL"sv, "INCREMENTAL:NO"sv, "INFERASANLIBS"sv, "INTEGRITYCHECK"sv, "LARGEADDRESSAWARE"sv, "MANIFEST"sv,
         "MANIFEST:NO"sv, "NOASSEMBLY"sv, "NODEFAULTLIB"sv, "NOENTRY"sv, "NOFUNCTIONPADSECTION"sv, "NOLOGO"sv, "NXCOMPAT"sv,
         "PROFILE"sv, "RELEASE"sv, "SAFESEH"sv, "TIME"sv, "TSAWARE"sv, "VERBOSE"sv, "WHOLEARCHIVE"sv, "WX"sv, "WX:NO"sv,
     };
@@ -203,7 +206,7 @@ ParameterClassification classify_linker_parameter(const std::string_view argumen
         "CETCOMPAT:"sv, "CGTHREADS:"sv, "CLRIMAGETYPE:"sv, "COMMENT:"sv, "DEBUGTYPE:"sv, "DEF:"sv, "DEFAULTLIB:"sv, "DELAY:"sv, "DELAYSIGN:"sv, "DELAYLOAD:"sv,
         "DEPENDENTLOADFLAG:"sv, "DYNAMICBASE:"sv, "ENTRY:"sv, "EXPORT:"sv, "FILEALIGN:"sv, "FIXED:"sv, "FORCE:"sv, "GUARD:"sv,
         "HEAP:"sv, "HIGHENTROPYVA:"sv, "IGNORE:"sv, "INCLUDE:"sv, "LARGEADDRESSAWARE:"sv, "LINKREPRO:"sv, "LINKREPROFULLPATHRSP:"sv,
-        "LINKREPROTARGET:"sv, "MANIFEST:"sv, "MANIFESTDEPENDENCY:"sv, "MANIFESTINPUT:"sv, "MANIFESTUAC:"sv, "MAP:"sv, "MAPINFO:"sv, "MERGE:"sv,
+        "LINKREPROTARGET:"sv, "MANIFEST:"sv, "MANIFESTDEPENDENCY:"sv, "MANIFESTINPUT:"sv, "MANIFESTUAC:"sv, "MAPINFO:"sv, "MERGE:"sv,
         "NODEFAULTLIB:"sv, "NXCOMPAT:"sv, "OPT:"sv, "ORDER:"sv, "PDBALTPATH:"sv, "SAFESEH:"sv, "SECTION:"sv, "STACK:"sv, "STUB:"sv, "SWAPRUN:"sv,
         "TIMESTAMP:"sv, "TLBID:"sv, "TSAWARE:"sv, "VERSION:"sv, "WHOLEARCHIVE:"sv,
     };

--- a/cpp/src/msvc/parameters/MsvcParameterRegistry.cpp
+++ b/cpp/src/msvc/parameters/MsvcParameterRegistry.cpp
@@ -190,14 +190,11 @@ ParameterClassification classify_linker_parameter(const std::string_view argumen
 
     static constexpr std::array unsupported_pgo_exact{"FASTGENPROFILE"sv, "GENPROFILE"sv, "SPGO"sv, "USEPROFILE"sv};
     if (contains_exact(std::string_view{body}, unsupported_pgo_exact)) return linker_unsupported(body, "profile-guided optimization artifacts are not yet represented in MQB's build graph");
-    if (body == "MAP" || body.starts_with("MAP:")) {
-        return linker_unsupported(body, "mapfile output is not yet represented in MQB's link cache/artifact graph");
-    }
 
     static constexpr std::array passthrough_exact{
         "?"sv, "ALLOWBIND"sv, "ALLOWISOLATION"sv, "APPCONTAINER"sv, "ASSEMBLYDEBUG"sv, "CETCOMPAT"sv, "DEBUG"sv, "DEBUG:FULL"sv, "DEBUG:NONE"sv,
         "DELAYSIGN"sv, "DYNAMICBASE"sv, "DYNAMICDEOPT"sv, "FIXED"sv, "FORCE"sv, "FUNCTIONPADMIN"sv, "HIGHENTROPYVA"sv, "IGNOREIDL"sv,
-        "INCREMENTAL"sv, "INCREMENTAL:NO"sv, "INFERASANLIBS"sv, "INTEGRITYCHECK"sv, "LARGEADDRESSAWARE"sv, "MANIFEST"sv,
+        "INCREMENTAL"sv, "INCREMENTAL:NO"sv, "INFERASANLIBS"sv, "INTEGRITYCHECK"sv, "LARGEADDRESSAWARE"sv, "MANIFEST"sv, "MAP"sv,
         "MANIFEST:NO"sv, "NOASSEMBLY"sv, "NODEFAULTLIB"sv, "NOENTRY"sv, "NOFUNCTIONPADSECTION"sv, "NOLOGO"sv, "NXCOMPAT"sv,
         "PROFILE"sv, "RELEASE"sv, "SAFESEH"sv, "TIME"sv, "TSAWARE"sv, "VERBOSE"sv, "WHOLEARCHIVE"sv, "WX"sv, "WX:NO"sv,
     };
@@ -206,7 +203,7 @@ ParameterClassification classify_linker_parameter(const std::string_view argumen
         "CETCOMPAT:"sv, "CGTHREADS:"sv, "CLRIMAGETYPE:"sv, "COMMENT:"sv, "DEBUGTYPE:"sv, "DEF:"sv, "DEFAULTLIB:"sv, "DELAY:"sv, "DELAYSIGN:"sv, "DELAYLOAD:"sv,
         "DEPENDENTLOADFLAG:"sv, "DYNAMICBASE:"sv, "ENTRY:"sv, "EXPORT:"sv, "FILEALIGN:"sv, "FIXED:"sv, "FORCE:"sv, "GUARD:"sv,
         "HEAP:"sv, "HIGHENTROPYVA:"sv, "IGNORE:"sv, "INCLUDE:"sv, "LARGEADDRESSAWARE:"sv, "LINKREPRO:"sv, "LINKREPROFULLPATHRSP:"sv,
-        "LINKREPROTARGET:"sv, "MANIFEST:"sv, "MANIFESTDEPENDENCY:"sv, "MANIFESTINPUT:"sv, "MANIFESTUAC:"sv, "MAPINFO:"sv, "MERGE:"sv,
+        "LINKREPROTARGET:"sv, "MANIFEST:"sv, "MANIFESTDEPENDENCY:"sv, "MANIFESTINPUT:"sv, "MANIFESTUAC:"sv, "MAP:"sv, "MAPINFO:"sv, "MERGE:"sv,
         "NODEFAULTLIB:"sv, "NXCOMPAT:"sv, "OPT:"sv, "ORDER:"sv, "PDBALTPATH:"sv, "SAFESEH:"sv, "SECTION:"sv, "STACK:"sv, "STUB:"sv, "SWAPRUN:"sv,
         "TIMESTAMP:"sv, "TLBID:"sv, "TSAWARE:"sv, "VERSION:"sv, "WHOLEARCHIVE:"sv,
     };
@@ -224,7 +221,9 @@ ParameterClassification classify_linker_parameter(const std::string_view argumen
                                 ? "MS-DOS stub executable is preserved in linker argv and tracked through MQB's generic link file-input freshness graph"
                                 : body.starts_with("MANIFESTINPUT:")
                                     ? "manifest input is preserved in linker argv and cumulatively tracked through MQB's generic link file-input freshness graph"
-                                    : "validated linker option is preserved verbatim in link identity");
+                                    : body == "MAP" || body.starts_with("MAP:")
+                                        ? "mapfile output is preserved in linker argv and tracked through MQB's link side-output repair graph"
+                                        : "validated linker option is preserved verbatim in link identity");
     }
     return unregistered(ParameterTool::linker, body);
 }

--- a/cpp/src/orchestration/incremental/MsvcIncrementalLinkCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalLinkCoordinator.cpp
@@ -82,7 +82,7 @@ void collect_existing_side_output(
     std::vector<fs::path>& outputs,
     std::vector<IncrementalLinkWarning>& warnings) {
     std::error_code error_code;
-    const bool exists = fs::exists(path, error_code);
+    const bool exists = fs::is_regular_file(path, error_code);
     if (error_code) {
         warnings.push_back(IncrementalLinkWarning{
             .code = IncrementalLinkWarningCode::file_snapshot_failed,
@@ -209,6 +209,13 @@ MsvcIncrementalLinkCoordinator::run(const IncrementalLinkRequest& request) const
         msvc::MsvcLinker::required_side_output_paths(
             request.output,
             request.options);
+    std::vector<fs::path> existing_optional_side_outputs;
+    if (msvc::MsvcLinker::external_manifest_enabled(request.options)) {
+        collect_existing_side_output(
+            msvc::MsvcLinker::manifest_file_path(request.output),
+            existing_optional_side_outputs,
+            result.warnings);
+    }
 
     std::optional<LinkCacheEntry> cached_entry;
     auto loaded = LinkCacheFile::load(request.cache_file);
@@ -263,10 +270,16 @@ MsvcIncrementalLinkCoordinator::run(const IncrementalLinkRequest& request) const
 
     if (cached_entry) {
         // Older cache entries may predate first-class tracking for deterministic
-        // PDB/manifest outputs. Force one safe relink to reseal the entry even
-        // when those files happen to exist on disk already.
+        // PDB output or for a conditional external manifest that already exists.
+        // Force one safe relink to reseal that evidence.
         for (const auto& required : required_side_outputs) {
             if (!contains_path(cached_entry->side_outputs, required)) {
+                add_reason(result.validation.reasons, BuildReason::missing_output);
+                break;
+            }
+        }
+        for (const auto& optional : existing_optional_side_outputs) {
+            if (!contains_path(cached_entry->side_outputs, optional)) {
                 add_reason(result.validation.reasons, BuildReason::missing_output);
                 break;
             }
@@ -338,12 +351,19 @@ MsvcIncrementalLinkCoordinator::run(const IncrementalLinkRequest& request) const
     std::vector<fs::path> side_outputs;
     side_outputs.reserve(
         required_side_outputs.size()
+        + (msvc::MsvcLinker::external_manifest_enabled(request.options) ? 1u : 0u)
         + (request.options.target_kind == TargetKind::dynamic_library ? 2u : 0u));
     for (const auto& required : required_side_outputs) {
         auto recorded = require_side_output(required, side_outputs);
         if (!recorded) {
             return std::unexpected(recorded.error());
         }
+    }
+    if (msvc::MsvcLinker::external_manifest_enabled(request.options)) {
+        collect_existing_side_output(
+            msvc::MsvcLinker::manifest_file_path(action->output),
+            side_outputs,
+            result.warnings);
     }
 
     if (request.options.target_kind == TargetKind::dynamic_library) {

--- a/cpp/src/orchestration/incremental/MsvcIncrementalLinkCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalLinkCoordinator.cpp
@@ -82,8 +82,11 @@ void collect_existing_side_output(
     std::vector<fs::path>& outputs,
     std::vector<IncrementalLinkWarning>& warnings) {
     std::error_code error_code;
-    const bool exists = fs::is_regular_file(path, error_code);
+    const fs::file_status status = fs::status(path, error_code);
     if (error_code) {
+        if (error_code == std::errc::no_such_file_or_directory) {
+            return;
+        }
         warnings.push_back(IncrementalLinkWarning{
             .code = IncrementalLinkWarningCode::file_snapshot_failed,
             .path = path,
@@ -91,7 +94,7 @@ void collect_existing_side_output(
         });
         return;
     }
-    if (exists) {
+    if (fs::is_regular_file(status)) {
         outputs.push_back(path);
     }
 }

--- a/cpp/src/orchestration/incremental/MsvcIncrementalLinkCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalLinkCoordinator.cpp
@@ -208,15 +208,28 @@ MsvcIncrementalLinkCoordinator::run(const IncrementalLinkRequest& request) const
         resolved_default_libraries->files.begin(),
         resolved_default_libraries->files.end());
 
-    const std::vector<fs::path> required_side_outputs =
-        msvc::MsvcLinker::required_side_output_paths(
+    const std::optional<fs::path> requested_map_output =
+        msvc::MsvcLinker::map_file_path(
             request.output,
-            request.options);
-    std::vector<fs::path> existing_optional_side_outputs;
+            request.options,
+            working_directory);
+
+    // PDB and external-manifest files are conditionally emitted by real LINK
+    // configurations. Observe them when present, seal them into the cache, and
+    // repair them once sealed; do not require fake/custom linker runners to
+    // synthesize outputs they never produced. /MAP is different: requesting it
+    // explicitly promises a concrete mapfile, so that output is strict.
+    std::vector<fs::path> existing_observed_side_outputs;
+    if (msvc::MsvcLinker::program_database_enabled(request.options)) {
+        collect_existing_side_output(
+            msvc::MsvcLinker::program_database_path(request.output),
+            existing_observed_side_outputs,
+            result.warnings);
+    }
     if (msvc::MsvcLinker::external_manifest_enabled(request.options)) {
         collect_existing_side_output(
             msvc::MsvcLinker::manifest_file_path(request.output),
-            existing_optional_side_outputs,
+            existing_observed_side_outputs,
             result.warnings);
     }
 
@@ -272,17 +285,16 @@ MsvcIncrementalLinkCoordinator::run(const IncrementalLinkRequest& request) const
         request.force_relink);
 
     if (cached_entry) {
-        // Older cache entries may predate first-class tracking for deterministic
-        // PDB output or for a conditional external manifest that already exists.
-        // Force one safe relink to reseal that evidence.
-        for (const auto& required : required_side_outputs) {
-            if (!contains_path(cached_entry->side_outputs, required)) {
-                add_reason(result.validation.reasons, BuildReason::missing_output);
-                break;
-            }
+        // /MAP is a requested deliverable, so an older cache must be resealed
+        // even when that output has already disappeared. PDB/manifest evidence
+        // is migration-sealed only when the current filesystem proves LINK had
+        // produced it under the same link identity.
+        if (requested_map_output
+            && !contains_path(cached_entry->side_outputs, *requested_map_output)) {
+            add_reason(result.validation.reasons, BuildReason::missing_output);
         }
-        for (const auto& optional : existing_optional_side_outputs) {
-            if (!contains_path(cached_entry->side_outputs, optional)) {
+        for (const auto& observed : existing_observed_side_outputs) {
+            if (!contains_path(cached_entry->side_outputs, observed)) {
                 add_reason(result.validation.reasons, BuildReason::missing_output);
                 break;
             }
@@ -353,14 +365,22 @@ MsvcIncrementalLinkCoordinator::run(const IncrementalLinkRequest& request) const
 
     std::vector<fs::path> side_outputs;
     side_outputs.reserve(
-        required_side_outputs.size()
+        (requested_map_output ? 1u : 0u)
+        + (msvc::MsvcLinker::program_database_enabled(request.options) ? 1u : 0u)
         + (msvc::MsvcLinker::external_manifest_enabled(request.options) ? 1u : 0u)
         + (request.options.target_kind == TargetKind::dynamic_library ? 2u : 0u));
-    for (const auto& required : required_side_outputs) {
-        auto recorded = require_side_output(required, side_outputs);
+
+    if (requested_map_output) {
+        auto recorded = require_side_output(*requested_map_output, side_outputs);
         if (!recorded) {
             return std::unexpected(recorded.error());
         }
+    }
+    if (msvc::MsvcLinker::program_database_enabled(request.options)) {
+        collect_existing_side_output(
+            msvc::MsvcLinker::program_database_path(action->output),
+            side_outputs,
+            result.warnings);
     }
     if (msvc::MsvcLinker::external_manifest_enabled(request.options)) {
         collect_existing_side_output(

--- a/cpp/src/orchestration/incremental/MsvcIncrementalLinkCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalLinkCoordinator.cpp
@@ -1,5 +1,6 @@
 #include "mqb/orchestration/MsvcIncrementalLinkCoordinator.hpp"
 
+#include <algorithm>
 #include <expected>
 #include <filesystem>
 #include <optional>
@@ -58,6 +59,24 @@ void snapshot_inputs(
     }
 }
 
+[[nodiscard]] bool same_path(const fs::path& left, const fs::path& right) {
+    return left == right || left.lexically_normal() == right.lexically_normal();
+}
+
+[[nodiscard]] bool contains_path(
+    const std::vector<fs::path>& paths,
+    const fs::path& expected) {
+    return std::any_of(paths.begin(), paths.end(), [&](const fs::path& path) {
+        return same_path(path, expected);
+    });
+}
+
+void add_reason(std::vector<BuildReason>& reasons, const BuildReason reason) {
+    if (std::find(reasons.begin(), reasons.end(), reason) == reasons.end()) {
+        reasons.push_back(reason);
+    }
+}
+
 void collect_existing_side_output(
     const fs::path& path,
     std::vector<fs::path>& outputs,
@@ -86,6 +105,27 @@ void collect_existing_side_output(
         .message = std::move(message),
         .linker_error = std::move(linker_error),
     };
+}
+
+[[nodiscard]] std::expected<void, IncrementalLinkError> require_side_output(
+    const fs::path& path,
+    std::vector<fs::path>& outputs) {
+    std::error_code error_code;
+    const bool regular = fs::is_regular_file(path, error_code);
+    if (error_code) {
+        return std::unexpected(link_failure(
+            IncrementalLinkErrorCode::link_failed,
+            "failed to validate required linker side output '"
+                + path.generic_string() + "': " + error_code.message()));
+    }
+    if (!regular) {
+        return std::unexpected(link_failure(
+            IncrementalLinkErrorCode::link_failed,
+            "MSVC linker succeeded without producing required side output '"
+                + path.generic_string() + "'"));
+    }
+    outputs.push_back(path);
+    return {};
 }
 
 } // namespace
@@ -165,6 +205,11 @@ MsvcIncrementalLinkCoordinator::run(const IncrementalLinkRequest& request) const
         resolved_default_libraries->files.begin(),
         resolved_default_libraries->files.end());
 
+    const std::vector<fs::path> required_side_outputs =
+        msvc::MsvcLinker::required_side_output_paths(
+            request.output,
+            request.options);
+
     std::optional<LinkCacheEntry> cached_entry;
     auto loaded = LinkCacheFile::load(request.cache_file);
     if (loaded) {
@@ -215,6 +260,18 @@ MsvcIncrementalLinkCoordinator::run(const IncrementalLinkRequest& request) const
         file_input_snapshots,
         side_output_snapshots,
         request.force_relink);
+
+    if (cached_entry) {
+        // Older cache entries may predate first-class tracking for deterministic
+        // PDB/manifest outputs. Force one safe relink to reseal the entry even
+        // when those files happen to exist on disk already.
+        for (const auto& required : required_side_outputs) {
+            if (!contains_path(cached_entry->side_outputs, required)) {
+                add_reason(result.validation.reasons, BuildReason::missing_output);
+                break;
+            }
+        }
+    }
 
     // A reusable link validation is already the final no-op decision. Avoid
     // materializing a generic LinkPlanItem/BuildPlan on the hot path; misses
@@ -279,6 +336,16 @@ MsvcIncrementalLinkCoordinator::run(const IncrementalLinkRequest& request) const
     result.process = std::move(*linked);
 
     std::vector<fs::path> side_outputs;
+    side_outputs.reserve(
+        required_side_outputs.size()
+        + (request.options.target_kind == TargetKind::dynamic_library ? 2u : 0u));
+    for (const auto& required : required_side_outputs) {
+        auto recorded = require_side_output(required, side_outputs);
+        if (!recorded) {
+            return std::unexpected(recorded.error());
+        }
+    }
+
     if (request.options.target_kind == TargetKind::dynamic_library) {
         collect_existing_side_output(
             msvc::MsvcLinker::import_library_path(action->output),

--- a/cpp/tests/msvc/linker/linker_arguments_tests.cpp
+++ b/cpp/tests/msvc/linker/linker_arguments_tests.cpp
@@ -25,6 +25,12 @@ void expect(const bool condition, const std::string_view message) {
     return std::find(arguments.begin(), arguments.end(), expected) != arguments.end();
 }
 
+[[nodiscard]] bool contains_path(
+    const std::vector<std::filesystem::path>& paths,
+    const std::filesystem::path& expected) {
+    return std::find(paths.begin(), paths.end(), expected) != paths.end();
+}
+
 } // namespace
 
 int main() {
@@ -37,7 +43,7 @@ int main() {
     invocation.options.subsystem = mqb::LinkSubsystem::console;
     invocation.options.library_directories = {"vendor libs"};
     invocation.options.libraries = {"user32.lib"};
-    invocation.options.additional_arguments = {"/MAP", "/OUT:ignored.exe"};
+    invocation.options.additional_arguments = {"/VERBOSE", "/OUT:ignored.exe"};
 
     const auto result = mqb::msvc::MsvcLinker::build_arguments(invocation);
     expect(result.has_value(), "valid link invocation should produce argv");
@@ -53,6 +59,8 @@ int main() {
                "linker should consume exact resolved library path");
         expect(!contains(*result, "user32.lib"),
                "unresolved library token must not be emitted alongside resolved file");
+        expect(contains(*result, "/PDB:bin/my app.pdb"),
+               "effective debug mode should route the linker PDB to an MQB-owned path");
         expect(contains(*result, "/MACHINE:X64"), "x64 should map to /MACHINE:X64");
         expect(contains(*result, "/SUBSYSTEM:CONSOLE"), "console subsystem should map correctly");
         expect(contains(*result, "/OUT:bin/my app.exe"), "structured output should be emitted");
@@ -62,6 +70,47 @@ int main() {
         expect(raw_out != result->end() && planned_out != result->end() && raw_out < planned_out,
                "planned output must override a conflicting raw /OUT");
     }
+
+    expect(mqb::msvc::MsvcLinker::program_database_path(invocation.output)
+               == std::filesystem::path{"bin/my app.pdb"},
+           "program database side-output path should be deterministic");
+    expect(mqb::msvc::MsvcLinker::manifest_file_path(invocation.output)
+               == std::filesystem::path{"bin/my app.exe.manifest"},
+           "external manifest side-output path should retain the binary extension");
+    expect(mqb::msvc::MsvcLinker::program_database_enabled(invocation.options),
+           "Debug configuration should enable a linker PDB by default");
+    expect(mqb::msvc::MsvcLinker::external_manifest_enabled(invocation.options),
+           "external manifest should be enabled by LINK's command-line default");
+    const auto debug_outputs = mqb::msvc::MsvcLinker::required_side_output_paths(
+        invocation.output,
+        invocation.options);
+    expect(contains_path(debug_outputs, "bin/my app.pdb"),
+           "Debug required side outputs should include the linker PDB");
+    expect(contains_path(debug_outputs, "bin/my app.exe.manifest"),
+           "default required side outputs should include the external manifest");
+
+    auto debug_none = invocation;
+    debug_none.options.additional_arguments = {"/DEBUG:NONE"};
+    const auto debug_none_result = mqb::msvc::MsvcLinker::build_arguments(debug_none);
+    expect(debug_none_result.has_value(), "/DEBUG:NONE link invocation should produce argv");
+    if (debug_none_result) {
+        expect(!contains(*debug_none_result, "/PDB:bin/my app.pdb"),
+               "/DEBUG:NONE should not emit an owned PDB path");
+    }
+    expect(!mqb::msvc::MsvcLinker::program_database_enabled(debug_none.options),
+           "raw /DEBUG:NONE should override Debug configuration for PDB output semantics");
+
+    auto embedded_manifest = invocation;
+    embedded_manifest.options.additional_arguments = {"/MANIFEST:EMBED"};
+    expect(!mqb::msvc::MsvcLinker::external_manifest_enabled(embedded_manifest.options),
+           "/MANIFEST:EMBED should remove the standalone manifest output");
+    const auto embedded_outputs = mqb::msvc::MsvcLinker::required_side_output_paths(
+        embedded_manifest.output,
+        embedded_manifest.options);
+    expect(contains_path(embedded_outputs, "bin/my app.pdb"),
+           "embedded manifest mode should retain an independently enabled PDB");
+    expect(!contains_path(embedded_outputs, "bin/my app.exe.manifest"),
+           "embedded manifest mode should not track a standalone manifest");
 
     auto changed_library = invocation;
     changed_library.force_full_link = true;
@@ -110,6 +159,8 @@ int main() {
     expect(dll_result.has_value(), "typed DLL link invocation should produce argv");
     if (dll_result) {
         expect(contains(*dll_result, "/DLL"), "DLL target should emit /DLL");
+        expect(contains(*dll_result, "/PDB:bin/plugin.pdb"),
+               "Debug DLL should own a deterministic linker PDB path");
         expect(contains(*dll_result, "/IMPLIB:bin/plugin.lib"),
                "DLL target should own deterministic import-library path");
         expect(contains(*dll_result, "/OUT:bin/plugin.dll"),
@@ -139,8 +190,21 @@ int main() {
         expect(contains(*release_result, "/INCREMENTAL:NO"), "release link should disable incremental linking");
         expect(contains(*release_result, "/OPT:REF"), "release link should enable reference elimination");
         expect(contains(*release_result, "/OPT:ICF"), "release link should enable COMDAT folding");
+        expect(!contains(*release_result, "/PDB:bin/my app.pdb"),
+               "Release without explicit /DEBUG should not request a linker PDB");
         expect(contains(*release_result, "/MACHINE:X86"), "x86 should map correctly");
         expect(contains(*release_result, "/SUBSYSTEM:WINDOWS"), "windows subsystem should map correctly");
+    }
+    expect(!mqb::msvc::MsvcLinker::program_database_enabled(release.options),
+           "Release without /DEBUG should not require a linker PDB");
+
+    auto release_debug = release;
+    release_debug.options.additional_arguments = {"/DEBUG:FULL"};
+    const auto release_debug_result = mqb::msvc::MsvcLinker::build_arguments(release_debug);
+    expect(release_debug_result.has_value(), "Release /DEBUG:FULL invocation should produce argv");
+    if (release_debug_result) {
+        expect(contains(*release_debug_result, "/PDB:bin/my app.pdb"),
+               "Release /DEBUG:FULL should request the owned linker PDB");
     }
 
     auto unresolved = invocation;

--- a/cpp/tests/msvc/linker/linker_arguments_tests.cpp
+++ b/cpp/tests/msvc/linker/linker_arguments_tests.cpp
@@ -80,14 +80,14 @@ int main() {
     expect(mqb::msvc::MsvcLinker::program_database_enabled(invocation.options),
            "Debug configuration should enable a linker PDB by default");
     expect(mqb::msvc::MsvcLinker::external_manifest_enabled(invocation.options),
-           "external manifest should be enabled by LINK's command-line default");
+           "external manifest emission should be allowed by LINK's command-line default");
     const auto debug_outputs = mqb::msvc::MsvcLinker::required_side_output_paths(
         invocation.output,
         invocation.options);
     expect(contains_path(debug_outputs, "bin/my app.pdb"),
            "Debug required side outputs should include the linker PDB");
-    expect(contains_path(debug_outputs, "bin/my app.exe.manifest"),
-           "default required side outputs should include the external manifest");
+    expect(!contains_path(debug_outputs, "bin/my app.exe.manifest"),
+           "external manifest is conditional on LINK actually producing content and must not be required blindly");
 
     auto debug_none = invocation;
     debug_none.options.additional_arguments = {"/DEBUG:NONE"};
@@ -103,14 +103,14 @@ int main() {
     auto embedded_manifest = invocation;
     embedded_manifest.options.additional_arguments = {"/MANIFEST:EMBED"};
     expect(!mqb::msvc::MsvcLinker::external_manifest_enabled(embedded_manifest.options),
-           "/MANIFEST:EMBED should remove the standalone manifest output");
+           "/MANIFEST:EMBED should disable standalone manifest observation");
     const auto embedded_outputs = mqb::msvc::MsvcLinker::required_side_output_paths(
         embedded_manifest.output,
         embedded_manifest.options);
     expect(contains_path(embedded_outputs, "bin/my app.pdb"),
            "embedded manifest mode should retain an independently enabled PDB");
     expect(!contains_path(embedded_outputs, "bin/my app.exe.manifest"),
-           "embedded manifest mode should not track a standalone manifest");
+           "external manifest should never be a deterministic required output");
 
     auto changed_library = invocation;
     changed_library.force_full_link = true;

--- a/tests/native/verify_link_side_output_repair.ps1
+++ b/tests/native/verify_link_side_output_repair.ps1
@@ -96,3 +96,4 @@ if ($map.Text -notmatch 'mapfile output is not yet represented') {
 }
 
 Write-Host 'Real MSVC linker PDB/conditional-manifest repair and /MAP fail-closed checks passed.'
+exit 0

--- a/tests/native/verify_link_side_output_repair.ps1
+++ b/tests/native/verify_link_side_output_repair.ps1
@@ -23,12 +23,18 @@ New-Item -ItemType Directory -Path $fixture -Force | Out-Null
 int main() { return 0; }
 '@ | Set-Content -LiteralPath (Join-Path $fixture 'main.cpp') -Encoding utf8
 
-function Invoke-ProbeBuild {
-    param([string[]]$ExtraArguments = @())
+$binary = Join-Path $fixture '.mqb/bin/link_side_output_probe.exe'
+$pdb = Join-Path $fixture '.mqb/bin/link_side_output_probe.pdb'
+$manifest = Join-Path $fixture '.mqb/bin/link_side_output_probe.exe.manifest'
+$map = Join-Path $fixture 'link_side_output_probe.map'
 
+function Invoke-ProbeBuild {
     Push-Location $fixture
     try {
-        $output = @(& $MqbPath build main.cpp --debug --no-discover -o link_side_output_probe @ExtraArguments 2>&1)
+        $output = @(
+            & $MqbPath build main.cpp --debug --no-discover -o link_side_output_probe `
+                /link "/MAP:$map" 2>&1
+        )
         $exitCode = $LASTEXITCODE
     }
     finally {
@@ -41,15 +47,11 @@ function Invoke-ProbeBuild {
     }
 }
 
-$binary = Join-Path $fixture '.mqb/bin/link_side_output_probe.exe'
-$pdb = Join-Path $fixture '.mqb/bin/link_side_output_probe.pdb'
-$manifest = Join-Path $fixture '.mqb/bin/link_side_output_probe.exe.manifest'
-
 $cold = Invoke-ProbeBuild
 if ($cold.ExitCode -ne 0) {
     throw "Cold Debug side-output probe failed:`n$($cold.Text)"
 }
-foreach ($path in @($binary, $pdb, $manifest)) {
+foreach ($path in @($binary, $pdb, $manifest, $map)) {
     if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
         throw "Cold Debug link did not produce expected output: $path`n$($cold.Text)"
     }
@@ -87,13 +89,17 @@ if ($manifestRepair.Text -notmatch '\[link\]\s+link_side_output_probe\.exe') {
     throw "Deleted external manifest did not invalidate the warm link cache:`n$($manifestRepair.Text)"
 }
 
-$map = Invoke-ProbeBuild -ExtraArguments @('/link', '/MAP')
-if ($map.ExitCode -eq 0) {
-    throw "Untracked /MAP output was unexpectedly admitted"
+Remove-Item -LiteralPath $map -Force
+$mapRepair = Invoke-ProbeBuild
+if ($mapRepair.ExitCode -ne 0) {
+    throw "MAP repair build failed:`n$($mapRepair.Text)"
 }
-if ($map.Text -notmatch 'mapfile output is not yet represented') {
-    throw "Rejected /MAP did not explain the artifact-ownership boundary:`n$($map.Text)"
+if (-not (Test-Path -LiteralPath $map -PathType Leaf)) {
+    throw "Deleted linker mapfile was not repaired"
+}
+if ($mapRepair.Text -notmatch '\[link\]\s+link_side_output_probe\.exe') {
+    throw "Deleted mapfile did not invalidate the warm link cache:`n$($mapRepair.Text)"
 }
 
-Write-Host 'Real MSVC linker PDB/conditional-manifest repair and /MAP fail-closed checks passed.'
+Write-Host 'Real MSVC linker PDB/conditional-manifest/MAP repair checks passed.'
 exit 0

--- a/tests/native/verify_link_side_output_repair.ps1
+++ b/tests/native/verify_link_side_output_repair.ps1
@@ -1,0 +1,95 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$MqbPath,
+    [Parameter(Mandatory = $true)][string]$RepoRoot
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+$MqbPath = [System.IO.Path]::GetFullPath($MqbPath)
+$RepoRoot = [System.IO.Path]::GetFullPath($RepoRoot)
+if (-not (Test-Path -LiteralPath $MqbPath -PathType Leaf)) {
+    throw "MQB executable not found: $MqbPath"
+}
+
+$fixture = Join-Path $RepoRoot 'native-test-work/link-side-output-repair'
+if (Test-Path -LiteralPath $fixture) {
+    Remove-Item -LiteralPath $fixture -Recurse -Force
+}
+New-Item -ItemType Directory -Path $fixture -Force | Out-Null
+Set-Content -LiteralPath (Join-Path $fixture 'main.cpp') -Encoding utf8 -Value 'int main() { return 0; }'
+
+function Invoke-ProbeBuild {
+    param([string[]]$ExtraArguments = @())
+
+    Push-Location $fixture
+    try {
+        $output = @(& $MqbPath build main.cpp --debug --no-discover -o link_side_output_probe @ExtraArguments 2>&1)
+        $exitCode = $LASTEXITCODE
+    }
+    finally {
+        Pop-Location
+    }
+    [PSCustomObject]@{
+        ExitCode = $exitCode
+        Output = @($output | ForEach-Object { [string]$_ })
+        Text = ($output -join [Environment]::NewLine)
+    }
+}
+
+$binary = Join-Path $fixture '.mqb/bin/link_side_output_probe.exe'
+$pdb = Join-Path $fixture '.mqb/bin/link_side_output_probe.pdb'
+$manifest = Join-Path $fixture '.mqb/bin/link_side_output_probe.exe.manifest'
+
+$cold = Invoke-ProbeBuild
+if ($cold.ExitCode -ne 0) {
+    throw "Cold Debug side-output probe failed:`n$($cold.Text)"
+}
+foreach ($path in @($binary, $pdb, $manifest)) {
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+        throw "Cold Debug link did not produce required output: $path`n$($cold.Text)"
+    }
+}
+
+$warm = Invoke-ProbeBuild
+if ($warm.ExitCode -ne 0) {
+    throw "Warm side-output probe failed:`n$($warm.Text)"
+}
+if ($warm.Text -notmatch '\[up-to-date\]\s+link_side_output_probe\.exe') {
+    throw "Warm build did not reuse sealed link outputs:`n$($warm.Text)"
+}
+
+Remove-Item -LiteralPath $pdb -Force
+$pdbRepair = Invoke-ProbeBuild
+if ($pdbRepair.ExitCode -ne 0) {
+    throw "PDB repair build failed:`n$($pdbRepair.Text)"
+}
+if (-not (Test-Path -LiteralPath $pdb -PathType Leaf)) {
+    throw "Deleted linker PDB was not repaired"
+}
+if ($pdbRepair.Text -notmatch '\[link\]\s+link_side_output_probe\.exe') {
+    throw "Deleted linker PDB did not invalidate the warm link cache:`n$($pdbRepair.Text)"
+}
+
+Remove-Item -LiteralPath $manifest -Force
+$manifestRepair = Invoke-ProbeBuild
+if ($manifestRepair.ExitCode -ne 0) {
+    throw "Manifest repair build failed:`n$($manifestRepair.Text)"
+}
+if (-not (Test-Path -LiteralPath $manifest -PathType Leaf)) {
+    throw "Deleted external linker manifest was not repaired"
+}
+if ($manifestRepair.Text -notmatch '\[link\]\s+link_side_output_probe\.exe') {
+    throw "Deleted external manifest did not invalidate the warm link cache:`n$($manifestRepair.Text)"
+}
+
+$map = Invoke-ProbeBuild -ExtraArguments @('/link', '/MAP')
+if ($map.ExitCode -eq 0) {
+    throw "Untracked /MAP output was unexpectedly admitted"
+}
+if ($map.Text -notmatch 'mapfile output is not yet represented') {
+    throw "Rejected /MAP did not explain the artifact-ownership boundary:`n$($map.Text)"
+}
+
+Write-Host 'Real MSVC linker PDB/manifest repair and /MAP fail-closed checks passed.'

--- a/tests/native/verify_link_side_output_repair.ps1
+++ b/tests/native/verify_link_side_output_repair.ps1
@@ -18,7 +18,10 @@ if (Test-Path -LiteralPath $fixture) {
     Remove-Item -LiteralPath $fixture -Recurse -Force
 }
 New-Item -ItemType Directory -Path $fixture -Force | Out-Null
-Set-Content -LiteralPath (Join-Path $fixture 'main.cpp') -Encoding utf8 -Value 'int main() { return 0; }'
+@'
+#pragma comment(linker, "\"/manifestdependency:type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' processorArchitecture='*' publicKeyToken='6595b64144ccf1df' language='*'\"")
+int main() { return 0; }
+'@ | Set-Content -LiteralPath (Join-Path $fixture 'main.cpp') -Encoding utf8
 
 function Invoke-ProbeBuild {
     param([string[]]$ExtraArguments = @())
@@ -48,7 +51,7 @@ if ($cold.ExitCode -ne 0) {
 }
 foreach ($path in @($binary, $pdb, $manifest)) {
     if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
-        throw "Cold Debug link did not produce required output: $path`n$($cold.Text)"
+        throw "Cold Debug link did not produce expected output: $path`n$($cold.Text)"
     }
 }
 
@@ -92,4 +95,4 @@ if ($map.Text -notmatch 'mapfile output is not yet represented') {
     throw "Rejected /MAP did not explain the artifact-ownership boundary:`n$($map.Text)"
 }
 
-Write-Host 'Real MSVC linker PDB/manifest repair and /MAP fail-closed checks passed.'
+Write-Host 'Real MSVC linker PDB/conditional-manifest repair and /MAP fail-closed checks passed.'

--- a/tests/native/verify_msvc_parameter_inventory.ps1
+++ b/tests/native/verify_msvc_parameter_inventory.ps1
@@ -168,6 +168,7 @@ foreach ($entry in $inventory) {
     $source.Add("verify(mqb::msvc::ParameterTool::$($entry.Tool), $(ConvertToCppString ([string]$entry.Canonical)));")
 }
 $source.Add('expect(mqb::msvc::ParameterTool::linker,"/DEBUG:NONE",mqb::msvc::ParameterOwnership::passthrough);')
+$source.Add('expect(mqb::msvc::ParameterTool::linker,"/MAP",mqb::msvc::ParameterOwnership::unsupported);')
 $source.Add('expect(mqb::msvc::ParameterTool::compiler,"/Zc:trigraphs",mqb::msvc::ParameterOwnership::unsupported);')
 $source.Add('expect(mqb::msvc::ParameterTool::compiler,"/std:c11",mqb::msvc::ParameterOwnership::passthrough);')
 $source.Add('expect(mqb::msvc::ParameterTool::compiler,"/std:c17",mqb::msvc::ParameterOwnership::passthrough);')

--- a/tests/native/verify_msvc_parameter_inventory.ps1
+++ b/tests/native/verify_msvc_parameter_inventory.ps1
@@ -168,7 +168,7 @@ foreach ($entry in $inventory) {
     $source.Add("verify(mqb::msvc::ParameterTool::$($entry.Tool), $(ConvertToCppString ([string]$entry.Canonical)));")
 }
 $source.Add('expect(mqb::msvc::ParameterTool::linker,"/DEBUG:NONE",mqb::msvc::ParameterOwnership::passthrough);')
-$source.Add('expect(mqb::msvc::ParameterTool::linker,"/MAP",mqb::msvc::ParameterOwnership::unsupported);')
+$source.Add('expect(mqb::msvc::ParameterTool::linker,"/MAP",mqb::msvc::ParameterOwnership::passthrough);')
 $source.Add('expect(mqb::msvc::ParameterTool::compiler,"/Zc:trigraphs",mqb::msvc::ParameterOwnership::unsupported);')
 $source.Add('expect(mqb::msvc::ParameterTool::compiler,"/std:c11",mqb::msvc::ParameterOwnership::passthrough);')
 $source.Add('expect(mqb::msvc::ParameterTool::compiler,"/std:c17",mqb::msvc::ParameterOwnership::passthrough);')


### PR DESCRIPTION
## Summary

Closes the third post-#103 productization final-audit blocker: correctness-bearing LINK side outputs were not fully represented in MQB's incremental link cache.

## Final model

- derive effective linker PDB semantics from build configuration plus ordered raw `/DEBUG*` options;
- route effective linker debug information to deterministic MQB-owned `<target>.pdb` via final `/PDB:`;
- treat linker PDB and external manifest as conditionally observed side outputs: when real LINK produces them, seal them into `LinkCacheEntry::side_outputs`, and repair them if they disappear later;
- support old-cache migration by resealing matching PDB/manifest evidence already present on disk;
- keep `/MAP` and `/MAP:<filename>` supported as native linker passthrough, while parsing the actual mapfile path and tracking it as a strict requested side output;
- whenever an actual link action requests a mapfile, emit final `/INCREMENTAL:NO` so LINK reliably recreates a deleted `.map`; warm cache hits still skip LINK entirely;
- preserve existing DLL `.lib`/`.exp` side-output tracking;
- deliberately keep `.ilk` outside the correctness artifact set because it is rebuildable incremental-link performance state;
- pin `/MAP -> passthrough`, `/Z7 -> passthrough`, and `/Zi`/`/ZI -> unsupported` in the exact 444-entry MSVC inventory contract.

## Real MSVC regression contract

`tests/native/verify_link_side_output_repair.ps1` uses real VS2026/MSVC and verifies:

1. cold Debug link produces EXE, linker PDB, a forced external manifest, and explicit MAP;
2. warm unchanged invocation is reusable;
3. deleting the linker PDB triggers relink and repairs it;
4. deleting the external manifest triggers relink and repairs it;
5. deleting the mapfile triggers relink and repairs it.

The ambient `CL/_CL_/LINK/_LINK_` isolation regression remains green as well.

## Exact validation

Validated code tree: `38de8fd0ecaff35ad87ff2059f77b0950bb7fb6d`.
Validated code commit: `17f1731e8a34f8c0aeceab5ce0bcf97b23758c04`.

The current PR head contains only no-op commits after that validated commit; its tree is byte-for-byte identical to the validated tree.

- Native C++ #390: **success**
  - current Debug self-build: success
  - ambient MSVC option isolation: success
  - real PDB / conditional-manifest / MAP cold-warm-delete-repair gate: success
  - exact 444-entry MSVC inventory: success
  - 4/4 Debug shards + final gate: success
- Native Release #335: **success**
  - Stage 0 Release self-build: success
  - shared Release product library: success
  - 4/4 Release shards: success
  - stable self-host: success
  - runtime-only package staging/validation/upload: success
- Performance Evidence #121: skipped as expected for a correctness `fix:` PR.

## Scope boundary

This PR does not make `.ilk` a deliverable artifact. Compiler Program Database mode (`/Zi` / `/ZI`) remains a separate compile-artifact concern and is already fail-closed by PR #105.