### PR TITLE
perf: seal include search resolution freshness

### DIFF
--- a/.github/workflows/native-ci.yml
+++ b/.github/workflows/native-ci.yml
@@ -150,6 +150,14 @@ jobs:
             -RepoRoot $PWD
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
+      - name: Verify include search resolution freshness
+        shell: pwsh
+        run: |
+          & (Join-Path $PWD 'tests/native/verify_include_search_freshness.ps1') `
+            -MqbPath (Join-Path $PWD 'native-out/debug/mqb.exe') `
+            -RepoRoot $PWD
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
       - name: Verify linker side-output repair
         shell: pwsh
         run: |

--- a/.github/workflows/native-ci.yml
+++ b/.github/workflows/native-ci.yml
@@ -158,6 +158,14 @@ jobs:
             -RepoRoot $PWD
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
+      - name: Verify __has_include freshness
+        shell: pwsh
+        run: |
+          & (Join-Path $PWD 'tests/native/verify_has_include_freshness.ps1') `
+            -MqbPath (Join-Path $PWD 'native-out/debug/mqb.exe') `
+            -RepoRoot $PWD
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
       - name: Verify linker side-output repair
         shell: pwsh
         run: |

--- a/cpp/include/mqb/core/CompileCache.hpp
+++ b/cpp/include/mqb/core/CompileCache.hpp
@@ -35,11 +35,6 @@ struct CompileCacheEntry {
     // including environment-backed root replacement/removal.
     std::vector<std::filesystem::path> include_search_roots;
     std::optional<ModuleScanEvidence> module_scan;
-    // True only for cache-format v4+ entries produced after Include Search
-    // Resolution Freshness existed. This avoids inferring migration state from
-    // non-empty evidence: `/X` with no /I and no textual headers is a valid
-    // sealed entry whose root/directory evidence is intentionally empty.
-    bool include_search_freshness_sealed{false};
 };
 
 struct CompileCacheValidation {

--- a/cpp/include/mqb/core/CompileCache.hpp
+++ b/cpp/include/mqb/core/CompileCache.hpp
@@ -29,6 +29,11 @@ struct CompileCacheEntry {
     BuildSignature signature;
     std::vector<Artifact> outputs;
     std::vector<std::filesystem::path> dependencies;
+    // Exact ordered compiler-global include roots (/I, native /I or
+    // /external:I, then vcvars INCLUDE unless /X). Directory timestamps answer
+    // namespace freshness; this vector answers root identity/order freshness,
+    // including environment-backed root replacement/removal.
+    std::vector<std::filesystem::path> include_search_roots;
     std::optional<ModuleScanEvidence> module_scan;
 };
 

--- a/cpp/include/mqb/core/CompileCache.hpp
+++ b/cpp/include/mqb/core/CompileCache.hpp
@@ -35,6 +35,11 @@ struct CompileCacheEntry {
     // including environment-backed root replacement/removal.
     std::vector<std::filesystem::path> include_search_roots;
     std::optional<ModuleScanEvidence> module_scan;
+    // True only for cache-format v4+ entries produced after Include Search
+    // Resolution Freshness existed. This avoids inferring migration state from
+    // non-empty evidence: `/X` with no /I and no textual headers is a valid
+    // sealed entry whose root/directory evidence is intentionally empty.
+    bool include_search_freshness_sealed{false};
 };
 
 struct CompileCacheValidation {

--- a/cpp/include/mqb/msvc/MsvcIncludeSearchFreshness.hpp
+++ b/cpp/include/mqb/msvc/MsvcIncludeSearchFreshness.hpp
@@ -197,10 +197,9 @@ include_search_freshness_directories(
     using namespace include_freshness_detail;
 
     const fs::path working = effective_working_directory(working_directory);
+    const fs::path absolute_source = absolute_search_path(source, working);
     std::vector<fs::path> ordered_roots;
-    append_unique(
-        ordered_roots,
-        absolute_search_path(source.parent_path(), working));
+    append_unique(ordered_roots, absolute_source.parent_path());
     for (const auto& include_directory : options.include_directories) {
         append_unique(
             ordered_roots,

--- a/cpp/include/mqb/msvc/MsvcIncludeSearchFreshness.hpp
+++ b/cpp/include/mqb/msvc/MsvcIncludeSearchFreshness.hpp
@@ -91,6 +91,15 @@ inline void append_unique(std::vector<fs::path>& paths, fs::path path) {
     }
 }
 
+// Compiler search-root identity is an ordered argv/environment fact, not a
+// filesystem-equivalence set. Preserve each normalized spelling (including
+// duplicates) exactly as MSVC sees it. Besides being more faithful, this keeps
+// the warm path free of equivalent()/status syscalls while constructing roots.
+inline void append_search_root(std::vector<fs::path>& roots, fs::path path) {
+    if (path.empty()) return;
+    roots.push_back(path.lexically_normal());
+}
+
 [[nodiscard]] inline fs::path deepest_existing_directory(fs::path candidate) {
     candidate = candidate.lexically_normal();
     while (!candidate.empty()) {
@@ -174,7 +183,7 @@ inline void append_raw_include_roots(
         }
 
         if (value && !value->empty()) {
-            append_unique(
+            append_search_root(
                 roots,
                 absolute_search_path(utf8_path(*value), working_directory));
         }
@@ -202,7 +211,7 @@ inline void append_environment_include_roots(
                 variable.value.data() + begin,
                 (end == std::string::npos ? variable.value.size() : end) - begin};
             if (!part.empty()) {
-                append_unique(
+                append_search_root(
                     roots,
                     absolute_search_path(utf8_path(part), working_directory));
             }
@@ -349,11 +358,12 @@ inline void record_literal_operand(
 
 } // namespace include_freshness_detail
 
-// Return the ordered compiler-global include roots. Typed -I roots are emitted
-// before native passthrough arguments, matching CompilerArgumentBuilder; the
-// vcvars INCLUDE list follows them unless /X disables standard include paths.
-// The exact ordered list is persisted in the compile cache so environment-root
-// replacement/removal is identity, not merely directory timestamp evidence.
+// Return the exact ordered compiler-global include roots. Typed -I roots are
+// emitted before native passthrough arguments, matching CompilerArgumentBuilder;
+// the vcvars INCLUDE list follows them unless /X disables standard include paths.
+// Ordered normalized spellings (including duplicates) are persisted in the
+// compile cache so environment-root replacement/removal is identity without any
+// filesystem lookup on the warm path.
 [[nodiscard]] inline std::vector<std::filesystem::path> include_search_roots(
     const CompilerOptions& options,
     const std::span<const process::EnvironmentVariable> environment,
@@ -363,7 +373,7 @@ inline void record_literal_operand(
     const std::filesystem::path working = effective_working_directory(working_directory);
     std::vector<std::filesystem::path> roots;
     for (const auto& include_directory : options.include_directories) {
-        append_unique(
+        append_search_root(
             roots,
             absolute_search_path(include_directory, working));
     }
@@ -403,10 +413,6 @@ include_search_freshness_directories(
 
     const fs::path working = effective_working_directory(working_directory);
     const fs::path absolute_source = absolute_search_path(source, working);
-    const std::vector<fs::path> global_roots = include_search_roots(
-        options,
-        environment,
-        working_directory);
 
     std::vector<fs::path> normalized_dependencies;
     normalized_dependencies.reserve(resolved_includes.size());
@@ -444,6 +450,14 @@ include_search_freshness_directories(
     // cannot be rerouted by directory namespace churn. Exact global-root identity
     // is still stored separately so ambient INCLUDE replacement remains visible.
     if (!any_search_usage && normalized_dependencies.empty()) return {};
+
+    // Build global root identity only after the no-search fast exit. The compile
+    // executor calls this function after a successful compile; source files with
+    // no include lookup therefore avoid even lexical vcvars INCLUDE processing.
+    const std::vector<fs::path> global_roots = include_search_roots(
+        options,
+        environment,
+        working_directory);
 
     std::vector<fs::path> watched;
     for (const auto& root : local_roots) {

--- a/cpp/include/mqb/msvc/MsvcIncludeSearchFreshness.hpp
+++ b/cpp/include/mqb/msvc/MsvcIncludeSearchFreshness.hpp
@@ -18,7 +18,11 @@ namespace include_freshness_detail {
 namespace fs = std::filesystem;
 
 [[nodiscard]] inline bool same_path(const fs::path& left, const fs::path& right) {
-    return left == right || left.lexically_normal() == right.lexically_normal();
+    if (left == right || left.lexically_normal() == right.lexically_normal()) {
+        return true;
+    }
+    std::error_code error_code;
+    return fs::equivalent(left, right, error_code) && !error_code;
 }
 
 [[nodiscard]] inline bool ascii_iequals(
@@ -95,10 +99,9 @@ inline void append_unique(std::vector<fs::path>& paths, fs::path path) {
     return {};
 }
 
-[[nodiscard]] inline std::optional<fs::path> relative_if_within(
+[[nodiscard]] inline std::optional<fs::path> lexical_relative_if_within(
     const fs::path& child,
     const fs::path& root) {
-    if (child.empty() || root.empty()) return std::nullopt;
     const fs::path relative = child.lexically_normal().lexically_relative(root.lexically_normal());
     if (relative.empty()) {
         return same_path(child, root) ? std::optional<fs::path>{fs::path{}} : std::nullopt;
@@ -108,6 +111,35 @@ inline void append_unique(std::vector<fs::path>& paths, fs::path path) {
         if (component == "..") return std::nullopt;
     }
     return relative;
+}
+
+// The compiler reports resolved dependency paths using filesystem spelling,
+// while a user-supplied /I root may differ only by Windows casing or by an
+// equivalent path spelling. Fall back to an ancestor walk using equivalent()
+// so we still recover the include-relative suffix in those cases.
+[[nodiscard]] inline std::optional<fs::path> relative_if_within(
+    const fs::path& child,
+    const fs::path& root) {
+    if (child.empty() || root.empty()) return std::nullopt;
+    if (auto relative = lexical_relative_if_within(child, root)) {
+        return relative;
+    }
+
+    fs::path cursor = child.lexically_normal();
+    fs::path suffix;
+    while (!cursor.empty()) {
+        if (same_path(cursor, root)) {
+            return suffix;
+        }
+        const fs::path filename = cursor.filename();
+        if (!filename.empty()) {
+            suffix = suffix.empty() ? filename : filename / suffix;
+        }
+        const fs::path parent = cursor.parent_path();
+        if (parent.empty() || parent == cursor) break;
+        cursor = parent;
+    }
+    return std::nullopt;
 }
 
 inline void append_raw_include_roots(
@@ -173,23 +205,63 @@ inline void append_environment_include_roots(
     }
 }
 
+inline void collect_relative_parent_suffix(
+    std::vector<fs::path>& suffixes,
+    const fs::path& dependency,
+    const fs::path& search_root) {
+    const auto relative = relative_if_within(dependency, search_root);
+    if (!relative) return;
+    const fs::path parent = relative->parent_path();
+    if (!parent.empty()) append_unique(suffixes, parent);
+}
+
 } // namespace include_freshness_detail
+
+// Return the ordered compiler-global include roots. Typed -I roots are emitted
+// before native passthrough arguments, matching CompilerArgumentBuilder; the
+// vcvars INCLUDE list follows them unless /X disables standard include paths.
+// The exact ordered list is persisted in the compile cache so environment-root
+// replacement/removal is identity, not merely directory timestamp evidence.
+[[nodiscard]] inline std::vector<std::filesystem::path> include_search_roots(
+    const CompilerOptions& options,
+    const std::span<const process::EnvironmentVariable> environment,
+    const std::optional<std::filesystem::path>& working_directory) {
+    using namespace include_freshness_detail;
+
+    const std::filesystem::path working = effective_working_directory(working_directory);
+    std::vector<std::filesystem::path> roots;
+    for (const auto& include_directory : options.include_directories) {
+        append_unique(
+            roots,
+            absolute_search_path(include_directory, working));
+    }
+    append_raw_include_roots(roots, options.additional_arguments, working);
+    if (!ignores_environment_include_roots(options.additional_arguments)) {
+        append_environment_include_roots(roots, environment, working);
+    }
+    return roots;
+}
 
 // Return directory paths whose namespace determines whether a previously
 // resolved include remains the first MSVC search hit. These paths are sealed
 // into the existing compile/module-scan dependency evidence. Warm validation
 // only stats them; it never launches cl.exe or /scanDependencies.
 //
-// Ordinary source/header directories are conservative quote-include roots.
-// The synthetic PCH creator is the exception: its source lives beside MQB-owned
-// outputs and contains no textual includes, so watching that artifact directory
-// would make its own first build alter its freshness evidence. Its forced PCH
-// header and every transitive include are still represented by resolved-header
-// parent directories below. Ordered /I and /external:I roots are watched
-// directly, and for a dependency resolved below a later root we also watch the
-// corresponding parent directory (or its deepest existing ancestor) in every
-// higher-priority root. This catches a new same-name header appearing without
-// changing argv or the previously resolved file.
+// Quoted includes may search the current header's directory and directories of
+// still-open parent headers before the global /I + INCLUDE roots. /sourceDependencies
+// reports the resolved files but not those include edges/spellings, so every
+// resolved header parent is conservatively treated as a possible local root.
+// For every include-relative parent suffix we can recover from the resolved
+// dependency graph, the corresponding directory (or deepest existing ancestor)
+// is watched under every possible local/global root. This catches a new shadow
+// file even when its candidate subdirectory already existed and only that nested
+// directory's mtime changes.
+//
+// The synthetic PCH creator is the exception to adding its source directory as
+// a local root: that source lives beside MQB-owned outputs and has no textual
+// includes, so watching its artifact directory would self-invalidate. Its
+// forced PCH header and all transitive includes still contribute real local
+// roots and relative-suffix evidence.
 [[nodiscard]] inline std::vector<std::filesystem::path>
 include_search_freshness_directories(
     const std::span<const std::filesystem::path> resolved_includes,
@@ -202,50 +274,51 @@ include_search_freshness_directories(
 
     const fs::path working = effective_working_directory(working_directory);
     const fs::path absolute_source = absolute_search_path(source, working);
-    std::vector<fs::path> ordered_roots;
-    const bool synthetic_pch_creator = options.precompiled_header
-        && options.precompiled_header->role == PrecompiledHeaderRole::create;
-    if (!synthetic_pch_creator) {
-        append_unique(ordered_roots, absolute_source.parent_path());
-    }
-    for (const auto& include_directory : options.include_directories) {
-        append_unique(
-            ordered_roots,
-            absolute_search_path(include_directory, working));
-    }
-    append_raw_include_roots(ordered_roots, options.additional_arguments, working);
-    if (!ignores_environment_include_roots(options.additional_arguments)) {
-        append_environment_include_roots(ordered_roots, environment, working);
-    }
-
-    std::vector<fs::path> watched;
-    for (const auto& root : ordered_roots) {
-        append_unique(watched, deepest_existing_directory(root));
-    }
+    const std::vector<fs::path> global_roots = include_search_roots(
+        options,
+        environment,
+        working_directory);
 
     std::vector<fs::path> normalized_dependencies;
     normalized_dependencies.reserve(resolved_includes.size());
     for (const auto& dependency : resolved_includes) {
-        const fs::path normalized = absolute_search_path(dependency, working);
-        normalized_dependencies.push_back(normalized);
-        append_unique(watched, deepest_existing_directory(normalized.parent_path()));
+        normalized_dependencies.push_back(absolute_search_path(dependency, working));
     }
 
+    std::vector<fs::path> local_roots;
+    const bool synthetic_pch_creator = options.precompiled_header
+        && options.precompiled_header->role == PrecompiledHeaderRole::create;
+    if (!synthetic_pch_creator) {
+        append_unique(local_roots, absolute_source.parent_path());
+    }
     for (const auto& dependency : normalized_dependencies) {
-        for (std::size_t winning_index = 0; winning_index < ordered_roots.size(); ++winning_index) {
-            const auto relative = relative_if_within(dependency, ordered_roots[winning_index]);
-            if (!relative) continue;
+        append_unique(local_roots, dependency.parent_path());
+    }
 
-            const fs::path relative_parent = relative->parent_path();
-            for (std::size_t candidate_index = 0;
-                 candidate_index <= winning_index;
-                 ++candidate_index) {
-                append_unique(
-                    watched,
-                    deepest_existing_directory(
-                        ordered_roots[candidate_index] / relative_parent));
-            }
-            break;
+    std::vector<fs::path> watched;
+    for (const auto& root : local_roots) {
+        append_unique(watched, deepest_existing_directory(root));
+    }
+    for (const auto& root : global_roots) {
+        append_unique(watched, deepest_existing_directory(root));
+    }
+
+    std::vector<fs::path> relative_parent_suffixes;
+    for (const auto& dependency : normalized_dependencies) {
+        for (const auto& root : local_roots) {
+            collect_relative_parent_suffix(relative_parent_suffixes, dependency, root);
+        }
+        for (const auto& root : global_roots) {
+            collect_relative_parent_suffix(relative_parent_suffixes, dependency, root);
+        }
+    }
+
+    for (const auto& suffix : relative_parent_suffixes) {
+        for (const auto& root : local_roots) {
+            append_unique(watched, deepest_existing_directory(root / suffix));
+        }
+        for (const auto& root : global_roots) {
+            append_unique(watched, deepest_existing_directory(root / suffix));
         }
     }
 

--- a/cpp/include/mqb/msvc/MsvcIncludeSearchFreshness.hpp
+++ b/cpp/include/mqb/msvc/MsvcIncludeSearchFreshness.hpp
@@ -216,18 +216,74 @@ inline void collect_relative_parent_suffix(
     if (!parent.empty()) append_unique(suffixes, parent);
 }
 
-// A local directory participates in MSVC's special quoted-include search only
-// when the corresponding source/header can issue a quoted (or macro-expanded)
-// include. Pure angle-include files do not search their own directory. This
-// cheap cold-path source inspection prevents unrelated artifacts created beside
-// a TU (for example LINK /MAP output) from poisoning the compile warm path.
-// Unknown/macro include operands conservatively opt into local search.
-[[nodiscard]] inline bool may_use_local_include_search(const fs::path& file) {
-    std::ifstream stream{file, std::ios::binary};
-    if (!stream) return true;
+struct IncludeSearchUse {
+    bool any_search{false};
+    bool may_search_local{false};
+    std::vector<fs::path> parent_suffixes;
+};
 
-    std::string line;
-    while (std::getline(stream, line)) {
+inline void record_literal_operand(
+    IncludeSearchUse& use,
+    const std::string_view line,
+    std::size_t position) {
+    while (position < line.size()
+        && (line[position] == ' ' || line[position] == '\t')) {
+        ++position;
+    }
+    if (position >= line.size()) {
+        use.any_search = true;
+        use.may_search_local = true;
+        return;
+    }
+
+    const char opener = line[position];
+    if (opener != '<' && opener != '"') {
+        // Macro-expanded include / __has_include operand. Its eventual form may
+        // be quoted, so preserve local-search freshness conservatively.
+        use.any_search = true;
+        use.may_search_local = true;
+        return;
+    }
+
+    use.any_search = true;
+    if (opener == '"') use.may_search_local = true;
+    const char closer = opener == '<' ? '>' : '"';
+    const std::size_t end = line.find(closer, position + 1u);
+    if (end == std::string_view::npos) return;
+
+    const fs::path operand = utf8_path(line.substr(position + 1u, end - position - 1u));
+    const fs::path parent = operand.parent_path();
+    if (!parent.empty()) append_unique(use.parent_suffixes, parent);
+}
+
+// Cold-path inspection distinguishes files that can participate in MSVC's
+// local quoted-include search from pure angle/no-include files. It also records
+// literal parent suffixes for unresolved probes such as __has_include(<x/y.hpp>)
+// so a file appearing inside an already-existing nested directory is visible.
+// Unknown/macro operands opt into local search conservatively.
+[[nodiscard]] inline IncludeSearchUse inspect_include_search_use(const fs::path& file) {
+    std::ifstream stream{file, std::ios::binary};
+    if (!stream) {
+        return IncludeSearchUse{.any_search = true, .may_search_local = true};
+    }
+
+    IncludeSearchUse use;
+    std::string line_storage;
+    while (std::getline(stream, line_storage)) {
+        const std::string_view line{line_storage};
+
+        std::size_t has_include = 0;
+        while ((has_include = line.find("__has_include", has_include)) != std::string_view::npos) {
+            std::size_t position = has_include + std::string_view{"__has_include"}.size();
+            while (position < line.size()
+                && (line[position] == ' ' || line[position] == '\t')) {
+                ++position;
+            }
+            if (position < line.size() && line[position] == '(') ++position;
+            record_literal_operand(use, line, position);
+            has_include = position;
+        }
+
         std::size_t position = 0;
         while (position < line.size()
             && (line[position] == ' ' || line[position] == '\t')) {
@@ -241,7 +297,7 @@ inline void collect_relative_parent_suffix(
         }
         constexpr std::string_view include_token = "include";
         if (position + include_token.size() > line.size()
-            || std::string_view{line}.substr(position, include_token.size()) != include_token) {
+            || line.substr(position, include_token.size()) != include_token) {
             continue;
         }
         position += include_token.size();
@@ -252,15 +308,9 @@ inline void collect_relative_parent_suffix(
             && line[position] != '<') {
             continue;
         }
-        while (position < line.size()
-            && (line[position] == ' ' || line[position] == '\t')) {
-            ++position;
-        }
-        if (position >= line.size()) return true;
-        if (line[position] == '<') continue;
-        return true;
+        record_literal_operand(use, line, position);
     }
-    return false;
+    return use;
 }
 
 } // namespace include_freshness_detail
@@ -290,27 +340,23 @@ inline void collect_relative_parent_suffix(
     return roots;
 }
 
-// Return directory paths whose namespace determines whether a previously
-// resolved include remains the first MSVC search hit. These paths are sealed
-// into the existing compile/module-scan dependency evidence. Warm validation
-// only stats them; it never launches cl.exe or /scanDependencies.
+// Return directory paths whose namespace determines whether include-search
+// resolution can change. These paths are sealed into the existing compile and
+// module-scan freshness evidence. Warm validation only stats filesystem
+// metadata; it never launches cl.exe or /scanDependencies.
 //
 // Quoted includes may search the current header's directory and directories of
-// still-open parent headers before the global /I + INCLUDE roots. /sourceDependencies
-// reports the resolved files but not those include edges/spellings, so every
-// resolved header that can actually issue a quoted/macro include contributes a
-// conservative possible local root. Pure angle-only files do not: their local
-// directory is irrelevant to resolution and may contain unrelated build output.
-// For every include-relative parent suffix we can recover from the resolved
-// dependency graph, the corresponding directory (or deepest existing ancestor)
-// is watched under every possible local/global root. This catches a new shadow
-// file even when its candidate subdirectory already existed and only that nested
-// directory's mtime changes.
+// still-open parent headers before global /I + INCLUDE roots. /sourceDependencies
+// reports resolved files but not include edges/spellings, so every source/header
+// that can issue a quoted or macro include contributes a conservative possible
+// local root. Pure angle/no-include files do not, preventing unrelated artifacts
+// created beside a TU (for example LINK /MAP output) from poisoning the compile
+// warm path.
 //
-// The synthetic PCH creator is the exception to adding its source directory as
-// a local root: that source lives beside MQB-owned outputs and has no textual
-// includes. Its forced PCH header and all transitive includes still contribute
-// real local/global freshness evidence.
+// Literal #include / __has_include operands additionally contribute parent
+// suffixes even when the header was not resolved on the previous build. This
+// covers the important "absent then appears" case, including a file appearing
+// in an already-existing nested candidate directory.
 [[nodiscard]] inline std::vector<std::filesystem::path>
 include_search_freshness_directories(
     const std::span<const std::filesystem::path> resolved_includes,
@@ -323,6 +369,10 @@ include_search_freshness_directories(
 
     const fs::path working = effective_working_directory(working_directory);
     const fs::path absolute_source = absolute_search_path(source, working);
+    const std::vector<fs::path> global_roots = include_search_roots(
+        options,
+        environment,
+        working_directory);
 
     std::vector<fs::path> normalized_dependencies;
     normalized_dependencies.reserve(resolved_includes.size());
@@ -330,27 +380,36 @@ include_search_freshness_directories(
         normalized_dependencies.push_back(absolute_search_path(dependency, working));
     }
 
-    // No resolved textual header means there is no previous include resolution
-    // for directory namespace churn to reroute. Exact global-root identity is
-    // still persisted separately by include_search_roots().
-    if (normalized_dependencies.empty()) return {};
-
-    const std::vector<fs::path> global_roots = include_search_roots(
-        options,
-        environment,
-        working_directory);
-
+    bool any_search_usage = false;
     std::vector<fs::path> local_roots;
+    std::vector<fs::path> relative_parent_suffixes;
+
     const bool synthetic_pch_creator = options.precompiled_header
         && options.precompiled_header->role == PrecompiledHeaderRole::create;
-    if (!synthetic_pch_creator && may_use_local_include_search(absolute_source)) {
+    const IncludeSearchUse source_use = inspect_include_search_use(absolute_source);
+    any_search_usage = any_search_usage || source_use.any_search;
+    if (!synthetic_pch_creator && source_use.may_search_local) {
         append_unique(local_roots, absolute_source.parent_path());
     }
+    for (const auto& suffix : source_use.parent_suffixes) {
+        append_unique(relative_parent_suffixes, suffix);
+    }
+
     for (const auto& dependency : normalized_dependencies) {
-        if (may_use_local_include_search(dependency)) {
+        const IncludeSearchUse dependency_use = inspect_include_search_use(dependency);
+        any_search_usage = any_search_usage || dependency_use.any_search;
+        if (dependency_use.may_search_local) {
             append_unique(local_roots, dependency.parent_path());
         }
+        for (const auto& suffix : dependency_use.parent_suffixes) {
+            append_unique(relative_parent_suffixes, suffix);
+        }
     }
+
+    // A successful TU with no textual include search (and no __has_include)
+    // cannot be rerouted by directory namespace churn. Exact global-root identity
+    // is still stored separately so ambient INCLUDE replacement remains visible.
+    if (!any_search_usage && normalized_dependencies.empty()) return {};
 
     std::vector<fs::path> watched;
     for (const auto& root : local_roots) {
@@ -360,7 +419,6 @@ include_search_freshness_directories(
         append_unique(watched, deepest_existing_directory(root));
     }
 
-    std::vector<fs::path> relative_parent_suffixes;
     for (const auto& dependency : normalized_dependencies) {
         for (const auto& root : local_roots) {
             collect_relative_parent_suffix(relative_parent_suffixes, dependency, root);

--- a/cpp/include/mqb/msvc/MsvcIncludeSearchFreshness.hpp
+++ b/cpp/include/mqb/msvc/MsvcIncludeSearchFreshness.hpp
@@ -180,12 +180,16 @@ inline void append_environment_include_roots(
 // into the existing compile/module-scan dependency evidence. Warm validation
 // only stats them; it never launches cl.exe or /scanDependencies.
 //
-// Source and previously included-header directories are deliberately watched
-// as conservative quote-include roots. Ordered /I and /external:I roots are
-// watched directly, and for a dependency resolved below a later root we also
-// watch the corresponding parent directory (or its deepest existing ancestor)
-// in every higher-priority root. This catches a new same-name header appearing
-// without changing argv or the previously resolved file.
+// Ordinary source/header directories are conservative quote-include roots.
+// The synthetic PCH creator is the exception: its source lives beside MQB-owned
+// outputs and contains no textual includes, so watching that artifact directory
+// would make its own first build alter its freshness evidence. Its forced PCH
+// header and every transitive include are still represented by resolved-header
+// parent directories below. Ordered /I and /external:I roots are watched
+// directly, and for a dependency resolved below a later root we also watch the
+// corresponding parent directory (or its deepest existing ancestor) in every
+// higher-priority root. This catches a new same-name header appearing without
+// changing argv or the previously resolved file.
 [[nodiscard]] inline std::vector<std::filesystem::path>
 include_search_freshness_directories(
     const std::span<const std::filesystem::path> resolved_includes,
@@ -199,7 +203,11 @@ include_search_freshness_directories(
     const fs::path working = effective_working_directory(working_directory);
     const fs::path absolute_source = absolute_search_path(source, working);
     std::vector<fs::path> ordered_roots;
-    append_unique(ordered_roots, absolute_source.parent_path());
+    const bool synthetic_pch_creator = options.precompiled_header
+        && options.precompiled_header->role == PrecompiledHeaderRole::create;
+    if (!synthetic_pch_creator) {
+        append_unique(ordered_roots, absolute_source.parent_path());
+    }
     for (const auto& include_directory : options.include_directories) {
         append_unique(
             ordered_roots,

--- a/cpp/include/mqb/msvc/MsvcIncludeSearchFreshness.hpp
+++ b/cpp/include/mqb/msvc/MsvcIncludeSearchFreshness.hpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <filesystem>
+#include <fstream>
 #include <optional>
 #include <span>
 #include <string>
@@ -215,6 +216,53 @@ inline void collect_relative_parent_suffix(
     if (!parent.empty()) append_unique(suffixes, parent);
 }
 
+// A local directory participates in MSVC's special quoted-include search only
+// when the corresponding source/header can issue a quoted (or macro-expanded)
+// include. Pure angle-include files do not search their own directory. This
+// cheap cold-path source inspection prevents unrelated artifacts created beside
+// a TU (for example LINK /MAP output) from poisoning the compile warm path.
+// Unknown/macro include operands conservatively opt into local search.
+[[nodiscard]] inline bool may_use_local_include_search(const fs::path& file) {
+    std::ifstream stream{file, std::ios::binary};
+    if (!stream) return true;
+
+    std::string line;
+    while (std::getline(stream, line)) {
+        std::size_t position = 0;
+        while (position < line.size()
+            && (line[position] == ' ' || line[position] == '\t')) {
+            ++position;
+        }
+        if (position >= line.size() || line[position] != '#') continue;
+        ++position;
+        while (position < line.size()
+            && (line[position] == ' ' || line[position] == '\t')) {
+            ++position;
+        }
+        constexpr std::string_view include_token = "include";
+        if (position + include_token.size() > line.size()
+            || std::string_view{line}.substr(position, include_token.size()) != include_token) {
+            continue;
+        }
+        position += include_token.size();
+        if (position < line.size()
+            && line[position] != ' '
+            && line[position] != '\t'
+            && line[position] != '"'
+            && line[position] != '<') {
+            continue;
+        }
+        while (position < line.size()
+            && (line[position] == ' ' || line[position] == '\t')) {
+            ++position;
+        }
+        if (position >= line.size()) return true;
+        if (line[position] == '<') continue;
+        return true;
+    }
+    return false;
+}
+
 } // namespace include_freshness_detail
 
 // Return the ordered compiler-global include roots. Typed -I roots are emitted
@@ -250,7 +298,9 @@ inline void collect_relative_parent_suffix(
 // Quoted includes may search the current header's directory and directories of
 // still-open parent headers before the global /I + INCLUDE roots. /sourceDependencies
 // reports the resolved files but not those include edges/spellings, so every
-// resolved header parent is conservatively treated as a possible local root.
+// resolved header that can actually issue a quoted/macro include contributes a
+// conservative possible local root. Pure angle-only files do not: their local
+// directory is irrelevant to resolution and may contain unrelated build output.
 // For every include-relative parent suffix we can recover from the resolved
 // dependency graph, the corresponding directory (or deepest existing ancestor)
 // is watched under every possible local/global root. This catches a new shadow
@@ -259,9 +309,8 @@ inline void collect_relative_parent_suffix(
 //
 // The synthetic PCH creator is the exception to adding its source directory as
 // a local root: that source lives beside MQB-owned outputs and has no textual
-// includes, so watching its artifact directory would self-invalidate. Its
-// forced PCH header and all transitive includes still contribute real local
-// roots and relative-suffix evidence.
+// includes. Its forced PCH header and all transitive includes still contribute
+// real local/global freshness evidence.
 [[nodiscard]] inline std::vector<std::filesystem::path>
 include_search_freshness_directories(
     const std::span<const std::filesystem::path> resolved_includes,
@@ -274,10 +323,6 @@ include_search_freshness_directories(
 
     const fs::path working = effective_working_directory(working_directory);
     const fs::path absolute_source = absolute_search_path(source, working);
-    const std::vector<fs::path> global_roots = include_search_roots(
-        options,
-        environment,
-        working_directory);
 
     std::vector<fs::path> normalized_dependencies;
     normalized_dependencies.reserve(resolved_includes.size());
@@ -285,14 +330,26 @@ include_search_freshness_directories(
         normalized_dependencies.push_back(absolute_search_path(dependency, working));
     }
 
+    // No resolved textual header means there is no previous include resolution
+    // for directory namespace churn to reroute. Exact global-root identity is
+    // still persisted separately by include_search_roots().
+    if (normalized_dependencies.empty()) return {};
+
+    const std::vector<fs::path> global_roots = include_search_roots(
+        options,
+        environment,
+        working_directory);
+
     std::vector<fs::path> local_roots;
     const bool synthetic_pch_creator = options.precompiled_header
         && options.precompiled_header->role == PrecompiledHeaderRole::create;
-    if (!synthetic_pch_creator) {
+    if (!synthetic_pch_creator && may_use_local_include_search(absolute_source)) {
         append_unique(local_roots, absolute_source.parent_path());
     }
     for (const auto& dependency : normalized_dependencies) {
-        append_unique(local_roots, dependency.parent_path());
+        if (may_use_local_include_search(dependency)) {
+            append_unique(local_roots, dependency.parent_path());
+        }
     }
 
     std::vector<fs::path> watched;

--- a/cpp/include/mqb/msvc/MsvcIncludeSearchFreshness.hpp
+++ b/cpp/include/mqb/msvc/MsvcIncludeSearchFreshness.hpp
@@ -41,6 +41,13 @@ namespace fs = std::filesystem;
     return true;
 }
 
+[[nodiscard]] inline bool ascii_identifier_char(const char value) noexcept {
+    return (value >= 'A' && value <= 'Z')
+        || (value >= 'a' && value <= 'z')
+        || (value >= '0' && value <= '9')
+        || value == '_';
+}
+
 [[nodiscard]] inline fs::path utf8_path(const std::string_view value) {
     std::u8string bytes;
     bytes.assign(
@@ -259,8 +266,10 @@ inline void record_literal_operand(
 // Cold-path inspection distinguishes files that can participate in MSVC's
 // local quoted-include search from pure angle/no-include files. It also records
 // literal parent suffixes for unresolved probes such as __has_include(<x/y.hpp>)
-// so a file appearing inside an already-existing nested directory is visible.
-// Unknown/macro operands opt into local search conservatively.
+// and C++ header-unit imports such as import <x/y.hpp> so a file appearing in an
+// already-existing nested directory is visible. Named-module imports do not
+// participate because they do not carry a header-name token. Unknown/macro
+// include operands opt into local search conservatively.
 [[nodiscard]] inline IncludeSearchUse inspect_include_search_use(const fs::path& file) {
     std::ifstream stream{file, std::ios::binary};
     if (!stream) {
@@ -282,6 +291,31 @@ inline void record_literal_operand(
             if (position < line.size() && line[position] == '(') ++position;
             record_literal_operand(use, line, position);
             has_include = position;
+        }
+
+        // C++20 Header Unit imports use the same header-name lookup semantics as
+        // textual includes. Recognize both `import <x>;` and `import "x";`
+        // (including `export import ...`). A named-module import such as
+        // `import math;` is deliberately ignored.
+        std::size_t import_position = 0;
+        constexpr std::string_view import_token = "import";
+        while ((import_position = line.find(import_token, import_position)) != std::string_view::npos) {
+            const bool left_boundary = import_position == 0
+                || !ascii_identifier_char(line[import_position - 1u]);
+            std::size_t operand_position = import_position + import_token.size();
+            const bool right_boundary = operand_position >= line.size()
+                || !ascii_identifier_char(line[operand_position]);
+            if (left_boundary && right_boundary) {
+                while (operand_position < line.size()
+                    && (line[operand_position] == ' ' || line[operand_position] == '\t')) {
+                    ++operand_position;
+                }
+                if (operand_position < line.size()
+                    && (line[operand_position] == '<' || line[operand_position] == '"')) {
+                    record_literal_operand(use, line, operand_position);
+                }
+            }
+            import_position += import_token.size();
         }
 
         std::size_t position = 0;
@@ -353,10 +387,10 @@ inline void record_literal_operand(
 // created beside a TU (for example LINK /MAP output) from poisoning the compile
 // warm path.
 //
-// Literal #include / __has_include operands additionally contribute parent
-// suffixes even when the header was not resolved on the previous build. This
-// covers the important "absent then appears" case, including a file appearing
-// in an already-existing nested candidate directory.
+// Literal #include / __has_include / Header Unit import operands additionally
+// contribute parent suffixes even when the header was not resolved on the
+// previous build. This covers the important "absent then appears" case,
+// including a file appearing in an already-existing nested candidate directory.
 [[nodiscard]] inline std::vector<std::filesystem::path>
 include_search_freshness_directories(
     const std::span<const std::filesystem::path> resolved_includes,
@@ -406,7 +440,7 @@ include_search_freshness_directories(
         }
     }
 
-    // A successful TU with no textual include search (and no __has_include)
+    // A successful TU with no textual/header-unit search (and no __has_include)
     // cannot be rerouted by directory namespace churn. Exact global-root identity
     // is still stored separately so ambient INCLUDE replacement remains visible.
     if (!any_search_usage && normalized_dependencies.empty()) return {};

--- a/cpp/include/mqb/msvc/MsvcIncludeSearchFreshness.hpp
+++ b/cpp/include/mqb/msvc/MsvcIncludeSearchFreshness.hpp
@@ -1,0 +1,248 @@
+#pragma once
+
+#include <algorithm>
+#include <filesystem>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <vector>
+
+#include "mqb/core/CompilerOptions.hpp"
+#include "mqb/process/Process.hpp"
+
+namespace mqb::msvc {
+namespace include_freshness_detail {
+
+namespace fs = std::filesystem;
+
+[[nodiscard]] inline bool same_path(const fs::path& left, const fs::path& right) {
+    return left == right || left.lexically_normal() == right.lexically_normal();
+}
+
+[[nodiscard]] inline bool ascii_iequals(
+    const std::string_view left,
+    const std::string_view right) noexcept {
+    if (left.size() != right.size()) return false;
+    for (std::size_t index = 0; index < left.size(); ++index) {
+        const auto fold = [](const char value) noexcept {
+            return value >= 'A' && value <= 'Z'
+                ? static_cast<char>(value - 'A' + 'a')
+                : value;
+        };
+        if (fold(left[index]) != fold(right[index])) return false;
+    }
+    return true;
+}
+
+[[nodiscard]] inline fs::path utf8_path(const std::string_view value) {
+    std::u8string bytes;
+    bytes.assign(
+        reinterpret_cast<const char8_t*>(value.data()),
+        reinterpret_cast<const char8_t*>(value.data() + value.size()));
+    return fs::path{bytes};
+}
+
+[[nodiscard]] inline fs::path effective_working_directory(
+    const std::optional<fs::path>& working_directory) {
+    std::error_code error_code;
+    if (working_directory && !working_directory->empty()) {
+        if (working_directory->is_absolute()) {
+            return working_directory->lexically_normal();
+        }
+        auto absolute = fs::absolute(*working_directory, error_code);
+        if (!error_code) return absolute.lexically_normal();
+        return working_directory->lexically_normal();
+    }
+    auto current = fs::current_path(error_code);
+    return error_code ? fs::path{} : current.lexically_normal();
+}
+
+[[nodiscard]] inline fs::path absolute_search_path(
+    const fs::path& path,
+    const fs::path& working_directory) {
+    if (path.empty()) return {};
+    if (path.is_absolute() || working_directory.empty()) {
+        return path.lexically_normal();
+    }
+    return (working_directory / path).lexically_normal();
+}
+
+inline void append_unique(std::vector<fs::path>& paths, fs::path path) {
+    if (path.empty()) return;
+    path = path.lexically_normal();
+    if (std::none_of(paths.begin(), paths.end(), [&](const fs::path& existing) {
+            return same_path(existing, path);
+        })) {
+        paths.push_back(std::move(path));
+    }
+}
+
+[[nodiscard]] inline fs::path deepest_existing_directory(fs::path candidate) {
+    candidate = candidate.lexically_normal();
+    while (!candidate.empty()) {
+        std::error_code error_code;
+        const auto status = fs::status(candidate, error_code);
+        if (!error_code && fs::is_directory(status)) {
+            return candidate;
+        }
+
+        const fs::path parent = candidate.parent_path();
+        if (parent.empty() || parent == candidate) break;
+        candidate = parent;
+    }
+    return {};
+}
+
+[[nodiscard]] inline std::optional<fs::path> relative_if_within(
+    const fs::path& child,
+    const fs::path& root) {
+    if (child.empty() || root.empty()) return std::nullopt;
+    const fs::path relative = child.lexically_normal().lexically_relative(root.lexically_normal());
+    if (relative.empty()) {
+        return same_path(child, root) ? std::optional<fs::path>{fs::path{}} : std::nullopt;
+    }
+    if (relative.is_absolute()) return std::nullopt;
+    for (const auto& component : relative) {
+        if (component == "..") return std::nullopt;
+    }
+    return relative;
+}
+
+inline void append_raw_include_roots(
+    std::vector<fs::path>& roots,
+    const std::vector<std::string>& arguments,
+    const fs::path& working_directory) {
+    for (std::size_t index = 0; index < arguments.size(); ++index) {
+        const std::string_view argument = arguments[index];
+        std::optional<std::string_view> value;
+
+        if (argument == "/I" || argument == "-I"
+            || argument == "/external:I" || argument == "-external:I") {
+            if (index + 1 < arguments.size()) {
+                value = arguments[++index];
+            }
+        } else if (argument.starts_with("/external:I") && argument.size() > 11u) {
+            value = argument.substr(11u);
+        } else if (argument.starts_with("-external:I") && argument.size() > 11u) {
+            value = argument.substr(11u);
+        } else if (argument.starts_with("/I") && argument.size() > 2u) {
+            value = argument.substr(2u);
+        } else if (argument.starts_with("-I") && argument.size() > 2u) {
+            value = argument.substr(2u);
+        }
+
+        if (value && !value->empty()) {
+            append_unique(
+                roots,
+                absolute_search_path(utf8_path(*value), working_directory));
+        }
+    }
+}
+
+[[nodiscard]] inline bool ignores_environment_include_roots(
+    const std::vector<std::string>& arguments) noexcept {
+    return std::any_of(arguments.begin(), arguments.end(), [](const std::string& argument) {
+        return ascii_iequals(argument, "/X") || ascii_iequals(argument, "-X");
+    });
+}
+
+inline void append_environment_include_roots(
+    std::vector<fs::path>& roots,
+    const std::span<const process::EnvironmentVariable> environment,
+    const fs::path& working_directory) {
+    for (const auto& variable : environment) {
+        if (!ascii_iequals(variable.name, "INCLUDE")) continue;
+
+        std::size_t begin = 0;
+        while (begin <= variable.value.size()) {
+            const std::size_t end = variable.value.find(';', begin);
+            const std::string_view part{
+                variable.value.data() + begin,
+                (end == std::string::npos ? variable.value.size() : end) - begin};
+            if (!part.empty()) {
+                append_unique(
+                    roots,
+                    absolute_search_path(utf8_path(part), working_directory));
+            }
+            if (end == std::string::npos) break;
+            begin = end + 1u;
+        }
+        return;
+    }
+}
+
+} // namespace include_freshness_detail
+
+// Return directory paths whose namespace determines whether a previously
+// resolved include remains the first MSVC search hit. These paths are sealed
+// into the existing compile/module-scan dependency evidence. Warm validation
+// only stats them; it never launches cl.exe or /scanDependencies.
+//
+// Source and previously included-header directories are deliberately watched
+// as conservative quote-include roots. Ordered /I and /external:I roots are
+// watched directly, and for a dependency resolved below a later root we also
+// watch the corresponding parent directory (or its deepest existing ancestor)
+// in every higher-priority root. This catches a new same-name header appearing
+// without changing argv or the previously resolved file.
+[[nodiscard]] inline std::vector<std::filesystem::path>
+include_search_freshness_directories(
+    const std::span<const std::filesystem::path> resolved_includes,
+    const std::filesystem::path& source,
+    const CompilerOptions& options,
+    const std::span<const process::EnvironmentVariable> environment,
+    const std::optional<std::filesystem::path>& working_directory) {
+    namespace fs = std::filesystem;
+    using namespace include_freshness_detail;
+
+    const fs::path working = effective_working_directory(working_directory);
+    std::vector<fs::path> ordered_roots;
+    append_unique(
+        ordered_roots,
+        absolute_search_path(source.parent_path(), working));
+    for (const auto& include_directory : options.include_directories) {
+        append_unique(
+            ordered_roots,
+            absolute_search_path(include_directory, working));
+    }
+    append_raw_include_roots(ordered_roots, options.additional_arguments, working);
+    if (!ignores_environment_include_roots(options.additional_arguments)) {
+        append_environment_include_roots(ordered_roots, environment, working);
+    }
+
+    std::vector<fs::path> watched;
+    for (const auto& root : ordered_roots) {
+        append_unique(watched, deepest_existing_directory(root));
+    }
+
+    std::vector<fs::path> normalized_dependencies;
+    normalized_dependencies.reserve(resolved_includes.size());
+    for (const auto& dependency : resolved_includes) {
+        const fs::path normalized = absolute_search_path(dependency, working);
+        normalized_dependencies.push_back(normalized);
+        append_unique(watched, deepest_existing_directory(normalized.parent_path()));
+    }
+
+    for (const auto& dependency : normalized_dependencies) {
+        for (std::size_t winning_index = 0; winning_index < ordered_roots.size(); ++winning_index) {
+            const auto relative = relative_if_within(dependency, ordered_roots[winning_index]);
+            if (!relative) continue;
+
+            const fs::path relative_parent = relative->parent_path();
+            for (std::size_t candidate_index = 0;
+                 candidate_index <= winning_index;
+                 ++candidate_index) {
+                append_unique(
+                    watched,
+                    deepest_existing_directory(
+                        ordered_roots[candidate_index] / relative_parent));
+            }
+            break;
+        }
+    }
+
+    return watched;
+}
+
+} // namespace mqb::msvc

--- a/cpp/src/core/cache/CompileCacheFile.cpp
+++ b/cpp/src/core/cache/CompileCacheFile.cpp
@@ -34,11 +34,13 @@ static_assert(std::is_integral_v<FileTimeRep> && sizeof(FileTimeRep) <= sizeof(s
 constexpr std::array<std::uint8_t, 8> magic{
     'M', 'Q', 'B', 'C', 'A', 'C', 'H', 'E'};
 constexpr std::uint32_t legacy_format_version = 2;
-constexpr std::uint32_t format_version = 3;
+constexpr std::uint32_t module_scan_format_version = 3;
+constexpr std::uint32_t format_version = 4;
 constexpr std::size_t max_cache_file_size = 64u * 1024u * 1024u;
 constexpr std::uint32_t max_string_size = 4u * 1024u * 1024u;
 constexpr std::uint32_t max_output_count = 100000u;
 constexpr std::uint32_t max_dependency_count = 100000u;
+constexpr std::uint32_t max_include_search_root_count = 100000u;
 
 [[nodiscard]] CompileCacheFileError make_error(
     const CompileCacheFileErrorCode code,
@@ -260,6 +262,7 @@ serialize(const fs::path& file, const CompileCacheEntry& entry) {
     }
     if (entry.outputs.size() > max_output_count
         || entry.dependencies.size() > max_dependency_count
+        || entry.include_search_roots.size() > max_include_search_root_count
         || (entry.module_scan
             && entry.module_scan->dependencies.size() > max_dependency_count)) {
         return std::unexpected(make_error(
@@ -308,6 +311,15 @@ serialize(const fs::path& file, const CompileCacheEntry& entry) {
         }
     }
 
+    writer.write_u32(static_cast<std::uint32_t>(entry.include_search_roots.size()));
+    for (const auto& root : entry.include_search_roots) {
+        if (root.empty() || !writer.write_path(root)) {
+            return std::unexpected(make_error(
+                CompileCacheFileErrorCode::file_write_failed, file, 0,
+                "include search root is empty or too long for cache format"));
+        }
+    }
+
     writer.write_u8(entry.module_scan ? 1u : 0u);
     if (entry.module_scan) {
         const auto& evidence = *entry.module_scan;
@@ -351,7 +363,9 @@ deserialize(const fs::path& file, const std::span<const std::uint8_t> bytes) {
     }
     auto version = reader.read_u32();
     if (!version) return std::unexpected(version.error());
-    if (*version != legacy_format_version && *version != format_version) {
+    if (*version != legacy_format_version
+        && *version != module_scan_format_version
+        && *version != format_version) {
         return std::unexpected(make_error(
             CompileCacheFileErrorCode::unsupported_version,
             file,
@@ -415,8 +429,26 @@ deserialize(const fs::path& file, const std::span<const std::uint8_t> bytes) {
         dependencies.push_back(std::move(*dependency));
     }
 
+    std::vector<fs::path> include_search_roots;
+    if (*version >= format_version) {
+        auto root_count = reader.read_u32();
+        if (!root_count) return std::unexpected(root_count.error());
+        if (*root_count > max_include_search_root_count) {
+            return std::unexpected(reader.corrupt("include search root count exceeds safety limit"));
+        }
+        include_search_roots.reserve(*root_count);
+        for (std::uint32_t index = 0; index < *root_count; ++index) {
+            auto root = reader.read_path();
+            if (!root) return std::unexpected(root.error());
+            if (root->empty()) {
+                return std::unexpected(reader.corrupt("include search root is empty"));
+            }
+            include_search_roots.push_back(std::move(*root));
+        }
+    }
+
     std::optional<ModuleScanEvidence> module_scan;
-    if (*version == format_version) {
+    if (*version >= module_scan_format_version) {
         auto present = reader.read_u8();
         if (!present) return std::unexpected(present.error());
         if (*present > 1u) {
@@ -473,6 +505,7 @@ deserialize(const fs::path& file, const std::span<const std::uint8_t> bytes) {
         }),
         .outputs = std::move(outputs),
         .dependencies = std::move(dependencies),
+        .include_search_roots = std::move(include_search_roots),
         .module_scan = std::move(module_scan),
     };
 }

--- a/cpp/src/core/model/BuildSignature.cpp
+++ b/cpp/src/core/model/BuildSignature.cpp
@@ -151,7 +151,10 @@ BuildSignature BuildSignature::for_compile(
     const ToolchainIdentity& toolchain,
     const CompilerOptions& options) {
     StableHasher hasher;
-    hasher.add_string("mqb.compile.signature.v4");
+    // v5 invalidates pre-include-search-freshness compile cache entries once.
+    // This is the migration marker even when a valid new recipe has no include
+    // roots and therefore no directory namespace evidence to persist.
+    hasher.add_string("mqb.compile.signature.v5");
 
     hasher.add_path(unit.source);
     hasher.add_enum(unit.kind);
@@ -198,7 +201,9 @@ BuildSignature BuildSignature::for_module_scan(
     const ToolchainIdentity& toolchain,
     const CompilerOptions& options) {
     StableHasher hasher;
-    hasher.add_string("mqb.module-scan.signature.v1");
+    // v2 invalidates pre-include-search-freshness P1689 evidence once so the
+    // next successful scan can seal directory namespace snapshots.
+    hasher.add_string("mqb.module-scan.signature.v2");
 
     hasher.add_path(source);
     hasher.add_enum(kind);

--- a/cpp/src/msvc/compiler/MsvcCompileExecutor.cpp
+++ b/cpp/src/msvc/compiler/MsvcCompileExecutor.cpp
@@ -251,6 +251,10 @@ MsvcCompileExecutor::execute(const CompileExecutionRequest& request) const {
         });
     }
 
+    const auto search_roots = include_search_roots(
+        request.options,
+        toolchain_.environment,
+        request.working_directory);
     const auto include_freshness = include_search_freshness_directories(
         dependencies->includes,
         request.unit.source,
@@ -282,6 +286,7 @@ MsvcCompileExecutor::execute(const CompileExecutionRequest& request) const {
             request.options),
         .outputs = request.unit.outputs,
         .dependencies = std::move(cache_dependencies),
+        .include_search_roots = search_roots,
     };
 
     return CompileExecutionResult{

--- a/cpp/src/msvc/compiler/MsvcCompileExecutor.cpp
+++ b/cpp/src/msvc/compiler/MsvcCompileExecutor.cpp
@@ -287,7 +287,6 @@ MsvcCompileExecutor::execute(const CompileExecutionRequest& request) const {
         .outputs = request.unit.outputs,
         .dependencies = std::move(cache_dependencies),
         .include_search_roots = search_roots,
-        .include_search_freshness_sealed = true,
     };
 
     return CompileExecutionResult{

--- a/cpp/src/msvc/compiler/MsvcCompileExecutor.cpp
+++ b/cpp/src/msvc/compiler/MsvcCompileExecutor.cpp
@@ -11,6 +11,7 @@
 #include "mqb/core/Artifact.hpp"
 #include "mqb/core/BuildSignature.hpp"
 #include "mqb/msvc/MsvcCompiler.hpp"
+#include "mqb/msvc/MsvcIncludeSearchFreshness.hpp"
 #include "mqb/msvc/MsvcSourceDependenciesReader.hpp"
 
 namespace mqb::msvc {
@@ -250,7 +251,17 @@ MsvcCompileExecutor::execute(const CompileExecutionRequest& request) const {
         });
     }
 
+    const auto include_freshness = include_search_freshness_directories(
+        dependencies->includes,
+        request.unit.source,
+        request.options,
+        toolchain_.environment,
+        request.working_directory);
+
     std::vector<fs::path> cache_dependencies = std::move(dependencies->includes);
+    for (const auto& directory : include_freshness) {
+        add_interface_dependency(cache_dependencies, directory);
+    }
     for (const auto& reference : request.unit.module_references) {
         add_interface_dependency(cache_dependencies, reference.interface_file);
     }

--- a/cpp/src/msvc/compiler/MsvcCompileExecutor.cpp
+++ b/cpp/src/msvc/compiler/MsvcCompileExecutor.cpp
@@ -287,6 +287,7 @@ MsvcCompileExecutor::execute(const CompileExecutionRequest& request) const {
         .outputs = request.unit.outputs,
         .dependencies = std::move(cache_dependencies),
         .include_search_roots = search_roots,
+        .include_search_freshness_sealed = true,
     };
 
     return CompileExecutionResult{

--- a/cpp/src/orchestration/incremental/IncrementalFileSnapshot.hpp
+++ b/cpp/src/orchestration/incremental/IncrementalFileSnapshot.hpp
@@ -35,7 +35,9 @@ struct IncrementalFileSnapshotResult {
     };
 }
 
-[[nodiscard]] inline IncrementalFileSnapshotResult snapshot_regular_file(const fs::path& path) {
+[[nodiscard]] inline IncrementalFileSnapshotResult snapshot_path(
+    const fs::path& path,
+    const bool require_regular_file) {
     if (path.empty()) {
         return missing_file_snapshot(path);
     }
@@ -57,7 +59,10 @@ struct IncrementalFileSnapshotResult {
             },
         };
     }
-    if (!fs::is_regular_file(status)) {
+    const bool supported_type = require_regular_file
+        ? fs::is_regular_file(status)
+        : (fs::is_regular_file(status) || fs::is_directory(status));
+    if (!supported_type) {
         return missing_file_snapshot(path);
     }
 
@@ -86,6 +91,15 @@ struct IncrementalFileSnapshotResult {
         },
         .failure = std::nullopt,
     };
+}
+
+[[nodiscard]] inline IncrementalFileSnapshotResult snapshot_regular_file(const fs::path& path) {
+    return snapshot_path(path, true);
+}
+
+[[nodiscard]] inline IncrementalFileSnapshotResult snapshot_file_or_directory(
+    const fs::path& path) {
+    return snapshot_path(path, false);
 }
 
 } // namespace mqb::orchestration::detail

--- a/cpp/src/orchestration/incremental/IncrementalFileSnapshot.hpp
+++ b/cpp/src/orchestration/incremental/IncrementalFileSnapshot.hpp
@@ -35,9 +35,7 @@ struct IncrementalFileSnapshotResult {
     };
 }
 
-[[nodiscard]] inline IncrementalFileSnapshotResult snapshot_path(
-    const fs::path& path,
-    const bool require_regular_file) {
+[[nodiscard]] inline IncrementalFileSnapshotResult snapshot_regular_file(const fs::path& path) {
     if (path.empty()) {
         return missing_file_snapshot(path);
     }
@@ -59,10 +57,7 @@ struct IncrementalFileSnapshotResult {
             },
         };
     }
-    const bool supported_type = require_regular_file
-        ? fs::is_regular_file(status)
-        : (fs::is_regular_file(status) || fs::is_directory(status));
-    if (!supported_type) {
+    if (!fs::is_regular_file(status)) {
         return missing_file_snapshot(path);
     }
 
@@ -93,13 +88,42 @@ struct IncrementalFileSnapshotResult {
     };
 }
 
-[[nodiscard]] inline IncrementalFileSnapshotResult snapshot_regular_file(const fs::path& path) {
-    return snapshot_path(path, true);
-}
-
 [[nodiscard]] inline IncrementalFileSnapshotResult snapshot_file_or_directory(
     const fs::path& path) {
-    return snapshot_path(path, false);
+    if (path.empty()) {
+        return missing_file_snapshot(path);
+    }
+
+    // Compile-cache dependencies intentionally admit both regular files and
+    // directories, and FileSnapshot identity is existence + last-write time.
+    // last_write_time() already fails for a missing path, so a preceding
+    // status() would duplicate one filesystem metadata probe on every warm hit.
+    std::error_code error_code;
+    const auto modified = fs::last_write_time(path, error_code);
+    if (error_code) {
+        if (error_code == std::errc::no_such_file_or_directory) {
+            return missing_file_snapshot(path);
+        }
+        return IncrementalFileSnapshotResult{
+            .snapshot = FileSnapshot{
+                .path = path,
+                .exists = false,
+            },
+            .failure = IncrementalFileSnapshotFailure{
+                .kind = IncrementalFileSnapshotFailureKind::timestamp,
+                .error_code = error_code,
+            },
+        };
+    }
+
+    return IncrementalFileSnapshotResult{
+        .snapshot = FileSnapshot{
+            .path = path,
+            .exists = true,
+            .modified = modified,
+        },
+        .failure = std::nullopt,
+    };
 }
 
 } // namespace mqb::orchestration::detail

--- a/cpp/src/orchestration/incremental/MsvcIncrementalCompileCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalCompileCoordinator.cpp
@@ -76,6 +76,10 @@ void add_reason_once(
 
 [[nodiscard]] bool has_include_search_freshness_marker(
     const CompileCacheEntry& entry) {
+    // Cache v4 persists exact ordered global roots even for a TU with no
+    // resolved textual headers. Such a TU has no directory namespace evidence
+    // to seal, but it is still a post-closure cache entry and must remain warm.
+    if (!entry.include_search_roots.empty()) return true;
     for (const auto& dependency : entry.dependencies) {
         std::error_code error_code;
         if (std::filesystem::is_directory(dependency, error_code) && !error_code) {
@@ -231,10 +235,10 @@ MsvcIncrementalCompileCoordinator::run(const IncrementalCompileRequest& request)
         toolchain_.environment,
         request.working_directory);
 
-    // Cache entries sealed before Include Search Resolution Freshness contain
-    // only file dependencies. New entries always contain directory namespace
-    // evidence. Force one conservative reseal after upgrading so a pre-fix
-    // cache cannot preserve the exact stale warm hit this closure fixes.
+    // Cache entries sealed before Include Search Resolution Freshness have no
+    // global-root identity and no directory namespace evidence. Force one
+    // conservative reseal after upgrading so a pre-fix cache cannot preserve
+    // the exact stale warm hit this closure fixes.
     if (cached_entry && !has_include_search_freshness_marker(*cached_entry)) {
         add_reason_once(result.validation.reasons, BuildReason::dependency_changed);
     }

--- a/cpp/src/orchestration/incremental/MsvcIncrementalCompileCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalCompileCoordinator.cpp
@@ -59,6 +59,17 @@ void add_reason_once(
     return left == right || left.lexically_normal() == right.lexically_normal();
 }
 
+[[nodiscard]] bool has_include_search_freshness_marker(
+    const CompileCacheEntry& entry) {
+    for (const auto& dependency : entry.dependencies) {
+        std::error_code error_code;
+        if (std::filesystem::is_directory(dependency, error_code) && !error_code) {
+            return true;
+        }
+    }
+    return false;
+}
+
 void add_dependency_once(
     std::vector<std::filesystem::path>& dependencies,
     const std::filesystem::path& dependency) {
@@ -199,6 +210,14 @@ MsvcIncrementalCompileCoordinator::run(const IncrementalCompileRequest& request)
         source_snapshot.snapshot,
         output_snapshots,
         dependency_snapshots);
+
+    // Cache entries sealed before Include Search Resolution Freshness contain
+    // only file dependencies. New entries always include at least the source
+    // directory namespace. Force one conservative reseal after upgrading so a
+    // pre-fix cache cannot preserve the exact stale warm hit this closure fixes.
+    if (cached_entry && !has_include_search_freshness_marker(*cached_entry)) {
+        add_reason_once(result.validation.reasons, BuildReason::dependency_changed);
+    }
 
     if (request.force_rebuild) {
         add_reason_once(result.validation.reasons, BuildReason::explicit_rebuild);

--- a/cpp/src/orchestration/incremental/MsvcIncrementalCompileCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalCompileCoordinator.cpp
@@ -5,6 +5,7 @@
 #include <expected>
 #include <filesystem>
 #include <optional>
+#include <span>
 #include <string>
 #include <utility>
 #include <vector>
@@ -56,7 +57,21 @@ void add_reason_once(
 [[nodiscard]] bool same_path(
     const std::filesystem::path& left,
     const std::filesystem::path& right) {
-    return left == right || left.lexically_normal() == right.lexically_normal();
+    if (left == right || left.lexically_normal() == right.lexically_normal()) {
+        return true;
+    }
+    std::error_code error_code;
+    return std::filesystem::equivalent(left, right, error_code) && !error_code;
+}
+
+[[nodiscard]] bool same_ordered_paths(
+    const std::span<const std::filesystem::path> left,
+    const std::span<const std::filesystem::path> right) {
+    if (left.size() != right.size()) return false;
+    for (std::size_t index = 0; index < left.size(); ++index) {
+        if (!same_path(left[index], right[index])) return false;
+    }
+    return true;
 }
 
 [[nodiscard]] bool has_include_search_freshness_marker(
@@ -211,11 +226,27 @@ MsvcIncrementalCompileCoordinator::run(const IncrementalCompileRequest& request)
         output_snapshots,
         dependency_snapshots);
 
+    const auto current_include_search_roots = msvc::include_search_roots(
+        request.options,
+        toolchain_.environment,
+        request.working_directory);
+
     // Cache entries sealed before Include Search Resolution Freshness contain
-    // only file dependencies. New entries always include at least the source
-    // directory namespace. Force one conservative reseal after upgrading so a
-    // pre-fix cache cannot preserve the exact stale warm hit this closure fixes.
+    // only file dependencies. New entries always contain directory namespace
+    // evidence. Force one conservative reseal after upgrading so a pre-fix
+    // cache cannot preserve the exact stale warm hit this closure fixes.
     if (cached_entry && !has_include_search_freshness_marker(*cached_entry)) {
+        add_reason_once(result.validation.reasons, BuildReason::dependency_changed);
+    }
+
+    // CompilerOptions already identify typed/native /I ordering, but vcvars
+    // INCLUDE is ambient toolchain environment rather than argv. Compare the
+    // exact ordered roots persisted by cache v4 so root replacement/removal is
+    // freshness even when all previously resolved headers still exist.
+    if (cached_entry
+        && !same_ordered_paths(
+            cached_entry->include_search_roots,
+            current_include_search_roots)) {
         add_reason_once(result.validation.reasons, BuildReason::dependency_changed);
     }
 

--- a/cpp/src/orchestration/incremental/MsvcIncrementalCompileCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalCompileCoordinator.cpp
@@ -74,21 +74,6 @@ void add_reason_once(
     return true;
 }
 
-[[nodiscard]] bool has_include_search_freshness_marker(
-    const CompileCacheEntry& entry) {
-    // Cache v4 persists exact ordered global roots even for a TU with no
-    // resolved textual headers. Such a TU has no directory namespace evidence
-    // to seal, but it is still a post-closure cache entry and must remain warm.
-    if (!entry.include_search_roots.empty()) return true;
-    for (const auto& dependency : entry.dependencies) {
-        std::error_code error_code;
-        if (std::filesystem::is_directory(dependency, error_code) && !error_code) {
-            return true;
-        }
-    }
-    return false;
-}
-
 void add_dependency_once(
     std::vector<std::filesystem::path>& dependencies,
     const std::filesystem::path& dependency) {
@@ -235,13 +220,10 @@ MsvcIncrementalCompileCoordinator::run(const IncrementalCompileRequest& request)
         toolchain_.environment,
         request.working_directory);
 
-    // Cache entries sealed before Include Search Resolution Freshness have no
-    // global-root identity and no directory namespace evidence. Force one
-    // conservative reseal after upgrading so a pre-fix cache cannot preserve
-    // the exact stale warm hit this closure fixes.
-    if (cached_entry && !has_include_search_freshness_marker(*cached_entry)) {
-        add_reason_once(result.validation.reasons, BuildReason::dependency_changed);
-    }
+    // Cache migration is owned by BuildSignature's compile domain. The v5
+    // domain invalidates pre-closure entries exactly once, including recipes
+    // with zero include roots and zero directory freshness evidence. Do not
+    // infer cache generation from whether those evidence vectors are empty.
 
     // CompilerOptions already identify typed/native /I ordering, but vcvars
     // INCLUDE is ambient toolchain environment rather than argv. Compare the

--- a/cpp/src/orchestration/incremental/MsvcIncrementalCompileCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalCompileCoordinator.cpp
@@ -13,6 +13,7 @@
 #include "mqb/core/CompileCache.hpp"
 #include "mqb/core/CompileCacheFile.hpp"
 #include "mqb/msvc/MsvcCompileExecutor.hpp"
+#include "mqb/msvc/MsvcIncludeSearchFreshness.hpp"
 #include "mqb/msvc/MsvcSourceDependenciesReader.hpp"
 
 #include "IncrementalFileSnapshot.hpp"
@@ -52,10 +53,27 @@ void add_reason_once(
     }
 }
 
+[[nodiscard]] bool same_path(
+    const std::filesystem::path& left,
+    const std::filesystem::path& right) {
+    return left == right || left.lexically_normal() == right.lexically_normal();
+}
+
+void add_dependency_once(
+    std::vector<std::filesystem::path>& dependencies,
+    const std::filesystem::path& dependency) {
+    if (dependency.empty()) return;
+    if (std::none_of(dependencies.begin(), dependencies.end(), [&](const auto& existing) {
+            return same_path(existing, dependency);
+        })) {
+        dependencies.push_back(dependency.lexically_normal());
+    }
+}
+
 void seal_module_scan_evidence(
     CompileCacheEntry& cache_entry,
     const IncrementalCompileRequest& request,
-    const ToolchainIdentity& toolchain,
+    const msvc::MsvcToolchain& toolchain,
     std::vector<IncrementalCompileWarning>& warnings) {
     if (!request.module_scan_output) {
         return;
@@ -78,10 +96,21 @@ void seal_module_scan_evidence(
         return;
     }
 
+    std::vector<std::filesystem::path> scan_dependencies = dependencies->includes;
+    const auto include_freshness = msvc::include_search_freshness_directories(
+        dependencies->includes,
+        request.unit.source,
+        request.options,
+        toolchain.environment,
+        request.working_directory);
+    for (const auto& directory : include_freshness) {
+        add_dependency_once(scan_dependencies, directory);
+    }
+
     std::vector<FileSnapshot> include_snapshots;
-    include_snapshots.reserve(dependencies->includes.size());
-    for (const auto& dependency : dependencies->includes) {
-        auto snapshot = detail::snapshot_regular_file(dependency);
+    include_snapshots.reserve(scan_dependencies.size());
+    for (const auto& dependency : scan_dependencies) {
+        auto snapshot = detail::snapshot_file_or_directory(dependency);
         append_snapshot_warning(warnings, dependency, std::move(snapshot.failure));
         if (!snapshot.snapshot.exists) {
             return;
@@ -89,10 +118,10 @@ void seal_module_scan_evidence(
         include_snapshots.push_back(std::move(snapshot.snapshot));
     }
 
-    // A source/header mutation after /scanDependencies but before the compile
-    // completed means the topology artifact is not a trustworthy description
-    // of the successful compile. In that case keep the normal compile cache but
-    // deliberately omit scan evidence so the next build rescans.
+    // A source/header/search-root mutation after /scanDependencies but before
+    // the compile completed means the topology artifact is not a trustworthy
+    // description of the successful compile. In that case keep the normal
+    // compile cache but deliberately omit scan evidence so the next build rescans.
     if (source.snapshot.modified > output.snapshot.modified) {
         return;
     }
@@ -106,7 +135,7 @@ void seal_module_scan_evidence(
         .signature = BuildSignature::for_module_scan(
             request.unit.source,
             request.unit.kind,
-            toolchain,
+            toolchain.identity,
             request.options),
         .source = std::move(source.snapshot),
         .output = std::move(output.snapshot),
@@ -153,7 +182,7 @@ MsvcIncrementalCompileCoordinator::run(const IncrementalCompileRequest& request)
     if (cached_entry) {
         dependency_snapshots.reserve(cached_entry->dependencies.size());
         for (const auto& dependency : cached_entry->dependencies) {
-            auto dependency_snapshot = detail::snapshot_regular_file(dependency);
+            auto dependency_snapshot = detail::snapshot_file_or_directory(dependency);
             append_snapshot_warning(
                 result.warnings,
                 dependency,
@@ -224,7 +253,7 @@ MsvcIncrementalCompileCoordinator::run(const IncrementalCompileRequest& request)
     seal_module_scan_evidence(
         executed->cache_entry,
         request,
-        toolchain_.identity,
+        toolchain_,
         result.warnings);
 
     auto saved_cache = CompileCacheFile::save(

--- a/cpp/src/orchestration/modules/ModuleTargetScanner.cpp
+++ b/cpp/src/orchestration/modules/ModuleTargetScanner.cpp
@@ -88,21 +88,6 @@ namespace fs = std::filesystem;
     return true;
 }
 
-[[nodiscard]] bool has_include_search_freshness_marker(
-    const CompileCacheEntry& entry,
-    const ModuleScanEvidence& evidence) {
-    // Cache v4's exact root vector is valid freshness identity even when a
-    // module source has no textual headers and therefore no directory snapshot.
-    if (!entry.include_search_roots.empty()) return true;
-    for (const auto& dependency : evidence.dependencies) {
-        std::error_code error_code;
-        if (fs::is_directory(dependency.path, error_code) && !error_code) {
-            return true;
-        }
-    }
-    return false;
-}
-
 [[nodiscard]] std::optional<std::string> read_text_file(const fs::path& path) {
     std::ifstream stream{path, std::ios::binary};
     if (!stream) return std::nullopt;
@@ -125,12 +110,9 @@ namespace fs = std::filesystem;
     const auto& entry = **loaded;
     const auto& evidence = *entry.module_scan;
 
-    // Pre-closure scan evidence has neither cache-v4 root identity nor any
-    // directory namespace snapshot. Rescan once after upgrading and reseal.
-    if (!has_include_search_freshness_marker(entry, evidence)) {
-        return std::nullopt;
-    }
-
+    // Module-scan migration is encoded in BuildSignature's v2 scan domain.
+    // Old evidence fails signature validation exactly once; valid new evidence
+    // may legitimately have zero include roots and zero directory snapshots.
     const auto current_roots = msvc::include_search_roots(
         options,
         scanner.toolchain().environment,

--- a/cpp/src/orchestration/modules/ModuleTargetScanner.cpp
+++ b/cpp/src/orchestration/modules/ModuleTargetScanner.cpp
@@ -68,6 +68,17 @@ namespace fs = std::filesystem;
     return snapshot_path(path, false);
 }
 
+[[nodiscard]] bool has_include_search_freshness_marker(
+    const ModuleScanEvidence& evidence) {
+    for (const auto& dependency : evidence.dependencies) {
+        std::error_code error_code;
+        if (fs::is_directory(dependency.path, error_code) && !error_code) {
+            return true;
+        }
+    }
+    return false;
+}
+
 [[nodiscard]] std::optional<std::string> read_text_file(const fs::path& path) {
     std::ifstream stream{path, std::ios::binary};
     if (!stream) return std::nullopt;
@@ -87,6 +98,13 @@ namespace fs = std::filesystem;
         return std::nullopt;
     }
     const auto& evidence = *(**loaded).module_scan;
+
+    // Pre-closure scan evidence contains only file snapshots and therefore
+    // cannot prove that a higher-priority include namespace stayed unchanged.
+    // Rescan once after upgrading and reseal directory-backed evidence.
+    if (!has_include_search_freshness_marker(evidence)) {
+        return std::nullopt;
+    }
 
     const BuildSignature signature = BuildSignature::for_module_scan(
         source.source,
@@ -189,7 +207,7 @@ scan_requested_module_sources(
     batch.scans.reserve(request.sources.size());
     batch.units.reserve(request.sources.size() + 2u);
 
-    for (std::size_t index = 0; index < attempts.size(); ++index) {
+    for (std::size_t index = 0; index < request.sources.size(); ++index) {
         if (!attempts[index]) {
             return std::unexpected(failure(
                 IncrementalModuleTargetErrorCode::scheduling_failed,

--- a/cpp/src/orchestration/modules/ModuleTargetScanner.cpp
+++ b/cpp/src/orchestration/modules/ModuleTargetScanner.cpp
@@ -5,6 +5,7 @@
 #include <fstream>
 #include <iterator>
 #include <optional>
+#include <span>
 #include <string>
 #include <utility>
 #include <vector>
@@ -14,6 +15,7 @@
 #include "mqb/core/CompileCacheFile.hpp"
 #include "mqb/core/FileSnapshot.hpp"
 #include "mqb/modules/P1689.hpp"
+#include "mqb/msvc/MsvcIncludeSearchFreshness.hpp"
 #include "mqb/orchestration/BoundedWorkScheduler.hpp"
 
 namespace mqb::orchestration::detail {
@@ -68,6 +70,24 @@ namespace fs = std::filesystem;
     return snapshot_path(path, false);
 }
 
+[[nodiscard]] bool same_path(const fs::path& left, const fs::path& right) {
+    if (left == right || left.lexically_normal() == right.lexically_normal()) {
+        return true;
+    }
+    std::error_code error_code;
+    return fs::equivalent(left, right, error_code) && !error_code;
+}
+
+[[nodiscard]] bool same_ordered_paths(
+    const std::span<const fs::path> left,
+    const std::span<const fs::path> right) {
+    if (left.size() != right.size()) return false;
+    for (std::size_t index = 0; index < left.size(); ++index) {
+        if (!same_path(left[index], right[index])) return false;
+    }
+    return true;
+}
+
 [[nodiscard]] bool has_include_search_freshness_marker(
     const ModuleScanEvidence& evidence) {
     for (const auto& dependency : evidence.dependencies) {
@@ -92,17 +112,27 @@ namespace fs = std::filesystem;
 [[nodiscard]] std::optional<msvc::ModuleScanResult> try_reuse_scan(
     const ModuleCompileSourceRequest& source,
     const CompilerOptions& options,
+    const std::optional<fs::path>& working_directory,
     msvc::MsvcModuleDependencyScanner& scanner) {
     auto loaded = CompileCacheFile::load(source.artifacts.compile_cache);
     if (!loaded || !*loaded || !(**loaded).module_scan) {
         return std::nullopt;
     }
-    const auto& evidence = *(**loaded).module_scan;
+    const auto& entry = **loaded;
+    const auto& evidence = *entry.module_scan;
 
     // Pre-closure scan evidence contains only file snapshots and therefore
     // cannot prove that a higher-priority include namespace stayed unchanged.
     // Rescan once after upgrading and reseal directory-backed evidence.
     if (!has_include_search_freshness_marker(evidence)) {
+        return std::nullopt;
+    }
+
+    const auto current_roots = msvc::include_search_roots(
+        options,
+        scanner.toolchain().environment,
+        working_directory);
+    if (!same_ordered_paths(entry.include_search_roots, current_roots)) {
         return std::nullopt;
     }
 
@@ -154,7 +184,14 @@ scan_module_source(
     const CompilerOptions& options,
     const fs::path& working_directory,
     msvc::MsvcModuleDependencyScanner& scanner) {
-    if (auto reused = try_reuse_scan(source, options, scanner)) {
+    const auto effective_working_directory = working_directory_for(
+        working_directory,
+        source.source);
+    if (auto reused = try_reuse_scan(
+            source,
+            options,
+            effective_working_directory,
+            scanner)) {
         return std::move(*reused);
     }
 
@@ -163,7 +200,7 @@ scan_module_source(
         .output_file = source.artifacts.module_dependencies,
         .options = options,
         .kind = source.kind,
-        .working_directory = working_directory_for(working_directory, source.source),
+        .working_directory = effective_working_directory,
     });
 }
 

--- a/cpp/src/orchestration/modules/ModuleTargetScanner.cpp
+++ b/cpp/src/orchestration/modules/ModuleTargetScanner.cpp
@@ -89,7 +89,11 @@ namespace fs = std::filesystem;
 }
 
 [[nodiscard]] bool has_include_search_freshness_marker(
+    const CompileCacheEntry& entry,
     const ModuleScanEvidence& evidence) {
+    // Cache v4's exact root vector is valid freshness identity even when a
+    // module source has no textual headers and therefore no directory snapshot.
+    if (!entry.include_search_roots.empty()) return true;
     for (const auto& dependency : evidence.dependencies) {
         std::error_code error_code;
         if (fs::is_directory(dependency.path, error_code) && !error_code) {
@@ -121,10 +125,9 @@ namespace fs = std::filesystem;
     const auto& entry = **loaded;
     const auto& evidence = *entry.module_scan;
 
-    // Pre-closure scan evidence contains only file snapshots and therefore
-    // cannot prove that a higher-priority include namespace stayed unchanged.
-    // Rescan once after upgrading and reseal directory-backed evidence.
-    if (!has_include_search_freshness_marker(evidence)) {
+    // Pre-closure scan evidence has neither cache-v4 root identity nor any
+    // directory namespace snapshot. Rescan once after upgrading and reseal.
+    if (!has_include_search_freshness_marker(entry, evidence)) {
         return std::nullopt;
     }
 

--- a/cpp/src/orchestration/modules/ModuleTargetScanner.cpp
+++ b/cpp/src/orchestration/modules/ModuleTargetScanner.cpp
@@ -40,11 +40,17 @@ namespace fs = std::filesystem;
     return std::nullopt;
 }
 
-[[nodiscard]] std::optional<FileSnapshot> snapshot_regular_file(const fs::path& path) {
+[[nodiscard]] std::optional<FileSnapshot> snapshot_path(
+    const fs::path& path,
+    const bool require_regular_file) {
     if (path.empty()) return std::nullopt;
     std::error_code error_code;
     const auto status = fs::status(path, error_code);
-    if (error_code || !fs::is_regular_file(status)) return std::nullopt;
+    if (error_code) return std::nullopt;
+    const bool supported_type = require_regular_file
+        ? fs::is_regular_file(status)
+        : (fs::is_regular_file(status) || fs::is_directory(status));
+    if (!supported_type) return std::nullopt;
     const auto modified = fs::last_write_time(path, error_code);
     if (error_code) return std::nullopt;
     return FileSnapshot{
@@ -52,6 +58,14 @@ namespace fs = std::filesystem;
         .exists = true,
         .modified = modified,
     };
+}
+
+[[nodiscard]] std::optional<FileSnapshot> snapshot_regular_file(const fs::path& path) {
+    return snapshot_path(path, true);
+}
+
+[[nodiscard]] std::optional<FileSnapshot> snapshot_file_or_directory(const fs::path& path) {
+    return snapshot_path(path, false);
 }
 
 [[nodiscard]] std::optional<std::string> read_text_file(const fs::path& path) {
@@ -88,7 +102,7 @@ namespace fs = std::filesystem;
     std::vector<FileSnapshot> dependency_snapshots;
     dependency_snapshots.reserve(evidence.dependencies.size());
     for (const auto& dependency : evidence.dependencies) {
-        auto snapshot = snapshot_regular_file(dependency.path);
+        auto snapshot = snapshot_file_or_directory(dependency.path);
         if (!snapshot) return std::nullopt;
         dependency_snapshots.push_back(std::move(*snapshot));
     }
@@ -175,7 +189,7 @@ scan_requested_module_sources(
     batch.scans.reserve(request.sources.size());
     batch.units.reserve(request.sources.size() + 2u);
 
-    for (std::size_t index = 0; index < request.sources.size(); ++index) {
+    for (std::size_t index = 0; index < attempts.size(); ++index) {
         if (!attempts[index]) {
             return std::unexpected(failure(
                 IncrementalModuleTargetErrorCode::scheduling_failed,

--- a/cpp/src/orchestration/modules/ModuleTargetScanner.cpp
+++ b/cpp/src/orchestration/modules/ModuleTargetScanner.cpp
@@ -42,17 +42,11 @@ namespace fs = std::filesystem;
     return std::nullopt;
 }
 
-[[nodiscard]] std::optional<FileSnapshot> snapshot_path(
-    const fs::path& path,
-    const bool require_regular_file) {
+[[nodiscard]] std::optional<FileSnapshot> snapshot_regular_file(const fs::path& path) {
     if (path.empty()) return std::nullopt;
     std::error_code error_code;
     const auto status = fs::status(path, error_code);
-    if (error_code) return std::nullopt;
-    const bool supported_type = require_regular_file
-        ? fs::is_regular_file(status)
-        : (fs::is_regular_file(status) || fs::is_directory(status));
-    if (!supported_type) return std::nullopt;
+    if (error_code || !fs::is_regular_file(status)) return std::nullopt;
     const auto modified = fs::last_write_time(path, error_code);
     if (error_code) return std::nullopt;
     return FileSnapshot{
@@ -62,12 +56,19 @@ namespace fs = std::filesystem;
     };
 }
 
-[[nodiscard]] std::optional<FileSnapshot> snapshot_regular_file(const fs::path& path) {
-    return snapshot_path(path, true);
-}
-
 [[nodiscard]] std::optional<FileSnapshot> snapshot_file_or_directory(const fs::path& path) {
-    return snapshot_path(path, false);
+    if (path.empty()) return std::nullopt;
+    // Module-scan evidence admits both file and directory dependencies. Its
+    // identity is existence + mtime, so last_write_time() alone provides the
+    // required warm-path probe and avoids a redundant preceding status().
+    std::error_code error_code;
+    const auto modified = fs::last_write_time(path, error_code);
+    if (error_code) return std::nullopt;
+    return FileSnapshot{
+        .path = path,
+        .exists = true,
+        .modified = modified,
+    };
 }
 
 [[nodiscard]] bool same_path(const fs::path& left, const fs::path& right) {

--- a/cpp/tests/core/cache/compile_cache_file_tests.cpp
+++ b/cpp/tests/core/cache/compile_cache_file_tests.cpp
@@ -116,6 +116,11 @@ private:
             fs::path{"include/a.hpp"},
             fs::path{"include/nested/b.hpp"},
         },
+        .include_search_roots = {
+            fs::path{"include/first"},
+            fs::path{"include/second"},
+            fs::path{"toolchain/include"},
+        },
     };
 }
 
@@ -151,6 +156,10 @@ private:
             options),
         .outputs = unit.outputs,
         .dependencies = {fs::path{"include/shared.hpp"}},
+        .include_search_roots = {
+            fs::path{"include"},
+            fs::path{"toolchain/include"},
+        },
     };
     if (!ifc_only) {
         entry.module_scan = mqb::ModuleScanEvidence{
@@ -189,6 +198,14 @@ void write_bytes(
 void write_all(const fs::path& file, const std::vector<char>& bytes) {
     std::ofstream stream{file, std::ios::binary | std::ios::trunc};
     stream.write(bytes.data(), static_cast<std::streamsize>(bytes.size()));
+}
+
+void set_format_version(std::vector<char>& bytes, const std::uint32_t version) {
+    if (bytes.size() < 12) return;
+    bytes[8] = static_cast<char>(version & 0xffu);
+    bytes[9] = static_cast<char>((version >> 8u) & 0xffu);
+    bytes[10] = static_cast<char>((version >> 16u) & 0xffu);
+    bytes[11] = static_cast<char>((version >> 24u) & 0xffu);
 }
 
 void expect_round_trip(
@@ -234,6 +251,9 @@ void expect_round_trip(
     expect(
         entry.dependencies == original.dependencies,
         std::string{description} + " dependencies should round-trip");
+    expect(
+        entry.include_search_roots == original.include_search_roots,
+        std::string{description} + " ordered include-search roots should round-trip");
     expect(
         entry.module_scan.has_value() == original.module_scan.has_value(),
         std::string{description} + " scan-evidence presence should round-trip");
@@ -293,29 +313,49 @@ int main() {
         make_module_entry(true),
         "IFC-only cache entry");
 
-    // A v3 entry without scan evidence is exactly the v2 payload plus a zero
-    // presence marker. Remove the marker and rewrite the version to prove old
-    // v2 cache files remain readable and simply lack the new optimization.
+    // Cache v4 inserts an ordered include-root vector between dependencies and
+    // the v3 scan-evidence marker. Build v2/v3 fixtures from a v4 entry with an
+    // empty root vector so removing the final four-byte root count recreates
+    // the old payload exactly (plus/removing the v3 presence marker).
+    auto legacy = original;
+    legacy.include_search_roots.clear();
+    legacy.module_scan.reset();
+
+    const fs::path v3_file = fixture.path() / "legacy-v3.mqbcache";
+    expect(
+        mqb::CompileCacheFile::save(v3_file, legacy).has_value(),
+        "v3 fixture should start as v4");
+    auto v3_bytes = read_all(v3_file);
+    expect(v3_bytes.size() > 16, "v3 fixture should contain root count and scan marker");
+    if (v3_bytes.size() > 16) {
+        // The v4 tail for zero roots/no scan is: root_count(u32=0), present(u8=0).
+        v3_bytes.erase(v3_bytes.end() - 5, v3_bytes.end() - 1);
+        set_format_version(v3_bytes, 3);
+        write_all(v3_file, v3_bytes);
+        const auto v3 = mqb::CompileCacheFile::load(v3_file);
+        expect(v3 && *v3, "legacy v3 should load");
+        if (v3 && *v3) {
+            expect((**v3).include_search_roots.empty(), "legacy v3 should have no root identity evidence");
+            expect(!(**v3).module_scan, "legacy v3 no-scan fixture should remain no-scan");
+        }
+    }
+
     const fs::path v2_file = fixture.path() / "legacy-v2.mqbcache";
     expect(
-        mqb::CompileCacheFile::save(v2_file, original).has_value(),
-        "v2 fixture should start as v3");
+        mqb::CompileCacheFile::save(v2_file, legacy).has_value(),
+        "v2 fixture should start as v4");
     auto v2_bytes = read_all(v2_file);
-    expect(
-        v2_bytes.size() > 13,
-        "v2 fixture should contain payload and presence marker");
-    if (v2_bytes.size() > 13) {
-        v2_bytes[8] = 2;
-        v2_bytes[9] = 0;
-        v2_bytes[10] = 0;
-        v2_bytes[11] = 0;
-        v2_bytes.pop_back();
+    expect(v2_bytes.size() > 16, "v2 fixture should contain root count and scan marker");
+    if (v2_bytes.size() > 16) {
+        v2_bytes.resize(v2_bytes.size() - 5);
+        set_format_version(v2_bytes, 2);
         write_all(v2_file, v2_bytes);
-
         const auto v2 = mqb::CompileCacheFile::load(v2_file);
-        expect(
-            v2 && *v2 && !(**v2).module_scan,
-            "legacy v2 should load without scan evidence");
+        expect(v2 && *v2, "legacy v2 should load");
+        if (v2 && *v2) {
+            expect((**v2).include_search_roots.empty(), "legacy v2 should have no root identity evidence");
+            expect(!(**v2).module_scan, "legacy v2 should load without scan evidence");
+        }
     }
 
     auto empty_outputs = original;
@@ -337,7 +377,7 @@ int main() {
         "replacement should not leave stale metadata");
 
     const fs::path bad_magic = fixture.path() / "bad.mqbcache";
-    write_bytes(bad_magic, {0, 1, 2, 3, 4, 5, 6, 7, 3, 0, 0, 0});
+    write_bytes(bad_magic, {0, 1, 2, 3, 4, 5, 6, 7, 4, 0, 0, 0});
     const auto bad_result = mqb::CompileCacheFile::load(bad_magic);
     expect(!bad_result, "bad magic should fail");
     if (!bad_result) {
@@ -359,7 +399,7 @@ int main() {
     }
 
     const fs::path future = fixture.path() / "future.mqbcache";
-    write_bytes(future, {'M', 'Q', 'B', 'C', 'A', 'C', 'H', 'E', 4, 0, 0, 0});
+    write_bytes(future, {'M', 'Q', 'B', 'C', 'A', 'C', 'H', 'E', 5, 0, 0, 0});
     const auto future_result = mqb::CompileCacheFile::load(future);
     expect(!future_result, "future version should fail");
     if (!future_result) {

--- a/cpp/tests/msvc/compiler/compile_executor_tests.cpp
+++ b/cpp/tests/msvc/compiler/compile_executor_tests.cpp
@@ -3,6 +3,7 @@
 #include <expected>
 #include <filesystem>
 #include <fstream>
+#include <initializer_list>
 #include <iostream>
 #include <string>
 #include <string_view>
@@ -106,6 +107,31 @@ void write_dependencies(
         }) != entry.dependencies.end();
 }
 
+[[nodiscard]] bool has_only_expected_files_and_freshness_directories(
+    const mqb::CompileCacheEntry& entry,
+    const std::initializer_list<fs::path> expected_files) {
+    for (const auto& expected : expected_files) {
+        if (!has_dependency(entry, expected)) return false;
+    }
+
+    for (const auto& dependency : entry.dependencies) {
+        const auto normalized = dependency.lexically_normal();
+        const bool expected_file = std::any_of(
+            expected_files.begin(),
+            expected_files.end(),
+            [&normalized](const fs::path& expected) {
+                return expected.lexically_normal() == normalized;
+            });
+        if (expected_file) continue;
+
+        std::error_code error_code;
+        if (!fs::is_directory(dependency, error_code) || error_code) {
+            return false;
+        }
+    }
+    return true;
+}
+
 [[nodiscard]] bool has_output(
     const mqb::CompileCacheEntry& entry,
     const fs::path& expected,
@@ -203,9 +229,10 @@ int main() {
                "cache entry should preserve toolchain version");
         expect(result->cache_entry.toolchain.binary_stamp == toolchain.identity.binary_stamp,
                "cache entry should preserve compiler binary stamp");
-        expect(result->cache_entry.dependencies.size() == 1
-                   && result->cache_entry.dependencies.front() == header.lexically_normal(),
-               "cache entry should store compiler-discovered include dependencies");
+        expect(has_only_expected_files_and_freshness_directories(
+                   result->cache_entry,
+                   {header}),
+               "cache entry should store compiler includes plus only directory namespace evidence");
         expect(result->cache_entry.signature
                    == mqb::BuildSignature::for_compile(unit, toolchain.identity, options),
                "cache entry should persist the compile recipe signature");
@@ -344,8 +371,10 @@ int main() {
                "consumer cache should retain compiler-discovered headers");
         expect(has_dependency(consumer_result->cache_entry, module_ifc),
                "consumer cache should persist imported IFC as a freshness dependency");
-        expect(consumer_result->cache_entry.dependencies.size() == 2,
-               "consumer cache should store header and IFC without unrelated artifacts");
+        expect(has_only_expected_files_and_freshness_directories(
+                   consumer_result->cache_entry,
+                   {header, module_ifc}),
+               "consumer cache should contain header/IFC plus only directory namespace evidence");
     }
 
     const int calls_before_invalid_contracts = runner.calls;

--- a/tests/native/verify_has_include_freshness.ps1
+++ b/tests/native/verify_has_include_freshness.ps1
@@ -1,0 +1,81 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$MqbPath,
+    [Parameter(Mandatory = $true)][string]$RepoRoot
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+$MqbPath = [System.IO.Path]::GetFullPath($MqbPath)
+$RepoRoot = [System.IO.Path]::GetFullPath($RepoRoot)
+$fixture = Join-Path $RepoRoot 'native-test-work/has-include-freshness'
+if (Test-Path -LiteralPath $fixture) {
+    Remove-Item -LiteralPath $fixture -Recurse -Force
+}
+New-Item -ItemType Directory -Force -Path (Join-Path $fixture 'high/nested') | Out-Null
+
+Set-Content -LiteralPath (Join-Path $fixture 'main.cpp') -Encoding utf8 -Value @(
+    '#if __has_include(<nested/optional_feature.hpp>)',
+    '#include <nested/optional_feature.hpp>',
+    '#else',
+    'inline int feature_value() { return 61; }',
+    '#endif',
+    'int main() { return feature_value(); }'
+)
+
+function Invoke-Build {
+    Push-Location $fixture
+    try {
+        $output = @(& $MqbPath main.cpp --release --no-discover --env vs -I high -o has-include 2>&1)
+        $exitCode = $LASTEXITCODE
+    }
+    finally {
+        Pop-Location
+    }
+    if ($exitCode -ne 0) {
+        throw "MQB build failed (exit $exitCode):`n$($output -join [Environment]::NewLine)"
+    }
+    return ($output -join [Environment]::NewLine)
+}
+
+function Invoke-Probe {
+    $program = Join-Path $fixture '.mqb/bin/has-include.exe'
+    if (-not (Test-Path -LiteralPath $program -PathType Leaf)) {
+        throw "program output missing: $program"
+    }
+    & $program
+    return $LASTEXITCODE
+}
+
+$cold = Invoke-Build
+if ((Invoke-Probe) -ne 61) {
+    throw '__has_include cold build did not take the absent-header branch'
+}
+
+$warm = Invoke-Build
+if ($warm -notmatch '\[up-to-date\]\s+main\.cpp') {
+    throw "unchanged __has_include build was not warm:`n$warm"
+}
+if ($warm -match '\[compile\]\s+main\.cpp') {
+    throw "unchanged __has_include build launched an unnecessary compiler:`n$warm"
+}
+
+# The parent directory already exists. Only the nested directory mtime changes,
+# which proves that freshness is not accidentally coming from the top-level /I root.
+Start-Sleep -Milliseconds 100
+Set-Content -LiteralPath (Join-Path $fixture 'high/nested/optional_feature.hpp') -Encoding utf8 -Value @(
+    '#pragma once',
+    'inline int feature_value() { return 62; }'
+)
+
+$shadow = Invoke-Build
+if ($shadow -notmatch '\[compile\]\s+main\.cpp') {
+    throw "new __has_include candidate did not invalidate the warm compile cache:`n$shadow"
+}
+if ((Invoke-Probe) -ne 62) {
+    throw '__has_include did not observe the newly available nested header'
+}
+
+Write-Host '__has_include absent-to-present freshness check passed.'
+exit 0

--- a/tests/native/verify_include_search_freshness.ps1
+++ b/tests/native/verify_include_search_freshness.ps1
@@ -67,7 +67,7 @@ function Require-Compile {
         [Parameter(Mandatory = $true)][string]$Description
     )
     if ($Result.Text -notmatch ("\[compile\]\s+" + [Regex]::Escape($Source))) {
-        throw "$Description did not compile $Source:`n$($Result.Text)"
+        throw "$Description did not compile ${Source}:`n$($Result.Text)"
     }
 }
 
@@ -81,7 +81,7 @@ function Require-UpToDate {
         throw "$Description did not report $Source up-to-date:`n$($Result.Text)"
     }
     if ($Result.Text -match ("\[compile\]\s+" + [Regex]::Escape($Source))) {
-        throw "$Description launched an unnecessary compiler for $Source:`n$($Result.Text)"
+        throw "$Description launched an unnecessary compiler for ${Source}:`n$($Result.Text)"
     }
 }
 

--- a/tests/native/verify_include_search_freshness.ps1
+++ b/tests/native/verify_include_search_freshness.ps1
@@ -10,7 +10,7 @@ Set-StrictMode -Version 2.0
 $MqbPath = [System.IO.Path]::GetFullPath($MqbPath)
 $RepoRoot = [System.IO.Path]::GetFullPath($RepoRoot)
 if (-not (Test-Path -LiteralPath $MqbPath -PathType Leaf)) {
-    throw "MQB executable not found: $MqbPath"
+    throw ('MQB executable not found: {0}' -f $MqbPath)
 }
 
 $root = Join-Path $RepoRoot 'native-test-work/include-search-freshness'
@@ -20,10 +20,7 @@ if (Test-Path -LiteralPath $root) {
 New-Item -ItemType Directory -Force -Path $root | Out-Null
 
 function Write-Utf8 {
-    param(
-        [Parameter(Mandatory = $true)][string]$Path,
-        [Parameter(Mandatory = $true)][string[]]$Lines
-    )
+    param([string]$Path, [string[]]$Lines)
     $parent = Split-Path -Parent $Path
     if (-not [string]::IsNullOrWhiteSpace($parent)) {
         New-Item -ItemType Directory -Force -Path $parent | Out-Null
@@ -31,11 +28,15 @@ function Write-Utf8 {
     Set-Content -LiteralPath $Path -Encoding utf8 -Value $Lines
 }
 
-function Invoke-Mqb {
-    param(
-        [Parameter(Mandatory = $true)][string]$WorkingDirectory,
-        [Parameter(Mandatory = $true)][string[]]$Arguments
-    )
+function New-CaseDirectory {
+    param([string]$Name)
+    $path = Join-Path $root $Name
+    New-Item -ItemType Directory -Force -Path $path | Out-Null
+    return $path
+}
+
+function Invoke-MqbCase {
+    param([string]$WorkingDirectory, [string[]]$Arguments)
     Push-Location $WorkingDirectory
     try {
         $output = @(& $MqbPath @Arguments 2>&1)
@@ -44,256 +45,204 @@ function Invoke-Mqb {
     finally {
         Pop-Location
     }
-    [PSCustomObject]@{
+    return [PSCustomObject]@{
         ExitCode = $exitCode
         Text = ($output -join [Environment]::NewLine)
     }
 }
 
 function Require-Success {
-    param(
-        [Parameter(Mandatory = $true)]$Result,
-        [Parameter(Mandatory = $true)][string]$Description
-    )
+    param($Result, [string]$Description)
     if ($Result.ExitCode -ne 0) {
-        throw "$Description failed (exit $($Result.ExitCode)):`n$($Result.Text)"
+        throw ('{0} failed (exit {1}):{2}{3}' -f $Description, $Result.ExitCode, [Environment]::NewLine, $Result.Text)
     }
 }
 
 function Require-Compile {
-    param(
-        [Parameter(Mandatory = $true)]$Result,
-        [Parameter(Mandatory = $true)][string]$Source,
-        [Parameter(Mandatory = $true)][string]$Description
-    )
-    if ($Result.Text -notmatch ("\[compile\]\s+" + [Regex]::Escape($Source))) {
-        throw "$Description did not compile ${Source}:`n$($Result.Text)"
+    param($Result, [string]$Source, [string]$Description)
+    if ($Result.Text -notmatch ('\[compile\]\s+' + [Regex]::Escape($Source))) {
+        throw ('{0} did not compile {1}:{2}{3}' -f $Description, $Source, [Environment]::NewLine, $Result.Text)
     }
 }
 
 function Require-UpToDate {
-    param(
-        [Parameter(Mandatory = $true)]$Result,
-        [Parameter(Mandatory = $true)][string]$Source,
-        [Parameter(Mandatory = $true)][string]$Description
-    )
-    if ($Result.Text -notmatch ("\[up-to-date\]\s+" + [Regex]::Escape($Source))) {
-        throw "$Description did not report $Source up-to-date:`n$($Result.Text)"
+    param($Result, [string]$Source, [string]$Description)
+    if ($Result.Text -notmatch ('\[up-to-date\]\s+' + [Regex]::Escape($Source))) {
+        throw ('{0} did not report {1} up-to-date:{2}{3}' -f $Description, $Source, [Environment]::NewLine, $Result.Text)
     }
-    if ($Result.Text -match ("\[compile\]\s+" + [Regex]::Escape($Source))) {
-        throw "$Description launched an unnecessary compiler for ${Source}:`n$($Result.Text)"
+    if ($Result.Text -match ('\[compile\]\s+' + [Regex]::Escape($Source))) {
+        throw ('{0} launched an unnecessary compiler for {1}:{2}{3}' -f $Description, $Source, [Environment]::NewLine, $Result.Text)
     }
-}
-
-function Invoke-Program {
-    param([Parameter(Mandatory = $true)][string]$Path)
-    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
-        throw "program output missing: $Path"
-    }
-    & $Path
-    return $LASTEXITCODE
 }
 
 function Program-Path {
-    param(
-        [Parameter(Mandatory = $true)][string]$Fixture,
-        [Parameter(Mandatory = $true)][string]$OutputName
-    )
-    return Join-Path $Fixture ".mqb/bin/$OutputName.exe"
+    param([string]$Fixture, [string]$OutputName)
+    return Join-Path $Fixture ('.mqb/bin/{0}.exe' -f $OutputName)
 }
 
-function New-CaseDirectory {
-    param([Parameter(Mandatory = $true)][string]$Name)
-    $path = Join-Path $root $Name
-    New-Item -ItemType Directory -Force -Path $path | Out-Null
-    return $path
+function Require-ProgramExit {
+    param([string]$Path, [int]$Expected, [string]$Description)
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        throw ('{0}: program output missing: {1}' -f $Description, $Path)
+    }
+    & $Path | Out-Null
+    $actual = $LASTEXITCODE
+    if ($actual -ne $Expected) {
+        throw ('{0}: expected exit {1}, got {2}' -f $Description, $Expected, $actual)
+    }
 }
 
-# 1 + 2. Higher-priority typed -I root gains a same-name angle header, then
-# the active higher-priority header is removed. Neither transition changes argv.
+# 1 + 2 + 5. Typed /I angle resolution: high root initially misses, then gains
+# the same-name header, then loses it again. None of these transitions changes argv.
 $case1 = New-CaseDirectory 'typed-angle-shadow'
-$case1High = Join-Path $case1 'high'
-$case1Low = Join-Path $case1 'low'
-New-Item -ItemType Directory -Force -Path $case1High | Out-Null
-New-Item -ItemType Directory -Force -Path $case1Low | Out-Null
-Write-Utf8 (Join-Path $case1Low 'pick.hpp') @('inline int selected_value() { return 7; }')
-Write-Utf8 (Join-Path $case1 'main.cpp') @(
-    '#include <pick.hpp>',
-    'int main() { return selected_value(); }'
-)
-$case1Args = @('main.cpp', '--release', '--no-discover', '--env', 'vs', '-I', 'high', '-I', 'low', '-o', 'typed-angle')
-$case1Cold = Invoke-Mqb $case1 $case1Args
-Require-Success $case1Cold 'typed angle cold build'
-if ((Invoke-Program (Program-Path $case1 'typed-angle')) -ne 7) {
-    throw 'typed angle cold build did not resolve low/pick.hpp'
-}
-$case1Warm = Invoke-Mqb $case1 $case1Args
-Require-Success $case1Warm 'typed angle warm build'
-Require-UpToDate $case1Warm 'main.cpp' 'typed angle warm build'
-Start-Sleep -Milliseconds 50
-Write-Utf8 (Join-Path $case1High 'pick.hpp') @('inline int selected_value() { return 9; }')
-$case1Shadow = Invoke-Mqb $case1 $case1Args
-Require-Success $case1Shadow 'typed angle higher-priority shadow build'
-Require-Compile $case1Shadow 'main.cpp' 'typed angle higher-priority shadow build'
-if ((Invoke-Program (Program-Path $case1 'typed-angle')) -ne 9) {
-    throw 'new higher-priority typed -I header did not replace the cached low header'
-}
-Remove-Item -LiteralPath (Join-Path $case1High 'pick.hpp') -Force
-$case1Removed = Invoke-Mqb $case1 $case1Args
-Require-Success $case1Removed 'typed angle active-header removal build'
-Require-Compile $case1Removed 'main.cpp' 'typed angle active-header removal build'
-if ((Invoke-Program (Program-Path $case1 'typed-angle')) -ne 7) {
-    throw 'removing the active higher-priority header did not fall back to low/pick.hpp'
-}
+New-Item -ItemType Directory -Force -Path (Join-Path $case1 'high') | Out-Null
+New-Item -ItemType Directory -Force -Path (Join-Path $case1 'low') | Out-Null
+Write-Utf8 (Join-Path $case1 'low/pick.hpp') @('inline int selected_value() { return 7; }')
+Write-Utf8 (Join-Path $case1 'main.cpp') @('#include <pick.hpp>', 'int main() { return selected_value(); }')
+$args1 = @('main.cpp', '--release', '--no-discover', '--env', 'vs', '-I', 'high', '-I', 'low', '-o', 'typed-angle')
+$cold1 = Invoke-MqbCase $case1 $args1
+Require-Success $cold1 'typed angle cold build'
+Require-ProgramExit (Program-Path $case1 'typed-angle') 7 'typed angle cold build'
+$warm1 = Invoke-MqbCase $case1 $args1
+Require-Success $warm1 'typed angle warm build'
+Require-UpToDate $warm1 'main.cpp' 'typed angle warm build'
+Start-Sleep -Milliseconds 100
+Write-Utf8 (Join-Path $case1 'high/pick.hpp') @('inline int selected_value() { return 9; }')
+$shadow1 = Invoke-MqbCase $case1 $args1
+Require-Success $shadow1 'typed angle higher-priority shadow build'
+Require-Compile $shadow1 'main.cpp' 'typed angle higher-priority shadow build'
+Require-ProgramExit (Program-Path $case1 'typed-angle') 9 'typed angle higher-priority shadow build'
+Remove-Item -LiteralPath (Join-Path $case1 'high/pick.hpp') -Force
+$removed1 = Invoke-MqbCase $case1 $args1
+Require-Success $removed1 'typed angle active-header removal build'
+Require-Compile $removed1 'main.cpp' 'typed angle active-header removal build'
+Require-ProgramExit (Program-Path $case1 'typed-angle') 7 'typed angle active-header removal build'
 
-# 3. Include-directory order is compile identity and must invalidate even when
-# the directory contents themselves remain unchanged.
+# 3. Search-root order is compile identity.
 $case3 = New-CaseDirectory 'include-order'
 New-Item -ItemType Directory -Force -Path (Join-Path $case3 'a') | Out-Null
 New-Item -ItemType Directory -Force -Path (Join-Path $case3 'b') | Out-Null
 Write-Utf8 (Join-Path $case3 'a/pick.hpp') @('inline int selected_value() { return 3; }')
 Write-Utf8 (Join-Path $case3 'b/pick.hpp') @('inline int selected_value() { return 4; }')
 Write-Utf8 (Join-Path $case3 'main.cpp') @('#include <pick.hpp>', 'int main() { return selected_value(); }')
-$case3AFirst = Invoke-Mqb $case3 @('main.cpp', '--release', '--no-discover', '--env', 'vs', '-I', 'a', '-I', 'b', '-o', 'order')
-Require-Success $case3AFirst 'include-order a-first build'
-if ((Invoke-Program (Program-Path $case3 'order')) -ne 3) { throw 'a-first include order was not honored' }
-$case3BFirst = Invoke-Mqb $case3 @('main.cpp', '--release', '--no-discover', '--env', 'vs', '-I', 'b', '-I', 'a', '-o', 'order')
-Require-Success $case3BFirst 'include-order b-first build'
-Require-Compile $case3BFirst 'main.cpp' 'include-order b-first build'
-if ((Invoke-Program (Program-Path $case3 'order')) -ne 4) { throw 'reordered include search path was not honored' }
+$aFirst = Invoke-MqbCase $case3 @('main.cpp', '--release', '--no-discover', '--env', 'vs', '-I', 'a', '-I', 'b', '-o', 'order')
+Require-Success $aFirst 'include-order a-first build'
+Require-ProgramExit (Program-Path $case3 'order') 3 'include-order a-first build'
+$bFirst = Invoke-MqbCase $case3 @('main.cpp', '--release', '--no-discover', '--env', 'vs', '-I', 'b', '-I', 'a', '-o', 'order')
+Require-Success $bFirst 'include-order b-first build'
+Require-Compile $bFirst 'main.cpp' 'include-order b-first build'
+Require-ProgramExit (Program-Path $case3 'order') 4 'include-order b-first build'
 
-# 4. Quoted include resolution searches the source directory before /I. Adding
-# a source-adjacent same-name header must invalidate the cached /I resolution.
+# 4a. Quoted lookup prefers the including source directory over /I.
 $case4 = New-CaseDirectory 'quoted-shadow'
 New-Item -ItemType Directory -Force -Path (Join-Path $case4 'low') | Out-Null
 Write-Utf8 (Join-Path $case4 'low/pick.hpp') @('inline int selected_value() { return 5; }')
 Write-Utf8 (Join-Path $case4 'main.cpp') @('#include "pick.hpp"', 'int main() { return selected_value(); }')
-$case4Args = @('main.cpp', '--release', '--no-discover', '--env', 'vs', '-I', 'low', '-o', 'quoted')
-$case4Cold = Invoke-Mqb $case4 $case4Args
-Require-Success $case4Cold 'quoted cold build'
-if ((Invoke-Program (Program-Path $case4 'quoted')) -ne 5) { throw 'quoted cold build did not resolve low/pick.hpp' }
-$case4Warm = Invoke-Mqb $case4 $case4Args
-Require-Success $case4Warm 'quoted warm build'
-Require-UpToDate $case4Warm 'main.cpp' 'quoted warm build'
-Start-Sleep -Milliseconds 50
+$args4 = @('main.cpp', '--release', '--no-discover', '--env', 'vs', '-I', 'low', '-o', 'quoted')
+$cold4 = Invoke-MqbCase $case4 $args4
+Require-Success $cold4 'quoted cold build'
+Require-ProgramExit (Program-Path $case4 'quoted') 5 'quoted cold build'
+$warm4 = Invoke-MqbCase $case4 $args4
+Require-Success $warm4 'quoted warm build'
+Require-UpToDate $warm4 'main.cpp' 'quoted warm build'
+Start-Sleep -Milliseconds 100
 Write-Utf8 (Join-Path $case4 'pick.hpp') @('inline int selected_value() { return 6; }')
-$case4Shadow = Invoke-Mqb $case4 $case4Args
-Require-Success $case4Shadow 'quoted source-directory shadow build'
-Require-Compile $case4Shadow 'main.cpp' 'quoted source-directory shadow build'
-if ((Invoke-Program (Program-Path $case4 'quoted')) -ne 6) { throw 'quoted source-directory shadow was not selected' }
+$shadow4 = Invoke-MqbCase $case4 $args4
+Require-Success $shadow4 'quoted source-directory shadow build'
+Require-Compile $shadow4 'main.cpp' 'quoted source-directory shadow build'
+Require-ProgramExit (Program-Path $case4 'quoted') 6 'quoted source-directory shadow build'
 
-# 4b. Quoted lookup also searches the directory of the including header. Keep
-# that candidate subdirectory present before the cold build so adding only the
-# same-name file later changes the nested directory mtime, not the outer root.
+# 4b. Nested quote search: candidate subdirectory exists before cold build, so
+# only that nested namespace changes when the shadow file appears.
 $case4b = New-CaseDirectory 'nested-quoted-shadow'
 New-Item -ItemType Directory -Force -Path (Join-Path $case4b 'src/nested') | Out-Null
 New-Item -ItemType Directory -Force -Path (Join-Path $case4b 'low/nested') | Out-Null
 Write-Utf8 (Join-Path $case4b 'low/nested/pick.hpp') @('inline int nested_value() { return 51; }')
 Write-Utf8 (Join-Path $case4b 'src/outer.hpp') @('#pragma once', '#include "nested/pick.hpp"', 'inline int outer_value() { return nested_value(); }')
 Write-Utf8 (Join-Path $case4b 'main.cpp') @('#include "src/outer.hpp"', 'int main() { return outer_value(); }')
-$case4bArgs = @('main.cpp', '--release', '--no-discover', '--env', 'vs', '-I', 'low', '-o', 'nested-quoted')
-$case4bCold = Invoke-Mqb $case4b $case4bArgs
-Require-Success $case4bCold 'nested quoted cold build'
-if ((Invoke-Program (Program-Path $case4b 'nested-quoted')) -ne 51) { throw 'nested quoted cold build did not resolve low/nested/pick.hpp' }
-$case4bWarm = Invoke-Mqb $case4b $case4bArgs
-Require-Success $case4bWarm 'nested quoted warm build'
-Require-UpToDate $case4bWarm 'main.cpp' 'nested quoted warm build'
+$args4b = @('main.cpp', '--release', '--no-discover', '--env', 'vs', '-I', 'low', '-o', 'nested-quoted')
+$cold4b = Invoke-MqbCase $case4b $args4b
+Require-Success $cold4b 'nested quoted cold build'
+Require-ProgramExit (Program-Path $case4b 'nested-quoted') 51 'nested quoted cold build'
+$warm4b = Invoke-MqbCase $case4b $args4b
+Require-Success $warm4b 'nested quoted warm build'
+Require-UpToDate $warm4b 'main.cpp' 'nested quoted warm build'
 Start-Sleep -Milliseconds 100
 Write-Utf8 (Join-Path $case4b 'src/nested/pick.hpp') @('inline int nested_value() { return 52; }')
-$case4bShadow = Invoke-Mqb $case4b $case4bArgs
-Require-Success $case4bShadow 'nested quoted header-directory shadow build'
-Require-Compile $case4bShadow 'main.cpp' 'nested quoted header-directory shadow build'
-if ((Invoke-Program (Program-Path $case4b 'nested-quoted')) -ne 52) {
-    throw 'nested quoted include did not move to the including-header directory'
-}
+$shadow4b = Invoke-MqbCase $case4b $args4b
+Require-Success $shadow4b 'nested quoted header-directory shadow build'
+Require-Compile $shadow4b 'main.cpp' 'nested quoted header-directory shadow build'
+Require-ProgramExit (Program-Path $case4b 'nested-quoted') 52 'nested quoted header-directory shadow build'
 
-# 5. Native MSVC /I syntax participates in the same search freshness model;
-# this specifically covers raw passthrough roots rather than typed -I policy.
+# Native MSVC /I passthrough participates in the same model.
 $case5 = New-CaseDirectory 'native-angle-shadow'
 New-Item -ItemType Directory -Force -Path (Join-Path $case5 'high') | Out-Null
 New-Item -ItemType Directory -Force -Path (Join-Path $case5 'low') | Out-Null
 Write-Utf8 (Join-Path $case5 'low/pick.hpp') @('inline int selected_value() { return 11; }')
 Write-Utf8 (Join-Path $case5 'main.cpp') @('#include <pick.hpp>', 'int main() { return selected_value(); }')
-$case5Args = @('main.cpp', '--release', '--no-discover', '--env', 'vs', '/Ihigh', '/Ilow', '-o', 'native-angle')
-$case5Cold = Invoke-Mqb $case5 $case5Args
-Require-Success $case5Cold 'native /I angle cold build'
-if ((Invoke-Program (Program-Path $case5 'native-angle')) -ne 11) { throw 'native /I cold build did not resolve low/pick.hpp' }
-Start-Sleep -Milliseconds 50
+$args5 = @('main.cpp', '--release', '--no-discover', '--env', 'vs', '/Ihigh', '/Ilow', '-o', 'native-angle')
+$cold5 = Invoke-MqbCase $case5 $args5
+Require-Success $cold5 'native /I angle cold build'
+Require-ProgramExit (Program-Path $case5 'native-angle') 11 'native /I angle cold build'
+Start-Sleep -Milliseconds 100
 Write-Utf8 (Join-Path $case5 'high/pick.hpp') @('inline int selected_value() { return 12; }')
-$case5Shadow = Invoke-Mqb $case5 $case5Args
-Require-Success $case5Shadow 'native /I angle shadow build'
-Require-Compile $case5Shadow 'main.cpp' 'native /I angle shadow build'
-if ((Invoke-Program (Program-Path $case5 'native-angle')) -ne 12) { throw 'native /I search reroute did not select high/pick.hpp' }
+$shadow5 = Invoke-MqbCase $case5 $args5
+Require-Success $shadow5 'native /I angle shadow build'
+Require-Compile $shadow5 'main.cpp' 'native /I angle shadow build'
+Require-ProgramExit (Program-Path $case5 'native-angle') 12 'native /I angle shadow build'
 
-# 6 + 8. A named-module provider uses an angle header. The unchanged warm build
-# must reuse both P1689 metadata and compile caches; adding a higher-priority
-# header must rerun the scan and compile without any argv/source mutation.
+# 6 + 8. P1689 scan reuse must stay process-free on an unchanged build and
+# invalidate when a higher-priority header appears.
 $case6 = New-CaseDirectory 'p1689-shadow'
 New-Item -ItemType Directory -Force -Path (Join-Path $case6 'high') | Out-Null
 New-Item -ItemType Directory -Force -Path (Join-Path $case6 'low') | Out-Null
 Write-Utf8 (Join-Path $case6 'low/config.hpp') @('#define MQB_VALUE 21')
-Write-Utf8 (Join-Path $case6 'math.ixx') @(
-    'module;',
-    '#include <config.hpp>',
-    'export module math;',
-    'export int module_value() { return MQB_VALUE; }'
-)
+Write-Utf8 (Join-Path $case6 'math.ixx') @('module;', '#include <config.hpp>', 'export module math;', 'export int module_value() { return MQB_VALUE; }')
 Write-Utf8 (Join-Path $case6 'main.cpp') @('import math;', 'int main() { return module_value(); }')
-$case6Args = @('main.cpp', 'math.ixx', '--release', '--no-discover', '--env', 'vs', '--std', 'latest', '-I', 'high', '-I', 'low', '-o', 'p1689')
-$case6Cold = Invoke-Mqb $case6 $case6Args
-Require-Success $case6Cold 'P1689 cold build'
-if ((Invoke-Program (Program-Path $case6 'p1689')) -ne 21) { throw 'P1689 cold build did not use low/config.hpp' }
+$args6 = @('main.cpp', 'math.ixx', '--release', '--no-discover', '--env', 'vs', '--std', 'latest', '-I', 'high', '-I', 'low', '-o', 'p1689')
+$cold6 = Invoke-MqbCase $case6 $args6
+Require-Success $cold6 'P1689 cold build'
+Require-ProgramExit (Program-Path $case6 'p1689') 21 'P1689 cold build'
 $scanFile = Join-Path $case6 '.mqb/scan/math.ixx.json'
-if (-not (Test-Path -LiteralPath $scanFile -PathType Leaf)) { throw "P1689 scan artifact missing: $scanFile" }
+if (-not (Test-Path -LiteralPath $scanFile -PathType Leaf)) { throw ('P1689 scan artifact missing: {0}' -f $scanFile) }
 $scanColdTime = (Get-Item -LiteralPath $scanFile).LastWriteTimeUtc
-$case6Warm = Invoke-Mqb $case6 $case6Args
-Require-Success $case6Warm 'P1689 warm no-op build'
-Require-UpToDate $case6Warm 'math.ixx' 'P1689 warm no-op build'
-Require-UpToDate $case6Warm 'main.cpp' 'P1689 warm no-op build'
+$warm6 = Invoke-MqbCase $case6 $args6
+Require-Success $warm6 'P1689 warm no-op build'
+Require-UpToDate $warm6 'math.ixx' 'P1689 warm no-op build'
+Require-UpToDate $warm6 'main.cpp' 'P1689 warm no-op build'
 $scanWarmTime = (Get-Item -LiteralPath $scanFile).LastWriteTimeUtc
-if ($scanWarmTime -ne $scanColdTime) {
-    throw 'unchanged modules no-op rewrote P1689 scan metadata, indicating an unnecessary scanner launch'
-}
+if ($scanWarmTime -ne $scanColdTime) { throw 'unchanged modules no-op rewrote P1689 scan metadata' }
 Start-Sleep -Milliseconds 100
 Write-Utf8 (Join-Path $case6 'high/config.hpp') @('#define MQB_VALUE 22')
-$case6Shadow = Invoke-Mqb $case6 $case6Args
-Require-Success $case6Shadow 'P1689 higher-priority shadow build'
-Require-Compile $case6Shadow 'math.ixx' 'P1689 higher-priority shadow build'
+$shadow6 = Invoke-MqbCase $case6 $args6
+Require-Success $shadow6 'P1689 higher-priority shadow build'
+Require-Compile $shadow6 'math.ixx' 'P1689 higher-priority shadow build'
 $scanShadowTime = (Get-Item -LiteralPath $scanFile).LastWriteTimeUtc
-if ($scanShadowTime -le $scanWarmTime) {
-    throw 'higher-priority module header did not refresh P1689 scan metadata'
-}
-if ((Invoke-Program (Program-Path $case6 'p1689')) -ne 22) {
-    throw 'module rebuild did not observe the newly higher-priority config.hpp'
-}
+if ($scanShadowTime -le $scanWarmTime) { throw 'higher-priority module header did not refresh P1689 scan metadata' }
+Require-ProgramExit (Program-Path $case6 'p1689') 22 'P1689 higher-priority shadow build'
 
-# 7. Header-unit source identity is discovered from P1689. A new higher-priority
-# angle header must therefore invalidate scan evidence, allocate/rebuild the new
-# header-unit provider, and rebuild its consumer.
+# 7. Header Unit resolution must move to the newly higher-priority header.
 $case7 = New-CaseDirectory 'header-unit-shadow'
 New-Item -ItemType Directory -Force -Path (Join-Path $case7 'high') | Out-Null
 New-Item -ItemType Directory -Force -Path (Join-Path $case7 'low') | Out-Null
 Write-Utf8 (Join-Path $case7 'low/util.hpp') @('inline int header_value() { return 31; }')
 Write-Utf8 (Join-Path $case7 'main.cpp') @('import <util.hpp>;', 'int main() { return header_value(); }')
-$case7Args = @('main.cpp', '--release', '--env', 'vs', '--std', 'latest', '-I', 'high', '-I', 'low', '-o', 'header-unit-shadow')
-$case7Cold = Invoke-Mqb $case7 $case7Args
-Require-Success $case7Cold 'header-unit cold build'
-if ((Invoke-Program (Program-Path $case7 'header-unit-shadow')) -ne 31) { throw 'header-unit cold build did not use low/util.hpp' }
-$case7Warm = Invoke-Mqb $case7 $case7Args
-Require-Success $case7Warm 'header-unit warm build'
-Require-UpToDate $case7Warm 'main.cpp' 'header-unit warm build'
+$args7 = @('main.cpp', '--release', '--env', 'vs', '--std', 'latest', '-I', 'high', '-I', 'low', '-o', 'header-unit-shadow')
+$cold7 = Invoke-MqbCase $case7 $args7
+Require-Success $cold7 'header-unit cold build'
+Require-ProgramExit (Program-Path $case7 'header-unit-shadow') 31 'header-unit cold build'
+$warm7 = Invoke-MqbCase $case7 $args7
+Require-Success $warm7 'header-unit warm build'
+Require-UpToDate $warm7 'main.cpp' 'header-unit warm build'
 Start-Sleep -Milliseconds 100
 Write-Utf8 (Join-Path $case7 'high/util.hpp') @('inline int header_value() { return 32; }')
-$case7Shadow = Invoke-Mqb $case7 $case7Args
-Require-Success $case7Shadow 'header-unit higher-priority shadow build'
-Require-Compile $case7Shadow 'main.cpp' 'header-unit higher-priority shadow build'
-if ((Invoke-Program (Program-Path $case7 'header-unit-shadow')) -ne 32) {
-    throw 'header-unit resolution did not move to the newly higher-priority util.hpp'
-}
+$shadow7 = Invoke-MqbCase $case7 $args7
+Require-Success $shadow7 'header-unit higher-priority shadow build'
+Require-Compile $shadow7 'main.cpp' 'header-unit higher-priority shadow build'
+Require-ProgramExit (Program-Path $case7 'header-unit-shadow') 32 'header-unit higher-priority shadow build'
 
-# PCH creator + consumer coverage. The synthetic creator must stay warm when
-# unchanged, but a transitive include search reroute inside the forced PCH
-# header must rebuild the PCH and propagate rebuild to every consumer.
+# PCH creator + consumer: unchanged creator remains warm, transitive search
+# reroute rebuilds the PCH and propagates to its consumer.
 $casePch = New-CaseDirectory 'pch-shadow'
 New-Item -ItemType Directory -Force -Path (Join-Path $casePch 'high') | Out-Null
 New-Item -ItemType Directory -Force -Path (Join-Path $casePch 'low') | Out-Null
@@ -301,27 +250,21 @@ New-Item -ItemType Directory -Force -Path (Join-Path $casePch 'include') | Out-N
 Write-Utf8 (Join-Path $casePch 'low/pick.hpp') @('inline int pch_selected_value() { return 41; }')
 Write-Utf8 (Join-Path $casePch 'include/pch.hpp') @('#pragma once', '#include <pick.hpp>')
 Write-Utf8 (Join-Path $casePch 'main.cpp') @('int main() { return pch_selected_value(); }')
-$casePchArgs = @('build', 'main.cpp', '--release', '--no-discover', '--env', 'vs', '--pch', 'include/pch.hpp', '-I', 'high', '-I', 'low', '-o', 'pch-shadow')
-$casePchCold = Invoke-Mqb $casePch $casePchArgs
-Require-Success $casePchCold 'PCH include-search cold build'
-if ((Invoke-Program (Program-Path $casePch 'pch-shadow')) -ne 41) { throw 'PCH cold build did not use low/pick.hpp' }
-$casePchWarm = Invoke-Mqb $casePch $casePchArgs
-Require-Success $casePchWarm 'PCH include-search warm build'
-if ($casePchWarm.Text -notmatch '\[up-to-date\]\s+pch') {
-    throw "unchanged PCH creator did not remain warm:`n$($casePchWarm.Text)"
-}
-Require-UpToDate $casePchWarm 'main.cpp' 'PCH include-search warm build'
+$argsPch = @('build', 'main.cpp', '--release', '--no-discover', '--env', 'vs', '--pch', 'include/pch.hpp', '-I', 'high', '-I', 'low', '-o', 'pch-shadow')
+$coldPch = Invoke-MqbCase $casePch $argsPch
+Require-Success $coldPch 'PCH include-search cold build'
+Require-ProgramExit (Program-Path $casePch 'pch-shadow') 41 'PCH include-search cold build'
+$warmPch = Invoke-MqbCase $casePch $argsPch
+Require-Success $warmPch 'PCH include-search warm build'
+if ($warmPch.Text -notmatch '\[up-to-date\]\s+pch') { throw ('unchanged PCH creator did not remain warm:{0}{1}' -f [Environment]::NewLine, $warmPch.Text) }
+Require-UpToDate $warmPch 'main.cpp' 'PCH include-search warm build'
 Start-Sleep -Milliseconds 100
 Write-Utf8 (Join-Path $casePch 'high/pick.hpp') @('inline int pch_selected_value() { return 42; }')
-$casePchShadow = Invoke-Mqb $casePch $casePchArgs
-Require-Success $casePchShadow 'PCH higher-priority transitive shadow build'
-if ($casePchShadow.Text -notmatch '\[pch\]') {
-    throw "PCH transitive search reroute did not rebuild the creator:`n$($casePchShadow.Text)"
-}
-Require-Compile $casePchShadow 'main.cpp' 'PCH higher-priority transitive shadow build'
-if ((Invoke-Program (Program-Path $casePch 'pch-shadow')) -ne 42) {
-    throw 'PCH consumer did not observe newly higher-priority transitive header'
-}
+$shadowPch = Invoke-MqbCase $casePch $argsPch
+Require-Success $shadowPch 'PCH higher-priority transitive shadow build'
+if ($shadowPch.Text -notmatch '\[pch\]') { throw ('PCH transitive search reroute did not rebuild the creator:{0}{1}' -f [Environment]::NewLine, $shadowPch.Text) }
+Require-Compile $shadowPch 'main.cpp' 'PCH higher-priority transitive shadow build'
+Require-ProgramExit (Program-Path $casePch 'pch-shadow') 42 'PCH higher-priority transitive shadow build'
 
 Write-Host 'Include search resolution freshness checks passed: typed/native /I, removal, order, direct/nested quote and angle shadowing, P1689 reuse, header units, PCH creator/consumer, and zero-process no-op behavior.'
 exit 0

--- a/tests/native/verify_include_search_freshness.ps1
+++ b/tests/native/verify_include_search_freshness.ps1
@@ -1,0 +1,270 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$MqbPath,
+    [Parameter(Mandatory = $true)][string]$RepoRoot
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+$MqbPath = [System.IO.Path]::GetFullPath($MqbPath)
+$RepoRoot = [System.IO.Path]::GetFullPath($RepoRoot)
+if (-not (Test-Path -LiteralPath $MqbPath -PathType Leaf)) {
+    throw "MQB executable not found: $MqbPath"
+}
+
+$root = Join-Path $RepoRoot 'native-test-work/include-search-freshness'
+if (Test-Path -LiteralPath $root) {
+    Remove-Item -LiteralPath $root -Recurse -Force
+}
+New-Item -ItemType Directory -Force -Path $root | Out-Null
+
+function Write-Utf8 {
+    param(
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][string[]]$Lines
+    )
+    $parent = Split-Path -Parent $Path
+    if (-not [string]::IsNullOrWhiteSpace($parent)) {
+        New-Item -ItemType Directory -Force -Path $parent | Out-Null
+    }
+    Set-Content -LiteralPath $Path -Encoding utf8 -Value $Lines
+}
+
+function Invoke-Mqb {
+    param(
+        [Parameter(Mandatory = $true)][string]$WorkingDirectory,
+        [Parameter(Mandatory = $true)][string[]]$Arguments
+    )
+    Push-Location $WorkingDirectory
+    try {
+        $output = @(& $MqbPath @Arguments 2>&1)
+        $exitCode = $LASTEXITCODE
+    }
+    finally {
+        Pop-Location
+    }
+    [PSCustomObject]@{
+        ExitCode = $exitCode
+        Text = ($output -join [Environment]::NewLine)
+    }
+}
+
+function Require-Success {
+    param(
+        [Parameter(Mandatory = $true)]$Result,
+        [Parameter(Mandatory = $true)][string]$Description
+    )
+    if ($Result.ExitCode -ne 0) {
+        throw "$Description failed (exit $($Result.ExitCode)):`n$($Result.Text)"
+    }
+}
+
+function Require-Compile {
+    param(
+        [Parameter(Mandatory = $true)]$Result,
+        [Parameter(Mandatory = $true)][string]$Source,
+        [Parameter(Mandatory = $true)][string]$Description
+    )
+    if ($Result.Text -notmatch ("\[compile\]\s+" + [Regex]::Escape($Source))) {
+        throw "$Description did not compile $Source:`n$($Result.Text)"
+    }
+}
+
+function Require-UpToDate {
+    param(
+        [Parameter(Mandatory = $true)]$Result,
+        [Parameter(Mandatory = $true)][string]$Source,
+        [Parameter(Mandatory = $true)][string]$Description
+    )
+    if ($Result.Text -notmatch ("\[up-to-date\]\s+" + [Regex]::Escape($Source))) {
+        throw "$Description did not report $Source up-to-date:`n$($Result.Text)"
+    }
+    if ($Result.Text -match ("\[compile\]\s+" + [Regex]::Escape($Source))) {
+        throw "$Description launched an unnecessary compiler for $Source:`n$($Result.Text)"
+    }
+}
+
+function Invoke-Program {
+    param([Parameter(Mandatory = $true)][string]$Path)
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        throw "program output missing: $Path"
+    }
+    & $Path
+    return $LASTEXITCODE
+}
+
+function Program-Path {
+    param(
+        [Parameter(Mandatory = $true)][string]$Fixture,
+        [Parameter(Mandatory = $true)][string]$OutputName
+    )
+    return Join-Path $Fixture ".mqb/bin/$OutputName.exe"
+}
+
+function New-CaseDirectory {
+    param([Parameter(Mandatory = $true)][string]$Name)
+    $path = Join-Path $root $Name
+    New-Item -ItemType Directory -Force -Path $path | Out-Null
+    return $path
+}
+
+# 1 + 2. Higher-priority typed -I root gains a same-name angle header, then
+# the active higher-priority header is removed. Neither transition changes argv.
+$case1 = New-CaseDirectory 'typed-angle-shadow'
+$case1High = Join-Path $case1 'high'
+$case1Low = Join-Path $case1 'low'
+New-Item -ItemType Directory -Force -Path $case1High | Out-Null
+New-Item -ItemType Directory -Force -Path $case1Low | Out-Null
+Write-Utf8 (Join-Path $case1Low 'pick.hpp') @('inline int selected_value() { return 7; }')
+Write-Utf8 (Join-Path $case1 'main.cpp') @(
+    '#include <pick.hpp>',
+    'int main() { return selected_value(); }'
+)
+$case1Args = @('main.cpp', '--release', '--no-discover', '--env', 'vs', '-I', 'high', '-I', 'low', '-o', 'typed-angle')
+$case1Cold = Invoke-Mqb $case1 $case1Args
+Require-Success $case1Cold 'typed angle cold build'
+if ((Invoke-Program (Program-Path $case1 'typed-angle')) -ne 7) {
+    throw 'typed angle cold build did not resolve low/pick.hpp'
+}
+$case1Warm = Invoke-Mqb $case1 $case1Args
+Require-Success $case1Warm 'typed angle warm build'
+Require-UpToDate $case1Warm 'main.cpp' 'typed angle warm build'
+Start-Sleep -Milliseconds 50
+Write-Utf8 (Join-Path $case1High 'pick.hpp') @('inline int selected_value() { return 9; }')
+$case1Shadow = Invoke-Mqb $case1 $case1Args
+Require-Success $case1Shadow 'typed angle higher-priority shadow build'
+Require-Compile $case1Shadow 'main.cpp' 'typed angle higher-priority shadow build'
+if ((Invoke-Program (Program-Path $case1 'typed-angle')) -ne 9) {
+    throw 'new higher-priority typed -I header did not replace the cached low header'
+}
+Remove-Item -LiteralPath (Join-Path $case1High 'pick.hpp') -Force
+$case1Removed = Invoke-Mqb $case1 $case1Args
+Require-Success $case1Removed 'typed angle active-header removal build'
+Require-Compile $case1Removed 'main.cpp' 'typed angle active-header removal build'
+if ((Invoke-Program (Program-Path $case1 'typed-angle')) -ne 7) {
+    throw 'removing the active higher-priority header did not fall back to low/pick.hpp'
+}
+
+# 3. Include-directory order is compile identity and must invalidate even when
+# the directory contents themselves remain unchanged.
+$case3 = New-CaseDirectory 'include-order'
+New-Item -ItemType Directory -Force -Path (Join-Path $case3 'a') | Out-Null
+New-Item -ItemType Directory -Force -Path (Join-Path $case3 'b') | Out-Null
+Write-Utf8 (Join-Path $case3 'a/pick.hpp') @('inline int selected_value() { return 3; }')
+Write-Utf8 (Join-Path $case3 'b/pick.hpp') @('inline int selected_value() { return 4; }')
+Write-Utf8 (Join-Path $case3 'main.cpp') @('#include <pick.hpp>', 'int main() { return selected_value(); }')
+$case3AFirst = Invoke-Mqb $case3 @('main.cpp', '--release', '--no-discover', '--env', 'vs', '-I', 'a', '-I', 'b', '-o', 'order')
+Require-Success $case3AFirst 'include-order a-first build'
+if ((Invoke-Program (Program-Path $case3 'order')) -ne 3) { throw 'a-first include order was not honored' }
+$case3BFirst = Invoke-Mqb $case3 @('main.cpp', '--release', '--no-discover', '--env', 'vs', '-I', 'b', '-I', 'a', '-o', 'order')
+Require-Success $case3BFirst 'include-order b-first build'
+Require-Compile $case3BFirst 'main.cpp' 'include-order b-first build'
+if ((Invoke-Program (Program-Path $case3 'order')) -ne 4) { throw 'reordered include search path was not honored' }
+
+# 4. Quoted include resolution searches the source directory before /I. Adding
+# a source-adjacent same-name header must invalidate the cached /I resolution.
+$case4 = New-CaseDirectory 'quoted-shadow'
+New-Item -ItemType Directory -Force -Path (Join-Path $case4 'low') | Out-Null
+Write-Utf8 (Join-Path $case4 'low/pick.hpp') @('inline int selected_value() { return 5; }')
+Write-Utf8 (Join-Path $case4 'main.cpp') @('#include "pick.hpp"', 'int main() { return selected_value(); }')
+$case4Args = @('main.cpp', '--release', '--no-discover', '--env', 'vs', '-I', 'low', '-o', 'quoted')
+$case4Cold = Invoke-Mqb $case4 $case4Args
+Require-Success $case4Cold 'quoted cold build'
+if ((Invoke-Program (Program-Path $case4 'quoted')) -ne 5) { throw 'quoted cold build did not resolve low/pick.hpp' }
+$case4Warm = Invoke-Mqb $case4 $case4Args
+Require-Success $case4Warm 'quoted warm build'
+Require-UpToDate $case4Warm 'main.cpp' 'quoted warm build'
+Start-Sleep -Milliseconds 50
+Write-Utf8 (Join-Path $case4 'pick.hpp') @('inline int selected_value() { return 6; }')
+$case4Shadow = Invoke-Mqb $case4 $case4Args
+Require-Success $case4Shadow 'quoted source-directory shadow build'
+Require-Compile $case4Shadow 'main.cpp' 'quoted source-directory shadow build'
+if ((Invoke-Program (Program-Path $case4 'quoted')) -ne 6) { throw 'quoted source-directory shadow was not selected' }
+
+# 5. Native MSVC /I syntax participates in the same search freshness model;
+# this specifically covers raw passthrough roots rather than typed -I policy.
+$case5 = New-CaseDirectory 'native-angle-shadow'
+New-Item -ItemType Directory -Force -Path (Join-Path $case5 'high') | Out-Null
+New-Item -ItemType Directory -Force -Path (Join-Path $case5 'low') | Out-Null
+Write-Utf8 (Join-Path $case5 'low/pick.hpp') @('inline int selected_value() { return 11; }')
+Write-Utf8 (Join-Path $case5 'main.cpp') @('#include <pick.hpp>', 'int main() { return selected_value(); }')
+$case5Args = @('main.cpp', '--release', '--no-discover', '--env', 'vs', '/Ihigh', '/Ilow', '-o', 'native-angle')
+$case5Cold = Invoke-Mqb $case5 $case5Args
+Require-Success $case5Cold 'native /I angle cold build'
+if ((Invoke-Program (Program-Path $case5 'native-angle')) -ne 11) { throw 'native /I cold build did not resolve low/pick.hpp' }
+Start-Sleep -Milliseconds 50
+Write-Utf8 (Join-Path $case5 'high/pick.hpp') @('inline int selected_value() { return 12; }')
+$case5Shadow = Invoke-Mqb $case5 $case5Args
+Require-Success $case5Shadow 'native /I angle shadow build'
+Require-Compile $case5Shadow 'main.cpp' 'native /I angle shadow build'
+if ((Invoke-Program (Program-Path $case5 'native-angle')) -ne 12) { throw 'native /I search reroute did not select high/pick.hpp' }
+
+# 6 + 8. A named-module provider uses an angle header. The unchanged warm build
+# must reuse both P1689 metadata and compile caches; adding a higher-priority
+# header must rerun the scan and compile without any argv/source mutation.
+$case6 = New-CaseDirectory 'p1689-shadow'
+New-Item -ItemType Directory -Force -Path (Join-Path $case6 'high') | Out-Null
+New-Item -ItemType Directory -Force -Path (Join-Path $case6 'low') | Out-Null
+Write-Utf8 (Join-Path $case6 'low/config.hpp') @('#define MQB_VALUE 21')
+Write-Utf8 (Join-Path $case6 'math.ixx') @(
+    'module;',
+    '#include <config.hpp>',
+    'export module math;',
+    'export int module_value() { return MQB_VALUE; }'
+)
+Write-Utf8 (Join-Path $case6 'main.cpp') @('import math;', 'int main() { return module_value(); }')
+$case6Args = @('main.cpp', 'math.ixx', '--release', '--no-discover', '--env', 'vs', '--std', 'latest', '-I', 'high', '-I', 'low', '-o', 'p1689')
+$case6Cold = Invoke-Mqb $case6 $case6Args
+Require-Success $case6Cold 'P1689 cold build'
+if ((Invoke-Program (Program-Path $case6 'p1689')) -ne 21) { throw 'P1689 cold build did not use low/config.hpp' }
+$scanFile = Join-Path $case6 '.mqb/scan/math.ixx.json'
+if (-not (Test-Path -LiteralPath $scanFile -PathType Leaf)) { throw "P1689 scan artifact missing: $scanFile" }
+$scanColdTime = (Get-Item -LiteralPath $scanFile).LastWriteTimeUtc
+$case6Warm = Invoke-Mqb $case6 $case6Args
+Require-Success $case6Warm 'P1689 warm no-op build'
+Require-UpToDate $case6Warm 'math.ixx' 'P1689 warm no-op build'
+Require-UpToDate $case6Warm 'main.cpp' 'P1689 warm no-op build'
+$scanWarmTime = (Get-Item -LiteralPath $scanFile).LastWriteTimeUtc
+if ($scanWarmTime -ne $scanColdTime) {
+    throw 'unchanged modules no-op rewrote P1689 scan metadata, indicating an unnecessary scanner launch'
+}
+Start-Sleep -Milliseconds 100
+Write-Utf8 (Join-Path $case6 'high/config.hpp') @('#define MQB_VALUE 22')
+$case6Shadow = Invoke-Mqb $case6 $case6Args
+Require-Success $case6Shadow 'P1689 higher-priority shadow build'
+Require-Compile $case6Shadow 'math.ixx' 'P1689 higher-priority shadow build'
+$scanShadowTime = (Get-Item -LiteralPath $scanFile).LastWriteTimeUtc
+if ($scanShadowTime -le $scanWarmTime) {
+    throw 'higher-priority module header did not refresh P1689 scan metadata'
+}
+if ((Invoke-Program (Program-Path $case6 'p1689')) -ne 22) {
+    throw 'module rebuild did not observe the newly higher-priority config.hpp'
+}
+
+# 7. Header-unit source identity is discovered from P1689. A new higher-priority
+# angle header must therefore invalidate scan evidence, allocate/rebuild the new
+# header-unit provider, and rebuild its consumer.
+$case7 = New-CaseDirectory 'header-unit-shadow'
+New-Item -ItemType Directory -Force -Path (Join-Path $case7 'high') | Out-Null
+New-Item -ItemType Directory -Force -Path (Join-Path $case7 'low') | Out-Null
+Write-Utf8 (Join-Path $case7 'low/util.hpp') @('inline int header_value() { return 31; }')
+Write-Utf8 (Join-Path $case7 'main.cpp') @('import <util.hpp>;', 'int main() { return header_value(); }')
+$case7Args = @('main.cpp', '--release', '--env', 'vs', '--std', 'latest', '-I', 'high', '-I', 'low', '-o', 'header-unit-shadow')
+$case7Cold = Invoke-Mqb $case7 $case7Args
+Require-Success $case7Cold 'header-unit cold build'
+if ((Invoke-Program (Program-Path $case7 'header-unit-shadow')) -ne 31) { throw 'header-unit cold build did not use low/util.hpp' }
+$case7Warm = Invoke-Mqb $case7 $case7Args
+Require-Success $case7Warm 'header-unit warm build'
+Require-UpToDate $case7Warm 'main.cpp' 'header-unit warm build'
+Start-Sleep -Milliseconds 100
+Write-Utf8 (Join-Path $case7 'high/util.hpp') @('inline int header_value() { return 32; }')
+$case7Shadow = Invoke-Mqb $case7 $case7Args
+Require-Success $case7Shadow 'header-unit higher-priority shadow build'
+Require-Compile $case7Shadow 'main.cpp' 'header-unit higher-priority shadow build'
+if ((Invoke-Program (Program-Path $case7 'header-unit-shadow')) -ne 32) {
+    throw 'header-unit resolution did not move to the newly higher-priority util.hpp'
+}
+
+Write-Host 'Include search resolution freshness checks passed: typed/native /I, removal, order, quote/angle shadowing, P1689 reuse, header units, and zero-process no-op behavior.'
+exit 0

--- a/tests/native/verify_include_search_freshness.ps1
+++ b/tests/native/verify_include_search_freshness.ps1
@@ -266,5 +266,37 @@ if ((Invoke-Program (Program-Path $case7 'header-unit-shadow')) -ne 32) {
     throw 'header-unit resolution did not move to the newly higher-priority util.hpp'
 }
 
-Write-Host 'Include search resolution freshness checks passed: typed/native /I, removal, order, quote/angle shadowing, P1689 reuse, header units, and zero-process no-op behavior.'
+# PCH creator + consumer coverage. The synthetic creator must stay warm when
+# unchanged, but a transitive include search reroute inside the forced PCH
+# header must rebuild the PCH and propagate rebuild to every consumer.
+$casePch = New-CaseDirectory 'pch-shadow'
+New-Item -ItemType Directory -Force -Path (Join-Path $casePch 'high') | Out-Null
+New-Item -ItemType Directory -Force -Path (Join-Path $casePch 'low') | Out-Null
+New-Item -ItemType Directory -Force -Path (Join-Path $casePch 'include') | Out-Null
+Write-Utf8 (Join-Path $casePch 'low/pick.hpp') @('inline int pch_selected_value() { return 41; }')
+Write-Utf8 (Join-Path $casePch 'include/pch.hpp') @('#pragma once', '#include <pick.hpp>')
+Write-Utf8 (Join-Path $casePch 'main.cpp') @('int main() { return pch_selected_value(); }')
+$casePchArgs = @('build', 'main.cpp', '--release', '--no-discover', '--env', 'vs', '--pch', 'include/pch.hpp', '-I', 'high', '-I', 'low', '-o', 'pch-shadow')
+$casePchCold = Invoke-Mqb $casePch $casePchArgs
+Require-Success $casePchCold 'PCH include-search cold build'
+if ((Invoke-Program (Program-Path $casePch 'pch-shadow')) -ne 41) { throw 'PCH cold build did not use low/pick.hpp' }
+$casePchWarm = Invoke-Mqb $casePch $casePchArgs
+Require-Success $casePchWarm 'PCH include-search warm build'
+if ($casePchWarm.Text -notmatch '\[up-to-date\]\s+pch') {
+    throw "unchanged PCH creator did not remain warm:`n$($casePchWarm.Text)"
+}
+Require-UpToDate $casePchWarm 'main.cpp' 'PCH include-search warm build'
+Start-Sleep -Milliseconds 100
+Write-Utf8 (Join-Path $casePch 'high/pick.hpp') @('inline int pch_selected_value() { return 42; }')
+$casePchShadow = Invoke-Mqb $casePch $casePchArgs
+Require-Success $casePchShadow 'PCH higher-priority transitive shadow build'
+if ($casePchShadow.Text -notmatch '\[pch\]') {
+    throw "PCH transitive search reroute did not rebuild the creator:`n$($casePchShadow.Text)"
+}
+Require-Compile $casePchShadow 'main.cpp' 'PCH higher-priority transitive shadow build'
+if ((Invoke-Program (Program-Path $casePch 'pch-shadow')) -ne 42) {
+    throw 'PCH consumer did not observe newly higher-priority transitive header'
+}
+
+Write-Host 'Include search resolution freshness checks passed: typed/native /I, removal, order, quote/angle shadowing, P1689 reuse, header units, PCH creator/consumer, and zero-process no-op behavior.'
 exit 0

--- a/tests/native/verify_include_search_freshness.ps1
+++ b/tests/native/verify_include_search_freshness.ps1
@@ -182,6 +182,31 @@ Require-Success $case4Shadow 'quoted source-directory shadow build'
 Require-Compile $case4Shadow 'main.cpp' 'quoted source-directory shadow build'
 if ((Invoke-Program (Program-Path $case4 'quoted')) -ne 6) { throw 'quoted source-directory shadow was not selected' }
 
+# 4b. Quoted lookup also searches the directory of the including header. Keep
+# that candidate subdirectory present before the cold build so adding only the
+# same-name file later changes the nested directory mtime, not the outer root.
+$case4b = New-CaseDirectory 'nested-quoted-shadow'
+New-Item -ItemType Directory -Force -Path (Join-Path $case4b 'src/nested') | Out-Null
+New-Item -ItemType Directory -Force -Path (Join-Path $case4b 'low/nested') | Out-Null
+Write-Utf8 (Join-Path $case4b 'low/nested/pick.hpp') @('inline int nested_value() { return 51; }')
+Write-Utf8 (Join-Path $case4b 'src/outer.hpp') @('#pragma once', '#include "nested/pick.hpp"', 'inline int outer_value() { return nested_value(); }')
+Write-Utf8 (Join-Path $case4b 'main.cpp') @('#include "src/outer.hpp"', 'int main() { return outer_value(); }')
+$case4bArgs = @('main.cpp', '--release', '--no-discover', '--env', 'vs', '-I', 'low', '-o', 'nested-quoted')
+$case4bCold = Invoke-Mqb $case4b $case4bArgs
+Require-Success $case4bCold 'nested quoted cold build'
+if ((Invoke-Program (Program-Path $case4b 'nested-quoted')) -ne 51) { throw 'nested quoted cold build did not resolve low/nested/pick.hpp' }
+$case4bWarm = Invoke-Mqb $case4b $case4bArgs
+Require-Success $case4bWarm 'nested quoted warm build'
+Require-UpToDate $case4bWarm 'main.cpp' 'nested quoted warm build'
+Start-Sleep -Milliseconds 100
+Write-Utf8 (Join-Path $case4b 'src/nested/pick.hpp') @('inline int nested_value() { return 52; }')
+$case4bShadow = Invoke-Mqb $case4b $case4bArgs
+Require-Success $case4bShadow 'nested quoted header-directory shadow build'
+Require-Compile $case4bShadow 'main.cpp' 'nested quoted header-directory shadow build'
+if ((Invoke-Program (Program-Path $case4b 'nested-quoted')) -ne 52) {
+    throw 'nested quoted include did not move to the including-header directory'
+}
+
 # 5. Native MSVC /I syntax participates in the same search freshness model;
 # this specifically covers raw passthrough roots rather than typed -I policy.
 $case5 = New-CaseDirectory 'native-angle-shadow'
@@ -298,5 +323,5 @@ if ((Invoke-Program (Program-Path $casePch 'pch-shadow')) -ne 42) {
     throw 'PCH consumer did not observe newly higher-priority transitive header'
 }
 
-Write-Host 'Include search resolution freshness checks passed: typed/native /I, removal, order, quote/angle shadowing, P1689 reuse, header units, PCH creator/consumer, and zero-process no-op behavior.'
+Write-Host 'Include search resolution freshness checks passed: typed/native /I, removal, order, direct/nested quote and angle shadowing, P1689 reuse, header units, PCH creator/consumer, and zero-process no-op behavior.'
 exit 0


### PR DESCRIPTION
## Final Closure #1 — Include Search Resolution Freshness

Closes the P0 warm-cache correctness hole where unchanged source/argv/old dependencies could reuse an object or P1689 topology after MSVC include resolution changed.

### Correctness model

- persists the exact ordered normalized MSVC include-root identity in compile-cache format v4: typed include directories, native `/I` / `-I` / `/external:I`, and vcvars `INCLUDE` unless `/X` disables environment search
- seals include-search directory namespace freshness into the existing compile dependency evidence after successful `/sourceDependencies`
- watches higher-priority candidate namespaces, including deepest existing ancestors when a nested candidate directory does not exist yet
- covers quoted local search, nested quoted includes, macro/conservative include search, `__has_include`, and C++ Header Unit `import <...>` / `import "..."` operands while ignoring named-module imports
- seals the same directory evidence into P1689 scan reuse; ordinary compile, PCH creator/consumer, module consumer compile, and Header Unit compile share the incremental coordinator path
- bumps compile signature domain to `mqb.compile.signature.v5` and module-scan domain to `mqb.module-scan.signature.v2`, invalidating pre-closure evidence exactly once even when a valid new recipe has zero include roots / zero directory evidence
- keeps warm validation metadata-only: no `cl.exe`, preprocessor, or dependency scanner is launched on a valid no-op hit

### Real-MSVC regression coverage

`tests/native/verify_include_search_freshness.ps1` plus `verify_has_include_freshness.ps1` cover:

1. higher-priority typed `-I` gains a same-name header
2. active higher-priority header is removed and resolution falls back
3. include-directory order changes
4. quoted source-directory shadowing
5. nested quoted include shadowing
6. native MSVC `/I` angle-include shadowing
7. P1689 warm-scan invalidation/reuse
8. Header Unit import resolution moving to the newly higher-priority header
9. PCH creator/consumer freshness
10. nested `__has_include` absent → present
11. unchanged ordinary/modules no-op stays compiler/scanner-free
12. linker side-output creation does not self-invalidate the compile cache

### Performance closure

The first correct implementation exposed unnecessary warm-path filesystem work. Final head removes filesystem-equivalence probes from include-root identity construction and uses one mtime probe for file-or-directory freshness evidence while retaining strict regular-file checks for source/output artifacts.

Exact PR base `37875614f29a2837296dc16a28fc5c9cd512bc03` vs final head `b0240ba3add1300f5df69d8da4019a4dfb0fdd6f`, same Windows runner, 5-sample medians:

| Scenario | Base | Final | Delta |
|---|---:|---:|---:|
| no-op | 5.10 ms | 5.80 ms | +0.70 ms (+13.76%) |
| modules-no-op | 5.78 ms | 5.99 ms | +0.22 ms (+3.76%) |
| discovery-no-op | 5.71 ms | 7.29 ms | +1.58 ms (+27.68%) |
| single-tu | 110.31 ms | 106.62 ms | -3.69 ms (-3.34%) |
| public-header | 114.56 ms | 124.47 ms | +9.92 ms (+8.66%) |

For comparison, the pre-optimization correct implementation regressed `no-op` by +4.43 ms and `modules-no-op` by +4.50 ms; those obvious fast-path regressions are removed in the final head.

### Final gates

- Performance Evidence run `31931720493`: SUCCESS
- Native C++ run `31931720504`: Debug build, targeted real-MSVC checks, exact parameter inventory, all 4 test shards, and final gate: SUCCESS
- Native Release run `31931720502`: Stage 0 Release build, all 4 Release shards, Stage 0 → Stage 1 → Stage 2 MQB-native self-host closure, exact runtime-only package validation: SUCCESS
- unresolved review threads: none

### Correctness policy

This remains deliberately conservative where required: a watched namespace mutation may trade a cache hit for a rebuild, but MQB must not reuse an object or module topology after MSVC's first-match include resolution could have changed.