### PR TITLE
fix: track transitive default-library freshness

### DIFF
--- a/.github/workflows/native-ci.yml
+++ b/.github/workflows/native-ci.yml
@@ -142,6 +142,14 @@ jobs:
             -RepoRoot $PWD
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
+      - name: Verify transitive default-library freshness
+        shell: pwsh
+        run: |
+          & (Join-Path $PWD 'tests/native/verify_transitive_default_library_freshness.ps1') `
+            -MqbPath (Join-Path $PWD 'native-out/debug/mqb.exe') `
+            -RepoRoot $PWD
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
       - name: Verify linker side-output repair
         shell: pwsh
         run: |

--- a/cpp/include/mqb/core/LinkCache.hpp
+++ b/cpp/include/mqb/core/LinkCache.hpp
@@ -3,7 +3,6 @@
 #include <filesystem>
 #include <optional>
 #include <span>
-#include <string>
 #include <vector>
 
 #include "mqb/core/BuildSignature.hpp"
@@ -24,11 +23,6 @@ struct LinkCacheEntry {
     // are not ordinary object/library inputs (initially native /DEF files).
     std::vector<std::filesystem::path> file_inputs;
     std::vector<std::filesystem::path> side_outputs;
-    // Opaque state for the library search roots used to resolve LINK-observed
-    // transitive default libraries. When unchanged, cached absolute library
-    // paths can be reused without repeating basename search on every warm build.
-    // This state is validation metadata only and is not linker argv/identity.
-    std::string observed_library_search_state;
 };
 
 struct LinkCacheValidation {

--- a/cpp/include/mqb/core/LinkCache.hpp
+++ b/cpp/include/mqb/core/LinkCache.hpp
@@ -3,6 +3,7 @@
 #include <filesystem>
 #include <optional>
 #include <span>
+#include <string>
 #include <vector>
 
 #include "mqb/core/BuildSignature.hpp"
@@ -23,6 +24,11 @@ struct LinkCacheEntry {
     // are not ordinary object/library inputs (initially native /DEF files).
     std::vector<std::filesystem::path> file_inputs;
     std::vector<std::filesystem::path> side_outputs;
+    // Opaque state for the library search roots used to resolve LINK-observed
+    // transitive default libraries. When unchanged, cached absolute library
+    // paths can be reused without repeating basename search on every warm build.
+    // This state is validation metadata only and is not linker argv/identity.
+    std::string observed_library_search_state;
 };
 
 struct LinkCacheValidation {

--- a/cpp/include/mqb/msvc/MsvcLibraryResolver.hpp
+++ b/cpp/include/mqb/msvc/MsvcLibraryResolver.hpp
@@ -47,6 +47,20 @@ public:
         std::span<const std::string> libraries,
         std::span<const std::filesystem::path> library_directories,
         const std::filesystem::path& working_directory = {});
+
+    // Refresh full library paths previously observed from LINK /VERBOSE:LIB.
+    // Libraries that were selected from the normal -L / working-directory / LIB
+    // search path are re-resolved by basename so a newly higher-priority same-name
+    // library is visible before LINK runs again. Paths outside those search roots
+    // are treated as absolute directive inputs and keep their exact identity.
+    // Non-library paths are ignored, allowing callers to pass mixed cached
+    // file-input evidence without duplicating library-search policy.
+    [[nodiscard]] static std::expected<ResolvedLibraries, LibraryResolutionError>
+    refresh_observed(
+        const MsvcToolchain& toolchain,
+        std::span<const std::filesystem::path> observed_inputs,
+        std::span<const std::filesystem::path> library_directories,
+        const std::filesystem::path& working_directory = {});
 };
 
 } // namespace mqb::msvc

--- a/cpp/include/mqb/msvc/MsvcLibraryResolver.hpp
+++ b/cpp/include/mqb/msvc/MsvcLibraryResolver.hpp
@@ -49,10 +49,13 @@ public:
         const std::filesystem::path& working_directory = {});
 
     // Refresh full library paths previously observed from LINK /VERBOSE:LIB.
-    // Libraries that were selected from the normal -L / working-directory / LIB
-    // search path are re-resolved by basename so a newly higher-priority same-name
-    // library is visible before LINK runs again. Paths outside those search roots
-    // are treated as absolute directive inputs and keep their exact identity.
+    // The link-cache file is written only after LINK's observation has been
+    // sealed. If no search directory changed after that seal time, the cached
+    // absolute paths are already authoritative and basename search is skipped.
+    // Once any -L / working-directory / LIB search root changes, libraries that
+    // came from those roots are re-resolved by basename so a newly higher-
+    // priority same-name library is visible before LINK runs again. Paths outside
+    // those roots are absolute directive inputs and keep their exact identity.
     // Non-library paths are ignored, allowing callers to pass mixed cached
     // file-input evidence without duplicating library-search policy.
     [[nodiscard]] static std::expected<ResolvedLibraries, LibraryResolutionError>
@@ -60,7 +63,8 @@ public:
         const MsvcToolchain& toolchain,
         std::span<const std::filesystem::path> observed_inputs,
         std::span<const std::filesystem::path> library_directories,
-        const std::filesystem::path& working_directory = {});
+        const std::filesystem::path& working_directory,
+        const std::filesystem::path& observation_seal_file);
 };
 
 } // namespace mqb::msvc

--- a/cpp/include/mqb/msvc/MsvcLinker.hpp
+++ b/cpp/include/mqb/msvc/MsvcLinker.hpp
@@ -4,6 +4,7 @@
 #include <filesystem>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "mqb/core/LinkOptions.hpp"
@@ -23,6 +24,10 @@ struct LinkInvocation {
     // This avoids stale archive-member reuse inside MSVC's .ilk state while
     // preserving ordinary Debug incremental linking for object-only changes.
     bool force_full_link{false};
+    // Ask LINK itself to report the exact libraries it searches while resolving
+    // object/archive directives. This is observation only: it does not alter the
+    // user's linker policy or explicit library argv.
+    bool observe_library_search{false};
 };
 
 enum class LinkerErrorCode {
@@ -83,6 +88,20 @@ public:
         const std::filesystem::path& output,
         const LinkOptions& options,
         const std::filesystem::path& working_directory = {});
+
+    // Parse /VERBOSE:LIB output without depending on localized progress labels.
+    // LINK documents that the library/object names are emitted as full paths;
+    // MQB extracts only absolute .lib path tokens and treats them as non-owning
+    // freshness evidence.
+    [[nodiscard]] static std::vector<std::filesystem::path>
+    observed_library_paths(std::string_view stdout_text);
+
+    // Internal /VERBOSE:LIB is an implementation detail. Unless the user asked
+    // for linker progress output themselves, retain only LNK diagnostics in the
+    // visible stdout after observation has been parsed.
+    static void sanitize_library_observation_output(
+        process::ProcessResult& result,
+        const LinkOptions& options);
 
     [[nodiscard]] static std::expected<std::vector<std::string>, LinkerError>
     build_arguments(const LinkInvocation& invocation);

--- a/cpp/src/msvc/linker/MsvcLibraryResolver.cpp
+++ b/cpp/src/msvc/linker/MsvcLibraryResolver.cpp
@@ -186,6 +186,31 @@ void add_search_directory(
     return search_directories;
 }
 
