### PR TITLE
fix: track raw WHOLEARCHIVE library freshness

### DIFF
--- a/cpp/include/mqb/msvc/MsvcWholeArchivePolicy.hpp
+++ b/cpp/include/mqb/msvc/MsvcWholeArchivePolicy.hpp
@@ -1,0 +1,110 @@
+#pragma once
+
+#include <algorithm>
+#include <expected>
+#include <filesystem>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "mqb/msvc/MsvcParameterEngine.hpp"
+
+namespace mqb::msvc {
+
+struct WholeArchiveRouting {
+    std::vector<std::string> passthrough;
+    // Every path-bearing /WHOLEARCHIVE:<library> is an actual required LINK
+    // input. Bare /WHOLEARCHIVE introduces no additional library by itself.
+    std::vector<std::string> libraries;
+};
+
+class MsvcWholeArchivePolicy {
+public:
+    [[nodiscard]] static std::expected<WholeArchiveRouting, ParameterError>
+    route(
+        const std::span<const std::string> arguments,
+        const std::optional<std::filesystem::path> path_base = std::nullopt) {
+        auto validated = MsvcParameterEngine::route_linker(arguments);
+        if (!validated) {
+            return std::unexpected(validated.error());
+        }
+
+        const auto starts_with_ascii_ci = [](
+            const std::string_view value,
+            const std::string_view prefix) {
+            if (value.size() < prefix.size()) return false;
+            for (std::size_t index = 0; index < prefix.size(); ++index) {
+                char left = value[index];
+                char right = prefix[index];
+                if (left >= 'a' && left <= 'z') left = static_cast<char>(left - 'a' + 'A');
+                if (right >= 'a' && right <= 'z') right = static_cast<char>(right - 'a' + 'A');
+                if (left != right) return false;
+            }
+            return true;
+        };
+        const auto path_from_utf8 = [](const std::string_view value) {
+            std::u8string bytes;
+            bytes.assign(
+                reinterpret_cast<const char8_t*>(value.data()),
+                reinterpret_cast<const char8_t*>(value.data() + value.size()));
+            return std::filesystem::path{bytes};
+        };
+        const auto path_text = [](const std::filesystem::path& path) {
+            const auto bytes = path.generic_u8string();
+            return std::string{
+                reinterpret_cast<const char*>(bytes.data()),
+                bytes.size()};
+        };
+        const auto path_bearing_library = [](const std::filesystem::path& library) {
+            return library.has_root_path() || library.has_parent_path();
+        };
+
+        WholeArchiveRouting result;
+        result.passthrough.reserve(validated->passthrough.size());
+
+        for (const auto& argument : validated->passthrough) {
+            const std::string_view body = argument.size() >= 2
+                    && (argument.front() == '/' || argument.front() == '-')
+                ? std::string_view{argument}.substr(1)
+                : std::string_view{};
+
+            constexpr std::string_view prefix = "WHOLEARCHIVE:";
+            if (!starts_with_ascii_ci(body, prefix)) {
+                result.passthrough.push_back(argument);
+                continue;
+            }
+            if (body.size() == prefix.size()) {
+                return std::unexpected(ParameterError{
+                    .code = ParameterErrorCode::invalid_value,
+                    .tool = ParameterTool::linker,
+                    .argument = argument,
+                    .message = "MSVC linker /WHOLEARCHIVE:<library> requires a library name or path",
+                });
+            }
+
+            const std::string_view payload = body.substr(prefix.size());
+            std::filesystem::path library = path_from_utf8(payload);
+            if (path_base && path_bearing_library(library) && library.is_relative()) {
+                library = (*path_base / library).lexically_normal();
+            } else if (path_bearing_library(library)) {
+                library = library.lexically_normal();
+            }
+
+            const std::string request = path_bearing_library(library)
+                ? path_text(library)
+                : std::string{payload};
+            result.libraries.push_back(request);
+            result.passthrough.push_back(
+                path_bearing_library(library)
+                    ? argument.substr(0, 1 + prefix.size()) + request
+                    : argument);
+        }
+
+        return result;
+    }
+};
+
+} // namespace mqb::msvc

--- a/cpp/src/orchestration/incremental/MsvcIncrementalLinkCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalLinkCoordinator.cpp
@@ -19,6 +19,7 @@
 #include "mqb/msvc/MsvcLibraryResolver.hpp"
 #include "mqb/msvc/MsvcLinker.hpp"
 #include "mqb/msvc/MsvcParameterEngine.hpp"
+#include "mqb/msvc/MsvcWholeArchivePolicy.hpp"
 
 #include "IncrementalFileSnapshot.hpp"
 
