### PR TITLE
fix: track classic OpenMP runtime freshness

### DIFF
--- a/.github/workflows/native-ci.yml
+++ b/.github/workflows/native-ci.yml
@@ -134,6 +134,14 @@ jobs:
             -RepoRoot $PWD
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
+      - name: Verify OpenMP runtime policy
+        shell: pwsh
+        run: |
+          & (Join-Path $PWD 'tests/native/verify_openmp_runtime_policy.ps1') `
+            -MqbPath (Join-Path $PWD 'native-out/debug/mqb.exe') `
+            -RepoRoot $PWD
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
       - name: Verify linker side-output repair
         shell: pwsh
         run: |

--- a/cpp/include/mqb/core/LinkOptions.hpp
+++ b/cpp/include/mqb/core/LinkOptions.hpp
@@ -38,6 +38,11 @@ struct LinkOptions {
     // default-library directive into objects; the CRT mode is carried here so
     // MQB can seal that implicit linker file input without re-emitting it.
     std::optional<RuntimeLibrary> fuzzer_runtime_library;
+    // True for the classic Microsoft OpenMP runtime selected by /openmp or
+    // /openmp:experimental. cl.exe may inject vcomp.lib or vcompd.lib through
+    // object default-library directives, so LINK freshness must observe those
+    // toolchain inputs without rewriting the user's native linker argv.
+    bool msvc_openmp_runtime{false};
     std::vector<std::filesystem::path> library_directories;
     std::vector<std::string> libraries;
     std::vector<std::string> additional_arguments;

--- a/cpp/include/mqb/msvc/MsvcOpenMpPolicy.hpp
+++ b/cpp/include/mqb/msvc/MsvcOpenMpPolicy.hpp
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <array>
+#include <cctype>
+#include <span>
+#include <string>
+#include <string_view>
+
+#include "mqb/core/CompilerOptions.hpp"
+#include "mqb/core/LinkOptions.hpp"
+
+namespace mqb::msvc {
+
+class MsvcOpenMpPolicy {
+public:
+    [[nodiscard]] static bool classic_runtime_enabled(
+        const std::span<const std::string> arguments) noexcept {
+        bool enabled = false;
+        for (const auto& argument : arguments) {
+            const std::string_view body = option_body(argument);
+            if (ascii_iequals(body, "openmp")
+                || ascii_iequals(body, "openmp:experimental")) {
+                enabled = true;
+            } else if (ascii_iequals(body, "openmp-")) {
+                enabled = false;
+            }
+        }
+        return enabled;
+    }
+
+    static void apply_link_policy(
+        const CompilerOptions& compiler_options,
+        LinkOptions& link_options) noexcept {
+        link_options.msvc_openmp_runtime =
+            classic_runtime_enabled(compiler_options.additional_arguments);
+    }
+
+    [[nodiscard]] static constexpr std::array<std::string_view, 2>
+    implicit_library_candidates() noexcept {
+        // MSVC selects VCOMPD only when _DEBUG is defined and omp.h is included;
+        // otherwise it selects VCOMP. That decision is translation-unit-local,
+        // while MQB's link freshness policy is target-level. Observing every
+        // available candidate is conservative: it may cause an extra relink if
+        // an unused runtime changes, but it cannot miss the runtime LINK reads.
+        return {"vcomp.lib", "vcompd.lib"};
+    }
+
+private:
+    [[nodiscard]] static std::string_view option_body(
+        const std::string_view argument) noexcept {
+        if (argument.size() >= 2
+            && (argument.front() == '/' || argument.front() == '-')) {
+            return argument.substr(1);
+        }
+        return {};
+    }
+
+    [[nodiscard]] static bool ascii_iequals(
+        const std::string_view left,
+        const std::string_view right) noexcept {
+        if (left.size() != right.size()) {
+            return false;
+        }
+        for (std::size_t index = 0; index < left.size(); ++index) {
+            const auto a = static_cast<unsigned char>(left[index]);
+            const auto b = static_cast<unsigned char>(right[index]);
+            if (std::tolower(a) != std::tolower(b)) {
+                return false;
+            }
+        }
+        return true;
+    }
+};
+
+} // namespace mqb::msvc

--- a/cpp/src/core/model/BuildSignature.cpp
+++ b/cpp/src/core/model/BuildSignature.cpp
@@ -283,6 +283,12 @@ BuildSignature BuildSignature::for_link(
         hasher.add_string("mqb.libfuzzer.link.v1");
         hasher.add_enum(*options.fuzzer_runtime_library);
     }
+    if (options.msvc_openmp_runtime) {
+        // Classic /openmp and /openmp:experimental can inject vcomp/vcompd
+        // default-library directives into objects. Preserve non-OpenMP link
+        // identities and append only the cross-stage runtime ownership domain.
+        hasher.add_string("mqb.msvc-openmp.link.v1");
+    }
     return BuildSignature{hasher.finish()};
 }
 

