### PR TITLE
fix: track compiler-injected VCAsan library inputs

### DIFF
--- a/cpp/include/mqb/core/LinkOptions.hpp
+++ b/cpp/include/mqb/core/LinkOptions.hpp
@@ -28,6 +28,11 @@ struct LinkOptions {
     // enforce the sanitizer's non-incremental link contract without rewriting
     // the user's native compiler/linker argv.
     std::optional<RuntimeLibrary> address_sanitizer_runtime_library;
+    // Present when /fsanitize=address also leaves MSVC's VCAsan default-library
+    // directive enabled. This is separate from /INFERASANLIBS: the compiler
+    // injects vcasan*.lib through ordinary default-library metadata, and /Zl or
+    // /fno-sanitize-address-vcasan-lib can suppress that compiler-side input.
+    std::optional<RuntimeLibrary> address_sanitizer_vcasan_runtime_library;
     // Present when all target translation units are compiled with
     // /fsanitize=fuzzer. cl.exe injects the matching clang_rt.fuzzer_<CRT>
     // default-library directive into objects; the CRT mode is carried here so

--- a/cpp/include/mqb/msvc/MsvcAddressSanitizerPolicy.hpp
+++ b/cpp/include/mqb/msvc/MsvcAddressSanitizerPolicy.hpp
@@ -27,6 +27,18 @@ public:
         return false;
     }
 
