### PR TITLE
fix: model AddressSanitizer link policy

### DIFF
--- a/.github/workflows/native-ci.yml
+++ b/.github/workflows/native-ci.yml
@@ -110,6 +110,14 @@ jobs:
             -RepoRoot $PWD
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
+      - name: Verify AddressSanitizer link policy
+        shell: pwsh
+        run: |
+          & (Join-Path $PWD 'tests/native/verify_asan_link_policy.ps1') `
+            -MqbPath (Join-Path $PWD 'native-out/debug/mqb.exe') `
+            -RepoRoot $PWD
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
       - name: Verify linker side-output repair
         shell: pwsh
         run: |

--- a/cpp/include/mqb/core/BuildTypes.hpp
+++ b/cpp/include/mqb/core/BuildTypes.hpp
@@ -24,6 +24,13 @@ enum class CppStandard {
     cpp17 = 4,
 };
 
+enum class RuntimeLibrary {
+    md,
+    mdd,
+    mt,
+    mtd,
+};
+
 enum class TargetKind {
     executable,
     dynamic_library,

--- a/cpp/include/mqb/core/CompilerOptions.hpp
+++ b/cpp/include/mqb/core/CompilerOptions.hpp
@@ -9,13 +9,6 @@
 
 namespace mqb {
 
-enum class RuntimeLibrary {
-    md,
-    mdd,
-    mt,
-    mtd,
-};
-
 struct PrecompiledHeaderPolicy {
     bool enabled{false};
     std::filesystem::path header;

--- a/cpp/include/mqb/core/LinkOptions.hpp
+++ b/cpp/include/mqb/core/LinkOptions.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <filesystem>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -21,6 +22,12 @@ struct LinkOptions {
     // Coupled with CompilerOptions::link_time_code_generation. False preserves
     // the historical link signature/recipe; true makes /LTCG structured policy.
     bool link_time_code_generation{false};
+    // Present when all target translation units are compiled with
+    // /fsanitize=address. The effective CRT mode is carried across the
+    // compile->link boundary so MQB can track LINK's inferred ASan libraries and
+    // enforce the sanitizer's non-incremental link contract without rewriting
+    // the user's native compiler/linker argv.
+    std::optional<RuntimeLibrary> address_sanitizer_runtime_library;
     std::vector<std::filesystem::path> library_directories;
     std::vector<std::string> libraries;
     std::vector<std::string> additional_arguments;

--- a/cpp/include/mqb/msvc/MsvcAddressSanitizerPolicy.hpp
+++ b/cpp/include/mqb/msvc/MsvcAddressSanitizerPolicy.hpp
@@ -1,0 +1,202 @@
+#pragma once
+
+#include <cctype>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "mqb/core/CompilerOptions.hpp"
+#include "mqb/core/LinkOptions.hpp"
+#include "mqb/msvc/MsvcToolchainLocator.hpp"
+#include "mqb/process/Process.hpp"
+
+namespace mqb::msvc {
+
+class MsvcAddressSanitizerPolicy {
+public:
+    [[nodiscard]] static bool compiler_enabled(
+        const std::span<const std::string> arguments) noexcept {
+        for (const auto& argument : arguments) {
+            if (ascii_iequals(option_body(argument), "fsanitize=address")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    [[nodiscard]] static RuntimeLibrary effective_runtime_library(
+        const CompilerOptions& options) noexcept {
+        if (options.runtime_library) {
+            return *options.runtime_library;
+        }
+        return options.configuration == BuildConfiguration::debug
+            ? RuntimeLibrary::mdd
+            : RuntimeLibrary::md;
+    }
+
+    [[nodiscard]] static bool inferred_libraries_enabled(
+        const std::span<const std::string> linker_arguments) noexcept {
+        // LINK enables inferred ASan libraries by default. Preserve native
+        // last-option-wins behavior for the explicit advanced override.
+        bool enabled = true;
+        for (const auto& argument : linker_arguments) {
+            const std::string_view body = option_body(argument);
+            if (ascii_iequals(body, "INFERASANLIBS")) {
+                enabled = true;
+            } else if (ascii_iequals(body, "INFERASANLIBS:NO")) {
+                enabled = false;
+            }
+        }
+        return enabled;
+    }
+
+    [[nodiscard]] static std::vector<std::string> inferred_library_names(
+        const RuntimeLibrary runtime,
+        const Architecture architecture,
+        const TargetKind target_kind,
+        const std::string_view toolchain_version) {
+        const std::string arch = architecture == Architecture::x86
+            ? "i386"
+            : "x86_64";
+        const bool static_crt = runtime == RuntimeLibrary::mt
+            || runtime == RuntimeLibrary::mtd;
+        const bool debug_crt = runtime == RuntimeLibrary::mdd
+            || runtime == RuntimeLibrary::mtd;
+
+        if (modern_runtime_model(toolchain_version)) {
+            return {
+                "clang_rt.asan_dynamic-" + arch + ".lib",
+                "clang_rt.asan_"
+                    + std::string{static_crt ? "static" : "dynamic"}
+                    + "_runtime_thunk-" + arch + ".lib",
+            };
+        }
+
+        // Visual Studio versions before the 17.7 Preview 3 runtime unification
+        // used configuration- and target-kind-specific ASan libraries.
+        if (!static_crt) {
+            if (debug_crt) {
+                return {
+                    "clang_rt.asan_dbg_dynamic-" + arch + ".lib",
+                    "clang_rt.asan_dbg_dynamic_runtime_thunk-" + arch + ".lib",
+                };
+            }
+            return {
+                "clang_rt.asan_dynamic-" + arch + ".lib",
+                "clang_rt.asan_dynamic_runtime_thunk-" + arch + ".lib",
+            };
+        }
+
+        if (target_kind == TargetKind::dynamic_library) {
+            return {
+                "clang_rt.asan_"
+                    + std::string{debug_crt ? "dbg_dll_thunk" : "dll_thunk"}
+                    + "-" + arch + ".lib",
+            };
+        }
+        if (debug_crt) {
+            return {
+                "clang_rt.asan_dbg-" + arch + ".lib",
+                "clang_rt.asan_cxx_dbg-" + arch + ".lib",
+            };
+        }
+        return {
+            "clang_rt.asan-" + arch + ".lib",
+            "clang_rt.asan_cxx-" + arch + ".lib",
+        };
+    }
+
+    static void apply_runtime_path(
+        process::ProcessSpec& spec,
+        const MsvcToolchain& toolchain) {
+        // ASan runtime DLLs live beside the selected MSVC compiler. Both
+        // Visual Studio and portable discovery capture a toolchain PATH that
+        // includes that directory. Override only PATH for the launched target;
+        // do not leak INCLUDE/LIB or other build-only variables into programs.
+        for (const auto& variable : toolchain.environment) {
+            if (ascii_iequals(variable.name, "PATH")) {
+                spec.environment.push_back(variable);
+                return;
+            }
+        }
+    }
+
+private:
+    [[nodiscard]] static std::string_view option_body(
+        const std::string_view argument) noexcept {
+        if (argument.size() >= 2
+            && (argument.front() == '/' || argument.front() == '-')) {
+            return argument.substr(1);
+        }
+        return {};
+    }
+
+    [[nodiscard]] static bool ascii_iequals(
+        const std::string_view left,
+        const std::string_view right) noexcept {
+        if (left.size() != right.size()) {
+            return false;
+        }
+        for (std::size_t index = 0; index < left.size(); ++index) {
+            const auto a = static_cast<unsigned char>(left[index]);
+            const auto b = static_cast<unsigned char>(right[index]);
+            if (std::tolower(a) != std::tolower(b)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    [[nodiscard]] static std::optional<std::pair<unsigned, unsigned>>
+    major_minor(const std::string_view version) noexcept {
+        std::size_t index = 0;
+        unsigned major = 0;
+        bool major_digit = false;
+        while (index < version.size()
+            && std::isdigit(static_cast<unsigned char>(version[index])) != 0) {
+            major_digit = true;
+            major = major * 10u + static_cast<unsigned>(version[index] - '0');
+            ++index;
+        }
+        if (!major_digit || index >= version.size() || version[index] != '.') {
+            return std::nullopt;
+        }
+        ++index;
+        unsigned minor = 0;
+        bool minor_digit = false;
+        while (index < version.size()
+            && std::isdigit(static_cast<unsigned char>(version[index])) != 0) {
+            minor_digit = true;
+            minor = minor * 10u + static_cast<unsigned>(version[index] - '0');
+            ++index;
+        }
+        if (!minor_digit) {
+            return std::nullopt;
+        }
+        return std::pair{major, minor};
+    }
+
+    [[nodiscard]] static bool modern_runtime_model(
+        const std::string_view toolchain_version) noexcept {
+        const auto parsed = major_minor(toolchain_version);
+        if (!parsed) {
+            // Unknown future/custom version strings should prefer the current
+            // runtime model rather than silently selecting obsolete library names.
+            return true;
+        }
+        const auto [major, minor] = *parsed;
+        if (major == 19u || major == 14u) {
+            return minor >= 37u;
+        }
+        if (major > 19u) {
+            return true;
+        }
+        // Version schemes other than compiler 19.x / VC Tools 14.x are not
+        // historical MSVC schemes known to MQB; use the current model.
+        return major != 18u && major != 17u && major != 16u;
+    }
+};
+
+} // namespace mqb::msvc

--- a/cpp/include/mqb/msvc/MsvcAddressSanitizerPolicy.hpp
+++ b/cpp/include/mqb/msvc/MsvcAddressSanitizerPolicy.hpp
@@ -5,6 +5,7 @@
 #include <span>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include "mqb/core/CompilerOptions.hpp"

--- a/cpp/include/mqb/msvc/MsvcAddressSanitizerPolicy.hpp
+++ b/cpp/include/mqb/msvc/MsvcAddressSanitizerPolicy.hpp
@@ -36,6 +36,17 @@ public:
             : RuntimeLibrary::md;
     }
 
+    static void apply_link_policy(
+        const CompilerOptions& compiler_options,
+        LinkOptions& link_options) noexcept {
+        if (compiler_enabled(compiler_options.additional_arguments)) {
+            link_options.address_sanitizer_runtime_library =
+                effective_runtime_library(compiler_options);
+        } else {
+            link_options.address_sanitizer_runtime_library.reset();
+        }
+    }
+
     [[nodiscard]] static bool inferred_libraries_enabled(
         const std::span<const std::string> linker_arguments) noexcept {
         // LINK enables inferred ASan libraries by default. Preserve native

--- a/cpp/src/app/Application.cpp
+++ b/cpp/src/app/Application.cpp
@@ -21,6 +21,7 @@
 #include "mqb/core/ProjectArtifactLayout.hpp"
 #include "mqb/core/TranslationUnitClassifier.hpp"
 #include "mqb/discovery/SourceDiscovery.hpp"
+#include "mqb/msvc/MsvcAddressSanitizerPolicy.hpp"
 #include "mqb/msvc/MsvcCompileExecutor.hpp"
 #include "mqb/msvc/MsvcLinker.hpp"
 #include "mqb/msvc/MsvcParameterCapabilities.hpp"
@@ -603,6 +604,10 @@ int Application::run(const std::span<const std::string_view> arguments) {
     run_spec.working_directory = project_root;
     run_spec.capture_stdout = true;
     run_spec.capture_stderr = true;
+    if (mqb::msvc::MsvcAddressSanitizerPolicy::compiler_enabled(
+            request.compiler_options.additional_arguments)) {
+        mqb::msvc::MsvcAddressSanitizerPolicy::apply_runtime_path(run_spec, *toolchain);
+    }
 
     auto run_result = runner.run(run_spec);
     if (!run_result) {

--- a/cpp/src/app/targets/ModuleCliTarget.cpp
+++ b/cpp/src/app/targets/ModuleCliTarget.cpp
@@ -9,6 +9,7 @@
 #include "PerformanceTimings.hpp"
 #include "mqb/core/BuildTypes.hpp"
 #include "mqb/core/TranslationUnitClassifier.hpp"
+#include "mqb/msvc/MsvcAddressSanitizerPolicy.hpp"
 #include "mqb/msvc/MsvcCompileExecutor.hpp"
 #include "mqb/msvc/MsvcLinker.hpp"
 #include "mqb/msvc/MsvcModuleDependencyScanner.hpp"
@@ -214,6 +215,10 @@ int run_module_target(
     run_spec.working_directory = request.project_root;
     run_spec.capture_stdout = true;
     run_spec.capture_stderr = true;
+    if (msvc::MsvcAddressSanitizerPolicy::compiler_enabled(
+            target_request.compiler_options.additional_arguments)) {
+        msvc::MsvcAddressSanitizerPolicy::apply_runtime_path(run_spec, toolchain);
+    }
     auto run_result = runner.run(run_spec);
     if (!run_result) {
         diagnostics::print_error("failed to run executable: " + run_result.error().message);

--- a/cpp/src/core/model/BuildSignature.cpp
+++ b/cpp/src/core/model/BuildSignature.cpp
@@ -263,6 +263,12 @@ BuildSignature BuildSignature::for_link(
         // Preserve historical executable/DLL link identities when LTCG is off.
         hasher.add_string("mqb.ltcg.link.v1");
     }
+    if (options.address_sanitizer_runtime_library) {
+        // Preserve the historical link signature byte stream for every
+        // non-ASan target. ASan links append only their cross-stage CRT policy.
+        hasher.add_string("mqb.address-sanitizer.link.v1");
+        hasher.add_enum(*options.address_sanitizer_runtime_library);
+    }
     return BuildSignature{hasher.finish()};
 }
 

--- a/cpp/src/msvc/parameters/MsvcParameterRegistry.cpp
+++ b/cpp/src/msvc/parameters/MsvcParameterRegistry.cpp
@@ -200,7 +200,7 @@ ParameterClassification classify_linker_parameter(const std::string_view argumen
     static constexpr std::array passthrough_exact{
         "?"sv, "ALLOWBIND"sv, "ALLOWISOLATION"sv, "APPCONTAINER"sv, "ASSEMBLYDEBUG"sv, "CETCOMPAT"sv, "DEBUG"sv, "DEBUG:FULL"sv, "DEBUG:NONE"sv,
         "DELAYSIGN"sv, "DYNAMICBASE"sv, "DYNAMICDEOPT"sv, "FIXED"sv, "FORCE"sv, "FUNCTIONPADMIN"sv, "HIGHENTROPYVA"sv, "IGNOREIDL"sv,
-        "INCREMENTAL"sv, "INCREMENTAL:NO"sv, "INFERASANLIBS"sv, "INTEGRITYCHECK"sv, "LARGEADDRESSAWARE"sv, "MANIFEST"sv, "MAP"sv,
+        "INCREMENTAL"sv, "INCREMENTAL:NO"sv, "INFERASANLIBS"sv, "INFERASANLIBS:NO"sv, "INTEGRITYCHECK"sv, "LARGEADDRESSAWARE"sv, "MANIFEST"sv, "MAP"sv,
         "MANIFEST:NO"sv, "NOASSEMBLY"sv, "NODEFAULTLIB"sv, "NOENTRY"sv, "NOFUNCTIONPADSECTION"sv, "NOLOGO"sv, "NXCOMPAT"sv,
         "PROFILE"sv, "RELEASE"sv, "SAFESEH"sv, "TIME"sv, "TSAWARE"sv, "VERBOSE"sv, "WHOLEARCHIVE"sv, "WX"sv, "WX:NO"sv,
     };
@@ -217,19 +217,21 @@ ParameterClassification classify_linker_parameter(const std::string_view argumen
         return classified(ParameterTool::linker, ParameterOwnership::passthrough, "/" + body,
             body.starts_with("WHOLEARCHIVE:")
                 ? "path-bearing /WHOLEARCHIVE is preserved in linker argv and its resolved library is tracked through MQB's generic link file-input freshness graph"
-                : body.starts_with("DEFAULTLIB:")
-                    ? "user-declared default library remains in raw LINK argv while MQB resolves the effective declaration separately for freshness without changing library search priority"
-                    : body.starts_with("DEF:")
-                        ? "module-definition input is preserved in linker argv and tracked through MQB's generic link file-input freshness graph"
-                        : body.starts_with("ORDER:")
-                            ? "function-order input is preserved in linker argv, tracked through MQB's generic link file-input freshness graph, and requires non-incremental linking when LINK runs"
-                            : body.starts_with("STUB:")
-                                ? "MS-DOS stub executable is preserved in linker argv and tracked through MQB's generic link file-input freshness graph"
-                                : body.starts_with("MANIFESTINPUT:")
-                                    ? "manifest input is preserved in linker argv and cumulatively tracked through MQB's generic link file-input freshness graph"
-                                    : body == "MAP" || body.starts_with("MAP:")
-                                        ? "mapfile output is preserved in linker argv and tracked through MQB's link side-output repair graph"
-                                        : "validated linker option is preserved verbatim in link identity");
+                : body == "INFERASANLIBS" || body == "INFERASANLIBS:NO"
+                    ? "AddressSanitizer runtime inference mode is preserved in linker argv; when inference is enabled MQB tracks the resolved runtime libraries as link freshness inputs"
+                    : body.starts_with("DEFAULTLIB:")
+                        ? "user-declared default library remains in raw LINK argv while MQB resolves the effective declaration separately for freshness without changing library search priority"
+                        : body.starts_with("DEF:")
+                            ? "module-definition input is preserved in linker argv and tracked through MQB's generic link file-input freshness graph"
+                            : body.starts_with("ORDER:")
+                                ? "function-order input is preserved in linker argv, tracked through MQB's generic link file-input freshness graph, and requires non-incremental linking when LINK runs"
+                                : body.starts_with("STUB:")
+                                    ? "MS-DOS stub executable is preserved in linker argv and tracked through MQB's generic link file-input freshness graph"
+                                    : body.starts_with("MANIFESTINPUT:")
+                                        ? "manifest input is preserved in linker argv and cumulatively tracked through MQB's generic link file-input freshness graph"
+                                        : body == "MAP" || body.starts_with("MAP:")
+                                            ? "mapfile output is preserved in linker argv and tracked through MQB's link side-output repair graph"
+                                            : "validated linker option is preserved verbatim in link identity");
     }
     return unregistered(ParameterTool::linker, body);
 }

--- a/cpp/src/orchestration/incremental/MsvcIncrementalLinkCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalLinkCoordinator.cpp
@@ -15,6 +15,7 @@
 #include "mqb/core/FileSnapshot.hpp"
 #include "mqb/core/LinkCache.hpp"
 #include "mqb/core/LinkCacheFile.hpp"
+#include "mqb/msvc/MsvcAddressSanitizerPolicy.hpp"
 #include "mqb/msvc/MsvcDefaultLibraryPolicy.hpp"
 #include "mqb/msvc/MsvcLibraryResolver.hpp"
 #include "mqb/msvc/MsvcLinker.hpp"
@@ -243,6 +244,35 @@ MsvcIncrementalLinkCoordinator::run(const IncrementalLinkRequest& request) const
             resolved_whole_archive_libraries->files.end());
     }
 
+    if (request.options.address_sanitizer_runtime_library
+        && msvc::MsvcAddressSanitizerPolicy::inferred_libraries_enabled(
+            request.options.additional_arguments)) {
+        LinkOptions asan_options = request.options;
+        asan_options.libraries =
+            msvc::MsvcAddressSanitizerPolicy::inferred_library_names(
+                *request.options.address_sanitizer_runtime_library,
+                request.options.architecture,
+                request.options.target_kind,
+                toolchain_.identity.version);
+        auto resolved_asan_libraries = msvc::MsvcLibraryResolver::resolve(
+            toolchain_,
+            asan_options,
+            working_directory);
+        if (!resolved_asan_libraries) {
+            IncrementalLinkError error{
+                .code = IncrementalLinkErrorCode::library_resolution_failed,
+                .message = "failed to resolve inferred MSVC AddressSanitizer runtime library: "
+                    + resolved_asan_libraries.error().message,
+                .library_resolution_error = resolved_asan_libraries.error(),
+            };
+            return std::unexpected(std::move(error));
+        }
+        linker_file_inputs.insert(
+            linker_file_inputs.end(),
+            resolved_asan_libraries->files.begin(),
+            resolved_asan_libraries->files.end());
+    }
+
     const std::optional<fs::path> requested_map_output =
         msvc::MsvcLinker::map_file_path(
             request.output,
@@ -385,7 +415,8 @@ MsvcIncrementalLinkCoordinator::run(const IncrementalLinkRequest& request) const
         .working_directory = working_directory,
         .force_full_link = result.validation.library_inputs_changed
             || result.validation.file_inputs_changed
-            || linker_file_routing->requires_full_link,
+            || linker_file_routing->requires_full_link
+            || request.options.address_sanitizer_runtime_library.has_value(),
     };
     auto linked = linker_.link(invocation);
     if (!linked) {

--- a/cpp/src/orchestration/incremental/MsvcIncrementalTargetCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalTargetCoordinator.cpp
@@ -12,6 +12,7 @@
 
 #include "mqb/core/Artifact.hpp"
 #include "mqb/core/TranslationUnit.hpp"
+#include "mqb/msvc/MsvcAddressSanitizerPolicy.hpp"
 #include "mqb/orchestration/BoundedWorkScheduler.hpp"
 
 namespace mqb::orchestration {
@@ -196,10 +197,15 @@ MsvcIncrementalTargetCoordinator::run(const IncrementalTargetRequest& request) c
         objects.push_back(request.sources[index].artifacts.object);
     }
 
+    LinkOptions effective_link_options = request.link_options;
+    msvc::MsvcAddressSanitizerPolicy::apply_link_policy(
+        request.compiler_options,
+        effective_link_options);
+
     IncrementalLinkRequest link_request{
         .objects = std::move(objects),
         .output = request.target.executable,
-        .options = request.link_options,
+        .options = std::move(effective_link_options),
         .cache_file = request.target.link_cache,
         .working_directory = request.working_directory,
         .force_relink = request.force_downstream_rebuild || result.any_compiled,

--- a/cpp/src/orchestration/modules/ModuleTargetLinkRequestFactory.cpp
+++ b/cpp/src/orchestration/modules/ModuleTargetLinkRequestFactory.cpp
@@ -5,6 +5,8 @@
 #include <utility>
 #include <vector>
 
+#include "mqb/msvc/MsvcAddressSanitizerPolicy.hpp"
+
 namespace mqb::orchestration::detail {
 
 namespace fs = std::filesystem;
@@ -19,10 +21,15 @@ IncrementalLinkRequest make_module_target_link_request(
         objects.push_back(source.artifacts.object);
     }
 
+    LinkOptions effective_link_options = request.link_options;
+    msvc::MsvcAddressSanitizerPolicy::apply_link_policy(
+        request.compiler_options,
+        effective_link_options);
+
     return IncrementalLinkRequest{
         .objects = std::move(objects),
         .output = request.target.executable,
-        .options = request.link_options,
+        .options = std::move(effective_link_options),
         .cache_file = request.target.link_cache,
         .working_directory = request.working_directory.empty()
             ? std::nullopt

--- a/tests/native/verify_asan_link_policy.ps1
+++ b/tests/native/verify_asan_link_policy.ps1
@@ -1,0 +1,122 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$MqbPath,
+    [Parameter(Mandatory = $true)][string]$RepoRoot
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+$MqbPath = [System.IO.Path]::GetFullPath($MqbPath)
+$RepoRoot = [System.IO.Path]::GetFullPath($RepoRoot)
+if (-not (Test-Path -LiteralPath $MqbPath -PathType Leaf)) {
+    throw "MQB executable not found: $MqbPath"
+}
+
+$fixture = Join-Path $RepoRoot 'native-test-work/asan-link-policy'
+if (Test-Path -LiteralPath $fixture) {
+    Remove-Item -LiteralPath $fixture -Recurse -Force
+}
+New-Item -ItemType Directory -Path $fixture -Force | Out-Null
+Set-Content -LiteralPath (Join-Path $fixture 'main.cpp') -Encoding utf8 -Value @(
+    '#include <cstdlib>',
+    'int main() {',
+    '    int* value = new int[1];',
+    '    value[0] = 42;',
+    '    const int result = value[0] == 42 ? 0 : 1;',
+    '    delete[] value;',
+    '    return result;',
+    '}'
+)
+
+function Invoke-AsanBuild {
+    param(
+        [Parameter(Mandatory = $true)][string]$Target,
+        [switch]$RawIncremental
+    )
+
+    Push-Location $fixture
+    try {
+        $arguments = @(
+            'build', 'main.cpp', '--debug', '--no-discover', '-o', $Target,
+            '/fsanitize=address'
+        )
+        if ($RawIncremental) {
+            $arguments += @('/link', '/INCREMENTAL')
+        }
+        $output = @(& $MqbPath @arguments 2>&1)
+        $exitCode = $LASTEXITCODE
+    }
+    finally {
+        Pop-Location
+    }
+    [PSCustomObject]@{
+        ExitCode = $exitCode
+        Text = ($output -join [Environment]::NewLine)
+    }
+}
+
+$cold = Invoke-AsanBuild -Target 'asan_probe'
+if ($cold.ExitCode -ne 0) {
+    throw "Cold AddressSanitizer build failed:`n$($cold.Text)"
+}
+$exe = Join-Path $fixture '.mqb/bin/asan_probe.exe'
+$ilk = Join-Path $fixture '.mqb/bin/asan_probe.ilk'
+$linkCache = Join-Path $fixture '.mqb/cache/link/asan_probe.linkcache'
+if (-not (Test-Path -LiteralPath $exe -PathType Leaf)) {
+    throw "AddressSanitizer build did not produce expected executable: $exe"
+}
+if (Test-Path -LiteralPath $ilk) {
+    throw "AddressSanitizer Debug link produced an .ilk even though incremental linking is unsupported: $ilk"
+}
+if (-not (Test-Path -LiteralPath $linkCache -PathType Leaf)) {
+    throw "AddressSanitizer link cache missing: $linkCache"
+}
+
+$cacheText = [Text.Encoding]::UTF8.GetString([IO.File]::ReadAllBytes($linkCache))
+foreach ($library in @(
+    'clang_rt.asan_dynamic-x86_64.lib',
+    'clang_rt.asan_dynamic_runtime_thunk-x86_64.lib'
+)) {
+    if ($cacheText -notmatch [Regex]::Escape($library)) {
+        throw "AddressSanitizer link cache did not seal inferred runtime input '$library'"
+    }
+}
+
+$warm = Invoke-AsanBuild -Target 'asan_probe'
+if ($warm.ExitCode -ne 0) {
+    throw "Warm AddressSanitizer build failed:`n$($warm.Text)"
+}
+if ($warm.Text -notmatch '\[up-to-date\]\s+asan_probe\.exe') {
+    throw "Warm AddressSanitizer build did not reuse sealed link inputs:`n$($warm.Text)"
+}
+
+$rawIncremental = Invoke-AsanBuild -Target 'asan_raw_incremental' -RawIncremental
+if ($rawIncremental.ExitCode -ne 0) {
+    throw "AddressSanitizer build with raw /INCREMENTAL failed:`n$($rawIncremental.Text)"
+}
+$rawIncrementalIlk = Join-Path $fixture '.mqb/bin/asan_raw_incremental.ilk'
+if (Test-Path -LiteralPath $rawIncrementalIlk) {
+    throw "Raw /INCREMENTAL overrode MQB's required AddressSanitizer /INCREMENTAL:NO policy"
+}
+
+# The advanced opt-out spelling must remain a recognized native LINK option.
+# This non-sanitized target has no ASan unresolveds, so the check isolates
+# parameter routing without requiring manual sanitizer library declarations.
+Push-Location $fixture
+try {
+    $optOut = @(
+        & $MqbPath build main.cpp --debug --no-discover -o inferasanlibs_no `
+            /link /INFERASANLIBS:NO 2>&1
+    )
+    $optOutExit = $LASTEXITCODE
+}
+finally {
+    Pop-Location
+}
+if ($optOutExit -ne 0) {
+    throw "/INFERASANLIBS:NO was not accepted as a native linker override:`n$($optOut -join [Environment]::NewLine)"
+}
+
+Write-Host 'Real MSVC AddressSanitizer inferred-library freshness and non-incremental link checks passed.'
+exit 0

--- a/tests/native/verify_asan_link_policy.ps1
+++ b/tests/native/verify_asan_link_policy.ps1
@@ -56,6 +56,19 @@ function Invoke-AsanBuild {
     }
 }
 
+function Invoke-WithMinimalParentPath {
+    param([Parameter(Mandatory = $true)][scriptblock]$Action)
+
+    $previousPath = $env:PATH
+    $env:PATH = (Join-Path $env:SystemRoot 'System32') + ';' + $env:SystemRoot
+    try {
+        & $Action
+    }
+    finally {
+        $env:PATH = $previousPath
+    }
+}
+
 $cold = Invoke-AsanBuild -Target 'asan_probe'
 if ($cold.ExitCode -ne 0) {
     throw "Cold AddressSanitizer build failed:`n$($cold.Text)"
@@ -100,6 +113,58 @@ if (Test-Path -LiteralPath $rawIncrementalIlk) {
     throw "Raw /INCREMENTAL overrode MQB's required AddressSanitizer /INCREMENTAL:NO policy"
 }
 
+# Prove `mqb run` does not depend on the invoking shell already containing the
+# selected compiler directory. LINK/CL use MQB's captured toolchain environment;
+# the user program receives only the selected toolchain PATH when ASan is active.
+Push-Location $fixture
+try {
+    $runOutput = @(
+        Invoke-WithMinimalParentPath {
+            & $MqbPath run main.cpp --debug --no-discover -o asan_run_probe `
+                /fsanitize=address 2>&1
+        }
+    )
+    $runExit = $LASTEXITCODE
+}
+finally {
+    Pop-Location
+}
+if ($runExit -ne 0) {
+    throw "AddressSanitizer mqb run failed with compiler paths removed from parent PATH:`n$($runOutput -join [Environment]::NewLine)"
+}
+if (($runOutput -join [Environment]::NewLine) -notmatch '\[run\]\s+asan_run_probe\.exe') {
+    throw "AddressSanitizer ordinary run gate did not reach the user program"
+}
+
+# Exercise the same compile->link->run policy through the named-module route.
+Set-Content -LiteralPath (Join-Path $fixture 'math.ixx') -Encoding utf8 -Value @(
+    'export module math;',
+    'export int answer() { return 42; }'
+)
+Set-Content -LiteralPath (Join-Path $fixture 'module_main.cpp') -Encoding utf8 -Value @(
+    'import math;',
+    'int main() { return answer() == 42 ? 0 : 1; }'
+)
+Push-Location $fixture
+try {
+    $moduleRunOutput = @(
+        Invoke-WithMinimalParentPath {
+            & $MqbPath run module_main.cpp math.ixx --debug --no-discover `
+                -o asan_module_run /fsanitize=address 2>&1
+        }
+    )
+    $moduleRunExit = $LASTEXITCODE
+}
+finally {
+    Pop-Location
+}
+if ($moduleRunExit -ne 0) {
+    throw "AddressSanitizer module mqb run failed with compiler paths removed from parent PATH:`n$($moduleRunOutput -join [Environment]::NewLine)"
+}
+if (($moduleRunOutput -join [Environment]::NewLine) -notmatch '\[run\]\s+asan_module_run\.exe') {
+    throw "AddressSanitizer module run gate did not reach the user program"
+}
+
 # The advanced opt-out spelling must remain a recognized native LINK option.
 # This non-sanitized target has no ASan unresolveds, so the check isolates
 # parameter routing without requiring manual sanitizer library declarations.
@@ -118,5 +183,5 @@ if ($optOutExit -ne 0) {
     throw "/INFERASANLIBS:NO was not accepted as a native linker override:`n$($optOut -join [Environment]::NewLine)"
 }
 
-Write-Host 'Real MSVC AddressSanitizer inferred-library freshness and non-incremental link checks passed.'
+Write-Host 'Real MSVC AddressSanitizer link freshness, non-incremental LINK, and mqb run runtime checks passed.'
 exit 0


### PR DESCRIPTION
## Summary

Closes the next post-#103 cross-stage correctness gap: `/fsanitize=address` was accepted as compiler passthrough, while MQB Debug linking still used incremental LINK and did not seal the ASan runtime libraries that MSVC infers automatically.

## Problem

MSVC AddressSanitizer is a compiler-to-linker-to-runtime contract. Instrumented objects request `clang_rt.asan*` runtimes, LINK normally infers those libraries, incremental linking is unsupported, and modern MSVC ASan executables require the matching runtime DLL to be discoverable when they run. MQB previously kept `/fsanitize=address` only in compile identity, so Debug targets could still emit `/INCREMENTAL`, inferred runtime `.lib` files were outside link freshness, compile-side policy was not represented in link identity, and `mqb run` depended on the caller already having the MSVC runtime directory on PATH.

## Fix

- move `RuntimeLibrary` to the shared core build types so compiler and linker policy can carry the same exact CRT mode;
- add an optional AddressSanitizer runtime mode to `LinkOptions`, set only when the effective compiler args contain `/fsanitize=address`;
- project that compile-side policy into both ordinary target links and module target links;
- preserve ordinary link-signature byte streams and append a versioned ASan link domain only for sanitizer targets;
- model modern and pre-VS-17.7-Preview-3 MSVC ASan runtime library names by architecture, CRT mode, target kind, and VC Tools version;
- when LINK inference is enabled, resolve the inferred ASan runtime libraries through MQB's existing library search order and seal their exact paths as non-owning link file-input freshness evidence;
- keep LINK argv native: MQB does not re-emit inferred libraries or change their search priority;
- force every actual ASan LINK to end with MQB's `/INCREMENTAL:NO`, while warm cache hits remain true no-op links;
- admit the advanced `/INFERASANLIBS:NO` spelling and stop inferred-library freshness when the user explicitly disables LINK inference;
- for `mqb run`, project only the selected toolchain PATH into ASan program launches so the matching `clang_rt.asan_dynamic-<arch>.dll` is discoverable without leaking INCLUDE/LIB or other build-only variables.

## Real MSVC gate

The exact-head gate builds and runs Debug x64 ASan targets and verifies:

- no `.ilk` is produced;
- the link cache seals `clang_rt.asan_dynamic-x86_64.lib` and `clang_rt.asan_dynamic_runtime_thunk-x86_64.lib` as exact inputs;
- a warm rebuild is up-to-date;
- raw `/link /INCREMENTAL` cannot override the sanitizer's required final non-incremental policy;
- ordinary `mqb run` succeeds with compiler paths removed from the parent PATH;
- the same run-time PATH policy succeeds through the named-module pipeline;
- `/INFERASANLIBS:NO` remains a recognized advanced LINK override.

## Exact-head regression evidence

Validated head: `600df83d94956a9c82bbc1adbcd2f49b4ab31d91`.

- Native C++ #405: **success**
  - current Debug self-build: success
  - ambient MSVC option isolation: success
  - `/external:env` ownership gate: success
  - real AddressSanitizer link + run policy gate: success
  - linker side-output integrity gate: success
  - exact 444-entry MSVC parameter inventory: success
  - 4/4 Debug shards + aggregate gate: success
- Native Release #346: **success**
  - Stage 0 Release self-build: success
  - shared Release product library: success
  - 4/4 Release shards: success
  - stable self-host: success
  - runtime-only package staging/validation/upload: success
- Performance Evidence #140: skipped as expected for this correctness `fix:` PR.

Base: `24b7cbf8779cca4a8efa66ed8dbbc567842eab5a`.