--- a/cpp/src/msvc/parameters/MsvcParameterRegistry.cpp
+++ b/cpp/src/msvc/parameters/MsvcParameterRegistry.cpp
@@ -101,6 +101,12 @@ ParameterClassification classify_compiler_parameter(const std::string_view argum
     if (body == "fno-sanitize-address-vcasan-lib") {
         return classified(ParameterTool::compiler, ParameterOwnership::passthrough, "/fno-sanitize-address-vcasan-lib", "VCAsan default-library opt-out is preserved verbatim in compile identity and projected into ASan link freshness policy");
     }
+    if (body == "openmp:llvm") {
+        return compiler_unsupported(body, "LLVM OpenMP selects the separate experimental libomp runtime whose libraries/DLL deployment are not yet represented in MQB's link/runtime ownership model; use classic /openmp or /openmp:experimental for now");
+    }
+    if (body == "openmp" || body == "openmp:experimental" || body == "openmp-") {
+        return classified(ParameterTool::compiler, ParameterOwnership::passthrough, "/" + std::string{body}, "classic MSVC OpenMP mode is preserved verbatim in compile identity and projected into vcomp/vcompd link freshness policy");
+    }
     if (body == "experimental:log" || body.starts_with("experimental:log")) {
         return compiler_unsupported(body, "option creates a diagnostic log artifact that is not represented in MQB's cache/artifact graph");
     }
@@ -147,7 +153,7 @@ ParameterClassification classify_compiler_parameter(const std::string_view argum
         "AI"sv, "arch"sv, "await"sv, "cgthreads"sv, "constexpr:"sv, "D"sv, "diagnostics"sv, "EH"sv,
         "execution-charset"sv, "external:"sv, "favor:"sv, "feature"sv, "FI"sv, "forceInterlockedFunctions"sv,
         "fp:"sv, "fpcvt:"sv, "fsanitize"sv, "Gd"sv, "Gr"sv, "GR"sv, "GS"sv, "Gs"sv, "Gu"sv, "guard:"sv, "Gw"sv, "Gy"sv,
-        "I"sv, "Ob"sv, "Oi"sv, "openmp"sv, "Qpar"sv, "Qpar-report:"sv, "Qspectre"sv, "Qvec-report:"sv, "RTC"sv,
+        "I"sv, "Ob"sv, "Oi"sv, "Qpar"sv, "Qpar-report:"sv, "Qspectre"sv, "Qvec-report:"sv, "RTC"sv,
         "source-charset"sv, "U"sv, "vd"sv, "vm"sv, "volatile:"sv, "w1"sv, "w2"sv, "w3"sv, "w4"sv, "wd"sv, "we"sv, "wo"sv,
         "Wv:"sv, "Zc:"sv, "ZH:"sv, "Zm"sv, "Zo"sv, "Zp"sv,
     };

--- a/cpp/src/orchestration/incremental/MsvcIncrementalLinkCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalLinkCoordinator.cpp
@@ -20,6 +20,7 @@
 #include "mqb/msvc/MsvcFuzzerPolicy.hpp"
 #include "mqb/msvc/MsvcLibraryResolver.hpp"
 #include "mqb/msvc/MsvcLinker.hpp"
+#include "mqb/msvc/MsvcOpenMpPolicy.hpp"
 #include "mqb/msvc/MsvcParameterEngine.hpp"
 #include "mqb/msvc/MsvcWholeArchivePolicy.hpp"
 
@@ -330,6 +331,37 @@ MsvcIncrementalLinkCoordinator::run(const IncrementalLinkRequest& request) const
                 linker_file_inputs.end(),
                 resolved_fuzzer_library->files.begin(),
                 resolved_fuzzer_library->files.end());