+[[nodiscard]] bool search_roots_changed_since(
+    const std::vector<fs::path>& search_directories,
+    const fs::path& observation_seal_file) {
+    if (observation_seal_file.empty()) {
+        return true;
+    }
+
+    std::error_code error_code;
+    const auto sealed = fs::last_write_time(observation_seal_file, error_code);
+    if (error_code) {
+        return true;
+    }
+
+    for (const auto& directory : search_directories) {
+        error_code.clear();
+        const auto modified = fs::last_write_time(directory, error_code);
+        // Missing/inaccessible search roots need the conservative path. A root
+        // can become available later and introduce a higher-priority library.
+        if (error_code || modified > sealed) {
+            return true;
+        }
+    }
+    return false;
+}
+
 [[nodiscard]] bool regular_file(const fs::path& path) {
     std::error_code error_code;
     return fs::is_regular_file(path, error_code) && !error_code;
@@ -304,7 +329,8 @@ MsvcLibraryResolver::refresh_observed(
     const MsvcToolchain& toolchain,
     const std::span<const fs::path> observed_inputs,
     const std::span<const fs::path> library_directories,
-    const fs::path& requested_working_directory) {
+    const fs::path& requested_working_directory,
+    const fs::path& observation_seal_file) {
     auto working_directory = resolve_working_directory(requested_working_directory);
     if (!working_directory) {
         return std::unexpected(working_directory.error());
@@ -313,6 +339,9 @@ MsvcLibraryResolver::refresh_observed(
         toolchain,
         library_directories,
         *working_directory);
+    const bool reroute = search_roots_changed_since(
+        search_directories,
+        observation_seal_file);
 
     ResolvedLibraries result;
     result.files.reserve(observed_inputs.size());
@@ -322,7 +351,7 @@ MsvcLibraryResolver::refresh_observed(
         }
 
         fs::path current = make_absolute(*working_directory, observed_input);
-        if (contains_windows_path(search_directories, current.parent_path())) {
+        if (reroute && contains_windows_path(search_directories, current.parent_path())) {
             const std::vector<std::string> basename{path_to_utf8(current.filename())};
             auto rerouted = resolve_requests(
                 toolchain,

--- a/cpp/src/msvc/linker/MsvcLibraryResolver.cpp
+++ b/cpp/src/msvc/linker/MsvcLibraryResolver.cpp
@@ -37,6 +37,13 @@ namespace fs = std::filesystem;
     return fs::path{bytes};
 }
 
+[[nodiscard]] std::string path_to_utf8(const fs::path& path) {
+    const auto bytes = path.generic_u8string();
+    return std::string{
+        reinterpret_cast<const char*>(bytes.data()),
+        bytes.size()};
+}
+
 [[nodiscard]] bool ascii_iequals(
     const std::string_view left,
     const std::string_view right) {
@@ -51,6 +58,36 @@ namespace fs = std::filesystem;
         }
     }
     return true;
+}
+
+[[nodiscard]] std::string windows_path_key(const fs::path& path) {
+    std::string value = path.lexically_normal().generic_string();
+    std::transform(
+        value.begin(),
+        value.end(),
+        value.begin(),
+        [](const unsigned char character) {
+            return static_cast<char>(std::tolower(character));
+        });
+    return value;
+}
+
+[[nodiscard]] bool same_windows_path(const fs::path& left, const fs::path& right) {
+    return windows_path_key(left) == windows_path_key(right);
+}
+
+[[nodiscard]] bool contains_windows_path(
+    const std::vector<fs::path>& paths,
+    const fs::path& expected) {
+    return std::any_of(paths.begin(), paths.end(), [&](const fs::path& path) {
+        return same_windows_path(path, expected);
+    });
+}
+
+void append_unique_path(std::vector<fs::path>& paths, const fs::path& path) {
+    if (!contains_windows_path(paths, path)) {
+        paths.push_back(path.lexically_normal());
+    }
 }
 
 [[nodiscard]] std::string_view environment_value(
@@ -128,9 +165,25 @@ void add_search_directory(
         return;
     }
     const fs::path normalized = make_absolute(working_directory, directory);
-    if (std::find(directories.begin(), directories.end(), normalized) == directories.end()) {
+    if (!contains_windows_path(directories, normalized)) {
         directories.push_back(normalized);
     }
+}
+
+[[nodiscard]] std::vector<fs::path> search_directories_for(
+    const MsvcToolchain& toolchain,
+    const std::span<const fs::path> library_directories,
+    const fs::path& working_directory) {
+    std::vector<fs::path> search_directories;
+    search_directories.reserve(library_directories.size() + 8);
+    for (const auto& directory : library_directories) {
+        add_search_directory(search_directories, working_directory, directory);
+    }
+    add_search_directory(search_directories, working_directory, working_directory);
+    for (const auto& directory : split_library_path(environment_value(toolchain, "LIB"))) {
+        add_search_directory(search_directories, working_directory, directory);
+    }
+    return search_directories;
 }
 
 [[nodiscard]] bool regular_file(const fs::path& path) {
@@ -146,6 +199,10 @@ void add_search_directory(
     return library;
 }
 
+[[nodiscard]] bool library_path(const fs::path& path) {
+    return ascii_iequals(path_to_utf8(path.extension()), ".lib");
+}
+
 [[nodiscard]] std::expected<ResolvedLibraries, LibraryResolutionError>
 resolve_requests(
     const MsvcToolchain& toolchain,
@@ -158,15 +215,10 @@ resolve_requests(
         return std::unexpected(working_directory.error());
     }
 
-    std::vector<fs::path> search_directories;
-    search_directories.reserve(library_directories.size() + 8);
-    for (const auto& directory : library_directories) {
-        add_search_directory(search_directories, *working_directory, directory);
-    }
-    add_search_directory(search_directories, *working_directory, *working_directory);
-    for (const auto& directory : split_library_path(environment_value(toolchain, "LIB"))) {
-        add_search_directory(search_directories, *working_directory, directory);
-    }
+    const auto search_directories = search_directories_for(
+        toolchain,
+        library_directories,
+        *working_directory);
 
     ResolvedLibraries result;
     result.files.reserve(libraries.size());
@@ -245,6 +297,49 @@ MsvcLibraryResolver::resolve_available(
         library_directories,
         requested_working_directory,
         false);
+}
+
+std::expected<ResolvedLibraries, LibraryResolutionError>
+MsvcLibraryResolver::refresh_observed(
+    const MsvcToolchain& toolchain,
+    const std::span<const fs::path> observed_inputs,
+    const std::span<const fs::path> library_directories,
+    const fs::path& requested_working_directory) {
+    auto working_directory = resolve_working_directory(requested_working_directory);
+    if (!working_directory) {
+        return std::unexpected(working_directory.error());
+    }
+    const auto search_directories = search_directories_for(
+        toolchain,
+        library_directories,
+        *working_directory);
+
+    ResolvedLibraries result;
+    result.files.reserve(observed_inputs.size());
+    for (const auto& observed_input : observed_inputs) {
+        if (!library_path(observed_input)) {
+            continue;
+        }
+
+        fs::path current = make_absolute(*working_directory, observed_input);
+        if (contains_windows_path(search_directories, current.parent_path())) {
+            const std::vector<std::string> basename{path_to_utf8(current.filename())};
+            auto rerouted = resolve_requests(
+                toolchain,
+                basename,
+                library_directories,
+                *working_directory,
+                false);
+            if (!rerouted) {
+                return std::unexpected(rerouted.error());
+            }
+            if (!rerouted->files.empty()) {
+                current = rerouted->files.front();
+            }
+        }
+        append_unique_path(result.files, current);
+    }
+    return result;
 }
 
 } // namespace mqb::msvc

--- a/cpp/src/msvc/linker/MsvcLinker.cpp
+++ b/cpp/src/msvc/linker/MsvcLinker.cpp
@@ -1,11 +1,13 @@
 #include "mqb/msvc/MsvcLinker.hpp"
 
+#include <algorithm>
 #include <cctype>
 #include <filesystem>
 #include <string>
 #include <string_view>
 #include <system_error>
 #include <utility>
+#include <vector>
 
 namespace mqb::msvc {
 namespace {
@@ -83,6 +85,149 @@ void suppress_ambient_linker_options(
         character = static_cast<char>(std::toupper(static_cast<unsigned char>(character)));
     }
     return body;
+}
+
+[[nodiscard]] bool ascii_iequals(
+    const std::string_view left,
+    const std::string_view right) noexcept {
+    if (left.size() != right.size()) {
+        return false;
+    }
+    for (std::size_t index = 0; index < left.size(); ++index) {
+        const auto a = static_cast<unsigned char>(left[index]);
+        const auto b = static_cast<unsigned char>(right[index]);
+        if (std::tolower(a) != std::tolower(b)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+[[nodiscard]] std::size_t find_ascii_icase(
+    const std::string_view text,
+    const std::string_view needle,
+    const std::size_t from = 0) noexcept {
+    if (needle.empty() || from > text.size() || needle.size() > text.size() - from) {
+        return std::string_view::npos;
+    }
+    for (std::size_t index = from; index + needle.size() <= text.size(); ++index) {
+        if (ascii_iequals(text.substr(index, needle.size()), needle)) {
+            return index;
+        }
+    }
+    return std::string_view::npos;
+}
+
+[[nodiscard]] std::string windows_path_key(const fs::path& path) {
+    std::string key = path.lexically_normal().generic_string();
+    std::transform(
+        key.begin(),
+        key.end(),
+        key.begin(),
+        [](const unsigned char character) {
+            return static_cast<char>(std::tolower(character));
+        });
+    return key;
+}
+
+void add_unique_path(std::vector<fs::path>& paths, const fs::path& path) {
+    const std::string key = windows_path_key(path);
+    const auto duplicate = std::find_if(
+        paths.begin(),
+        paths.end(),
+        [&](const fs::path& existing) {
+            return windows_path_key(existing) == key;
+        });
+    if (duplicate == paths.end()) {
+        paths.push_back(path.lexically_normal());
+    }
+}
+
+[[nodiscard]] std::optional<std::size_t> absolute_windows_path_start(
+    const std::string_view line,
+    const std::size_t before) noexcept {
+    if (before > line.size()) {
+        return std::nullopt;
+    }
+
+    for (std::size_t cursor = before; cursor > 0; --cursor) {
+        const std::size_t index = cursor - 1;
+        if (index + 2 < before
+            && std::isalpha(static_cast<unsigned char>(line[index])) != 0
+            && line[index + 1] == ':'
+            && (line[index + 2] == '\\' || line[index + 2] == '/')) {
+            return index;
+        }
+    }
+
+    for (std::size_t cursor = before; cursor > 1; --cursor) {
+        const std::size_t index = cursor - 2;
+        if (line[index] == '\\' && line[index + 1] == '\\') {
+            if (index == 0
+                || std::isspace(static_cast<unsigned char>(line[index - 1])) != 0
+                || line[index - 1] == '"') {
+                return index;
+            }
+        }
+    }
+    return std::nullopt;
+}
+
+[[nodiscard]] bool has_user_progress_output(const LinkOptions& options) {
+    return std::any_of(
+        options.additional_arguments.begin(),
+        options.additional_arguments.end(),
+        [](const std::string& argument) {
+            const std::string body = linker_option_body_upper(argument);
+            return body.starts_with("VERBOSE") || body == "TIME";
+        });
+}
+
+[[nodiscard]] bool already_reports_library_search(const LinkOptions& options) {
+    return std::any_of(
+        options.additional_arguments.begin(),
+        options.additional_arguments.end(),
+        [](const std::string& argument) {
+            const std::string body = linker_option_body_upper(argument);
+            return body == "VERBOSE" || body == "VERBOSE:LIB";
+        });
+}
+
+[[nodiscard]] bool has_lnk_diagnostic(const std::string_view line) noexcept {
+    std::size_t from = 0;
+    while (from < line.size()) {
+        const std::size_t marker = line.find("LNK", from);
+        if (marker == std::string_view::npos) {
+            return false;
+        }
+        if (marker + 7 <= line.size()
+            && std::isdigit(static_cast<unsigned char>(line[marker + 3])) != 0
+            && std::isdigit(static_cast<unsigned char>(line[marker + 4])) != 0
+            && std::isdigit(static_cast<unsigned char>(line[marker + 5])) != 0
+            && std::isdigit(static_cast<unsigned char>(line[marker + 6])) != 0) {
+            return true;
+        }
+        from = marker + 3;
+    }
+    return false;
+}
+
+[[nodiscard]] std::string keep_lnk_diagnostics(const std::string_view text) {
+    std::string filtered;
+    std::size_t begin = 0;
+    while (begin < text.size()) {
+        const std::size_t newline = text.find('\n', begin);
+        const std::size_t end = newline == std::string_view::npos ? text.size() : newline + 1;
+        const std::string_view line = text.substr(begin, end - begin);
+        if (has_lnk_diagnostic(line)) {
+            filtered.append(line);
+        }
+        if (newline == std::string_view::npos) {
+            break;
+        }
+        begin = newline + 1;
+    }
+    return filtered;
 }
 
 } // namespace
@@ -233,6 +378,51 @@ std::vector<fs::path> MsvcLinker::required_side_output_paths(
     return paths;
 }
 
+std::vector<fs::path> MsvcLinker::observed_library_paths(
+    const std::string_view stdout_text) {
+    std::vector<fs::path> paths;
+    std::size_t begin = 0;
+    while (begin < stdout_text.size()) {
+        const std::size_t newline = stdout_text.find('\n', begin);
+        const std::size_t end = newline == std::string_view::npos
+            ? stdout_text.size()
+            : newline;
+        const std::string_view line = stdout_text.substr(begin, end - begin);
+
+        std::size_t search_from = 0;
+        while (search_from < line.size()) {
+            const std::size_t extension = find_ascii_icase(line, ".lib", search_from);
+            if (extension == std::string_view::npos) {
+                break;
+            }
+            const std::size_t path_end = extension + 4;
+            if (auto path_start = absolute_windows_path_start(line, extension)) {
+                const fs::path candidate = path_from_utf8(
+                    line.substr(*path_start, path_end - *path_start));
+                if (candidate.is_absolute()) {
+                    add_unique_path(paths, candidate);
+                }
+            }
+            search_from = path_end;
+        }
+
+        if (newline == std::string_view::npos) {
+            break;
+        }
+        begin = newline + 1;
+    }
+    return paths;
+}
+
+void MsvcLinker::sanitize_library_observation_output(
+    process::ProcessResult& result,
+    const LinkOptions& options) {
+    if (has_user_progress_output(options)) {
+        return;
+    }
+    result.stdout_text = keep_lnk_diagnostics(result.stdout_text);
+}
+
 std::expected<std::vector<std::string>, LinkerError>
 MsvcLinker::build_arguments(const LinkInvocation& invocation) {
     if (invocation.options.target_kind == TargetKind::static_library) {
@@ -272,7 +462,7 @@ MsvcLinker::build_arguments(const LinkInvocation& invocation) {
 
     std::vector<std::string> arguments;
     arguments.reserve(
-        18
+        19
         + invocation.objects.size()
         + invocation.options.library_directories.size()
         + invocation.libraries.size()
@@ -311,6 +501,14 @@ MsvcLinker::build_arguments(const LinkInvocation& invocation) {
                 "additional linker argument must not be empty"));
         }
         arguments.push_back(argument);
+    }
+
+    if (invocation.observe_library_search
+        && !already_reports_library_search(invocation.options)) {
+        // Microsoft documents /VERBOSE:LIB as reporting each searched library
+        // and object with its full path. Keep this after raw user flags so the
+        // observation cannot be disabled by an earlier progress-mode switch.
+        arguments.emplace_back("/VERBOSE:LIB");
     }
 
     // Library/file-input changes already require a full link to avoid stale

--- a/cpp/src/orchestration/incremental/MsvcIncrementalLinkCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalLinkCoordinator.cpp
@@ -6,7 +6,6 @@
 #include <filesystem>
 #include <optional>
 #include <string>
-#include <string_view>
 #include <system_error>
 #include <utility>
 #include <variant>
@@ -113,130 +112,6 @@ void append_unique_paths(
     return std::any_of(paths.begin(), paths.end(), [&](const fs::path& path) {
         return same_path(path, expected);
     });
-}
-
-[[nodiscard]] bool ascii_iequals(
-    const std::string_view left,
-    const std::string_view right) noexcept {
-    if (left.size() != right.size()) {
-        return false;
-    }
-    for (std::size_t index = 0; index < left.size(); ++index) {
-        const auto a = static_cast<unsigned char>(left[index]);
-        const auto b = static_cast<unsigned char>(right[index]);
-        if (std::tolower(a) != std::tolower(b)) {
-            return false;
-        }
-    }
-    return true;
-}
-
-[[nodiscard]] std::string path_to_utf8(const fs::path& path) {
-    const auto bytes = path.generic_u8string();
-    return std::string{
-        reinterpret_cast<const char*>(bytes.data()),
-        bytes.size()};
-}
-
-[[nodiscard]] fs::path path_from_utf8(const std::string_view value) {
-    std::u8string bytes;
-    bytes.assign(
-        reinterpret_cast<const char8_t*>(value.data()),
-        reinterpret_cast<const char8_t*>(value.data() + value.size()));
-    return fs::path{bytes};
-}
-
-[[nodiscard]] std::string_view environment_value(
-    const msvc::MsvcToolchain& toolchain,
-    const std::string_view name) noexcept {
-    for (const auto& variable : toolchain.environment) {
-        if (ascii_iequals(variable.name, name)) {
-            return variable.value;
-        }
-    }
-    return {};
-}
-
-[[nodiscard]] std::vector<fs::path> split_library_path(const std::string_view value) {
-    std::vector<fs::path> result;
-    std::size_t begin = 0;
-    while (begin <= value.size()) {
-        const std::size_t separator = value.find(';', begin);
-        const std::size_t end = separator == std::string_view::npos
-            ? value.size()
-            : separator;
-        std::string_view token = value.substr(begin, end - begin);
-        while (!token.empty()
-            && std::isspace(static_cast<unsigned char>(token.front())) != 0) {
-            token.remove_prefix(1);
-        }
-        while (!token.empty()
-            && std::isspace(static_cast<unsigned char>(token.back())) != 0) {
-            token.remove_suffix(1);
-        }
-        if (token.size() >= 2 && token.front() == '"' && token.back() == '"') {
-            token.remove_prefix(1);
-            token.remove_suffix(1);
-        }
-        if (!token.empty()) {
-            result.push_back(path_from_utf8(token));
-        }
-        if (separator == std::string_view::npos) {
-            break;
-        }
-        begin = separator + 1;
-    }
-    return result;
-}
-
-void add_search_directory(
-    std::vector<fs::path>& directories,
-    const fs::path& base,
-    const fs::path& directory) {
-    if (directory.empty()) {
-        return;
-    }
-    const fs::path normalized = directory.is_absolute()
-        ? directory.lexically_normal()
-        : (base / directory).lexically_normal();
-    if (!contains_windows_path(directories, normalized)) {
-        directories.push_back(normalized);
-    }
-}
-
-[[nodiscard]] std::vector<fs::path> library_search_directories(
-    const msvc::MsvcToolchain& toolchain,
-    const std::vector<fs::path>& configured,
-    const fs::path& requested_working_directory) {
-    std::error_code error_code;
-    fs::path base = requested_working_directory.empty()
-        ? fs::current_path(error_code)
-        : fs::absolute(requested_working_directory, error_code);
-    if (error_code) {
-        return {};
-    }
-    base = base.lexically_normal();
-
-    std::vector<fs::path> directories;
-    directories.reserve(configured.size() + 8);
-    for (const auto& directory : configured) {
-        add_search_directory(directories, base, directory);
-    }
-    add_search_directory(directories, base, base);
-    for (const auto& directory : split_library_path(environment_value(toolchain, "LIB"))) {
-        add_search_directory(directories, base, directory);
-    }
-    return directories;
-}
-
-[[nodiscard]] bool library_path(const fs::path& path) {
-    return ascii_iequals(path_to_utf8(path.extension()), ".lib");
-}
-
-[[nodiscard]] bool parent_is_search_directory(
-    const fs::path& library,
-    const std::vector<fs::path>& directories) {
-    return contains_windows_path(directories, library.parent_path());
 }
 
 void add_reason(std::vector<BuildReason>& reasons, const BuildReason reason) {
@@ -560,46 +435,31 @@ MsvcIncrementalLinkCoordinator::run(const IncrementalLinkRequest& request) const
     }
 
     if (cached_entry) {
-        const auto search_directories = library_search_directories(
-            toolchain_,
-            request.options.library_directories,
-            working_directory);
+        std::vector<fs::path> cached_observed_inputs;
+        cached_observed_inputs.reserve(cached_entry->file_inputs.size());
         for (const auto& cached_input : cached_entry->file_inputs) {
-            if (!library_path(cached_input)
-                || contains_windows_path(declared_linker_file_inputs, cached_input)
+            if (contains_windows_path(declared_linker_file_inputs, cached_input)
                 || contains_windows_path(resolved_libraries->files, cached_input)) {
                 continue;
             }
-
-            fs::path current_input = cached_input;
-            // A library previously found in LINK's normal search directories is
-            // re-resolved by basename on every warm validation. This catches a
-            // new higher-priority same-name library without requiring another
-            // link first. Libraries outside the search path are treated as
-            // absolute directive inputs and retain their exact path.
-            if (parent_is_search_directory(cached_input, search_directories)) {
-                const std::vector<std::string> request_name{
-                    path_to_utf8(cached_input.filename())};
-                auto rerouted = msvc::MsvcLibraryResolver::resolve_available(
-                    toolchain_,
-                    request_name,
-                    request.options.library_directories,
-                    working_directory);
-                if (!rerouted) {
-                    IncrementalLinkError error{
-                        .code = IncrementalLinkErrorCode::library_resolution_failed,
-                        .message = "failed to re-resolve cached transitive MSVC library evidence: "
-                            + rerouted.error().message,
-                        .library_resolution_error = rerouted.error(),
-                    };
-                    return std::unexpected(std::move(error));
-                }
-                if (!rerouted->files.empty()) {
-                    current_input = rerouted->files.front();
-                }
-            }
-            append_unique_path(linker_file_inputs, current_input);
+            cached_observed_inputs.push_back(cached_input);
         }
+
+        auto refreshed_observed = msvc::MsvcLibraryResolver::refresh_observed(
+            toolchain_,
+            cached_observed_inputs,
+            request.options.library_directories,
+            working_directory);
+        if (!refreshed_observed) {
+            IncrementalLinkError error{
+                .code = IncrementalLinkErrorCode::library_resolution_failed,
+                .message = "failed to refresh cached transitive MSVC library evidence: "
+                    + refreshed_observed.error().message,
+                .library_resolution_error = refreshed_observed.error(),
+            };
+            return std::unexpected(std::move(error));
+        }
+        append_unique_paths(linker_file_inputs, refreshed_observed->files);
     }
 
     auto output_snapshot_result = detail::snapshot_regular_file(request.output);

--- a/cpp/src/orchestration/incremental/MsvcIncrementalLinkCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalLinkCoordinator.cpp
@@ -449,7 +449,8 @@ MsvcIncrementalLinkCoordinator::run(const IncrementalLinkRequest& request) const
             toolchain_,
             cached_observed_inputs,
             request.options.library_directories,
-            working_directory);
+            working_directory,
+            request.cache_file);
         if (!refreshed_observed) {
             IncrementalLinkError error{
                 .code = IncrementalLinkErrorCode::library_resolution_failed,

--- a/cpp/src/orchestration/incremental/MsvcIncrementalLinkCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalLinkCoordinator.cpp
@@ -1,10 +1,12 @@
 #include "mqb/orchestration/MsvcIncrementalLinkCoordinator.hpp"
 
 #include <algorithm>
+#include <cctype>
 #include <expected>
 #include <filesystem>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <system_error>
 #include <utility>
 #include <variant>
@@ -67,12 +69,174 @@ void snapshot_inputs(
     return left == right || left.lexically_normal() == right.lexically_normal();
 }
 
+[[nodiscard]] std::string windows_path_key(const fs::path& path) {
+    std::string value = path.lexically_normal().generic_string();
+    std::transform(
+        value.begin(),
+        value.end(),
+        value.begin(),
+        [](const unsigned char character) {
+            return static_cast<char>(std::tolower(character));
+        });
+    return value;
+}
+
+[[nodiscard]] bool same_windows_path(const fs::path& left, const fs::path& right) {
+    return windows_path_key(left) == windows_path_key(right);
+}
+
+[[nodiscard]] bool contains_windows_path(
+    const std::vector<fs::path>& paths,
+    const fs::path& expected) {
+    return std::any_of(paths.begin(), paths.end(), [&](const fs::path& path) {
+        return same_windows_path(path, expected);
+    });
+}
+
+void append_unique_path(std::vector<fs::path>& paths, const fs::path& path) {
+    if (!contains_windows_path(paths, path)) {
+        paths.push_back(path.lexically_normal());
+    }
+}
+
+void append_unique_paths(
+    std::vector<fs::path>& paths,
+    const std::vector<fs::path>& additions) {
+    for (const auto& path : additions) {
+        append_unique_path(paths, path);
+    }
+}
+
 [[nodiscard]] bool contains_path(
     const std::vector<fs::path>& paths,
     const fs::path& expected) {
     return std::any_of(paths.begin(), paths.end(), [&](const fs::path& path) {
         return same_path(path, expected);
     });
+}
+
+[[nodiscard]] bool ascii_iequals(
+    const std::string_view left,
+    const std::string_view right) noexcept {
+    if (left.size() != right.size()) {
+        return false;
+    }
+    for (std::size_t index = 0; index < left.size(); ++index) {
+        const auto a = static_cast<unsigned char>(left[index]);
+        const auto b = static_cast<unsigned char>(right[index]);
+        if (std::tolower(a) != std::tolower(b)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+[[nodiscard]] std::string path_to_utf8(const fs::path& path) {
+    const auto bytes = path.generic_u8string();
+    return std::string{
+        reinterpret_cast<const char*>(bytes.data()),
+        bytes.size()};
+}
+
+[[nodiscard]] fs::path path_from_utf8(const std::string_view value) {
+    std::u8string bytes;
+    bytes.assign(
+        reinterpret_cast<const char8_t*>(value.data()),
+        reinterpret_cast<const char8_t*>(value.data() + value.size()));
+    return fs::path{bytes};
+}
+
+[[nodiscard]] std::string_view environment_value(
+    const msvc::MsvcToolchain& toolchain,
+    const std::string_view name) noexcept {
+    for (const auto& variable : toolchain.environment) {
+        if (ascii_iequals(variable.name, name)) {
+            return variable.value;
+        }
+    }
+    return {};
+}
+
+[[nodiscard]] std::vector<fs::path> split_library_path(const std::string_view value) {
+    std::vector<fs::path> result;
+    std::size_t begin = 0;
+    while (begin <= value.size()) {
+        const std::size_t separator = value.find(';', begin);
+        const std::size_t end = separator == std::string_view::npos
+            ? value.size()
+            : separator;
+        std::string_view token = value.substr(begin, end - begin);
+        while (!token.empty()
+            && std::isspace(static_cast<unsigned char>(token.front())) != 0) {
+            token.remove_prefix(1);
+        }
+        while (!token.empty()
+            && std::isspace(static_cast<unsigned char>(token.back())) != 0) {
+            token.remove_suffix(1);
+        }
+        if (token.size() >= 2 && token.front() == '"' && token.back() == '"') {
+            token.remove_prefix(1);
+            token.remove_suffix(1);
+        }
+        if (!token.empty()) {
+            result.push_back(path_from_utf8(token));
+        }
+        if (separator == std::string_view::npos) {
+            break;
+        }
+        begin = separator + 1;
+    }
+    return result;
+}
+
+void add_search_directory(
+    std::vector<fs::path>& directories,
+    const fs::path& base,
+    const fs::path& directory) {
+    if (directory.empty()) {
+        return;
+    }
+    const fs::path normalized = directory.is_absolute()
+        ? directory.lexically_normal()
+        : (base / directory).lexically_normal();
+    if (!contains_windows_path(directories, normalized)) {
+        directories.push_back(normalized);
+    }
+}
+
+[[nodiscard]] std::vector<fs::path> library_search_directories(
+    const msvc::MsvcToolchain& toolchain,
+    const std::vector<fs::path>& configured,
+    const fs::path& requested_working_directory) {
+    std::error_code error_code;
+    fs::path base = requested_working_directory.empty()
+        ? fs::current_path(error_code)
+        : fs::absolute(requested_working_directory, error_code);
+    if (error_code) {
+        return {};
+    }
+    base = base.lexically_normal();
+
+    std::vector<fs::path> directories;
+    directories.reserve(configured.size() + 8);
+    for (const auto& directory : configured) {
+        add_search_directory(directories, base, directory);
+    }
+    add_search_directory(directories, base, base);
+    for (const auto& directory : split_library_path(environment_value(toolchain, "LIB"))) {
+        add_search_directory(directories, base, directory);
+    }
+    return directories;
+}
+
+[[nodiscard]] bool library_path(const fs::path& path) {
+    return ascii_iequals(path_to_utf8(path.extension()), ".lib");
+}
+
+[[nodiscard]] bool parent_is_search_directory(
+    const fs::path& library,
+    const std::vector<fs::path>& directories) {
+    return contains_windows_path(directories, library.parent_path());
 }
 
 void add_reason(std::vector<BuildReason>& reasons, const BuildReason reason) {
@@ -161,10 +325,15 @@ MsvcIncrementalLinkCoordinator::run(const IncrementalLinkRequest& request) const
         });
     }
     std::vector<fs::path> linker_file_inputs;
-    linker_file_inputs.reserve(linker_file_routing->inputs.size());
+    linker_file_inputs.reserve(linker_file_routing->inputs.size() + 16);
     for (const auto& input : linker_file_routing->inputs) {
-        linker_file_inputs.push_back(input.path);
+        append_unique_path(linker_file_inputs, input.path);
     }
+    // Observer-schema sentinel. Every cache created after transitive library
+    // observation includes the exact link.exe as a file input. Pre-observation
+    // caches lack it, so the first upgraded build must relink and seal LINK's
+    // real library-search evidence instead of incorrectly reusing stale state.
+    append_unique_path(linker_file_inputs, toolchain_.linker);
 
     auto default_library_routing = msvc::MsvcDefaultLibraryPolicy::route(
         request.options.additional_arguments);
@@ -219,10 +388,7 @@ MsvcIncrementalLinkCoordinator::run(const IncrementalLinkRequest& request) const
         };
         return std::unexpected(std::move(error));
     }
-    linker_file_inputs.insert(
-        linker_file_inputs.end(),
-        resolved_default_libraries->files.begin(),
-        resolved_default_libraries->files.end());
+    append_unique_paths(linker_file_inputs, resolved_default_libraries->files);
 
     if (!whole_archive_routing->libraries.empty()) {
         LinkOptions whole_archive_options = request.options;
@@ -240,10 +406,7 @@ MsvcIncrementalLinkCoordinator::run(const IncrementalLinkRequest& request) const
             };
             return std::unexpected(std::move(error));
         }
-        linker_file_inputs.insert(
-            linker_file_inputs.end(),
-            resolved_whole_archive_libraries->files.begin(),
-            resolved_whole_archive_libraries->files.end());
+        append_unique_paths(linker_file_inputs, resolved_whole_archive_libraries->files);
     }
 
     if (request.options.address_sanitizer_runtime_library
@@ -269,10 +432,7 @@ MsvcIncrementalLinkCoordinator::run(const IncrementalLinkRequest& request) const
             };
             return std::unexpected(std::move(error));
         }
-        linker_file_inputs.insert(
-            linker_file_inputs.end(),
-            resolved_asan_libraries->files.begin(),
-            resolved_asan_libraries->files.end());
+        append_unique_paths(linker_file_inputs, resolved_asan_libraries->files);
     }
 
     if (request.options.address_sanitizer_vcasan_runtime_library) {
@@ -297,10 +457,7 @@ MsvcIncrementalLinkCoordinator::run(const IncrementalLinkRequest& request) const
                 };
                 return std::unexpected(std::move(error));
             }
-            linker_file_inputs.insert(
-                linker_file_inputs.end(),
-                resolved_vcasan_library->files.begin(),
-                resolved_vcasan_library->files.end());
+            append_unique_paths(linker_file_inputs, resolved_vcasan_library->files);
         }
     }
 
@@ -327,10 +484,7 @@ MsvcIncrementalLinkCoordinator::run(const IncrementalLinkRequest& request) const
                 };
                 return std::unexpected(std::move(error));
             }
