### PR TITLE
fix: track /BASE response-file freshness

### DIFF
--- a/cpp/include/mqb/msvc/MsvcBaseAddressPolicy.hpp
+++ b/cpp/include/mqb/msvc/MsvcBaseAddressPolicy.hpp
@@ -1,0 +1,247 @@
+#pragma once
+
+#include <cctype>
+#include <expected>
+#include <filesystem>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+#include "mqb/msvc/MsvcToolchainLocator.hpp"
+
+namespace mqb::msvc {
+
+enum class BaseAddressErrorCode {
+    invalid_response_file,
+    working_directory_failed,
+    response_file_not_found,
+};
+
+struct BaseAddressError {
+    BaseAddressErrorCode code{BaseAddressErrorCode::invalid_response_file};
+    std::string argument;
+    std::filesystem::path path;
+    std::string message;
+};
+
+struct BaseAddressRouting {
+    std::optional<std::filesystem::path> response_file;
+};
+
+class MsvcBaseAddressPolicy {
+public:
+    // Observe only the effective /BASE option. LINK uses last-one-wins option
+    // semantics, so an earlier /BASE:@file,key must not remain freshness
+    // evidence when a later numeric /BASE replaces it.
+    //
+    // The raw linker argv is deliberately left untouched. In particular, a
+    // bare /BASE:@filename,key is resolved through the VC toolchain's LIB
+    // environment exactly for freshness observation; rewriting it to an
+    // absolute path would change native LINK search semantics.
+    [[nodiscard]] static std::expected<BaseAddressRouting, BaseAddressError>
+    route(
+        const MsvcToolchain& toolchain,
+        const std::span<const std::string> arguments,
+        const std::filesystem::path& working_directory = {}) {
+        namespace fs = std::filesystem;
+
+        std::optional<std::string> effective_argument;
+        std::optional<std::string_view> effective_payload;
+        for (const auto& argument : arguments) {
+            if (argument.size() < 2
+                || (argument.front() != '/' && argument.front() != '-')) {
+                continue;
+            }
+            const std::string_view body{argument.data() + 1, argument.size() - 1};
+            constexpr std::string_view prefix = "BASE:";
+            if (!starts_with_ascii_ci(body, prefix)) {
+                continue;
+            }
+            effective_argument = argument;
+            effective_payload = std::string_view{*effective_argument}.substr(1 + prefix.size());
+        }
+
+        if (!effective_payload || effective_payload->empty()
+            || effective_payload->front() != '@') {
+            return BaseAddressRouting{};
+        }
+
+        const std::string_view response_spec = effective_payload->substr(1);
+        const std::size_t comma = response_spec.find(',');
+        if (comma == std::string_view::npos
+            || comma == 0
+            || comma + 1 == response_spec.size()) {
+            return std::unexpected(BaseAddressError{
+                .code = BaseAddressErrorCode::invalid_response_file,
+                .argument = effective_argument.value_or(std::string{}),
+                .path = {},
+                .message = "MSVC linker /BASE response-file form requires /BASE:@<filename>,<key>",
+            });
+        }
+
+        std::string_view filename = response_spec.substr(0, comma);
+        const std::string_view key = response_spec.substr(comma + 1);
+        if (key.empty()) {
+            return std::unexpected(BaseAddressError{
+                .code = BaseAddressErrorCode::invalid_response_file,
+                .argument = effective_argument.value_or(std::string{}),
+                .path = {},
+                .message = "MSVC linker /BASE response-file form requires a non-empty key",
+            });
+        }
+        if (filename.size() >= 2 && filename.front() == '"' && filename.back() == '"') {
+            filename.remove_prefix(1);
+            filename.remove_suffix(1);
+        }
+        if (filename.empty()) {
+            return std::unexpected(BaseAddressError{
+                .code = BaseAddressErrorCode::invalid_response_file,
+                .argument = effective_argument.value_or(std::string{}),
+                .path = {},
+                .message = "MSVC linker /BASE response-file form requires a non-empty filename",
+            });
+        }
+
+        auto resolved_working_directory = resolve_working_directory(working_directory);
+        if (!resolved_working_directory) {
+            return std::unexpected(resolved_working_directory.error());
+        }
+
+        const fs::path requested = path_from_utf8(filename);
+        if (requested.is_absolute() || requested.has_parent_path()) {
+            const fs::path resolved = requested.is_absolute()
+                ? requested.lexically_normal()
+                : (*resolved_working_directory / requested).lexically_normal();
+            return BaseAddressRouting{.response_file = resolved};
+        }
+
+        // Microsoft documents a distinct search rule for this /BASE form:
+        // when filename has no path, LINK searches directories from LIB. Do
+        // not add MQB -L directories or the working directory here.
+        for (const auto& directory : split_search_path(environment_value(toolchain, "LIB"))) {
+            const fs::path root = directory.is_absolute()
+                ? directory.lexically_normal()
+                : (*resolved_working_directory / directory).lexically_normal();
+            const fs::path candidate = (root / requested).lexically_normal();
+            std::error_code error_code;
+            if (fs::is_regular_file(candidate, error_code) && !error_code) {
+                return BaseAddressRouting{.response_file = candidate};
+            }
+        }
+
+        return std::unexpected(BaseAddressError{
+            .code = BaseAddressErrorCode::response_file_not_found,
+            .argument = effective_argument.value_or(std::string{}),
+            .path = requested,
+            .message = "MSVC linker /BASE response file '" + path_to_utf8(requested)
+                + "' was not found in the toolchain LIB search path",
+        });
+    }
+
+private:
+    [[nodiscard]] static bool starts_with_ascii_ci(
+        const std::string_view value,
+        const std::string_view prefix) noexcept {
+        if (value.size() < prefix.size()) {
+            return false;
+        }
+        for (std::size_t index = 0; index < prefix.size(); ++index) {
+            unsigned char left = static_cast<unsigned char>(value[index]);
+            unsigned char right = static_cast<unsigned char>(prefix[index]);
+            if (std::tolower(left) != std::tolower(right)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    [[nodiscard]] static bool ascii_iequals(
+        const std::string_view left,
+        const std::string_view right) noexcept {
+        return left.size() == right.size() && starts_with_ascii_ci(left, right);
+    }
+
+    [[nodiscard]] static std::filesystem::path path_from_utf8(
+        const std::string_view value) {
+        std::u8string bytes;
+        bytes.assign(
+            reinterpret_cast<const char8_t*>(value.data()),
+            reinterpret_cast<const char8_t*>(value.data() + value.size()));
+        return std::filesystem::path{bytes};
+    }
+
+    [[nodiscard]] static std::string path_to_utf8(
+        const std::filesystem::path& path) {
+        const auto bytes = path.generic_u8string();
+        return std::string{
+            reinterpret_cast<const char*>(bytes.data()),
+            bytes.size()};
+    }
+
+    [[nodiscard]] static std::string_view environment_value(
+        const MsvcToolchain& toolchain,
+        const std::string_view name) noexcept {
+        for (const auto& variable : toolchain.environment) {
+            if (ascii_iequals(variable.name, name)) {
+                return variable.value;
+            }
+        }
+        return {};
+    }
+
+    [[nodiscard]] static std::vector<std::filesystem::path> split_search_path(
+        const std::string_view value) {
+        std::vector<std::filesystem::path> result;
+        std::size_t begin = 0;
+        while (begin <= value.size()) {
+            const std::size_t separator = value.find(';', begin);
+            const std::size_t end = separator == std::string_view::npos
+                ? value.size()
+                : separator;
+            std::string_view token = value.substr(begin, end - begin);
+            while (!token.empty() && (token.front() == ' ' || token.front() == '\t')) {
+                token.remove_prefix(1);
+            }
+            while (!token.empty() && (token.back() == ' ' || token.back() == '\t')) {
+                token.remove_suffix(1);
+            }
+            if (token.size() >= 2 && token.front() == '"' && token.back() == '"') {
+                token.remove_prefix(1);
+                token.remove_suffix(1);
+            }
+            if (!token.empty()) {
+                result.push_back(path_from_utf8(token));
+            }
+            if (separator == std::string_view::npos) {
+                break;
+            }
+            begin = separator + 1;
+        }
+        return result;
+    }
+
+    [[nodiscard]] static std::expected<std::filesystem::path, BaseAddressError>
+    resolve_working_directory(const std::filesystem::path& requested) {
+        namespace fs = std::filesystem;
+        std::error_code error_code;
+        fs::path result = requested.empty()
+            ? fs::current_path(error_code)
+            : fs::absolute(requested, error_code);
+        if (error_code) {
+            return std::unexpected(BaseAddressError{
+                .code = BaseAddressErrorCode::working_directory_failed,
+                .argument = {},
+                .path = requested,
+                .message = "failed to resolve /BASE response-file working directory: "
+                    + error_code.message(),
+            });
+        }
+        return result.lexically_normal();
+    }
+};
+
+} // namespace mqb::msvc

--- a/cpp/src/orchestration/incremental/MsvcIncrementalLinkCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalLinkCoordinator.cpp
@@ -17,6 +17,7 @@
 #include "mqb/core/LinkCache.hpp"
 #include "mqb/core/LinkCacheFile.hpp"
 #include "mqb/msvc/MsvcAddressSanitizerPolicy.hpp"
+#include "mqb/msvc/MsvcBaseAddressPolicy.hpp"
 #include "mqb/msvc/MsvcDefaultLibraryPolicy.hpp"
 #include "mqb/msvc/MsvcFuzzerPolicy.hpp"
 #include "mqb/msvc/MsvcLibraryResolver.hpp"
@@ -235,6 +236,22 @@ MsvcIncrementalLinkCoordinator::run(const IncrementalLinkRequest& request) const
 
     const fs::path working_directory =
         request.working_directory.value_or(fs::path{});
+
+    auto base_address_routing = msvc::MsvcBaseAddressPolicy::route(
+        toolchain_,
+        request.options.additional_arguments,
+        working_directory);
+    if (!base_address_routing) {
+        return std::unexpected(IncrementalLinkError{
+            .code = IncrementalLinkErrorCode::linker_parameter_invalid,
+            .message = "invalid native MSVC /BASE response-file policy: "
+                + base_address_routing.error().message,
+        });
+    }
+    if (base_address_routing->response_file) {
+        append_unique_path(linker_file_inputs, *base_address_routing->response_file);
+    }
+
     auto resolved_libraries = msvc::MsvcLibraryResolver::resolve(
         toolchain_,
         request.options,

--- a/cpp/tests/msvc/linker/library_resolver_tests.cpp
+++ b/cpp/tests/msvc/linker/library_resolver_tests.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "mqb/core/LinkOptions.hpp"
+#include "mqb/msvc/MsvcBaseAddressPolicy.hpp"
 #include "mqb/msvc/MsvcDefaultLibraryPolicy.hpp"
 #include "mqb/msvc/MsvcLibraryResolver.hpp"
 #include "mqb/msvc/MsvcToolchainLocator.hpp"
@@ -116,6 +117,75 @@ int main() {
     empty_options.libraries = {""};
     const auto empty = mqb::msvc::MsvcLibraryResolver::resolve(toolchain, empty_options, work);
     expect(!empty, "empty requested library should be rejected");
+
+    const fs::path env_base_file = env_dir / "bases.txt";
+    const fs::path local_shadow_base_file = work / "bases.txt";
+    const fs::path explicit_base_file = work / "nested" / "bases.txt";
+    touch(env_base_file);
+    touch(local_shadow_base_file);
+    touch(explicit_base_file);
+
+    const auto numeric_base = mqb::msvc::MsvcBaseAddressPolicy::route(
+        toolchain,
+        std::vector<std::string>{"/BASE:0x140000000"},
+        work);
+    expect(numeric_base.has_value() && !numeric_base->response_file,
+           "numeric /BASE should not invent a tracked file input");
+
+    const auto explicit_base = mqb::msvc::MsvcBaseAddressPolicy::route(
+        toolchain,
+        std::vector<std::string>{"/BASE:@nested/bases.txt,app"},
+        work);
+    expect(explicit_base.has_value()
+               && explicit_base->response_file == explicit_base_file.lexically_normal(),
+           "path-bearing /BASE response file should resolve from link working directory");
+
+    const auto env_base = mqb::msvc::MsvcBaseAddressPolicy::route(
+        toolchain,
+        std::vector<std::string>{"/BASE:@bases.txt,app"},
+        work);
+    expect(env_base.has_value()
+               && env_base->response_file == env_base_file.lexically_normal(),
+           "bare /BASE response file must use LIB and must not prefer the working directory");
+
+    const auto numeric_wins = mqb::msvc::MsvcBaseAddressPolicy::route(
+        toolchain,
+        std::vector<std::string>{
+            "/BASE:@bases.txt,app",
+            "/base:0x150000000",
+        },
+        work);
+    expect(numeric_wins.has_value() && !numeric_wins->response_file,
+           "last numeric /BASE should replace earlier response-file freshness evidence");
+
+    const auto response_file_wins = mqb::msvc::MsvcBaseAddressPolicy::route(
+        toolchain,
+        std::vector<std::string>{
+            "/BASE:0x150000000",
+            "-base:@bases.txt,app",
+        },
+        work);
+    expect(response_file_wins.has_value()
+               && response_file_wins->response_file == env_base_file.lexically_normal(),
+           "last response-file /BASE should become effective regardless of option case/prefix");
+
+    const auto malformed_base = mqb::msvc::MsvcBaseAddressPolicy::route(
+        toolchain,
+        std::vector<std::string>{"/BASE:@bases.txt"},
+        work);
+    expect(!malformed_base
+               && malformed_base.error().code
+                   == mqb::msvc::BaseAddressErrorCode::invalid_response_file,
+           "malformed /BASE response-file form should fail closed");
+
+    const auto missing_base = mqb::msvc::MsvcBaseAddressPolicy::route(
+        toolchain,
+        std::vector<std::string>{"/BASE:@missing-bases.txt,app"},
+        work);
+    expect(!missing_base
+               && missing_base.error().code
+                   == mqb::msvc::BaseAddressErrorCode::response_file_not_found,
+           "bare /BASE response file absent from LIB must fail before LINK");
 
     const std::vector<std::string> default_policy_args{
         "/DEFAULTLIB:math",

--- a/cpp/tests/orchestration/incremental/incremental_link_coordinator_tests.cpp
+++ b/cpp/tests/orchestration/incremental/incremental_link_coordinator_tests.cpp
@@ -327,6 +327,76 @@ int main() {
     expect(order_runner.calls == 3,
            "changed /ORDER file should cause exactly one additional link execution");
 
+    const fs::path base_lib_directory = fixture.path() / "base-lib";
+    const fs::path base_file = base_lib_directory / "bases.txt";
+    const fs::path base_output = fixture.path() / "bin" / "based.exe";
+    const fs::path base_cache = fixture.path() / "cache" / "based.linkcache";
+    write_text(base_file, "app 0x160000000\n");
+
+    auto base_toolchain = toolchain;
+    base_toolchain.environment.push_back({
+        .name = "LIB",
+        .value = path_text(base_lib_directory),
+    });
+    LinkerLikeRunner base_runner;
+    base_runner.output = base_output;
+    mqb::msvc::MsvcLinker base_linker{base_toolchain, base_runner};
+    mqb::orchestration::MsvcIncrementalLinkCoordinator base_coordinator{
+        base_toolchain, base_linker};
+
+    mqb::LinkOptions base_options = debug_options;
+    base_options.additional_arguments = {"/BASE:@bases.txt,app"};
+    const mqb::orchestration::IncrementalLinkRequest base_request{
+        .objects = {object},
+        .output = base_output,
+        .options = base_options,
+        .cache_file = base_cache,
+        .working_directory = fixture.path(),
+        .force_relink = false,
+    };
+
+    const auto base_cold = base_coordinator.run(base_request);
+    expect(base_cold.has_value() && base_cold->linked,
+           "cold /BASE response-file link should execute successfully");
+    expect(base_runner.calls == 1,
+           "cold /BASE response-file link should invoke link.exe once");
+    if (base_runner.calls == 1) {
+        expect(std::find(
+                   base_runner.last_spec.arguments.begin(),
+                   base_runner.last_spec.arguments.end(),
+                   "/BASE:@bases.txt,app") != base_runner.last_spec.arguments.end(),
+               "/BASE freshness observation must preserve the user's raw LINK argv");
+    }
+
+    const auto base_warm = base_coordinator.run(base_request);
+    expect(base_warm.has_value() && !base_warm->linked,
+           "unchanged /BASE response file should remain a warm no-op");
+    expect(base_runner.calls == 1,
+           "warm /BASE response-file link should skip link.exe");
+
+    std::error_code base_time_error;
+    const auto base_output_time = fs::last_write_time(base_output, base_time_error);
+    expect(!base_time_error,
+           "BASE response-file fixture should read linked output timestamp");
+    write_text(base_file, "app 0x170000000\n");
+    base_time_error.clear();
+    fs::last_write_time(
+        base_file,
+        base_output_time + std::chrono::seconds{2},
+        base_time_error);
+    expect(!base_time_error,
+           "BASE response-file fixture should make the response file newer than output");
+
+    const auto base_changed = base_coordinator.run(base_request);
+    expect(base_changed.has_value() && base_changed->linked,
+           "changed /BASE response file should invalidate link freshness");
+    if (base_changed) {
+        expect(base_changed->validation.file_inputs_changed,
+               "changed /BASE response file should be a tracked linker file-input change");
+    }
+    expect(base_runner.calls == 2,
+           "changed /BASE response file should cause exactly one additional link execution");
+
     write_text(cache_file, "not an MQB link cache");
     const auto corrupt = coordinator.run(request);
     expect(corrupt.has_value(),


### PR DESCRIPTION
## Final audit original #5

Closes the remaining correctness hole for MSVC `/BASE:@filename,key` without changing native LINK argv semantics.

### What changed
- add a toolchain-aware `MsvcBaseAddressPolicy`
- observe only the effective last `/BASE` option
- keep numeric `/BASE` file-input free
- resolve path-bearing response files relative to the link working directory
- resolve bare response-file names strictly through the toolchain `LIB` environment, matching LINK semantics
- seal the resolved response file into incremental link `file_inputs`
- preserve the user's raw `/BASE:@...` argument verbatim for LINK

### Regression coverage
- policy tests cover numeric vs response-file forms, explicit paths, `LIB` lookup, malformed/missing response files, option case/prefix handling, and last-one-wins behavior
- incremental-link tests prove cold link → warm reuse → response-file-only mutation forces a relink with `file_inputs_changed`

This is original Final Audit item **#5**, not a new audit number. After merge the original audit should be **7/8 CLOSED**, leaving only original #8 (Librarian native parameter layer).