### PR TITLE
feat: expose native librarian parameters

### DIFF
--- a/cpp/include/mqb/config/ProjectConfig.hpp
+++ b/cpp/include/mqb/config/ProjectConfig.hpp
@@ -29,6 +29,7 @@ struct BuildOverrides {
     std::vector<std::string> libraries;
     std::vector<std::string> compiler_arguments;
     std::vector<std::string> linker_arguments;
+    std::vector<std::string> librarian_arguments;
 };
 
 struct DiscoveryOverrides {

--- a/cpp/include/mqb/config/ProjectOptions.hpp
+++ b/cpp/include/mqb/config/ProjectOptions.hpp
@@ -31,6 +31,7 @@ struct EffectiveProjectOptions {
     std::vector<std::string> libraries;
     std::vector<std::string> compiler_arguments;
     std::vector<std::string> linker_arguments;
+    std::vector<std::string> librarian_arguments;
 
     bool discovery_enabled{true};
     std::vector<std::filesystem::path> discovery_exclude_directories;

--- a/cpp/include/mqb/core/ArchiveCache.hpp
+++ b/cpp/include/mqb/core/ArchiveCache.hpp
@@ -3,6 +3,7 @@
 #include <filesystem>
 #include <optional>
 #include <span>
+#include <string>
 #include <vector>
 
 #include "mqb/core/BuildSignature.hpp"
@@ -35,7 +36,9 @@ public:
         const FileSnapshot& output_snapshot,
         std::span<const FileSnapshot> object_snapshots,
         bool force_archive = false,
-        bool link_time_code_generation = false);
+        bool link_time_code_generation = false,
+        Architecture architecture = Architecture::x64,
+        std::span<const std::string> additional_arguments = {});
 };
 
 } // namespace mqb

--- a/cpp/include/mqb/core/BuildSignature.hpp
+++ b/cpp/include/mqb/core/BuildSignature.hpp
@@ -52,7 +52,9 @@ public:
         std::span<const std::filesystem::path> objects,
         const std::filesystem::path& output,
         const LibrarianIdentity& librarian,