+        }
+    }
+
+    if (request.options.msvc_openmp_runtime) {
+        std::vector<std::string> candidates;
+        for (const auto library : msvc::MsvcOpenMpPolicy::implicit_library_candidates()) {
+            if (msvc::MsvcDefaultLibraryPolicy::allows_implicit_library(
+                    *default_library_routing,
+                    library)) {
+                candidates.emplace_back(library);
+            }
+        }
+        if (!candidates.empty()) {
+            auto resolved_openmp_libraries = msvc::MsvcLibraryResolver::resolve_available(
+                toolchain_,
+                candidates,
+                request.options.library_directories,
+                working_directory);
+            if (!resolved_openmp_libraries) {
+                IncrementalLinkError error{
+                    .code = IncrementalLinkErrorCode::library_resolution_failed,
+                    .message = "failed to resolve MSVC OpenMP runtime freshness evidence: "
+                        + resolved_openmp_libraries.error().message,
+                    .library_resolution_error = resolved_openmp_libraries.error(),
+                };
+                return std::unexpected(std::move(error));
+            }
+            linker_file_inputs.insert(
+                linker_file_inputs.end(),
+                resolved_openmp_libraries->files.begin(),
+                resolved_openmp_libraries->files.end());
         }
     }
 

--- a/cpp/src/orchestration/incremental/MsvcIncrementalTargetCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalTargetCoordinator.cpp
@@ -14,6 +14,7 @@
 #include "mqb/core/TranslationUnit.hpp"
 #include "mqb/msvc/MsvcAddressSanitizerPolicy.hpp"
 #include "mqb/msvc/MsvcFuzzerPolicy.hpp"
+#include "mqb/msvc/MsvcOpenMpPolicy.hpp"
 #include "mqb/orchestration/BoundedWorkScheduler.hpp"
 
 namespace mqb::orchestration {
@@ -203,6 +204,9 @@ MsvcIncrementalTargetCoordinator::run(const IncrementalTargetRequest& request) c
         request.compiler_options,
         effective_link_options);
     msvc::MsvcFuzzerPolicy::apply_link_policy(
+        request.compiler_options,
+        effective_link_options);
+    msvc::MsvcOpenMpPolicy::apply_link_policy(
         request.compiler_options,
         effective_link_options);
 

--- a/cpp/src/orchestration/modules/ModuleTargetLinkRequestFactory.cpp
+++ b/cpp/src/orchestration/modules/ModuleTargetLinkRequestFactory.cpp
@@ -7,6 +7,7 @@
 
 #include "mqb/msvc/MsvcAddressSanitizerPolicy.hpp"
 #include "mqb/msvc/MsvcFuzzerPolicy.hpp"