-            linker_file_inputs.insert(
-                linker_file_inputs.end(),
-                resolved_fuzzer_library->files.begin(),
-                resolved_fuzzer_library->files.end());
+            append_unique_paths(linker_file_inputs, resolved_fuzzer_library->files);
         }
     }
 
@@ -358,12 +512,15 @@ MsvcIncrementalLinkCoordinator::run(const IncrementalLinkRequest& request) const
                 };
                 return std::unexpected(std::move(error));
             }
-            linker_file_inputs.insert(
-                linker_file_inputs.end(),
-                resolved_openmp_libraries->files.begin(),
-                resolved_openmp_libraries->files.end());
+            append_unique_paths(linker_file_inputs, resolved_openmp_libraries->files);
         }
     }
+
+    // Keep a clean declaration-derived set. Cached transitive observations are
+    // merged only for validation; after a real LINK pass the cache is rebuilt
+    // from this set plus the newly observed search evidence, so removed object
+    // directives cannot linger forever.
+    const std::vector<fs::path> declared_linker_file_inputs = linker_file_inputs;
 
     const std::optional<fs::path> requested_map_output =
         msvc::MsvcLinker::map_file_path(
@@ -400,6 +557,49 @@ MsvcIncrementalLinkCoordinator::run(const IncrementalLinkRequest& request) const
             .path = request.cache_file,
             .message = loaded.error().message,
         });
