### PR TITLE
fix: isolate LINKREPRO diagnostic artifacts

### DIFF
--- a/cpp/src/msvc/librarian/MsvcLibrarian.cpp
+++ b/cpp/src/msvc/librarian/MsvcLibrarian.cpp
@@ -35,6 +35,14 @@ void remove_if_present(const fs::path& path) noexcept {
     fs::remove(path, ignored);
 }
 
+void suppress_ambient_librarian_repro(
+    std::vector<process::EnvironmentVariable>& environment) {
+    // LINK/LIB honor the link_repro environment variable independently of the
+    // explicit argv. Repro packages are diagnostic artifact trees outside the
+    // archive cache identity, so ambient state must not enable them implicitly.
+    environment.push_back(process::EnvironmentVariable{"link_repro", {}});
+}
+
 } // namespace
 
 std::expected<LibrarianIdentity, LibrarianError>
@@ -122,6 +130,7 @@ MsvcLibrarian::archive(const ArchiveInvocation& invocation) const {
     spec.arguments = std::move(*arguments);
     spec.working_directory = invocation.working_directory;
     spec.environment = toolchain_.environment;
+    suppress_ambient_librarian_repro(spec.environment);
     spec.inherit_environment = true;
     spec.capture_stdout = true;
     spec.capture_stderr = true;

--- a/cpp/src/msvc/linker/MsvcLinker.cpp
+++ b/cpp/src/msvc/linker/MsvcLinker.cpp
@@ -65,12 +65,13 @@ namespace fs = std::filesystem;
 
 void suppress_ambient_linker_options(
     std::vector<process::EnvironmentVariable>& environment) {
-    // link.exe prepends LINK and appends _LINK_ to its explicit argv. Hidden
-    // arguments could otherwise bypass MQB-owned /OUT, target policy, tracked
-    // linker inputs, and link identity. Preserve LIB/PATH/vcvars state while
-    // making the explicit MQB argv authoritative.
+    // link.exe prepends LINK and appends _LINK_ to its explicit argv. It also
+    // honors link_repro as an implicit diagnostic-artifact request. Hidden
+    // state could otherwise bypass MQB-owned routing/cache identity. Preserve
+    // LIB/PATH/vcvars state while making the explicit MQB argv authoritative.
     environment.push_back(process::EnvironmentVariable{"LINK", {}});
     environment.push_back(process::EnvironmentVariable{"_LINK_", {}});
+    environment.push_back(process::EnvironmentVariable{"link_repro", {}});
 }
 
 [[nodiscard]] std::string linker_option_body_upper(const std::string_view argument) {

--- a/cpp/src/msvc/parameters/MsvcParameterRegistry.cpp
+++ b/cpp/src/msvc/parameters/MsvcParameterRegistry.cpp
@@ -171,6 +171,9 @@ ParameterClassification classify_linker_parameter(const std::string_view argumen
     if (body == "LTCG:INCREMENTAL" || body == "LTCG:NOSTATUS" || body == "LTCG:STATUS") return linker_unsupported(body, "current MQB LTCG policy is boolean and cannot preserve this /LTCG mode yet");
     if (body == "DRIVER" || body.starts_with("DRIVER:")) return linker_unsupported(body, "kernel-driver target shape requires a first-class MQB target policy");
     if (body == "KERNEL") return linker_unsupported(body, "kernel-mode linking is coupled to compiler policy that MQB does not model yet");
+    if (body.starts_with("LINKREPRO:") || body.starts_with("LINKREPROFULLPATHRSP:") || body.starts_with("LINKREPROTARGET:")) {
+        return linker_unsupported(body, "link repro generation creates diagnostic artifact files/directories outside MQB's link artifact graph");
+    }
 
     static constexpr std::array deprecated_exact{"POGOSAFEMODE"sv};
     static constexpr std::array deprecated_prefix{"ERRORREPORT"sv};
@@ -202,8 +205,8 @@ ParameterClassification classify_linker_parameter(const std::string_view argumen
         "ALIGN:"sv, "ALLOWBIND:"sv, "ALLOWISOLATION:"sv, "APPCONTAINER:"sv, "ARM64XFUNCTIONPADMINX64:"sv, "ASSEMBLYDEBUG:"sv, "BASE:"sv,
         "CETCOMPAT:"sv, "CGTHREADS:"sv, "CLRIMAGETYPE:"sv, "COMMENT:"sv, "DEBUGTYPE:"sv, "DEF:"sv, "DEFAULTLIB:"sv, "DELAY:"sv, "DELAYSIGN:"sv, "DELAYLOAD:"sv,
         "DEPENDENTLOADFLAG:"sv, "DYNAMICBASE:"sv, "ENTRY:"sv, "EXPORT:"sv, "FILEALIGN:"sv, "FIXED:"sv, "FORCE:"sv, "GUARD:"sv,
-        "HEAP:"sv, "HIGHENTROPYVA:"sv, "IGNORE:"sv, "INCLUDE:"sv, "LARGEADDRESSAWARE:"sv, "LINKREPRO:"sv, "LINKREPROFULLPATHRSP:"sv,
-        "LINKREPROTARGET:"sv, "MANIFEST:"sv, "MANIFESTDEPENDENCY:"sv, "MANIFESTINPUT:"sv, "MANIFESTUAC:"sv, "MAP:"sv, "MAPINFO:"sv, "MERGE:"sv,
+        "HEAP:"sv, "HIGHENTROPYVA:"sv, "IGNORE:"sv, "INCLUDE:"sv, "LARGEADDRESSAWARE:"sv,
+        "MANIFEST:"sv, "MANIFESTDEPENDENCY:"sv, "MANIFESTINPUT:"sv, "MANIFESTUAC:"sv, "MAP:"sv, "MAPINFO:"sv, "MERGE:"sv,
         "NODEFAULTLIB:"sv, "NXCOMPAT:"sv, "OPT:"sv, "ORDER:"sv, "PDBALTPATH:"sv, "SAFESEH:"sv, "SECTION:"sv, "STACK:"sv, "STUB:"sv, "SWAPRUN:"sv,
         "TIMESTAMP:"sv, "TLBID:"sv, "TSAWARE:"sv, "VERSION:"sv, "WHOLEARCHIVE:"sv,
     };
@@ -239,9 +242,12 @@ ParameterClassification classify_librarian_parameter(const std::string_view argu
     if (body.starts_with("OUT:")) return classified(ParameterTool::librarian, ParameterOwnership::mqb_owned, "/OUT", "MQB owns archive output identity and atomic replacement");
     if (body == "LIST" || body.starts_with("DEF:") || body.starts_with("EXTRACT:") || body.starts_with("NAME:") || body.starts_with("REMOVE:")) return librarian_unsupported(body, "option changes lib.exe operating mode or archive membership outside MQB's build graph");
     if (body.starts_with("ERRORREPORT")) return librarian_unsupported(body, "option is deprecated in current MSVC toolchains");
+    if (body.starts_with("LINKREPRO:") || body.starts_with("LINKREPROTARGET:")) {
+        return librarian_unsupported(body, "library repro generation creates diagnostic artifact files/directories outside MQB's archive artifact graph");
+    }
 
     static constexpr std::array passthrough_exact{"?"sv, "NODEFAULTLIB"sv, "NOLOGO"sv, "VERBOSE"sv, "WX"sv, "WX:NO"sv};
-    static constexpr std::array passthrough_prefix{"EXPORT:"sv, "INCLUDE:"sv, "LIBPATH:"sv, "LINKREPRO:"sv, "LINKREPROTARGET:"sv, "NODEFAULTLIB:"sv, "SUBSYSTEM:"sv};
+    static constexpr std::array passthrough_prefix{"EXPORT:"sv, "INCLUDE:"sv, "LIBPATH:"sv, "NODEFAULTLIB:"sv, "SUBSYSTEM:"sv};
     if (contains_exact(std::string_view{body}, passthrough_exact) || starts_with_any(std::string_view{body}, passthrough_prefix)) {
         return classified(ParameterTool::librarian, ParameterOwnership::passthrough, "/" + body, "validated librarian option is preserved verbatim in archive identity");
     }

--- a/tests/native/verify_link_side_output_repair.ps1
+++ b/tests/native/verify_link_side_output_repair.ps1
@@ -22,18 +22,50 @@ New-Item -ItemType Directory -Path $fixture -Force | Out-Null
 #pragma comment(linker, "\"/manifestdependency:type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' processorArchitecture='*' publicKeyToken='6595b64144ccf1df' language='*'\"")
 int main() { return 0; }
 '@ | Set-Content -LiteralPath (Join-Path $fixture 'main.cpp') -Encoding utf8
+Set-Content -LiteralPath (Join-Path $fixture 'static.cpp') -Encoding utf8 -Value 'int static_value() { return 42; }'
 
 $binary = Join-Path $fixture '.mqb/bin/link_side_output_probe.exe'
 $pdb = Join-Path $fixture '.mqb/bin/link_side_output_probe.pdb'
 $manifest = Join-Path $fixture '.mqb/bin/link_side_output_probe.exe.manifest'
 $map = Join-Path $fixture 'link_side_output_probe.map'
+$staticLibrary = Join-Path $fixture '.mqb/bin/link_repro_static.lib'
+$linkRepro = Join-Path $fixture 'ambient-link-repro'
+New-Item -ItemType Directory -Path $linkRepro -Force | Out-Null
+
+function Invoke-WithAmbientLinkRepro {
+    param([Parameter(Mandatory = $true)][scriptblock]$Action)
+
+    $hadPrevious = Test-Path Env:link_repro
+    $previous = if ($hadPrevious) { $env:link_repro } else { $null }
+    $env:link_repro = $linkRepro
+    try {
+        & $Action
+    }
+    finally {
+        if ($hadPrevious) {
+            $env:link_repro = $previous
+        }
+        else {
+            Remove-Item Env:link_repro -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+function Assert-NoAmbientLinkReproArtifacts {
+    $artifacts = @(Get-ChildItem -LiteralPath $linkRepro -Force -ErrorAction Stop)
+    if ($artifacts.Count -ne 0) {
+        throw "Ambient link_repro leaked diagnostic artifacts: $($artifacts.FullName -join ', ')"
+    }
+}
 
 function Invoke-ProbeBuild {
     Push-Location $fixture
     try {
         $output = @(
-            & $MqbPath build main.cpp --debug --no-discover -o link_side_output_probe `
-                /link "/MAP:$map" 2>&1
+            Invoke-WithAmbientLinkRepro {
+                & $MqbPath build main.cpp --debug --no-discover -o link_side_output_probe `
+                    /link "/MAP:$map" 2>&1
+            }
         )
         $exitCode = $LASTEXITCODE
     }
@@ -56,6 +88,7 @@ foreach ($path in @($binary, $pdb, $manifest, $map)) {
         throw "Cold Debug link did not produce expected output: $path`n$($cold.Text)"
     }
 }
+Assert-NoAmbientLinkReproArtifacts
 
 $warm = Invoke-ProbeBuild
 if ($warm.ExitCode -ne 0) {
@@ -64,6 +97,7 @@ if ($warm.ExitCode -ne 0) {
 if ($warm.Text -notmatch '\[up-to-date\]\s+link_side_output_probe\.exe') {
     throw "Warm build did not reuse sealed link outputs:`n$($warm.Text)"
 }
+Assert-NoAmbientLinkReproArtifacts
 
 Remove-Item -LiteralPath $pdb -Force
 $pdbRepair = Invoke-ProbeBuild
@@ -76,6 +110,7 @@ if (-not (Test-Path -LiteralPath $pdb -PathType Leaf)) {
 if ($pdbRepair.Text -notmatch '\[link\]\s+link_side_output_probe\.exe') {
     throw "Deleted linker PDB did not invalidate the warm link cache:`n$($pdbRepair.Text)"
 }
+Assert-NoAmbientLinkReproArtifacts
 
 Remove-Item -LiteralPath $manifest -Force
 $manifestRepair = Invoke-ProbeBuild
@@ -88,6 +123,7 @@ if (-not (Test-Path -LiteralPath $manifest -PathType Leaf)) {
 if ($manifestRepair.Text -notmatch '\[link\]\s+link_side_output_probe\.exe') {
     throw "Deleted external manifest did not invalidate the warm link cache:`n$($manifestRepair.Text)"
 }
+Assert-NoAmbientLinkReproArtifacts
 
 Remove-Item -LiteralPath $map -Force
 $mapRepair = Invoke-ProbeBuild
@@ -100,6 +136,48 @@ if (-not (Test-Path -LiteralPath $map -PathType Leaf)) {
 if ($mapRepair.Text -notmatch '\[link\]\s+link_side_output_probe\.exe') {
     throw "Deleted mapfile did not invalidate the warm link cache:`n$($mapRepair.Text)"
 }
+Assert-NoAmbientLinkReproArtifacts
 
-Write-Host 'Real MSVC linker PDB/conditional-manifest/MAP repair checks passed.'
+Push-Location $fixture
+try {
+    $staticOutput = @(
+        Invoke-WithAmbientLinkRepro {
+            & $MqbPath build static.cpp --debug --no-discover --type static -o link_repro_static 2>&1
+        }
+    )
+    $staticExit = $LASTEXITCODE
+}
+finally {
+    Pop-Location
+}
+if ($staticExit -ne 0) {
+    throw "Static-library ambient link_repro probe failed:`n$($staticOutput -join [Environment]::NewLine)"
+}
+if (-not (Test-Path -LiteralPath $staticLibrary -PathType Leaf)) {
+    throw "Static-library ambient link_repro probe did not produce expected archive: $staticLibrary"
+}
+Assert-NoAmbientLinkReproArtifacts
+
+$explicitRepro = Join-Path $fixture 'explicit-link-repro'
+New-Item -ItemType Directory -Path $explicitRepro -Force | Out-Null
+Push-Location $fixture
+try {
+    $rejected = @(& $MqbPath build main.cpp --debug --no-discover -o rejected_repro /link "/LINKREPRO:$explicitRepro" 2>&1)
+    $rejectedExit = $LASTEXITCODE
+}
+finally {
+    Pop-Location
+}
+if ($rejectedExit -eq 0) {
+    throw "Explicit /LINKREPRO artifact mode was unexpectedly admitted"
+}
+$rejectedText = $rejected -join [Environment]::NewLine
+if ($rejectedText -notmatch 'diagnostic artifact') {
+    throw "Rejected /LINKREPRO did not explain its artifact-ownership boundary:`n$rejectedText"
+}
+if (@(Get-ChildItem -LiteralPath $explicitRepro -Force).Count -ne 0) {
+    throw "Rejected /LINKREPRO still produced diagnostic artifacts"
+}
+
+Write-Host 'Real MSVC PDB/manifest/MAP repair plus LINK/LIB link_repro isolation checks passed.'
 exit 0


### PR DESCRIPTION
## Summary

Closes the next post-#103 final-audit ownership gap: MSVC LINK/LIB repro generation could escape MQB's parameter/artifact model through both explicit `/LINKREPRO*` options and the ambient `link_repro` environment variable.

## Problem

Microsoft documents `/LINKREPRO:<directory>` as generating diagnostic repro artifacts for both the linker and library tool, with the same behavior also available through the `link_repro` environment variable. MQB previously classified the LINK/LIB `/LINKREPRO*` families as safe passthrough and did not clear `link_repro`, so builds could create untracked artifact trees outside cache identity.

## Fix

- linker `/LINKREPRO:`, `/LINKREPROFULLPATHRSP:`, `/LINKREPROTARGET:` -> explicit unsupported/Class D;
- librarian `/LINKREPRO:`, `/LINKREPROTARGET:` -> explicit unsupported/Class D;
- clear ambient `link_repro` in every `link.exe` ProcessSpec while preserving vcvars/LIB/PATH state;
- clear ambient `link_repro` in every `lib.exe` ProcessSpec;
- extend the real-MSVC side-output gate with a pre-created ambient repro directory and prove ordinary EXE LINK plus static-library LIB leave it empty;
- verify explicit linker `/LINKREPRO:<dir>` is rejected before LINK and creates no artifacts.

## Real MSVC regression evidence

Exact validated head: `ace230159b89ec9129746c786b31343f30182a45`.

- Native C++ #396: **success**
  - current Debug self-build: success
  - ambient `CL/_CL_/LINK/_LINK_` isolation: success
  - real PDB/manifest/MAP repair + LINK/LIB `link_repro` isolation: success
  - exact 444-entry MSVC inventory: success
  - 4/4 Debug shards + final gate: success
- Native Release #340: **success**
  - Stage 0 Release self-build: success
  - shared Release native-test product library: success
  - 4/4 Release shards: success
  - stable self-host: success
  - runtime-only package staging/validation/upload: success
- Performance Evidence #128: skipped as expected for a correctness `fix:` PR.

## Scope

This PR intentionally does not make link repro packages first-class build artifacts. They are diagnostic/support bundles rather than normal target outputs, so fail-closed explicit ownership plus ambient isolation is the minimal correct product boundary.

Base: `9f3c405d44bb6cc9ab0e9e68b5a18a9790f609d3`.