@@ -173,6 +174,18 @@ MsvcIncrementalLinkCoordinator::run(const IncrementalLinkRequest& request) const
         });
     }
 
+    auto whole_archive_routing = msvc::MsvcWholeArchivePolicy::route(
+        request.options.additional_arguments,
+        request.working_directory);
+    if (!whole_archive_routing) {
+        return std::unexpected(IncrementalLinkError{
+            .code = IncrementalLinkErrorCode::linker_parameter_invalid,
+            .message = "invalid native MSVC WHOLEARCHIVE policy: "
+                + whole_archive_routing.error().message,
+            .parameter_error = whole_archive_routing.error(),
+        });
+    }
+
     const fs::path working_directory =
         request.working_directory.value_or(fs::path{});
     auto resolved_libraries = msvc::MsvcLibraryResolver::resolve(
@@ -207,6 +220,28 @@ MsvcIncrementalLinkCoordinator::run(const IncrementalLinkRequest& request) const
         linker_file_inputs.end(),
         resolved_default_libraries->files.begin(),
         resolved_default_libraries->files.end());
+
+    if (!whole_archive_routing->libraries.empty()) {
+        LinkOptions whole_archive_options = request.options;
+        whole_archive_options.libraries = whole_archive_routing->libraries;
+        auto resolved_whole_archive_libraries = msvc::MsvcLibraryResolver::resolve(
+            toolchain_,
+            whole_archive_options,
+            working_directory);
+        if (!resolved_whole_archive_libraries) {
+            IncrementalLinkError error{
+                .code = IncrementalLinkErrorCode::library_resolution_failed,
+                .message = "failed to resolve MSVC /WHOLEARCHIVE library input: "
+                    + resolved_whole_archive_libraries.error().message,
+                .library_resolution_error = resolved_whole_archive_libraries.error(),
+            };
+            return std::unexpected(std::move(error));
+        }
+        linker_file_inputs.insert(
+            linker_file_inputs.end(),
+            resolved_whole_archive_libraries->files.begin(),
+            resolved_whole_archive_libraries->files.end());
+    }
 
     const std::optional<fs::path> requested_map_output =
         msvc::MsvcLinker::map_file_path(

--- a/cpp/tests/msvc/linker/library_resolver_tests.cpp
+++ b/cpp/tests/msvc/linker/library_resolver_tests.cpp
@@ -11,6 +11,7 @@
 #include "mqb/msvc/MsvcDefaultLibraryPolicy.hpp"
 #include "mqb/msvc/MsvcLibraryResolver.hpp"
 #include "mqb/msvc/MsvcToolchainLocator.hpp"
+#include "mqb/msvc/MsvcWholeArchivePolicy.hpp"
 
 namespace {
 
@@ -168,6 +169,51 @@ int main() {
     const std::vector<std::string> invalid_ignore_args{"/NODEFAULTLIB:"};
     const auto invalid_ignore = mqb::msvc::MsvcDefaultLibraryPolicy::route(invalid_ignore_args);
     expect(!invalid_ignore, "empty NODEFAULTLIB:name declaration must fail before LINK");
+
+    const std::vector<std::string> whole_archive_args{
+        "/WHOLEARCHIVE",
+        "/WHOLEARCHIVE:math",
+        "/WHOLEARCHIVE:nested/direct",
+    };
+    const auto whole_archive = mqb::msvc::MsvcWholeArchivePolicy::route(
+        whole_archive_args,
+        work);
+    expect(whole_archive.has_value(), "valid WHOLEARCHIVE policy should route");
+    if (whole_archive) {
+        expect(whole_archive->passthrough.size() == whole_archive_args.size(),
+               "WHOLEARCHIVE observation must preserve raw linker argument count/order");
+        expect(whole_archive->libraries.size() == 2,
+               "bare WHOLEARCHIVE must not invent an input while path-bearing forms must be tracked");
+        if (whole_archive->libraries.size() == 2) {
+            expect(whole_archive->libraries[0] == "math",
+                   "bare WHOLEARCHIVE library name should preserve linker search semantics");
+            expect(whole_archive->libraries[1]
+                       == path_text((work / "nested/direct").lexically_normal()),
+                   "path-bearing WHOLEARCHIVE should resolve against its supplying layer base");
+
+            mqb::LinkOptions whole_archive_options;
+            whole_archive_options.library_directories = {explicit_dir};
+            whole_archive_options.libraries = whole_archive->libraries;
+            const auto whole_archive_files = mqb::msvc::MsvcLibraryResolver::resolve(
+                toolchain,
+                whole_archive_options,
+                work);
+            expect(whole_archive_files.has_value(),
+                   "WHOLEARCHIVE libraries should resolve as required LINK inputs");
+            if (whole_archive_files && whole_archive_files->files.size() == 2) {
+                expect(whole_archive_files->files[0] == explicit_math.lexically_normal(),
+                       "WHOLEARCHIVE bare names should share structured -L search precedence");
+                expect(whole_archive_files->files[1] == direct.lexically_normal(),
+                       "WHOLEARCHIVE path inputs should resolve to exact freshness files");
+            }
+        }
+    }
+
+    const auto invalid_whole_archive = mqb::msvc::MsvcWholeArchivePolicy::route(
+        std::vector<std::string>{"/WHOLEARCHIVE:"},
+        work);
+    expect(!invalid_whole_archive,
+           "empty WHOLEARCHIVE library declaration must fail before LINK");
 
     const std::vector<std::string> available_requests{
         "math",

--- a/tests/native/verify_link_side_output_repair.ps1
+++ b/tests/native/verify_link_side_output_repair.ps1
@@ -179,5 +179,93 @@ if (@(Get-ChildItem -LiteralPath $explicitRepro -Force).Count -ne 0) {
     throw "Rejected /LINKREPRO still produced diagnostic artifacts"
 }
 
-Write-Host 'Real MSVC PDB/manifest/MAP repair plus LINK/LIB link_repro isolation checks passed.'
+# Raw /WHOLEARCHIVE:<library> is itself a required LINK input. It must not need
+# a duplicate structured --lib declaration merely to participate in freshness.
+$wholeArchiveRoot = Join-Path $fixture 'wholearchive'
+New-Item -ItemType Directory -Path $wholeArchiveRoot -Force | Out-Null
+$wholeLibrarySource = Join-Path $wholeArchiveRoot 'library.cpp'
+$wholeMainSource = Join-Path $wholeArchiveRoot 'consumer.cpp'
+Set-Content -LiteralPath $wholeLibrarySource -Encoding utf8 -Value 'int whole_value() { return 100; }'
+Set-Content -LiteralPath $wholeMainSource -Encoding utf8 -Value @(
+    'int whole_value();',
+    'int main() { return whole_value() == 100 ? 0 : 1; }'
+)
+
+function Invoke-WholeArchiveLibraryBuild {
+    Push-Location $wholeArchiveRoot
+    try {
+        $output = @(& $MqbPath build library.cpp --debug --no-discover --type static -o whole_input 2>&1)
+        $exitCode = $LASTEXITCODE
+    }
+    finally {
+        Pop-Location
+    }
+    [PSCustomObject]@{ ExitCode = $exitCode; Text = ($output -join [Environment]::NewLine) }
+}
+
+function Invoke-WholeArchiveConsumerBuild {
+    Push-Location $wholeArchiveRoot
+    try {
+        $output = @(
+            & $MqbPath build consumer.cpp --debug --no-discover -o whole_consumer `
+                -L '.mqb/bin' /link '/WHOLEARCHIVE:whole_input.lib' 2>&1
+        )
+        $exitCode = $LASTEXITCODE
+    }
+    finally {
+        Pop-Location
+    }
+    [PSCustomObject]@{ ExitCode = $exitCode; Text = ($output -join [Environment]::NewLine) }
+}
+
+$wholeLibrary = Join-Path $wholeArchiveRoot '.mqb/bin/whole_input.lib'
+$wholeExecutable = Join-Path $wholeArchiveRoot '.mqb/bin/whole_consumer.exe'
+$wholeColdLibrary = Invoke-WholeArchiveLibraryBuild
+if ($wholeColdLibrary.ExitCode -ne 0 -or -not (Test-Path -LiteralPath $wholeLibrary -PathType Leaf)) {
+    throw "WHOLEARCHIVE fixture library cold build failed:`n$($wholeColdLibrary.Text)"
+}
+$wholeCold = Invoke-WholeArchiveConsumerBuild
+if ($wholeCold.ExitCode -ne 0 -or -not (Test-Path -LiteralPath $wholeExecutable -PathType Leaf)) {
+    throw "Raw WHOLEARCHIVE cold consumer build failed:`n$($wholeCold.Text)"
+}
+& $wholeExecutable
+if ($LASTEXITCODE -ne 0) {
+    throw "Raw WHOLEARCHIVE cold executable did not consume the library"
+}
+
+$wholeWarm = Invoke-WholeArchiveConsumerBuild
+if ($wholeWarm.ExitCode -ne 0) {
+    throw "Raw WHOLEARCHIVE warm consumer build failed:`n$($wholeWarm.Text)"
+}
+if ($wholeWarm.Text -notmatch '\[up-to-date\]\s+whole_consumer\.exe') {
+    throw "Raw WHOLEARCHIVE warm build did not reuse link cache:`n$($wholeWarm.Text)"
+}
+
+$wholeExecutableTime = (Get-Item -LiteralPath $wholeExecutable).LastWriteTimeUtc
+Set-Content -LiteralPath $wholeLibrarySource -Encoding utf8 -Value 'int whole_value() { return 101; }'
+$wholeChangedLibrary = Invoke-WholeArchiveLibraryBuild
+if ($wholeChangedLibrary.ExitCode -ne 0) {
+    throw "WHOLEARCHIVE fixture library rebuild failed:`n$($wholeChangedLibrary.Text)"
+}
+(Get-Item -LiteralPath $wholeLibrary).LastWriteTimeUtc = $wholeExecutableTime.AddSeconds(2)
+
+$wholeChanged = Invoke-WholeArchiveConsumerBuild
+if ($wholeChanged.ExitCode -ne 0) {
+    throw "Raw WHOLEARCHIVE changed-library build failed:`n$($wholeChanged.Text)"
+}
+if ($wholeChanged.Text -notmatch '\[up-to-date\]\s+consumer\.cpp') {
+    throw "WHOLEARCHIVE library-only change unexpectedly recompiled consumer.cpp:`n$($wholeChanged.Text)"
+}
+if ($wholeChanged.Text -notmatch '\[link\]\s+whole_consumer\.exe') {
+    throw "Changed raw WHOLEARCHIVE library did not trigger relink:`n$($wholeChanged.Text)"
+}
+if ($wholeChanged.Text -notmatch 'link inputs changed') {
+    throw "WHOLEARCHIVE library-driven relink was not explained as link inputs changed:`n$($wholeChanged.Text)"
+}
+& $wholeExecutable
+if ($LASTEXITCODE -eq 0) {
+    throw "Relinked WHOLEARCHIVE executable still contains stale library behavior"
+}
+
+Write-Host 'Real MSVC linker side-output/repro isolation plus raw WHOLEARCHIVE freshness checks passed.'
 exit 0


### PR DESCRIPTION
## Summary

Closes the next post-#103 final-audit freshness gap: `/WHOLEARCHIVE:<library>` was accepted as native LINK passthrough but the library could remain outside MQB's link input graph unless the user duplicated it through structured `--lib`.

## Problem

MSVC `/WHOLEARCHIVE:<library>` names an actual static-library input. MQB preserved the raw switch in link identity, but link freshness only tracked structured libraries plus a few recognized file-bearing options. A raw-only WHOLEARCHIVE library could therefore change while MQB still considered the target up to date.

## Fix

- add `MsvcWholeArchivePolicy` as a dedicated linker-input policy, symmetric with default-library policy;
- keep bare `/WHOLEARCHIVE` as passthrough with no invented input;
- parse every `/WHOLEARCHIVE:<library>` declaration as a required library request while preserving LINK argv/order;
- normalize path-bearing declarations against their supplying link working directory;
- resolve those requests through the existing `-L -> working directory -> MSVC LIB` library search policy;
- append exact resolved `.lib` paths to the generic link file-input freshness graph;
- fail before LINK if a declared WHOLEARCHIVE library cannot be resolved;
- because WHOLEARCHIVE files enter `file_inputs`, a library-only change triggers `link inputs changed` and forces a full relink.

## Real MSVC regression evidence

Exact validated head: `7c14efa293c147bc15fe3f84990f6239b88fc9c9`.

- Native C++ #398: **success**
  - current Debug self-build: success
  - ambient MSVC option isolation: success
  - real linker side-output/repro isolation gate: success
  - raw-only WHOLEARCHIVE cold/warm/library-change freshness gate: success
  - exact 444-entry MSVC inventory: success
  - 4/4 Debug shards + final gate: success
- Native Release #341: **success**
  - Stage 0 Release self-build: success
  - shared Release product library: success
  - 4/4 Release shards: success
  - stable self-host: success
  - runtime-only package staging/validation/upload: success
- Performance Evidence #131: skipped as expected for a correctness `fix:` PR.

The raw WHOLEARCHIVE regression uses only:

`-L .mqb/bin /link /WHOLEARCHIVE:whole_input.lib`

with no structured `--lib`. It proves cold link, warm no-op, then rebuilds only the archive and requires consumer TU reuse + relink + `link inputs changed`; the executable is run afterward to prove the new archive bytes were consumed.

## Scope

Bare `/WHOLEARCHIVE` remains supported and introduces no separate input; it only changes extraction policy for libraries already present in the effective LINK invocation. This PR does not rewrite raw WHOLEARCHIVE switches into structured `--lib` declarations.