+    }
+
+    if (cached_entry) {
+        const auto search_directories = library_search_directories(
+            toolchain_,
+            request.options.library_directories,
+            working_directory);
+        for (const auto& cached_input : cached_entry->file_inputs) {
+            if (!library_path(cached_input)
+                || contains_windows_path(declared_linker_file_inputs, cached_input)
+                || contains_windows_path(resolved_libraries->files, cached_input)) {
+                continue;
+            }
+
+            fs::path current_input = cached_input;
+            // A library previously found in LINK's normal search directories is
+            // re-resolved by basename on every warm validation. This catches a
+            // new higher-priority same-name library without requiring another
+            // link first. Libraries outside the search path are treated as
+            // absolute directive inputs and retain their exact path.
+            if (parent_is_search_directory(cached_input, search_directories)) {
+                const std::vector<std::string> request_name{
+                    path_to_utf8(cached_input.filename())};
+                auto rerouted = msvc::MsvcLibraryResolver::resolve_available(
+                    toolchain_,
+                    request_name,
+                    request.options.library_directories,
+                    working_directory);
+                if (!rerouted) {
+                    IncrementalLinkError error{
+                        .code = IncrementalLinkErrorCode::library_resolution_failed,
+                        .message = "failed to re-resolve cached transitive MSVC library evidence: "
+                            + rerouted.error().message,
+                        .library_resolution_error = rerouted.error(),
+                    };
+                    return std::unexpected(std::move(error));
+                }
+                if (!rerouted->files.empty()) {
+                    current_input = rerouted->files.front();
+                }
+            }
+            append_unique_path(linker_file_inputs, current_input);
+        }
     }
 
     auto output_snapshot_result = detail::snapshot_regular_file(request.output);
