### PR TITLE
fix: fail closed on environment-backed external includes

### DIFF
--- a/.github/workflows/native-ci.yml
+++ b/.github/workflows/native-ci.yml
@@ -102,6 +102,14 @@ jobs:
             Pop-Location
           }
 
+      - name: Verify external environment include ownership
+        shell: pwsh
+        run: |
+          & (Join-Path $PWD 'tests/native/verify_external_env_ownership.ps1') `
+            -MqbPath (Join-Path $PWD 'native-out/debug/mqb.exe') `
+            -RepoRoot $PWD
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
       - name: Verify linker side-output repair
         shell: pwsh
         run: |

--- a/cpp/src/msvc/parameters/MsvcParameterRegistry.cpp
+++ b/cpp/src/msvc/parameters/MsvcParameterRegistry.cpp
@@ -92,6 +92,9 @@ ParameterClassification classify_compiler_parameter(const std::string_view argum
     if (body == "FU" || body.starts_with("FU")) {
         return compiler_unsupported(body, "forced metadata references introduce an external file input that is not represented in MQB's compile freshness graph");
     }
+    if (body == "external:env" || body.starts_with("external:env:")) {
+        return compiler_unsupported(body, "environment-backed external include directories can change header search without entering MQB's compile identity or discovery model; use explicit /external:I or -I paths instead");
+    }
     if (body == "experimental:log" || body.starts_with("experimental:log")) {
         return compiler_unsupported(body, "option creates a diagnostic log artifact that is not represented in MQB's cache/artifact graph");
     }
@@ -213,7 +216,7 @@ ParameterClassification classify_linker_parameter(const std::string_view argumen
     if (contains_exact(std::string_view{body}, passthrough_exact) || starts_with_any(std::string_view{body}, passthrough_prefix)) {
         return classified(ParameterTool::linker, ParameterOwnership::passthrough, "/" + body,
             body.starts_with("WHOLEARCHIVE:")
-                ? "path-bearing /WHOLEARCHIVE is preserved in link identity; declare the same library through structured --lib input so freshness is tracked"
+                ? "path-bearing /WHOLEARCHIVE is preserved in linker argv and its resolved library is tracked through MQB's generic link file-input freshness graph"
                 : body.starts_with("DEFAULTLIB:")
                     ? "user-declared default library remains in raw LINK argv while MQB resolves the effective declaration separately for freshness without changing library search priority"
                     : body.starts_with("DEF:")

--- a/tests/native/verify_external_env_ownership.ps1
+++ b/tests/native/verify_external_env_ownership.ps1
@@ -1,0 +1,83 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$MqbPath,
+    [Parameter(Mandatory = $true)][string]$RepoRoot
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+$MqbPath = [System.IO.Path]::GetFullPath($MqbPath)
+$RepoRoot = [System.IO.Path]::GetFullPath($RepoRoot)
+if (-not (Test-Path -LiteralPath $MqbPath -PathType Leaf)) {
+    throw "MQB executable not found: $MqbPath"
+}
+
+$fixture = Join-Path $RepoRoot 'native-test-work/external-env-ownership'
+if (Test-Path -LiteralPath $fixture) {
+    Remove-Item -LiteralPath $fixture -Recurse -Force
+}
+$includeDir = Join-Path $fixture 'external include'
+New-Item -ItemType Directory -Path $includeDir -Force | Out-Null
+Set-Content -LiteralPath (Join-Path $includeDir 'external_value.hpp') -Encoding utf8 -Value '#define MQB_EXTERNAL_VALUE 73'
+Set-Content -LiteralPath (Join-Path $fixture 'main.cpp') -Encoding utf8 -Value @(
+    '#include <external_value.hpp>',
+    'int main() { return MQB_EXTERNAL_VALUE == 73 ? 0 : 1; }'
+)
+
+$hadPrevious = Test-Path Env:MQB_EXTERNAL_INCLUDE
+$previous = if ($hadPrevious) { $env:MQB_EXTERNAL_INCLUDE } else { $null }
+$env:MQB_EXTERNAL_INCLUDE = $includeDir
+try {
+    Push-Location $fixture
+    try {
+        $rejected = @(
+            & $MqbPath build main.cpp --debug --no-discover -o external_env_rejected `
+                /external:W0 /external:env:MQB_EXTERNAL_INCLUDE 2>&1
+        )
+        $rejectedExit = $LASTEXITCODE
+    }
+    finally {
+        Pop-Location
+    }
+}
+finally {
+    if ($hadPrevious) {
+        $env:MQB_EXTERNAL_INCLUDE = $previous
+    }
+    else {
+        Remove-Item Env:MQB_EXTERNAL_INCLUDE -ErrorAction SilentlyContinue
+    }
+}
+
+$rejectedText = $rejected -join [Environment]::NewLine
+if ($rejectedExit -eq 0) {
+    throw "Environment-backed /external:env unexpectedly reached cl.exe and compiled successfully"
+}
+if ($rejectedText -notmatch '/external:env:MQB_EXTERNAL_INCLUDE') {
+    throw "Rejected /external:env request did not identify the native option:`n$rejectedText"
+}
+if ($rejectedText -notmatch 'environment-backed external include') {
+    throw "Rejected /external:env request did not explain the hidden include-search ownership boundary:`n$rejectedText"
+}
+
+# The deterministic native replacement stays fully supported: explicit
+# /external:I carries the actual directory in argv/compile identity and MQB's
+# discovery/include model rather than naming ambient environment state.
+Push-Location $fixture
+try {
+    $explicit = @(
+        & $MqbPath run main.cpp --debug --no-discover -o external_explicit `
+            /external:W0 "/external:I$includeDir" 2>&1
+    )
+    $explicitExit = $LASTEXITCODE
+}
+finally {
+    Pop-Location
+}
+if ($explicitExit -ne 0) {
+    throw "Explicit /external:I replacement failed:`n$($explicit -join [Environment]::NewLine)"
+}
+
+Write-Host 'MSVC /external:env ownership boundary and explicit /external:I replacement checks passed.'
+exit 0


### PR DESCRIPTION
## Summary

Closes the next post-#103 compiler-input ownership gap: MSVC `/external:env:<var>` could alter actual header search through environment state that is not represented in MQB's compile identity or source-discovery model.

## Why fail closed instead of expanding it

Microsoft defines `/external:env:<var>` as reading a semicolon-separated external include-directory list from an environment variable; `/external:I` is the deterministic explicit-path form. MQB normalizes config/profile/CLI native parameters before toolchain discovery, while Visual Studio environment capture occurs later after `vcvarsall`. Therefore the effective value of environment variables such as `INCLUDE` may differ from the parent process value available during source discovery. Expanding early risks modeling the wrong include search; moving toolchain discovery ahead of source discovery would be a wider architecture change.

## Fix

- classify `/external:env` and `/external:env:*` as explicit unsupported/Class D before the broad `/external:*` passthrough family;
- explain that environment-backed external include paths can change header search outside compile identity/discovery;
- direct users to deterministic `/external:I` or `-I` paths instead;
- keep all other supported `/external:*` modes unchanged;
- add a real-MSVC gate with a valid environment-backed header path: `/external:env:MQB_EXTERNAL_INCLUDE` must fail before `cl.exe`, while the same source must build and run using explicit `/external:I<path>`;
- keep the canonical 444-entry inventory denominator unchanged.

## Exact-head regression evidence

Validated head: `4920020be0327806d11eface450729d9a47bb315`.

- Native C++ #400: **success**
  - current Debug self-build: success
  - ambient MSVC option isolation: success
  - `/external:env` ownership + explicit `/external:I` replacement gate: success
  - linker side-output/repro/WHOLEARCHIVE integrity gate: success
  - exact 444-entry parameter inventory: success
  - 4/4 Debug shards + aggregate gate: success
- Native Release #342: **success**
  - Stage 0 Release self-build: success
  - shared Release product library: success
  - 4/4 Release shards: success
  - stable self-host: success
  - runtime-only package staging/validation/upload: success
- Performance Evidence #134: skipped as expected for this correctness `fix:` PR.

## Additional cleanup

Updates the stale `/WHOLEARCHIVE:<lib>` registry rationale from PR #108 to describe the already-validated behavior: the resolved library is tracked through MQB's generic link file-input freshness graph. No WHOLEARCHIVE runtime behavior changes in this PR.

Base: `2e5d0609c82fdeab77d8e719f0b3fc2336515925`.