+#include "mqb/msvc/MsvcOpenMpPolicy.hpp"
 
 namespace mqb::orchestration::detail {
 
@@ -27,6 +28,9 @@ IncrementalLinkRequest make_module_target_link_request(
         request.compiler_options,
         effective_link_options);
     msvc::MsvcFuzzerPolicy::apply_link_policy(
+        request.compiler_options,
+        effective_link_options);
+    msvc::MsvcOpenMpPolicy::apply_link_policy(
         request.compiler_options,
         effective_link_options);
 

--- a/tests/native/verify_openmp_runtime_policy.ps1
+++ b/tests/native/verify_openmp_runtime_policy.ps1
@@ -1,0 +1,229 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$MqbPath,
+    [Parameter(Mandatory = $true)][string]$RepoRoot
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+$MqbPath = [System.IO.Path]::GetFullPath($MqbPath)
+$RepoRoot = [System.IO.Path]::GetFullPath($RepoRoot)
+if (-not (Test-Path -LiteralPath $MqbPath -PathType Leaf)) {
+    throw "MQB executable not found: $MqbPath"
+}
+
+$fixture = Join-Path $RepoRoot 'native-test-work/openmp-runtime-policy'
+if (Test-Path -LiteralPath $fixture) {
+    Remove-Item -LiteralPath $fixture -Recurse -Force
+}
+New-Item -ItemType Directory -Path $fixture -Force | Out-Null
+Set-Content -LiteralPath (Join-Path $fixture 'main.cpp') -Encoding utf8 -Value @(
+    '#include <omp.h>',
+    'int main() {',
+    '    int total = 0;',
+    '    #pragma omp parallel for reduction(+:total)',
+    '    for (int i = 0; i < 100; ++i) { total += i; }',
+    '    return total == 4950 ? 0 : 1;',
+    '}'
+)
+Set-Content -LiteralPath (Join-Path $fixture 'plain.cpp') -Encoding utf8 -Value 'int main() { return 0; }'
+
+function Invoke-OpenMpBuild {
+    param(
+        [Parameter(Mandatory = $true)][string]$Source,
+        [Parameter(Mandatory = $true)][string]$Target,
+        [string[]]$ExtraArguments = @()
+    )
+
+    Push-Location $fixture
+    try {
+        $arguments = @('build', $Source, '--release', '--no-discover', '-o', $Target, '/openmp')
+        $arguments += $ExtraArguments
+        $output = @(& $MqbPath @arguments 2>&1)
+        $exitCode = $LASTEXITCODE
+    }
+    finally {
+        Pop-Location
+    }
+    [PSCustomObject]@{
+        ExitCode = $exitCode
+        Text = ($output -join [Environment]::NewLine)
+    }
+}
+
+function Get-LinkCachePath([string]$Target) {
+    Join-Path $fixture ".mqb/cache/link/$Target.linkcache"
+}
+
+function Get-LinkCacheText([string]$Target) {
+    $cache = Get-LinkCachePath $Target
+    if (-not (Test-Path -LiteralPath $cache -PathType Leaf)) {
+        throw "OpenMP link cache missing: $cache"
+    }
+    [Text.Encoding]::UTF8.GetString([IO.File]::ReadAllBytes($cache))
+}
+
+function Find-SealedVcompPath([string]$CacheText) {
+    $match = [regex]::Match(
+        $CacheText,
+        '(?i)(?<path>[A-Z]:/[^\x00-\x1f]*?/vcomp\.lib)')
+    if (-not $match.Success) {
+        throw "OpenMP link cache did not expose a sealed vcomp.lib path"
+    }
+    [System.IO.Path]::GetFullPath($match.Groups['path'].Value.Replace('/', '\'))
+}
+
+$cold = Invoke-OpenMpBuild -Source 'main.cpp' -Target 'openmp_probe'
+if ($cold.ExitCode -ne 0) {
+    throw "Cold classic OpenMP build failed:`n$($cold.Text)"
+}
+$exe = Join-Path $fixture '.mqb/bin/openmp_probe.exe'
+if (-not (Test-Path -LiteralPath $exe -PathType Leaf)) {
+    throw "Classic OpenMP build did not produce expected executable: $exe"
+}
+& $exe
+if ($LASTEXITCODE -ne 0) {
+    throw "Classic OpenMP executable failed at runtime (exit $LASTEXITCODE)"
+}
+
+$cacheText = Get-LinkCacheText 'openmp_probe'
+if ($cacheText -notmatch '(?i)vcomp\.lib') {
+    throw "Classic OpenMP link cache did not seal vcomp.lib freshness evidence"
+}
+$vcomp = Find-SealedVcompPath $cacheText
+if (-not (Test-Path -LiteralPath $vcomp -PathType Leaf)) {
+    throw "Sealed OpenMP import library does not exist: $vcomp"
+}
+
+$warm = Invoke-OpenMpBuild -Source 'main.cpp' -Target 'openmp_probe'
+if ($warm.ExitCode -ne 0) {
+    throw "Warm classic OpenMP build failed:`n$($warm.Text)"
+}
+if ($warm.Text -notmatch '\[up-to-date\]\s+openmp_probe\.exe') {
+    throw "Warm classic OpenMP build did not reuse sealed runtime input:`n$($warm.Text)"
+}
+
+# Put an exact copy of the toolchain import library first in LINK search order.
+# This makes the compiler-injected /DEFAULTLIB:vcomp directive resolve to a
+# fixture-owned file whose freshness we can mutate without touching VS itself.
+$localLibDir = Join-Path $fixture 'local-lib'
+New-Item -ItemType Directory -Path $localLibDir -Force | Out-Null
+$localVcomp = Join-Path $localLibDir 'vcomp.lib'
+Copy-Item -LiteralPath $vcomp -Destination $localVcomp -Force
+
+$localCold = Invoke-OpenMpBuild `
+    -Source 'main.cpp' `
+    -Target 'openmp_local_probe' `
+    -ExtraArguments @('-L', $localLibDir)
+if ($localCold.ExitCode -ne 0) {
+    throw "Local-vcomp OpenMP cold build failed:`n$($localCold.Text)"
+}
+$localCacheText = Get-LinkCacheText 'openmp_local_probe'
+$normalizedLocal = [System.IO.Path]::GetFullPath($localVcomp).Replace('\', '/')
+if ($localCacheText -notmatch [Regex]::Escape($normalizedLocal)) {
+    throw "OpenMP freshness did not seal the -L-preferred fixture vcomp.lib"
+}
+
+$localWarm = Invoke-OpenMpBuild `
+    -Source 'main.cpp' `
+    -Target 'openmp_local_probe' `
+    -ExtraArguments @('-L', $localLibDir)
+if ($localWarm.ExitCode -ne 0) {
+    throw "Local-vcomp OpenMP warm build failed:`n$($localWarm.Text)"
+}
+if ($localWarm.Text -notmatch '\[up-to-date\]\s+openmp_local_probe\.exe') {
+    throw "Local-vcomp OpenMP warm build did not reuse link cache:`n$($localWarm.Text)"
+}
+
+(Get-Item -LiteralPath $localVcomp).LastWriteTimeUtc = (Get-Date).ToUniversalTime().AddSeconds(5)
+$changed = Invoke-OpenMpBuild `
+    -Source 'main.cpp' `
+    -Target 'openmp_local_probe' `
+    -ExtraArguments @('-L', $localLibDir)
+if ($changed.ExitCode -ne 0) {
+    throw "Changed-vcomp OpenMP build failed:`n$($changed.Text)"
+}
+if ($changed.Text -notmatch '\[up-to-date\]\s+main\.cpp') {
+    throw "OpenMP runtime-only freshness change unexpectedly recompiled main.cpp:`n$($changed.Text)"
+}
+if ($changed.Text -notmatch '\[link\]\s+openmp_local_probe\.exe') {
+    throw "Changed OpenMP import library did not trigger relink:`n$($changed.Text)"
+}
+if ($changed.Text -notmatch 'link inputs changed') {
+    throw "OpenMP runtime-driven relink was not explained as link inputs changed:`n$($changed.Text)"
+}
+
+# /NODEFAULTLIB remains authoritative. Use a source with no OpenMP unresolveds
+# so LINK can succeed while proving MQB also drops the suppressed freshness edge.
+$suppressed = Invoke-OpenMpBuild `
+    -Source 'plain.cpp' `
+    -Target 'openmp_suppressed' `
+    -ExtraArguments @('/link', '/NODEFAULTLIB:vcomp.lib', '/NODEFAULTLIB:vcompd.lib')
+if ($suppressed.ExitCode -ne 0) {
+    throw "OpenMP NODEFAULTLIB suppression probe failed:`n$($suppressed.Text)"
+}
+$suppressedCache = Get-LinkCacheText 'openmp_suppressed'
+if ($suppressedCache -match '(?i)vcompd?\.lib') {
+    throw "OpenMP link cache retained runtime freshness evidence suppressed by /NODEFAULTLIB"
+}
+
+# Exercise the compiler->link projection through the Modules pipeline as well.
+Set-Content -LiteralPath (Join-Path $fixture 'math.ixx') -Encoding utf8 -Value @(
+    'export module math;',
+    'export int answer() { return 42; }'
+)
+Set-Content -LiteralPath (Join-Path $fixture 'module_main.cpp') -Encoding utf8 -Value @(
+    '#include <omp.h>',
+    'import math;',
+    'int main() {',
+    '    int total = 0;',
+    '    #pragma omp parallel for reduction(+:total)',
+    '    for (int i = 0; i < 10; ++i) { total += i; }',
+    '    return answer() == 42 && total == 45 ? 0 : 1;',
+    '}'
+)
+Push-Location $fixture
+try {
+    $moduleOutput = @(
+        & $MqbPath build module_main.cpp math.ixx --release --no-discover `
+            -o openmp_module_probe /openmp 2>&1
+    )
+    $moduleExit = $LASTEXITCODE
+}
+finally {
+    Pop-Location
+}
+if ($moduleExit -ne 0) {
+    throw "Module classic OpenMP build failed:`n$($moduleOutput -join [Environment]::NewLine)"
+}
+if ((Get-LinkCacheText 'openmp_module_probe') -notmatch '(?i)vcomp\.lib') {
+    throw "Module OpenMP link cache did not seal vcomp.lib freshness evidence"
+}
+
+# LLVM OpenMP selects libomp and a different DLL deployment contract. It must
+# not silently enter the classic vcomp freshness model.
+Push-Location $fixture
+try {
+    $llvmRejected = @(
+        & $MqbPath build plain.cpp --release --no-discover -o openmp_llvm_rejected `
+            /openmp:llvm 2>&1
+    )
+    $llvmExit = $LASTEXITCODE
+}
+finally {
+    Pop-Location
+}
+$llvmText = $llvmRejected -join [Environment]::NewLine
+if ($llvmExit -eq 0) {
+    throw "/openmp:llvm unexpectedly entered MQB's classic OpenMP runtime pipeline"
+}
+if ($llvmText -notmatch 'libomp runtime') {
+    throw "Rejected /openmp:llvm did not explain its separate runtime ownership boundary:`n$llvmText"
+}
+if (Test-Path -LiteralPath (Join-Path $fixture '.mqb/bin/openmp_llvm_rejected.exe') -PathType Leaf) {
+    throw "Rejected /openmp:llvm unexpectedly produced an executable"
+}
+
+Write-Host 'Real MSVC classic OpenMP runtime freshness, NODEFAULTLIB, Modules, and LLVM ownership checks passed.'
+exit 0


### PR DESCRIPTION
## Summary

Closes the post-#103 classic OpenMP compiler->link freshness gap. `/openmp` and `/openmp:experimental` may inject Microsoft OpenMP runtime default-library directives into objects; MQB now seals the corresponding classic runtime inputs without rewriting native argv.

## Fix

- project classic `/openmp` / `/openmp:experimental` policy into ordinary and Modules link requests;
- append an OpenMP-specific domain to link identity only when active;
- keep native compiler/linker argv unchanged;
- observe available `vcomp.lib` / `vcompd.lib` as non-owning link freshness inputs;
- honor final `/NODEFAULTLIB` suppression;
- keep `/openmp`, `/openmp:experimental`, `/openmp-` admitted;
- fail closed on `/openmp:llvm` until the separate `libomp` runtime/DLL deployment contract is first-class.

## Real MSVC evidence

Exact validated head: `ff14b87346581bb2e7d80fc047badce2c3148c99`.

- Native C++ #413: **success**
  - current Debug self-build: success
  - ambient/external-env/KASAN/ASan/LibFuzzer regressions: success
  - real classic OpenMP runtime policy gate: success
    - Release `/openmp` compile/link/run
    - `vcomp.lib` sealed in link freshness
    - `-L`-preferred fixture `vcomp.lib` timestamp-only change -> TU reused, LINK reruns for `link inputs changed`
    - `/NODEFAULTLIB:vcomp.lib` and `/NODEFAULTLIB:vcompd.lib` suppress the freshness edges
    - named Modules path seals OpenMP runtime evidence
    - `/openmp:llvm` fails before compilation with separate-runtime ownership diagnostic
  - linker side-output integrity gate: success
  - exact 444-entry MSVC parameter inventory: success
  - 4/4 Debug shards + aggregate gate: success
- Native Release #350: **success**
  - Stage 0 Release self-build: success
  - shared Release product library: success
  - 4/4 Release shards: success
  - stable self-host: success
  - runtime-only package staging/validation/upload: success
- Performance Evidence #152: skipped as expected for this correctness `fix:` PR.

## Scope

This closes same-target compiler->link OpenMP runtime freshness. Transitive default-library directives embedded in separately built object/archive inputs remain a distinct audit boundary and are intentionally not folded into this PR.

Base: `a58bfaea6f1bf2f76783e0508dc13345d60b533d`.