@@ -509,6 +709,7 @@ MsvcIncrementalLinkCoordinator::run(const IncrementalLinkRequest& request) const
             || result.validation.file_inputs_changed
             || linker_file_routing->requires_full_link
             || request.options.address_sanitizer_runtime_library.has_value(),
+        .observe_library_search = true,
     };
     auto linked = linker_.link(invocation);
     if (!linked) {
@@ -517,6 +718,10 @@ MsvcIncrementalLinkCoordinator::run(const IncrementalLinkRequest& request) const
             "MSVC link action failed",
             linked.error()));
     }
+
+    const auto observed_libraries =
+        msvc::MsvcLinker::observed_library_paths(linked->stdout_text);
+    msvc::MsvcLinker::sanitize_library_observation_output(*linked, request.options);
 
     result.linked = true;
     result.process = std::move(*linked);
@@ -558,6 +763,18 @@ MsvcIncrementalLinkCoordinator::run(const IncrementalLinkRequest& request) const
             result.warnings);
     }
 
+    std::vector<fs::path> sealed_linker_file_inputs = declared_linker_file_inputs;
+    for (const auto& observed : observed_libraries) {
+        if (contains_windows_path(action->libraries, observed)) {
+            continue;
+        }
+        std::error_code error_code;
+        if (!fs::is_regular_file(observed, error_code) || error_code) {
+            continue;
+        }
+        append_unique_path(sealed_linker_file_inputs, observed);
+    }
+
     const LinkCacheEntry new_entry{
         .linker = *linker_identity,
         .signature = BuildSignature::for_link(
@@ -569,7 +786,7 @@ MsvcIncrementalLinkCoordinator::run(const IncrementalLinkRequest& request) const
         .objects = action->objects,
         .output = action->output,
         .libraries = action->libraries,
-        .file_inputs = linker_file_inputs,
+        .file_inputs = std::move(sealed_linker_file_inputs),
         .side_outputs = std::move(side_outputs),
     };
     auto saved = LinkCacheFile::save(request.cache_file, new_entry);

--- a/tests/native/verify_transitive_default_library_freshness.ps1
+++ b/tests/native/verify_transitive_default_library_freshness.ps1
@@ -1,0 +1,243 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$MqbPath,
+    [Parameter(Mandatory = $true)][string]$RepoRoot
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+$MqbPath = [System.IO.Path]::GetFullPath($MqbPath)
+$RepoRoot = [System.IO.Path]::GetFullPath($RepoRoot)
+if (-not (Test-Path -LiteralPath $MqbPath -PathType Leaf)) {
+    throw "MQB executable not found: $MqbPath"
+}
+
+$fixture = Join-Path $RepoRoot 'native-test-work/transitive-defaultlib-freshness'
+if (Test-Path -LiteralPath $fixture) {
+    Remove-Item -LiteralPath $fixture -Recurse -Force
+}
+New-Item -ItemType Directory -Force -Path $fixture | Out-Null
+$low = Join-Path $fixture 'low'
+$high = Join-Path $fixture 'high'
+New-Item -ItemType Directory -Force -Path $low | Out-Null
+New-Item -ItemType Directory -Force -Path $high | Out-Null
+
+function Invoke-Mqb {
+    param(
+        [Parameter(Mandatory = $true)][string]$WorkingDirectory,
+        [Parameter(Mandatory = $true)][string[]]$Arguments
+    )
+
+    Push-Location $WorkingDirectory
+    try {
+        $output = @(& $MqbPath @Arguments 2>&1)
+        $exitCode = $LASTEXITCODE
+    }
+    finally {
+        Pop-Location
+    }
+    [PSCustomObject]@{
+        ExitCode = $exitCode
+        Text = ($output -join [Environment]::NewLine)
+    }
+}
+
+function Require-Success {
+    param(
+        [Parameter(Mandatory = $true)]$Result,
+        [Parameter(Mandatory = $true)][string]$Description
+    )
+    if ($Result.ExitCode -ne 0) {
+        throw "$Description failed (exit $($Result.ExitCode)):`n$($Result.Text)"
+    }
+}
+
+function Invoke-Program {
+    param([Parameter(Mandatory = $true)][string]$Path)
+    & $Path
+    return $LASTEXITCODE
+}
+
+function Link-Cache-Text {
+    $cache = Join-Path $fixture '.mqb/cache/link/consumer.linkcache'
+    if (-not (Test-Path -LiteralPath $cache -PathType Leaf)) {
+        throw "consumer link cache missing: $cache"
+    }
+    return [Text.Encoding]::UTF8.GetString([IO.File]::ReadAllBytes($cache))
+}
+
+function Cache-Path-Token {
+    param([Parameter(Mandatory = $true)][string]$Path)
+    return ([System.IO.Path]::GetFullPath($Path) -replace '\\', '/')
+}
+
+Set-Content -LiteralPath (Join-Path $low 'dep.cpp') -Encoding utf8 -Value @(
+    'extern "C" int dep_value() { return 7; }'
+)
+$lowBuild = Invoke-Mqb -WorkingDirectory $low -Arguments @(
+    'dep.cpp', '--release', '--no-discover', '--env', 'vs', '--type', 'static', '-o', 'dep'
+)
+Require-Success $lowBuild 'low-priority dep.lib build'
+$lowLibrary = Join-Path $low '.mqb/bin/dep.lib'
+if (-not (Test-Path -LiteralPath $lowLibrary -PathType Leaf)) {
+    throw "low-priority dep.lib missing: $lowLibrary"
+}
+
+Set-Content -LiteralPath (Join-Path $fixture 'producer.cpp') -Encoding utf8 -Value @(
+    '#pragma comment(lib, "dep.lib")',
+    'extern "C" int dep_value();',
+    'extern "C" int producer_value() { return dep_value(); }'
+)
+$producerBuild = Invoke-Mqb -WorkingDirectory $fixture -Arguments @(
+    'producer.cpp', '--release', '--no-discover', '--env', 'vs', '--type', 'static', '-o', 'producer'
+)
+Require-Success $producerBuild 'producer archive build'
+$producerLibrary = Join-Path $fixture '.mqb/bin/producer.lib'
+if (-not (Test-Path -LiteralPath $producerLibrary -PathType Leaf)) {
+    throw "producer.lib missing: $producerLibrary"
+}
+
+Set-Content -LiteralPath (Join-Path $fixture 'consumer.cpp') -Encoding utf8 -Value @(
+    'extern "C" int producer_value();',
+    'int main() { return producer_value(); }'
+)
+
+$consumerArgs = @(
+    'consumer.cpp', '--release', '--no-discover', '--env', 'vs',
+    '-L', 'high/.mqb/bin',
+    '-L', 'low/.mqb/bin',
+    '-L', '.mqb/bin',
+    '-l', 'producer',
+    '-o', 'consumer'
+)
+$cold = Invoke-Mqb -WorkingDirectory $fixture -Arguments $consumerArgs
+Require-Success $cold 'cold transitive-defaultlib consumer link'
+$consumer = Join-Path $fixture '.mqb/bin/consumer.exe'
+if (-not (Test-Path -LiteralPath $consumer -PathType Leaf)) {
+    throw "consumer executable missing: $consumer"
+}
+if ((Invoke-Program $consumer) -ne 7) {
+    throw 'cold consumer did not resolve dep.lib through producer archive .drectve'
+}
+
+$cacheText = Link-Cache-Text
+$lowToken = Cache-Path-Token $lowLibrary
+if ($cacheText -notmatch [Regex]::Escape($lowToken)) {
+    throw "link cache did not seal transitive dep.lib selected by LINK: $lowToken"
+}
+if ($cold.Text -match '(?im)^\s*Searching\s+.*\.lib') {
+    throw "internal /VERBOSE:LIB observation leaked into ordinary MQB output:`n$($cold.Text)"
+}
+
+$warm = Invoke-Mqb -WorkingDirectory $fixture -Arguments $consumerArgs
+Require-Success $warm 'warm transitive-defaultlib consumer link'
+if ($warm.Text -notmatch '\[up-to-date\]\s+consumer\.cpp') {
+    throw "warm consumer unexpectedly recompiled its source:`n$($warm.Text)"
+}
+if ($warm.Text -notmatch '\[up-to-date\]\s+consumer\.exe') {
+    throw "warm consumer did not reuse sealed transitive library evidence:`n$($warm.Text)"
+}
+
+# Change only the transitive library. producer.lib and consumer.cpp stay byte-for-byte
+# unchanged. The cached dep.lib freshness edge must force LINK, not CL.
+Set-Content -LiteralPath (Join-Path $low 'dep.cpp') -Encoding utf8 -Value @(
+    'extern "C" int dep_value() { return 8; }'
+)
+$lowMutation = Invoke-Mqb -WorkingDirectory $low -Arguments @(
+    'dep.cpp', '--release', '--no-discover', '--env', 'vs', '--type', 'static', '-o', 'dep'
+)
+Require-Success $lowMutation 'mutated low-priority dep.lib build'
+
+$relink = Invoke-Mqb -WorkingDirectory $fixture -Arguments $consumerArgs
+Require-Success $relink 'consumer relink after transitive dep.lib mutation'
+if ($relink.Text -notmatch '\[up-to-date\]\s+consumer\.cpp') {
+    throw "transitive library mutation recompiled consumer.cpp:`n$($relink.Text)"
+}
+if ($relink.Text -notmatch '\[link\]\s+consumer\.exe') {
+    throw "transitive library mutation did not rerun LINK:`n$($relink.Text)"
+}
+if ($relink.Text -notmatch 'link inputs changed') {
+    throw "transitive library mutation did not report link-input invalidation:`n$($relink.Text)"
+}
+if ((Invoke-Program $consumer) -ne 8) {
+    throw 'consumer did not observe mutated transitive dep.lib behavior'
+}
+
+# The argv stays identical. Introduce a same-name dep.lib in the already-declared
+# higher-priority -L directory. Warm validation must re-resolve the cached basename,
+# notice LINK would now choose a different path, and relink before any source changes.
+Set-Content -LiteralPath (Join-Path $high 'dep.cpp') -Encoding utf8 -Value @(
+    'extern "C" int dep_value() { return 9; }'
+)
+$highBuild = Invoke-Mqb -WorkingDirectory $high -Arguments @(
+    'dep.cpp', '--release', '--no-discover', '--env', 'vs', '--type', 'static', '-o', 'dep'
+)
+Require-Success $highBuild 'high-priority dep.lib build'
+$highLibrary = Join-Path $high '.mqb/bin/dep.lib'
+if (-not (Test-Path -LiteralPath $highLibrary -PathType Leaf)) {
+    throw "high-priority dep.lib missing: $highLibrary"
+}
+
+$reroute = Invoke-Mqb -WorkingDirectory $fixture -Arguments $consumerArgs
+Require-Success $reroute 'consumer relink after transitive library search reroute'
+if ($reroute.Text -notmatch '\[up-to-date\]\s+consumer\.cpp') {
+    throw "search-priority reroute recompiled consumer.cpp:`n$($reroute.Text)"
+}
+if ($reroute.Text -notmatch '\[link\]\s+consumer\.exe') {
+    throw "new higher-priority transitive dep.lib did not rerun LINK:`n$($reroute.Text)"
+}
+if ($reroute.Text -notmatch 'link inputs changed') {
+    throw "search-priority reroute did not report link-input invalidation:`n$($reroute.Text)"
+}
+if ((Invoke-Program $consumer) -ne 9) {
+    throw 'consumer did not switch to the newly higher-priority transitive dep.lib'
+}
+
+$reroutedCacheText = Link-Cache-Text
+$highToken = Cache-Path-Token $highLibrary
+if ($reroutedCacheText -notmatch [Regex]::Escape($highToken)) {
+    throw "resealed link cache did not contain high-priority dep.lib: $highToken"
+}
+if ($reroutedCacheText -match [Regex]::Escape($lowToken)) {
+    throw "resealed link cache retained stale low-priority transitive dep.lib: $lowToken"
+}
+
+# Repeat the archive-directive route with /GL + /LTCG. DUMPBIN /DIRECTIVES cannot
+# inspect /GL objects, so this proves the implementation is based on actual LINK
+# search evidence rather than a COFF/.drectve parser that silently loses ILTCG.
+Set-Content -LiteralPath (Join-Path $fixture 'producer_gl.cpp') -Encoding utf8 -Value @(
+    '#pragma comment(lib, "dep.lib")',
+    'extern "C" int dep_value();',
+    'extern "C" int producer_gl_value() { return dep_value(); }'
+)
+$producerGl = Invoke-Mqb -WorkingDirectory $fixture -Arguments @(
+    'producer_gl.cpp', '--release', '--no-discover', '--env', 'vs', '--type', 'static', '--ltcg', '-o', 'producer_gl'
+)
+Require-Success $producerGl 'LTCG producer archive build'
+
+Set-Content -LiteralPath (Join-Path $fixture 'consumer_gl.cpp') -Encoding utf8 -Value @(
+    'extern "C" int producer_gl_value();',
+    'int main() { return producer_gl_value(); }'
+)
+$consumerGlArgs = @(
+    'consumer_gl.cpp', '--release', '--no-discover', '--env', 'vs', '--ltcg',
+    '-L', 'high/.mqb/bin',
+    '-L', '.mqb/bin',
+    '-l', 'producer_gl',
+    '-o', 'consumer_gl'
+)
+$glCold = Invoke-Mqb -WorkingDirectory $fixture -Arguments $consumerGlArgs
+Require-Success $glCold 'cold LTCG transitive-defaultlib consumer link'
+$consumerGl = Join-Path $fixture '.mqb/bin/consumer_gl.exe'
+if ((Invoke-Program $consumerGl) -ne 9) {
+    throw 'LTCG consumer did not resolve dep.lib embedded in /GL archive member directives'
+}
+$glCache = Join-Path $fixture '.mqb/cache/link/consumer_gl.linkcache'
+$glCacheText = [Text.Encoding]::UTF8.GetString([IO.File]::ReadAllBytes($glCache))
+if ($glCacheText -notmatch [Regex]::Escape($highToken)) {
+    throw 'LTCG consumer link cache did not seal transitive dep.lib from actual LINK evidence'
+}
+
+Write-Host 'Real MSVC transitive .drectve default-library freshness, search reroute, and LTCG checks passed.'
+exit 0


### PR DESCRIPTION
## Summary

Closes the next final-audit gap after #114: LINK can discover additional libraries from `.drectve` records embedded in object files and static-library members (for example `#pragma comment(lib, ...)`, CRT/OpenMP/sanitizer directives). MQB previously tracked explicit `-l`, raw `/DEFAULTLIB`, and several compiler->link policies, but an unchanged producer archive could hide a transitive library whose bytes or search resolution changed independently.

## Design

Use the real MSVC linker as the source of truth rather than implementing a partial COFF/archive directive parser:

- every actual LINK pass internally enables `/VERBOSE:LIB` unless the user already requested equivalent output;
- parse absolute `.lib` paths that LINK reports and seal non-explicit libraries into link freshness evidence;
- preserve ordinary MQB output by filtering internal observation noise while retaining LNK diagnostics;
- rebuild the observed set after every real LINK pass so removed directives do not linger;
- reuse sealed absolute paths on the warm path;
- only re-run basename/library-search resolution when a `-L`, working-directory, or MSVC `LIB` search root changed after the link-cache seal time, so higher-priority same-name libraries are still discovered without paying full `N libraries × M directories` search cost on every no-op;
- use the exact `link.exe` path as an observer-schema sentinel so pre-observation caches relink and reseal once after upgrade.

This deliberately avoids `DUMPBIN /DIRECTIVES`: `/GL` inputs require the real linker path, and LINK observation covers ordinary COFF, archive members, compiler-emitted directives, and LTCG through one mechanism.

## Real MSVC regression contract

The Windows gate builds `dep.lib`, a `producer.lib` archive member containing `#pragma comment(lib, "dep.lib")`, and a `consumer.exe` that links only `producer.lib`. It proves:

- cold LINK resolves and seals the hidden `dep.lib`;
- internal observation does not leak into ordinary MQB output;
- a warm rebuild is a true no-op;
- rebuilding only the hidden `dep.lib` keeps the consumer TU up-to-date but reruns LINK and changes runtime behavior;
- creating a same-name library in an already-declared higher-priority `-L` directory reroutes on the next warm validation even though argv/source/archive inputs are unchanged;
- the same route works through `/GL` + `/LTCG`.

## Exact-head validation

Final head: `940d8efd14735e194dc3eac52001433d1352ab0d`

- Native C++ #423: success, including transitive-defaultlib gate, sanitizer/OpenMP gates, linker side-output repair, exact 444-entry MSVC inventory, and Debug 4/4 shards.
- Native Release #359: success, including Release 4/4 shards and stable self-host/package validation.
- Performance Evidence #166: success, exact base `6548bcfd310e9635ad207627c29105973e09977a` vs candidate, 11 required scenarios × 5 iterations on one Windows runner.
- Warm no-op median: `4.037 ms -> 4.584 ms` (`+0.547 ms`). Modules no-op: `4.705 ms -> 5.369 ms` (`+0.664 ms`). Link-only: `58.005 ms -> 55.347 ms` (`-4.58%`). The remaining warm cost is the deliberate per-file freshness check for LINK-observed libraries; full basename re-resolution is skipped unless the search roots changed.
- No unresolved review threads or submitted reviews.