+    [[nodiscard]] static bool vcasan_default_library_enabled(
+        const std::span<const std::string> arguments) noexcept {
+        for (const auto& argument : arguments) {
+            const std::string_view body = option_body(argument);
+            if (ascii_iequals(body, "Zl")
+                || ascii_iequals(body, "fno-sanitize-address-vcasan-lib")) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     [[nodiscard]] static RuntimeLibrary effective_runtime_library(
         const CompilerOptions& options) noexcept {
         if (options.runtime_library) {
@@ -41,10 +53,18 @@ public:
         const CompilerOptions& compiler_options,
         LinkOptions& link_options) noexcept {
         if (compiler_enabled(compiler_options.additional_arguments)) {
-            link_options.address_sanitizer_runtime_library =
+            const RuntimeLibrary runtime =
                 effective_runtime_library(compiler_options);
+            link_options.address_sanitizer_runtime_library = runtime;
+            if (vcasan_default_library_enabled(
+                    compiler_options.additional_arguments)) {
+                link_options.address_sanitizer_vcasan_runtime_library = runtime;
+            } else {
+                link_options.address_sanitizer_vcasan_runtime_library.reset();
+            }
         } else {
             link_options.address_sanitizer_runtime_library.reset();
+            link_options.address_sanitizer_vcasan_runtime_library.reset();
         }
     }
 
@@ -118,6 +138,21 @@ public:
             "clang_rt.asan-" + arch + ".lib",
             "clang_rt.asan_cxx-" + arch + ".lib",
         };
+    }
+
+    [[nodiscard]] static std::string vcasan_library_name(
+        const RuntimeLibrary runtime) {
+        switch (runtime) {
+        case RuntimeLibrary::mt:
+            return "libvcasan.lib";
+        case RuntimeLibrary::md:
+            return "vcasan.lib";
+        case RuntimeLibrary::mtd:
+            return "libvcasand.lib";
+        case RuntimeLibrary::mdd:
+            return "vcasand.lib";
+        }
+        return "vcasan.lib";
     }
 
     static void apply_runtime_path(

--- a/cpp/src/core/model/BuildSignature.cpp
+++ b/cpp/src/core/model/BuildSignature.cpp
@@ -269,6 +269,13 @@ BuildSignature BuildSignature::for_link(
         hasher.add_string("mqb.address-sanitizer.link.v1");
         hasher.add_enum(*options.address_sanitizer_runtime_library);
     }
+    if (options.address_sanitizer_vcasan_runtime_library) {
+        // VCAsan is an independent compiler default-library directive. Keep its
+        // presence in link identity so /Zl or the official VCAsan opt-out cannot
+        // reuse a cache entry that assumed a hidden vcasan*.lib input.
+        hasher.add_string("mqb.address-sanitizer.vcasan.link.v1");
+        hasher.add_enum(*options.address_sanitizer_vcasan_runtime_library);
+    }
     if (options.fuzzer_runtime_library) {
         // Preserve every non-fuzzer link signature exactly. LibFuzzer targets
         // append only the compile-side CRT policy that selects the hidden

--- a/cpp/src/msvc/parameters/MsvcParameterRegistry.cpp
+++ b/cpp/src/msvc/parameters/MsvcParameterRegistry.cpp
@@ -98,6 +98,9 @@ ParameterClassification classify_compiler_parameter(const std::string_view argum
     if (body == "fsanitize=kernel-address") {
         return compiler_unsupported(body, "Kernel AddressSanitizer is a WDK kernel-driver pipeline that requires x64 kernel target policy and a target-OS-matched Windows SDK/KASan compatibility library; MQB currently models only native exe/dll/static targets");
     }
+    if (body == "fno-sanitize-address-vcasan-lib") {
+        return classified(ParameterTool::compiler, ParameterOwnership::passthrough, "/fno-sanitize-address-vcasan-lib", "VCAsan default-library opt-out is preserved verbatim in compile identity and projected into ASan link freshness policy");
+    }
     if (body == "experimental:log" || body.starts_with("experimental:log")) {
         return compiler_unsupported(body, "option creates a diagnostic log artifact that is not represented in MQB's cache/artifact graph");
     }

--- a/cpp/src/orchestration/incremental/MsvcIncrementalLinkCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalLinkCoordinator.cpp
@@ -274,6 +274,35 @@ MsvcIncrementalLinkCoordinator::run(const IncrementalLinkRequest& request) const
             resolved_asan_libraries->files.end());
     }
 
+    if (request.options.address_sanitizer_vcasan_runtime_library) {
+        const std::string vcasan_library =
+            msvc::MsvcAddressSanitizerPolicy::vcasan_library_name(
+                *request.options.address_sanitizer_vcasan_runtime_library);
+        if (msvc::MsvcDefaultLibraryPolicy::allows_implicit_library(
+                *default_library_routing,
+                vcasan_library)) {
+            LinkOptions vcasan_options = request.options;
+            vcasan_options.libraries = {vcasan_library};
+            auto resolved_vcasan_library = msvc::MsvcLibraryResolver::resolve(
+                toolchain_,
+                vcasan_options,
+                working_directory);
+            if (!resolved_vcasan_library) {
+                IncrementalLinkError error{
+                    .code = IncrementalLinkErrorCode::library_resolution_failed,
+                    .message = "failed to resolve inferred MSVC VCAsan runtime library: "
+                        + resolved_vcasan_library.error().message,
+                    .library_resolution_error = resolved_vcasan_library.error(),
+                };
+                return std::unexpected(std::move(error));
+            }
+            linker_file_inputs.insert(
+                linker_file_inputs.end(),
+                resolved_vcasan_library->files.begin(),
+                resolved_vcasan_library->files.end());
+        }
+    }
+
     if (request.options.fuzzer_runtime_library) {
         const std::string fuzzer_library =
             msvc::MsvcFuzzerPolicy::inferred_library_name(

--- a/tests/native/verify_asan_link_policy.ps1
+++ b/tests/native/verify_asan_link_policy.ps1
@@ -32,15 +32,21 @@ Set-Content -LiteralPath (Join-Path $fixture 'main.cpp') -Encoding utf8 -Value @
 function Invoke-AsanBuild {
     param(
         [Parameter(Mandatory = $true)][string]$Target,
+        [string]$Runtime,
+        [string[]]$CompilerArguments = @(),
         [switch]$RawIncremental
     )
 
     Push-Location $fixture
     try {
         $arguments = @(
-            'build', 'main.cpp', '--debug', '--no-discover', '-o', $Target,
-            '/fsanitize=address'
+            'build', 'main.cpp', '--debug', '--no-discover', '-o', $Target
         )
+        if (-not [string]::IsNullOrWhiteSpace($Runtime)) {
+            $arguments += @('--runtime', $Runtime)
+        }
+        $arguments += '/fsanitize=address'
+        $arguments += $CompilerArguments
         if ($RawIncremental) {
             $arguments += @('/link', '/INCREMENTAL')
         }
@@ -54,6 +60,16 @@ function Invoke-AsanBuild {
         ExitCode = $exitCode
         Text = ($output -join [Environment]::NewLine)
     }
+}
+
+function Get-LinkCacheText {
+    param([Parameter(Mandatory = $true)][string]$Target)
+
+    $linkCache = Join-Path $fixture ".mqb/cache/link/$Target.linkcache"
+    if (-not (Test-Path -LiteralPath $linkCache -PathType Leaf)) {
+        throw "AddressSanitizer link cache missing: $linkCache"
+    }
+    return [Text.Encoding]::UTF8.GetString([IO.File]::ReadAllBytes($linkCache))
 }
 
 function Invoke-WithMinimalParentPath {
@@ -75,21 +91,18 @@ if ($cold.ExitCode -ne 0) {
 }
 $exe = Join-Path $fixture '.mqb/bin/asan_probe.exe'
 $ilk = Join-Path $fixture '.mqb/bin/asan_probe.ilk'
-$linkCache = Join-Path $fixture '.mqb/cache/link/asan_probe.linkcache'
 if (-not (Test-Path -LiteralPath $exe -PathType Leaf)) {
     throw "AddressSanitizer build did not produce expected executable: $exe"
 }
 if (Test-Path -LiteralPath $ilk) {
     throw "AddressSanitizer Debug link produced an .ilk even though incremental linking is unsupported: $ilk"
 }
-if (-not (Test-Path -LiteralPath $linkCache -PathType Leaf)) {
-    throw "AddressSanitizer link cache missing: $linkCache"
-}
 
-$cacheText = [Text.Encoding]::UTF8.GetString([IO.File]::ReadAllBytes($linkCache))
+$cacheText = Get-LinkCacheText -Target 'asan_probe'
 foreach ($library in @(
     'clang_rt.asan_dynamic-x86_64.lib',
-    'clang_rt.asan_dynamic_runtime_thunk-x86_64.lib'
+    'clang_rt.asan_dynamic_runtime_thunk-x86_64.lib',
+    'vcasand.lib'
 )) {
     if ($cacheText -notmatch [Regex]::Escape($library)) {
         throw "AddressSanitizer link cache did not seal inferred runtime input '$library'"
@@ -102,6 +115,43 @@ if ($warm.ExitCode -ne 0) {
 }
 if ($warm.Text -notmatch '\[up-to-date\]\s+asan_probe\.exe') {
     throw "Warm AddressSanitizer build did not reuse sealed link inputs:`n$($warm.Text)"
+}
+
+# VCAsan is selected by the effective CRT independently from the clang_rt ASan
+# runtime family. Prove an explicit /MT compile seals libvcasan.lib rather than
+# reusing the default Debug /MDd vcasand.lib freshness evidence.
+$staticCrt = Invoke-AsanBuild -Target 'asan_mt_probe' -Runtime 'MT'
+if ($staticCrt.ExitCode -ne 0) {
+    throw "AddressSanitizer /MT build failed:`n$($staticCrt.Text)"
+}
+$staticCacheText = Get-LinkCacheText -Target 'asan_mt_probe'
+if ($staticCacheText -notmatch [Regex]::Escape('libvcasan.lib')) {
+    throw "AddressSanitizer /MT link cache did not seal 'libvcasan.lib'"
+}
+if ($staticCacheText -match [Regex]::Escape('vcasand.lib')) {
+    throw "AddressSanitizer /MT link cache incorrectly retained the /MDd VCAsan runtime"
+}
+
+# The official compiler-side opt-out suppresses only the VCAsan default-library
+# directive. LINK's clang_rt ASan inference remains enabled and must continue to
+# participate in freshness.
+$vcasanOptOut = Invoke-AsanBuild `
+    -Target 'asan_vcasan_optout' `
+    -CompilerArguments @('/fno-sanitize-address-vcasan-lib')
+if ($vcasanOptOut.ExitCode -ne 0) {
+    throw "AddressSanitizer VCAsan opt-out build failed:`n$($vcasanOptOut.Text)"
+}
+$optOutCacheText = Get-LinkCacheText -Target 'asan_vcasan_optout'
+foreach ($library in @(
+    'clang_rt.asan_dynamic-x86_64.lib',
+    'clang_rt.asan_dynamic_runtime_thunk-x86_64.lib'
+)) {
+    if ($optOutCacheText -notmatch [Regex]::Escape($library)) {
+        throw "VCAsan opt-out incorrectly removed ASan runtime freshness input '$library'"
+    }
+}
+if ($optOutCacheText -match [Regex]::Escape('vcasand.lib')) {
+    throw "VCAsan opt-out link cache incorrectly sealed the disabled 'vcasand.lib' input"
 }
 
 $rawIncremental = Invoke-AsanBuild -Target 'asan_raw_incremental' -RawIncremental
@@ -183,5 +233,5 @@ if ($optOutExit -ne 0) {
     throw "/INFERASANLIBS:NO was not accepted as a native linker override:`n$($optOut -join [Environment]::NewLine)"
 }
 
-Write-Host 'Real MSVC AddressSanitizer link freshness, non-incremental LINK, and mqb run runtime checks passed.'
+Write-Host 'Real MSVC AddressSanitizer runtime, VCAsan freshness/opt-out, non-incremental LINK, and mqb run checks passed.'
 exit 0


### PR DESCRIPTION
## Summary

Closes the next post-#103 AddressSanitizer freshness gap: `/fsanitize=address` automatically adds a CRT-specific VCAsan default library in addition to the `clang_rt.asan*` runtime libraries already modeled by MQB.

## Problem

MSVC automatically selects a VCAsan library for the improved Visual Studio debugging/crash-dump integration:

- `/MD` -> `vcasan.lib`
- `/MDd` -> `vcasand.lib`
- `/MT` -> `libvcasan.lib`
- `/MTd` -> `libvcasand.lib`

This is a compiler default-library directive, not LINK `/INFERASANLIBS`. MQB already sealed the `clang_rt.asan*` runtime inputs, but the VCAsan file remained outside link freshness. `/Zl`, `/fno-sanitize-address-vcasan-lib`, and LINK `/NODEFAULTLIB` can suppress that default-library input and must not leave stale freshness evidence behind.

## Fix

- carry a separate optional VCAsan CRT policy across the compile->link boundary for ASan targets;
- map the effective `RuntimeLibrary` to the official `vcasan*.lib` name;
- keep VCAsan independent from `/INFERASANLIBS` so disabling inferred `clang_rt.asan*` libraries does not incorrectly control the compiler default-library directive;
- suppress implicit VCAsan modeling when compiler `/Zl` or `/fno-sanitize-address-vcasan-lib` is present;
- respect final LINK `/NODEFAULTLIB` / `/NODEFAULTLIB:<name>` through the existing default-library policy;
- resolve the effective VCAsan library through MQB's existing library search order and seal only the exact resolved path as generic non-owning link file-input freshness evidence;
- never re-emit VCAsan in LINK argv or change native library search priority;
- append a versioned VCAsan link-identity domain only when the compiler default-library directive is effective;
- register the current official `/fno-sanitize-address-vcasan-lib` spelling as Class C passthrough.

## Real MSVC gate

The existing AddressSanitizer gate verifies:

- default Debug `/MDd` seals `vcasand.lib` together with the existing `clang_rt.asan*` inputs;
- a warm rebuild remains a true no-op link;
- explicit `/MT` seals `libvcasan.lib` and does not retain the `/MDd` VCAsan library;
- `/fno-sanitize-address-vcasan-lib` is accepted by real `cl.exe`, removes only VCAsan freshness evidence, and leaves `clang_rt.asan*` freshness intact;
- the existing non-incremental LINK, ordinary `mqb run`, named-module run, and `/INFERASANLIBS:NO` checks continue to pass.

The canonical 444-entry MSVC parameter inventory denominator remains unchanged.

## Exact-head regression evidence

Validated head: `55c709d30a00ade9c6ea9843aa5793c42f64eddf`.

- Native C++ #411: **success**
  - current Debug self-build: success
  - ambient MSVC option isolation: success
  - `/external:env` ownership gate: success
  - KASAN ownership gate: success
  - upgraded real AddressSanitizer + VCAsan freshness/opt-out gate: success
  - LibFuzzer link policy gate: success
  - linker side-output integrity gate: success
  - shared Debug native-test product library: success
  - exact 444-entry MSVC parameter inventory: success
  - 4/4 Debug shards + aggregate gate: success
- Native Release #349: **success**
  - Stage 0 Release self-build: success
  - shared Release product library: success
  - 4/4 Release shards: success
  - stable self-host: success
  - runtime-only package staging/validation/upload: success
- Performance Evidence #149: skipped as expected for this correctness `fix:` PR.

Base: `926b815a9a80ff270f3a591f8bca81768a579762`.