### PR TITLE
fix: fail closed on Kernel AddressSanitizer mode

### DIFF
--- a/.github/workflows/native-ci.yml
+++ b/.github/workflows/native-ci.yml
@@ -110,6 +110,14 @@ jobs:
             -RepoRoot $PWD
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
+      - name: Verify Kernel AddressSanitizer ownership
+        shell: pwsh
+        run: |
+          & (Join-Path $PWD 'tests/native/verify_kasan_ownership.ps1') `
+            -MqbPath (Join-Path $PWD 'native-out/debug/mqb.exe') `
+            -RepoRoot $PWD
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
       - name: Verify AddressSanitizer link policy
         shell: pwsh
         run: |

--- a/cpp/src/msvc/parameters/MsvcParameterRegistry.cpp
+++ b/cpp/src/msvc/parameters/MsvcParameterRegistry.cpp
@@ -95,6 +95,9 @@ ParameterClassification classify_compiler_parameter(const std::string_view argum
     if (body == "external:env" || body.starts_with("external:env:")) {
         return compiler_unsupported(body, "environment-backed external include directories can change header search without entering MQB's compile identity or discovery model; use explicit /external:I or -I paths instead");
     }
+    if (body == "fsanitize=kernel-address") {
+        return compiler_unsupported(body, "Kernel AddressSanitizer is a WDK kernel-driver pipeline that requires x64 kernel target policy and a target-OS-matched Windows SDK/KASan compatibility library; MQB currently models only native exe/dll/static targets");
+    }
     if (body == "experimental:log" || body.starts_with("experimental:log")) {
         return compiler_unsupported(body, "option creates a diagnostic log artifact that is not represented in MQB's cache/artifact graph");
     }

--- a/tests/native/verify_kasan_ownership.ps1
+++ b/tests/native/verify_kasan_ownership.ps1
@@ -1,0 +1,55 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$MqbPath,
+    [Parameter(Mandatory = $true)][string]$RepoRoot
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+$MqbPath = [System.IO.Path]::GetFullPath($MqbPath)
+$RepoRoot = [System.IO.Path]::GetFullPath($RepoRoot)
+if (-not (Test-Path -LiteralPath $MqbPath -PathType Leaf)) {
+    throw "MQB executable not found: $MqbPath"
+}
+
+$fixture = Join-Path $RepoRoot 'native-test-work/kasan-ownership'
+if (Test-Path -LiteralPath $fixture) {
+    Remove-Item -LiteralPath $fixture -Recurse -Force
+}
+New-Item -ItemType Directory -Path $fixture -Force | Out-Null
+Set-Content -LiteralPath (Join-Path $fixture 'main.cpp') -Encoding utf8 -Value 'int main() { return 0; }'
+
+Push-Location $fixture
+try {
+    $rejected = @(
+        & $MqbPath build main.cpp --debug --no-discover -o kasan_rejected `
+            /fsanitize=kernel-address 2>&1
+    )
+    $rejectedExit = $LASTEXITCODE
+}
+finally {
+    Pop-Location
+}
+
+$rejectedText = $rejected -join [Environment]::NewLine
+if ($rejectedExit -eq 0) {
+    throw "Kernel AddressSanitizer unexpectedly reached the native exe pipeline and built successfully"
+}
+if ($rejectedText -notmatch '/fsanitize=kernel-address') {
+    throw "Rejected KASAN request did not identify the native compiler option:`n$rejectedText"
+}
+if ($rejectedText -notmatch 'WDK kernel-driver pipeline') {
+    throw "Rejected KASAN request did not explain the first-class driver ownership boundary:`n$rejectedText"
+}
+if ($rejectedText -notmatch 'target-OS-matched Windows SDK') {
+    throw "Rejected KASAN request did not explain the target SDK compatibility-library requirement:`n$rejectedText"
+}
+
+$unexpectedExe = Join-Path $fixture '.mqb/bin/kasan_rejected.exe'
+if (Test-Path -LiteralPath $unexpectedExe -PathType Leaf) {
+    throw "Rejected KASAN request unexpectedly produced a native executable: $unexpectedExe"
+}
+
+Write-Host 'MSVC /fsanitize=kernel-address WDK/driver ownership boundary check passed.'
+exit 0


### PR DESCRIPTION
## Summary

Closes the next post-#103 sanitizer ownership gap: `/fsanitize=kernel-address` was admitted by the broad `/fsanitize*` compiler passthrough family even though MQB does not model a Windows kernel-driver/WDK target pipeline.

## Why fail closed

MSVC Kernel AddressSanitizer (KASAN) is specifically a Windows kernel-driver feature. Correct use requires an x64 kernel-driver target, a sufficiently new WDK/Windows SDK, a supported target OS, and a KASAN compatibility library matched to the target Windows SDK/OS. Current MQB owns native `exe` / `dll` / `static` targets and already rejects compiler `/kernel` plus linker `/KERNEL` and `/DRIVER`; silently passing `/fsanitize=kernel-address` through the ordinary native pipeline would therefore claim support for a build contract MQB does not own.

## Fix

- classify exact `/fsanitize=kernel-address` as explicit unsupported/Class D before the broad `/fsanitize*` passthrough family;
- explain that KASAN requires a first-class WDK kernel-driver target and target-OS-matched Windows SDK compatibility library;
- leave user-mode `/fsanitize=address` and `/fsanitize=fuzzer` unchanged and fully supported through their existing cross-stage policies;
- add a real CLI ownership gate requiring a normal source with `/fsanitize=kernel-address` to fail before producing a native executable and to explain the WDK/target-SDK boundary;
- keep the canonical 444-entry MSVC parameter inventory denominator unchanged.

## Scope

No toolchain, linker, cache, target, ASan, or LibFuzzer runtime behavior changes in this PR.

## Exact-head regression evidence

Validated head: `d807ada60b721d325540eb2397c413b8fdc7067b`.

- Native C++ #409: **success**
  - current Debug self-build: success
  - ambient MSVC option isolation: success
  - `/external:env` ownership gate: success
  - KASAN ownership gate: success
  - AddressSanitizer link policy gate: success
  - LibFuzzer link policy gate: success
  - linker side-output integrity gate: success
  - shared Debug native-test product library: success
  - exact 444-entry MSVC parameter inventory: success
  - 4/4 Debug shards + aggregate gate: success
- Native Release #348: **success**
  - Stage 0 Release self-build: success
  - shared Release product library: success
  - 4/4 Release shards: success
  - stable self-host: success
  - runtime-only package staging/validation/upload: success
- Performance Evidence #146: skipped as expected for this correctness `fix:` PR.

Base: `abfc8e9177893f68cc17594a29472e766c4d01a0`.