-        bool link_time_code_generation = false);
+        bool link_time_code_generation = false,
+        Architecture architecture = Architecture::x64,
+        std::span<const std::string> additional_arguments = {});
 
     [[nodiscard]] static BuildSignature from_digest(const SignatureDigest digest) noexcept {
         return BuildSignature{digest};

--- a/cpp/include/mqb/msvc/MsvcLibrarian.hpp
+++ b/cpp/include/mqb/msvc/MsvcLibrarian.hpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <vector>
 
+#include "mqb/core/BuildTypes.hpp"
 #include "mqb/core/LibrarianIdentity.hpp"
 #include "mqb/msvc/MsvcToolchainLocator.hpp"
 #include "mqb/process/Process.hpp"
@@ -16,7 +17,9 @@ struct ArchiveInvocation {
     std::vector<std::filesystem::path> objects;
     std::filesystem::path output;
     std::filesystem::path working_directory;
+    Architecture architecture{Architecture::x64};
     bool link_time_code_generation{false};
+    std::vector<std::string> additional_arguments;
 };
 
 enum class LibrarianErrorCode {

--- a/cpp/include/mqb/orchestration/MsvcIncrementalArchiveCoordinator.hpp
+++ b/cpp/include/mqb/orchestration/MsvcIncrementalArchiveCoordinator.hpp
@@ -9,6 +9,7 @@
 #include "mqb/core/ArchiveCache.hpp"
 #include "mqb/core/BuildPlan.hpp"
 #include "mqb/msvc/MsvcLibrarian.hpp"
+#include "mqb/msvc/MsvcParameterEngine.hpp"
 #include "mqb/msvc/MsvcToolchainLocator.hpp"
 #include "mqb/process/Process.hpp"
 
@@ -19,7 +20,9 @@ struct IncrementalArchiveRequest {
     std::filesystem::path output;
     std::filesystem::path cache_file;
     std::filesystem::path working_directory;
+    Architecture architecture{Architecture::x64};
     bool link_time_code_generation{false};
+    std::vector<std::string> additional_arguments;
     bool force_archive{false};
 };
 
@@ -37,6 +40,7 @@ struct IncrementalArchiveWarning {
 
 enum class IncrementalArchiveErrorCode {
     librarian_identity_failed,
+    librarian_parameter_invalid,
     planning_failed,
     archive_failed,
 };
@@ -44,6 +48,7 @@ enum class IncrementalArchiveErrorCode {
 struct IncrementalArchiveError {
     IncrementalArchiveErrorCode code{IncrementalArchiveErrorCode::planning_failed};
     std::string message;
+    std::optional<msvc::ParameterError> parameter_error;
     std::optional<msvc::LibrarianError> librarian_error;
 };
 

--- a/cpp/include/mqb/orchestration/MsvcIncrementalStaticTargetCoordinator.hpp
+++ b/cpp/include/mqb/orchestration/MsvcIncrementalStaticTargetCoordinator.hpp
@@ -22,6 +22,7 @@ struct IncrementalStaticTargetRequest {
     std::vector<std::filesystem::path> additional_objects;
     TargetArtifacts target;
     CompilerOptions compiler_options;
+    std::vector<std::string> librarian_arguments;
     std::filesystem::path working_directory;
     ParallelismPolicy max_parallel_compiles{};
     bool force_downstream_rebuild{false};

--- a/cpp/src/app/Application.cpp
+++ b/cpp/src/app/Application.cpp
@@ -324,6 +324,10 @@ int Application::run(const std::span<const std::string_view> arguments) {
         || !validate_parameter_capabilities(
             mqb::msvc::ParameterTool::linker,
             options.linker_arguments,
+            toolchain->identity.version)
+        || !validate_parameter_capabilities(
+            mqb::msvc::ParameterTool::librarian,
+            options.librarian_arguments,
             toolchain->identity.version)) {
         return 2;
     }
@@ -449,6 +453,7 @@ int Application::run(const std::span<const std::string_view> arguments) {
                     : std::vector<fs::path>{},
                 .target = std::move(*target_artifacts),
                 .compiler_options = std::move(compiler_options),
+                .librarian_arguments = std::move(options.librarian_arguments),
                 .project_root = project_root,
                 .target_name = target_name,
                 .max_parallel_jobs = parallelism,
@@ -458,6 +463,12 @@ int Application::run(const std::span<const std::string_view> arguments) {
             },
             *toolchain,
             runner);
+    }
+
+    if (!options.librarian_arguments.empty()) {
+        diagnostics::print_error(
+            "native MSVC librarian policy is only valid for static-library targets");
+        return 2;
     }
 
     mqb::LinkOptions link_options;

--- a/cpp/src/app/cli/Cli.hpp
+++ b/cpp/src/app/cli/Cli.hpp
@@ -43,6 +43,7 @@ struct Options {
     std::vector<std::string> libraries;
     std::vector<std::string> compiler_arguments;
     std::vector<std::string> linker_arguments;
+    std::vector<std::string> librarian_arguments;
     std::vector<ExternalModuleProvider> external_module_providers;
     msvc::ToolchainPreference toolchain_preference{msvc::ToolchainPreference::automatic};
     std::vector<std::filesystem::path> portable_roots;

--- a/cpp/src/app/project/ProjectSetup.cpp
+++ b/cpp/src/app/project/ProjectSetup.cpp
@@ -15,7 +15,6 @@ namespace mqb::app {
 namespace {
 
 namespace fs = std::filesystem;
-
 template <typename T>
 [[nodiscard]] std::expected<void, std::string> merge_semantic_value(
     std::optional<T>& structured,
@@ -49,6 +48,43 @@ template <typename T>
     message += ": ";
     message += error.message;
     return message;
+}
+
+[[nodiscard]] bool is_native_librarian_boundary(const std::string_view argument) noexcept {
+    return argument == "/lib" || argument == "-lib"
+        || argument == "/LIB" || argument == "-LIB";
+}
+
+[[nodiscard]] std::expected<void, std::string> extract_native_librarian_tail(
+    mqb::config::BuildOverrides& build,
+    const std::string_view layer) {
+    std::optional<std::size_t> boundary;
+    for (std::size_t index = 0; index < build.compiler_arguments.size(); ++index) {
+        if (!is_native_librarian_boundary(build.compiler_arguments[index])) {
+            continue;
+        }
+        if (boundary) {
+            return std::unexpected(
+                std::string{layer} + " contains a duplicate native MSVC /lib separator");
+        }
+        boundary = index;
+    }
+    if (!boundary) {
+        return {};
+    }
+    if (*boundary + 1 == build.compiler_arguments.size()) {
+        return std::unexpected(
+            std::string{layer} + " native MSVC /lib requires at least one librarian option");
+    }
+
+    build.librarian_arguments.insert(
+        build.librarian_arguments.end(),
+        std::make_move_iterator(build.compiler_arguments.begin() + *boundary + 1),
+        std::make_move_iterator(build.compiler_arguments.end()));
+    build.compiler_arguments.erase(
+        build.compiler_arguments.begin() + *boundary,
+        build.compiler_arguments.end());
+    return {};
 }
 
 [[nodiscard]] std::expected<void, std::string> append_linker_file_input(
@@ -101,6 +137,13 @@ template <typename T>
     if (!linker) {
         return std::unexpected(parameter_error_message(layer, linker.error()));
     }
+
+    auto librarian = mqb::msvc::MsvcParameterEngine::route_librarian(
+        std::span<const std::string>{build.librarian_arguments});
+    if (!librarian) {
+        return std::unexpected(parameter_error_message(layer, librarian.error()));
+    }
+
     auto linker_files = mqb::msvc::MsvcParameterEngine::linker_file_inputs(
         std::span<const std::string>{linker->passthrough},
         path_base);
@@ -141,6 +184,10 @@ template <typename T>
         return std::unexpected(merged.error());
     }
     if (auto merged = merge_semantic_value(
+            build.architecture, librarian->architecture, layer, "target architecture"); !merged) {
+        return std::unexpected(merged.error());
+    }
+    if (auto merged = merge_semantic_value(
             build.subsystem, linker->subsystem, layer, "target subsystem"); !merged) {
         return std::unexpected(merged.error());
     }
@@ -154,6 +201,14 @@ template <typename T>
         }
         routed_ltcg = linker->link_time_code_generation;
     }
+    if (librarian->link_time_code_generation) {
+        if (routed_ltcg && *routed_ltcg != *librarian->link_time_code_generation) {
+            return std::unexpected(
+                std::string{layer}
+                + " has conflicting compiler/linker/librarian LTCG policy");
+        }
+        routed_ltcg = librarian->link_time_code_generation;
+    }
     if (auto merged = merge_semantic_value(
             build.link_time_code_generation, routed_ltcg, layer, "LTCG"); !merged) {
         return std::unexpected(merged.error());
@@ -161,6 +216,7 @@ template <typename T>
 
     build.compiler_arguments = std::move(compiler->passthrough);
     build.linker_arguments = std::move(default_libraries->passthrough);
+    build.librarian_arguments = std::move(librarian->passthrough);
     return {};
 }
 
@@ -262,8 +318,16 @@ prepare_project(
     cli_overrides.build.libraries = options.libraries;
     cli_overrides.build.compiler_arguments = options.compiler_arguments;
     cli_overrides.build.linker_arguments = options.linker_arguments;
+    cli_overrides.build.librarian_arguments = options.librarian_arguments;
     cli_overrides.discovery.enabled = options.discovery_override;
     cli_overrides.modules.external_providers = options.external_module_providers;
+
+    if (auto extracted = extract_native_librarian_tail(cli_overrides.build, "CLI"); !extracted) {
+        return std::unexpected(ProjectSetupError{
+            .message = extracted.error(),
+            .config_error = std::nullopt,
+        });
+    }
 
     std::vector<fs::path> native_include_directories;
     // This app-layer vector exists only while resolving config/profile/CLI so
@@ -340,6 +404,7 @@ prepare_project(
     options.libraries = effective.libraries;
     options.compiler_arguments = effective.compiler_arguments;
     options.linker_arguments = effective.linker_arguments;
+    options.librarian_arguments = effective.librarian_arguments;
     options.external_module_providers = effective.external_module_providers;
 
     if (auto linker_requirements =

--- a/cpp/src/app/targets/StaticCliTarget.cpp
+++ b/cpp/src/app/targets/StaticCliTarget.cpp
@@ -59,6 +59,7 @@ int run_static_target(
         .additional_objects = std::move(request.additional_objects),
         .target = request.target,
         .compiler_options = std::move(request.compiler_options),
+        .librarian_arguments = std::move(request.librarian_arguments),
         .working_directory = request.project_root,
         .max_parallel_compiles = request.max_parallel_jobs,
         .force_downstream_rebuild = request.force_downstream_rebuild,

--- a/cpp/src/app/targets/StaticCliTarget.hpp
+++ b/cpp/src/app/targets/StaticCliTarget.hpp
@@ -23,6 +23,7 @@ struct StaticCliTargetRequest {
     std::vector<std::filesystem::path> additional_objects;
     TargetArtifacts target;
     CompilerOptions compiler_options;
+    std::vector<std::string> librarian_arguments;
     std::filesystem::path project_root;
     std::string target_name;
     orchestration::ParallelismPolicy max_parallel_jobs{};

--- a/cpp/src/config/resolution/ProjectOptions.cpp
+++ b/cpp/src/config/resolution/ProjectOptions.cpp
@@ -37,6 +37,7 @@ void apply_build(
     append_all(effective.libraries, overrides.libraries);
     append_all(effective.compiler_arguments, overrides.compiler_arguments);
     append_all(effective.linker_arguments, overrides.linker_arguments);
+    append_all(effective.librarian_arguments, overrides.librarian_arguments);
 }
 
 void apply_discovery(

--- a/cpp/src/config/schema/ProjectConfigSchema.cpp
+++ b/cpp/src/config/schema/ProjectConfigSchema.cpp
@@ -241,7 +241,7 @@ using JsonValue = json::Value;
         {
             "configuration", "architecture", "standard", "runtime", "ltcg",
             "subsystem", "type", "entry", "pch", "output", "defines", "include_dirs",
-            "library_dirs", "libraries", "compiler_args", "linker_args",
+            "library_dirs", "libraries", "compiler_args", "linker_args", "librarian_args",
         },
         "build");
     if (!known) return std::unexpected(known.error());
@@ -382,6 +382,12 @@ using JsonValue = json::Value;
         auto values = require_strings(file, it->second, "build.linker_args");
         if (!values) return std::unexpected(values.error());
         out.linker_arguments = std::move(*values);
+    }
+
+    if (auto it = (**object).find("librarian_args"); it != (**object).end()) {
+        auto values = require_strings(file, it->second, "build.librarian_args");
+        if (!values) return std::unexpected(values.error());
+        out.librarian_arguments = std::move(*values);
     }
 
     return {};

--- a/cpp/src/core/cache/ArchiveCache.cpp
+++ b/cpp/src/core/cache/ArchiveCache.cpp
@@ -67,7 +67,9 @@ ArchiveCacheValidation ArchiveCacheValidator::validate(
     const FileSnapshot& output_snapshot,
     const std::span<const FileSnapshot> object_snapshots,
     const bool force_archive,
-    const bool link_time_code_generation) {
+    const bool link_time_code_generation,
+    const Architecture architecture,
+    const std::span<const std::string> additional_arguments) {
     ArchiveCacheValidation result;
 
     if (force_archive) add_reason(result.reasons, BuildReason::explicit_rebuild);
@@ -89,7 +91,9 @@ ArchiveCacheValidation ArchiveCacheValidator::validate(
         current_objects,
         current_output,
         current_librarian,
-        link_time_code_generation);
+        link_time_code_generation,
+        architecture,
+        additional_arguments);
     if (cached.signature != signature && librarian_matches && inputs_match) {
         add_reason(result.reasons, BuildReason::archive_recipe_changed);
     }

--- a/cpp/src/core/model/BuildSignature.cpp
+++ b/cpp/src/core/model/BuildSignature.cpp
@@ -296,17 +296,25 @@ BuildSignature BuildSignature::for_archive(
     const std::span<const std::filesystem::path> objects,
     const std::filesystem::path& output,
     const LibrarianIdentity& librarian,
-    const bool link_time_code_generation) {
+    const bool link_time_code_generation,
+    const Architecture architecture,
+    const std::span<const std::string> additional_arguments) {
     StableHasher hasher;
-    hasher.add_string("mqb.archive.signature.v1");
+    // v2 intentionally invalidates pre-librarian-parameter cache entries. The
+    // archive recipe now owns architecture plus routed native LIB argv.
+    hasher.add_string("mqb.archive.signature.v2");
     hasher.add_paths(objects);
     hasher.add_path(output);
     hasher.add_path(librarian.librarian);
     hasher.add_string(librarian.version);
     hasher.add_string(librarian.binary_stamp);
+    hasher.add_enum(architecture);
     if (link_time_code_generation) {
-        // Preserve historical archive identities when LTCG is off.
         hasher.add_string("mqb.ltcg.archive.v1");
+    }
+    hasher.add_string("mqb.archive.native-arguments.v1");
+    for (const auto& argument : additional_arguments) {
+        hasher.add_string(argument);
     }
     return BuildSignature{hasher.finish()};
 }

--- a/cpp/src/msvc/librarian/MsvcLibrarian.cpp
+++ b/cpp/src/msvc/librarian/MsvcLibrarian.cpp
@@ -6,6 +6,8 @@
 #include <system_error>
 #include <utility>
 
+#include "mqb/msvc/MsvcParameterEngine.hpp"
+
 namespace mqb::msvc {
 namespace {
 
@@ -21,6 +23,10 @@ namespace fs = std::filesystem;
 [[nodiscard]] std::string path_to_utf8(const fs::path& path) {
     const auto bytes = path.generic_u8string();
     return std::string{reinterpret_cast<const char*>(bytes.data()), bytes.size()};
+}
+
+[[nodiscard]] std::string machine_argument(const Architecture architecture) {
+    return architecture == Architecture::x86 ? "/MACHINE:X86" : "/MACHINE:X64";
 }
 
 [[nodiscard]] fs::path temporary_archive_path(const fs::path& output) {
@@ -81,12 +87,34 @@ MsvcLibrarian::build_arguments(const ArchiveInvocation& invocation) {
         return std::unexpected(failure(
             LibrarianErrorCode::invalid_request, "archive output path is empty"));
     }
+
+    auto routed = MsvcParameterEngine::route_librarian(invocation.additional_arguments);
+    if (!routed) {
+        return std::unexpected(failure(
+            LibrarianErrorCode::invalid_request,
+            "invalid native MSVC librarian argument '" + routed.error().argument
+                + "': " + routed.error().message));
+    }
+    if (routed->architecture && *routed->architecture != invocation.architecture) {
+        return std::unexpected(failure(
+            LibrarianErrorCode::invalid_request,
+            "native MSVC librarian /MACHINE conflicts with the typed target architecture"));
+    }
+
+    const bool effective_ltcg = invocation.link_time_code_generation
+        || routed->link_time_code_generation.value_or(false);
+
     std::vector<std::string> arguments;
-    arguments.reserve(invocation.objects.size() + 3);
+    arguments.reserve(invocation.objects.size() + routed->passthrough.size() + 4);
     arguments.emplace_back("/NOLOGO");
-    if (invocation.link_time_code_generation) {
+    arguments.push_back(machine_argument(invocation.architecture));
+    if (effective_ltcg) {
         arguments.emplace_back("/LTCG");
     }
+    arguments.insert(
+        arguments.end(),
+        routed->passthrough.begin(),
+        routed->passthrough.end());
     arguments.push_back("/OUT:" + path_to_utf8(invocation.output));
     for (const auto& object : invocation.objects) {
         if (object.empty()) {

--- a/cpp/src/orchestration/incremental/MsvcIncrementalArchiveCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalArchiveCoordinator.cpp
@@ -68,6 +68,26 @@ MsvcIncrementalArchiveCoordinator::run(const IncrementalArchiveRequest& request)
         });
     }
 
+    auto librarian_routing = msvc::MsvcParameterEngine::route_librarian(
+        request.additional_arguments);
+    if (!librarian_routing) {
+        return std::unexpected(IncrementalArchiveError{
+            .code = IncrementalArchiveErrorCode::librarian_parameter_invalid,
+            .message = "invalid native MSVC librarian argument: "
+                + librarian_routing.error().message,
+            .parameter_error = librarian_routing.error(),
+        });
+    }
+    if (librarian_routing->architecture
+        && *librarian_routing->architecture != request.architecture) {
+        return std::unexpected(IncrementalArchiveError{
+            .code = IncrementalArchiveErrorCode::librarian_parameter_invalid,
+            .message = "native MSVC librarian /MACHINE conflicts with the typed target architecture",
+        });
+    }
+    const bool effective_ltcg = request.link_time_code_generation
+        || librarian_routing->link_time_code_generation.value_or(false);
+
     std::optional<ArchiveCacheEntry> cached_entry;
     auto loaded = ArchiveCacheFile::load(request.cache_file);
     if (loaded) {
@@ -101,7 +121,9 @@ MsvcIncrementalArchiveCoordinator::run(const IncrementalArchiveRequest& request)
         output_snapshot,
         object_snapshots,
         request.force_archive,
-        request.link_time_code_generation);
+        effective_ltcg,
+        request.architecture,
+        librarian_routing->passthrough);
 
     // A reusable archive validation already proves that there is no archive
     // action to schedule. Keep the generic planner on miss/rebuild paths only.
@@ -141,7 +163,9 @@ MsvcIncrementalArchiveCoordinator::run(const IncrementalArchiveRequest& request)
         .objects = action->objects,
         .output = action->output,
         .working_directory = request.working_directory,
-        .link_time_code_generation = request.link_time_code_generation,
+        .architecture = request.architecture,
+        .link_time_code_generation = effective_ltcg,
+        .additional_arguments = librarian_routing->passthrough,
     });
     if (!archived) {
         return std::unexpected(IncrementalArchiveError{
@@ -159,7 +183,9 @@ MsvcIncrementalArchiveCoordinator::run(const IncrementalArchiveRequest& request)
             action->objects,
             action->output,
             *librarian_identity,
-            request.link_time_code_generation),
+            effective_ltcg,
+            request.architecture,
+            librarian_routing->passthrough),
         .objects = action->objects,
         .output = action->output,
     };

--- a/cpp/src/orchestration/incremental/MsvcIncrementalStaticTargetCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalStaticTargetCoordinator.cpp
@@ -180,7 +180,9 @@ MsvcIncrementalStaticTargetCoordinator::run(const IncrementalStaticTargetRequest
         .output = request.target.executable,
         .cache_file = request.target.link_cache,
         .working_directory = request.working_directory,
+        .architecture = request.compiler_options.architecture,
         .link_time_code_generation = request.compiler_options.link_time_code_generation,
+        .additional_arguments = request.librarian_arguments,
         .force_archive = request.force_downstream_rebuild || result.any_compiled,
     });
     timings.archive = std::chrono::duration_cast<std::chrono::nanoseconds>(

--- a/cpp/tests/app/cli/build_policy_cli_tests.cpp
+++ b/cpp/tests/app/cli/build_policy_cli_tests.cpp
@@ -77,6 +77,105 @@ int main() {
     }
 
     {
+        const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
+        TempTree tree{
+            .root = fs::temp_directory_path()
+                / ("mqb_native_librarian_policy_" + std::to_string(unique)),
+        };
+        fs::create_directories(tree.root);
+
+        const std::vector arguments{
+            "main.cpp"sv,
+            "--type"sv, "static"sv,
+            "/W4"sv,
+            "/lib"sv,
+            "/EXPORT:mqb_export"sv,
+            "/WX"sv,
+        };
+        auto parsed = mqb::cli::parse_arguments(arguments);
+        expect(parsed.has_value(), "native /lib boundary should parse as native argv before project setup");
+        if (parsed) {
+            expect(parsed->compiler_arguments.size() == 4
+                       && parsed->compiler_arguments[0] == "/W4"
+                       && parsed->compiler_arguments[1] == "/lib"
+                       && parsed->compiler_arguments[2] == "/EXPORT:mqb_export"
+                       && parsed->compiler_arguments[3] == "/WX",
+                   "CLI parser should preserve /lib and its tail until ownership routing");
+
+            auto project = mqb::app::prepare_project(*parsed, tree.root);
+            expect(project.has_value(), "project setup should split and route native /lib policy");
+            if (project) {
+                expect(parsed->compiler_arguments.size() == 1
+                           && parsed->compiler_arguments[0] == "/W4",
+                       "compiler argv before /lib should remain compiler-owned");
+                expect(parsed->librarian_arguments.size() == 2
+                           && parsed->librarian_arguments[0] == "/EXPORT:mqb_export"
+                           && parsed->librarian_arguments[1] == "/WX",
+                       "every native option after /lib should become routed librarian policy in order");
+                expect(project->effective.target_kind == mqb::TargetKind::static_library,
+                       "native librarian policy should coexist with the typed static target kind");
+            }
+        }
+
+        const std::vector empty_tail_arguments{
+            "main.cpp"sv,
+            "--type"sv, "static"sv,
+            "/lib"sv,
+        };
+        auto empty_tail = mqb::cli::parse_arguments(empty_tail_arguments);
+        expect(empty_tail.has_value(), "bare /lib should remain syntactically parseable at CLI stage");
+        if (empty_tail) {
+            auto project = mqb::app::prepare_project(*empty_tail, tree.root);
+            expect(!project && project.error().message.find("requires at least one librarian option") != std::string::npos,
+                   "bare /lib should fail closed at ownership routing");
+        }
+
+        const std::vector owned_output_arguments{
+            "main.cpp"sv,
+            "--type"sv, "static"sv,
+            "/lib"sv,
+            "/OUT:hijack.lib"sv,
+        };
+        auto owned_output = mqb::cli::parse_arguments(owned_output_arguments);
+        expect(owned_output.has_value(), "Class A librarian option should reach ownership routing");
+        if (owned_output) {
+            auto project = mqb::app::prepare_project(*owned_output, tree.root);
+            expect(!project && project.error().message.find("/OUT:hijack.lib") != std::string::npos,
+                   "Class A /OUT after /lib should be rejected before product execution");
+        }
+
+        const std::vector wrong_tool_arguments{
+            "main.cpp"sv,
+            "--type"sv, "static"sv,
+            "/lib"sv,
+            "/W4"sv,
+        };
+        auto wrong_tool = mqb::cli::parse_arguments(wrong_tool_arguments);
+        expect(wrong_tool.has_value(), "compiler-only option after /lib should parse before classification");
+        if (wrong_tool) {
+            auto project = mqb::app::prepare_project(*wrong_tool, tree.root);
+            expect(!project,
+                   "compiler-only option after /lib must fail librarian classification instead of leaking back to cl.exe");
+        }
+
+        const std::vector duplicate_boundary_arguments{
+            "main.cpp"sv,
+            "--type"sv, "static"sv,
+            "/lib"sv,
+            "/WX"sv,
+            "/LIB"sv,
+            "/EXPORT:duplicate"sv,
+        };
+        auto duplicate_boundary = mqb::cli::parse_arguments(duplicate_boundary_arguments);
+        expect(duplicate_boundary.has_value(), "duplicate /lib boundary should parse before routing");
+        if (duplicate_boundary) {
+            auto project = mqb::app::prepare_project(*duplicate_boundary, tree.root);
+            expect(!project && project.error().message.find("duplicate native MSVC /lib separator") != std::string::npos,
+                   "duplicate /lib boundary should be rejected deterministically");
+        }
+    }
+
+    {
         const std::vector arguments{
             "main.cpp"sv,
             "--type"sv, "dll"sv,

--- a/cpp/tests/config/integration/project_config_tests.cpp
+++ b/cpp/tests/config/integration/project_config_tests.cpp
@@ -57,7 +57,8 @@ int main() {
     "defines": ["ONE=1", "TEXT=\u6d4b\u8bd5"],
     "include_dirs": ["include", "unicode/\u6d4b\u8bd5"],
     "library_dirs": ["vendor libs"],
-    "libraries": ["math", "codec.lib"]
+    "libraries": ["math", "codec.lib"],
+    "librarian_args": ["/EXPORT:config_symbol", "/WX"]
   },
   "discovery": {
     "enabled": false,
@@ -79,7 +80,8 @@ int main() {
         "runtime": "MDd",
         "defines": ["PROFILE_DEV=1"],
         "include_dirs": ["profiles/dev/include"],
-        "compiler_args": ["/W4"]
+        "compiler_args": ["/W4"],
+        "librarian_args": ["/IGNORE:4006"]
       },
       "discovery": {
         "enabled": true,
@@ -154,6 +156,10 @@ int main() {
                    && loaded->build.libraries[0] == "math"
                    && loaded->build.libraries[1] == "codec.lib",
                "library order should be preserved");
+        expect(loaded->build.librarian_arguments.size() == 2
+                   && loaded->build.librarian_arguments[0] == "/EXPORT:config_symbol"
+                   && loaded->build.librarian_arguments[1] == "/WX",
+               "build.librarian_args should decode in declaration order");
         expect(loaded->discovery.enabled && !*loaded->discovery.enabled,
                "discovery enabled override should decode false");
         expect(loaded->discovery.exclude_directories.size() == 1
@@ -198,6 +204,9 @@ int main() {
                        && dev->second.build.include_directories[0]
                            == (tree.root / "profiles/dev/include").lexically_normal(),
                    "profile paths should resolve relative to mqb.json");
+            expect(dev->second.build.librarian_arguments.size() == 1
+                       && dev->second.build.librarian_arguments[0] == "/IGNORE:4006",
+                   "profile build.librarian_args should decode independently from compiler args");
             expect(dev->second.discovery.enabled && *dev->second.discovery.enabled,
                    "profile discovery scalar should decode");
             expect(dev->second.discovery.extra_sources.size() == 1
@@ -227,7 +236,9 @@ int main() {
                    && !minimal->build.entry && !minimal->build.output_name,
                "missing build scalar/path fields must remain unset rather than receiving defaults");
         expect(minimal->build.defines.empty() && minimal->build.include_directories.empty()
-                   && minimal->build.library_directories.empty() && minimal->build.libraries.empty(),
+                   && minimal->build.library_directories.empty() && minimal->build.libraries.empty()
+                   && minimal->build.compiler_arguments.empty() && minimal->build.linker_arguments.empty()
+                   && minimal->build.librarian_arguments.empty(),
                "missing build list fields must remain empty overrides");
         expect(!minimal->discovery.enabled,
                "missing discovery enabled field must remain unset");
@@ -255,6 +266,12 @@ int main() {
     auto bad_profile_field = mqb::config::ProjectConfigLoader::load(config_file);
     expect(!bad_profile_field && bad_profile_field.error().code == mqb::config::ErrorCode::schema_error,
            "unknown profile fields should be rejected by strict schema");
+
+    write_text(config_file, R"json({"version":1,"build":{"librarian_args":"/WX"}})json");
+    auto bad_librarian_args = mqb::config::ProjectConfigLoader::load(config_file);
+    expect(!bad_librarian_args
+               && bad_librarian_args.error().code == mqb::config::ErrorCode::schema_error,
+           "build.librarian_args must be an array of non-empty strings");
 
     write_text(config_file, R"json({"version":1,"modules":{"external":{"vendor.math":7}}})json");
     auto bad_provider_type = mqb::config::ProjectConfigLoader::load(config_file);

--- a/cpp/tests/config/resolution/project_options_tests.cpp
+++ b/cpp/tests/config/resolution/project_options_tests.cpp
@@ -32,6 +32,8 @@ int main() {
                "smart discovery should be enabled by default");
         expect(!effective.output_name,
                "output should remain unset by default");
+        expect(effective.librarian_arguments.empty(),
+               "librarian argument policy should be empty by default");
         expect(effective.external_module_providers.empty(),
                "external module provider registry should be empty by default");
     }
@@ -46,6 +48,9 @@ int main() {
     project.build.include_directories = {fs::path{"config/include"}};
     project.build.library_directories = {fs::path{"config/lib"}};
     project.build.libraries = {"configlib"};
+    project.build.compiler_arguments = {"/W3"};
+    project.build.linker_arguments = {"/DEBUG:NONE"};
+    project.build.librarian_arguments = {"/EXPORT:config_symbol"};
     project.discovery.enabled = false;
     project.discovery.exclude_directories = {fs::path{"tests"}};
     project.discovery.extra_sources = {fs::path{"src/config-extra.cpp"}};
@@ -78,6 +83,8 @@ int main() {
                "project config should disable discovery");
         expect(effective.defines == project.build.defines,
                "project list values should populate effective options");
+        expect(effective.librarian_arguments == project.build.librarian_arguments,
+               "project librarian arguments should populate effective options");
         expect(effective.external_module_providers.size() == 2
                    && effective.external_module_providers[0].logical_name == "vendor.math"
                    && effective.external_module_providers[1].logical_name == "config.only",
@@ -91,6 +98,9 @@ int main() {
     profile.build.defines = {"PROFILE_B=2", "SHARED=profile"};
     profile.build.include_directories = {fs::path{"profile/include"}};
     profile.build.libraries = {"profilelib"};
+    profile.build.compiler_arguments = {"/W4"};
+    profile.build.linker_arguments = {"/OPT:REF"};
+    profile.build.librarian_arguments = {"/WX"};
     profile.discovery.enabled = true;
     profile.discovery.exclude_directories = {fs::path{"profile-tests"}};
     profile.modules.external_providers = {
@@ -132,6 +142,10 @@ int main() {
                    && effective.libraries[0] == "configlib"
                    && effective.libraries[1] == "profilelib",
                "profile libraries should append after base libraries");
+        expect(effective.librarian_arguments.size() == 2
+                   && effective.librarian_arguments[0] == "/EXPORT:config_symbol"
+                   && effective.librarian_arguments[1] == "/WX",
+               "profile librarian arguments should append after base librarian policy");
         expect(effective.external_module_providers.size() == 3,
                "profile modules should replace by logical name and append profile-only providers");
         if (effective.external_module_providers.size() == 3) {
@@ -157,6 +171,9 @@ int main() {
         cli.build.include_directories = {fs::path{"cli/include"}};
         cli.build.library_directories = {fs::path{"cli/lib"}};
         cli.build.libraries = {"clilib"};
+        cli.build.compiler_arguments = {"/WX"};
+        cli.build.linker_arguments = {"/OPT:NOREF"};
+        cli.build.librarian_arguments = {"/IGNORE:4006"};
         cli.discovery.enabled = false;
         cli.discovery.exclude_directories = {fs::path{"cli-tests"}};
         cli.discovery.extra_sources = {fs::path{"src/cli-extra.cpp"}};
@@ -205,6 +222,21 @@ int main() {
                    && effective.libraries[1] == "profilelib"
                    && effective.libraries[2] == "clilib",
                "libraries should append through all three layers");
+        expect(effective.compiler_arguments.size() == 3
+                   && effective.compiler_arguments[0] == "/W3"
+                   && effective.compiler_arguments[1] == "/W4"
+                   && effective.compiler_arguments[2] == "/WX",
+               "compiler arguments should append through all three layers");
+        expect(effective.linker_arguments.size() == 3
+                   && effective.linker_arguments[0] == "/DEBUG:NONE"
+                   && effective.linker_arguments[1] == "/OPT:REF"
+                   && effective.linker_arguments[2] == "/OPT:NOREF",
+               "linker arguments should append through all three layers");
+        expect(effective.librarian_arguments.size() == 3
+                   && effective.librarian_arguments[0] == "/EXPORT:config_symbol"
+                   && effective.librarian_arguments[1] == "/WX"
+                   && effective.librarian_arguments[2] == "/IGNORE:4006",
+               "librarian arguments should append base then profile then CLI without being dropped");
         expect(effective.discovery_exclude_directories.size() == 3,
                "discovery exclude directories should be additive across all layers");
         expect(effective.discovery_extra_sources.size() == 2,

--- a/cpp/tests/msvc/librarian/librarian_arguments_tests.cpp
+++ b/cpp/tests/msvc/librarian/librarian_arguments_tests.cpp
@@ -17,6 +17,9 @@ void expect(bool condition, std::string_view message) {
 [[nodiscard]] bool contains(const std::vector<std::string>& values, std::string_view expected) {
     return std::find(values.begin(), values.end(), expected) != values.end();
 }
+[[nodiscard]] std::size_t count(const std::vector<std::string>& values, std::string_view expected) {
+    return static_cast<std::size_t>(std::count(values.begin(), values.end(), expected));
+}
 } // namespace
 
 int main() {
@@ -27,6 +30,8 @@ int main() {
     expect(arguments.has_value(), "valid archive invocation should build argv");
     if (arguments) {
         expect(contains(*arguments, "/NOLOGO"), "librarian should suppress banner");
+        expect(contains(*arguments, "/MACHINE:X64"),
+               "typed target architecture should emit authoritative librarian /MACHINE");
         expect(!contains(*arguments, "/LTCG"), "default archive recipe should preserve non-LTCG behavior");
         expect(contains(*arguments, "/OUT:bin/math.lib"), "librarian should own archive output");
         expect(contains(*arguments, "obj/math one.obj"), "object path with spaces should stay one argv element");
@@ -41,6 +46,48 @@ int main() {
         expect(contains(*ltcg_arguments, "/LTCG"),
                "typed static LTCG should emit lib.exe /LTCG");
     }
+
+    auto native = invocation;
+    native.additional_arguments = {
+        "/EXPORT:mqb_export",
+        "/WX",
+        "/MACHINE:X64",
+        "/LTCG",
+    };
+    const auto native_arguments = mqb::msvc::MsvcLibrarian::build_arguments(native);
+    expect(native_arguments.has_value(), "supported native librarian arguments should build argv");
+    if (native_arguments) {
+        expect(contains(*native_arguments, "/EXPORT:mqb_export"),
+               "Class C /EXPORT should reach lib.exe unchanged");
+        expect(contains(*native_arguments, "/WX"),
+               "Class C /WX should reach lib.exe unchanged");
+        expect(count(*native_arguments, "/MACHINE:X64") == 1,
+               "semantic native /MACHINE should canonicalize to one authoritative argv element");
+        expect(count(*native_arguments, "/LTCG") == 1,
+               "semantic native /LTCG should canonicalize to one authoritative argv element");
+    }
+
+    auto x86 = invocation;
+    x86.architecture = mqb::Architecture::x86;
+    x86.additional_arguments = {"/MACHINE:X86"};
+    const auto x86_arguments = mqb::msvc::MsvcLibrarian::build_arguments(x86);
+    expect(x86_arguments.has_value() && contains(*x86_arguments, "/MACHINE:X86"),
+           "matching native x86 /MACHINE should be accepted");
+
+    auto conflicting_machine = invocation;
+    conflicting_machine.additional_arguments = {"/MACHINE:X86"};
+    expect(!mqb::msvc::MsvcLibrarian::build_arguments(conflicting_machine),
+           "native /MACHINE must not override conflicting MQB typed architecture");
+
+    auto owned_output = invocation;
+    owned_output.additional_arguments = {"/OUT:hijack.lib"};
+    expect(!mqb::msvc::MsvcLibrarian::build_arguments(owned_output),
+           "Class A librarian /OUT must fail closed before lib.exe");
+
+    auto repro = invocation;
+    repro.additional_arguments = {"/LINKREPRO:repro"};
+    expect(!mqb::msvc::MsvcLibrarian::build_arguments(repro),
+           "unsupported librarian repro artifacts must fail closed");
 
     auto empty = invocation;
     empty.objects.clear();

--- a/cpp/tests/orchestration/incremental/incremental_archive_coordinator_tests.cpp
+++ b/cpp/tests/orchestration/incremental/incremental_archive_coordinator_tests.cpp
@@ -56,10 +56,12 @@ void write_text(const fs::path& path, const std::string_view text) {
 class LibrarianLikeRunner final : public mqb::process::ProcessRunner {
 public:
     int calls{};
+    mqb::process::ProcessSpec last_spec;
 
     std::expected<mqb::process::ProcessResult, mqb::process::ProcessError>
     run(const mqb::process::ProcessSpec& spec) override {
         ++calls;
+        last_spec = spec;
         const auto output_argument = std::find_if(
             spec.arguments.begin(),
             spec.arguments.end(),
@@ -99,6 +101,13 @@ public:
         });
 }
 
+[[nodiscard]] bool has_argument(
+    const mqb::process::ProcessSpec& spec,
+    const std::string_view expected) {
+    return std::find(spec.arguments.begin(), spec.arguments.end(), expected)
+        != spec.arguments.end();
+}
+
 } // namespace
 
 int main() {
@@ -136,6 +145,7 @@ int main() {
         .output = output,
         .cache_file = cache_file,
         .working_directory = fixture.path(),
+        .architecture = mqb::Architecture::x64,
         .link_time_code_generation = false,
         .force_archive = false,
     };
@@ -163,6 +173,53 @@ int main() {
         expect(warm->validation.reusable(), "unchanged warm archive cache should be reusable");
     }
     expect(runner.calls == 1, "warm archive cache hit should not invoke lib.exe again");
+
+    auto native_request = request;
+    native_request.output = fixture.path() / "lib" / "native.lib";
+    native_request.cache_file = fixture.path() / "cache" / "native.archivecache";
+    native_request.additional_arguments = {"/EXPORT:mqb_export", "/WX"};
+
+    const auto native_cold = coordinator.run(native_request);
+    expect(native_cold.has_value() && native_cold->archived,
+           "cold native librarian policy should execute successfully");
+    expect(runner.calls == 2,
+           "cold native librarian policy should invoke lib.exe exactly once");
+    expect(has_argument(runner.last_spec, "/EXPORT:mqb_export"),
+           "Class C librarian /EXPORT should reach the real archive invocation");
+    expect(has_argument(runner.last_spec, "/WX"),
+           "Class C librarian /WX should reach the real archive invocation");
+    expect(has_argument(runner.last_spec, "/MACHINE:X64"),
+           "typed archive architecture should reach lib.exe as /MACHINE:X64");
+
+    const auto native_warm = coordinator.run(native_request);
+    expect(native_warm.has_value() && !native_warm->archived,
+           "unchanged native librarian policy should reuse the archive cache");
+    expect(runner.calls == 2,
+           "warm native librarian policy should not invoke lib.exe again");
+
+    auto changed_native_request = native_request;
+    changed_native_request.additional_arguments = {"/EXPORT:mqb_export", "/WX:NO"};
+    const auto native_changed = coordinator.run(changed_native_request);
+    expect(native_changed.has_value() && native_changed->archived,
+           "changing only librarian argv must invalidate archive freshness");
+    if (native_changed) {
+        expect(has_reason(native_changed->validation, mqb::BuildReason::archive_recipe_changed),
+               "librarian argv mutation should report archive_recipe_changed");
+    }
+    expect(runner.calls == 3,
+           "librarian argv mutation should cause exactly one additional lib.exe invocation");
+
+    auto owned_output_request = native_request;
+    owned_output_request.output = fixture.path() / "lib" / "owned-output.lib";
+    owned_output_request.cache_file = fixture.path() / "cache" / "owned-output.archivecache";
+    owned_output_request.additional_arguments = {"/OUT:hijack.lib"};
+    const auto owned_output = coordinator.run(owned_output_request);
+    expect(!owned_output
+               && owned_output.error().code
+                   == mqb::orchestration::IncrementalArchiveErrorCode::librarian_parameter_invalid,
+           "Class A /OUT should fail at archive parameter routing before lib.exe");
+    expect(runner.calls == 3,
+           "rejected Class A librarian policy must not launch lib.exe");
 
     std::error_code snapshot_error;
     const auto output_time = fs::last_write_time(output, snapshot_error);
@@ -193,7 +250,7 @@ int main() {
                    mqb::orchestration::IncrementalArchiveWarningCode::file_snapshot_failed),
                "non-regular object paths should be ordinary missing snapshots, not I/O warnings");
     }
-    expect(runner.calls == 2,
+    expect(runner.calls == 4,
            "directory object should force exactly one conservative rearchive");
     expect(fs::is_regular_file(output),
            "directory object regression should still leave a valid archive output");


### PR DESCRIPTION
## Final audit original #8

Closes the remaining gap between the registered LIB parameter inventory and the real static-archive product pipeline.

### Product path
- dedicated librarian argument channel through project/config/profile/CLI resolution
- `build.librarian_args` in `mqb.json`, with base → profile → CLI append precedence
- native `/lib` boundary for static builds; the tail is classified by `route_librarian()`
- Class C librarian options reach `lib.exe` unchanged
- semantic `/MACHINE` and `/LTCG` merge into MQB typed policy
- Class A `/OUT` and unsupported/unmodeled LIB options remain fail-closed
- librarian-only policy is rejected on exe/dll targets
- librarian options participate in toolset capability validation

### Correctness / cache identity
- archive invocation now carries target architecture, effective LTCG, and routed native librarian argv
- archive signature is versioned to v2 and seals that complete recipe
- changing only librarian argv invalidates warm archive reuse with `archive_recipe_changed`
- ambient `link_repro` remains suppressed so untracked repro artifacts cannot appear implicitly

### Regression coverage
- librarian argv/ownership tests prove Class C passthrough, semantic canonicalization, Class A rejection, and unsupported repro rejection
- archive coordinator tests prove cold → warm reuse → librarian-argv-only mutation → rearchive
- project option tests prove librarian policy layering across base/profile/CLI
- project config tests prove `build.librarian_args` schema decoding and type rejection
- CLI/app tests prove `/lib` splitting plus empty-tail, duplicate-boundary, wrong-tool, and `/OUT` fail-closed behavior

### Final gates for head `a092e49d371d9a21d27a1f7549daba032a17e8bc`
- Native C++ #433: success, Debug seed + all 4 native test shards green
- Native Release #367: success, Release seed + all 4 native test shards green
- Release self-host: success
- runtime-only package staging, exact package validation, and artifact upload: success

This is original Final Audit item **#8**, not a new audit number. After merge the original eight-point audit is **8/8 CLOSED**.