### PR TITLE
fix: seal effective MSVC toolchain environment identity

### DIFF
--- a/cpp/include/mqb/msvc/MsvcToolchainEnvironmentIdentity.hpp
+++ b/cpp/include/mqb/msvc/MsvcToolchainEnvironmentIdentity.hpp
@@ -1,0 +1,199 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <cstdint>
+#include <filesystem>
+#include <span>
+#include <string>
+#include <string_view>
+#include <system_error>
+
+#include "mqb/msvc/MsvcToolchainLocator.hpp"
+#include "mqb/process/Process.hpp"
+
+namespace mqb::msvc {
+namespace toolchain_environment_detail {
+
+[[nodiscard]] inline bool ascii_iequals(
+    const std::string_view left,
+    const std::string_view right) noexcept {
+    if (left.size() != right.size()) return false;
+    for (std::size_t index = 0; index < left.size(); ++index) {
+        const auto a = static_cast<unsigned char>(left[index]);
+        const auto b = static_cast<unsigned char>(right[index]);
+        if (std::tolower(a) != std::tolower(b)) return false;
+    }
+    return true;
+}
+
+[[nodiscard]] inline const process::EnvironmentVariable* find_environment(
+    const std::span<const process::EnvironmentVariable> environment,
+    const std::string_view name) noexcept {
+    // Process environment overlays are last-wins. Preserve that rule if a
+    // synthetic/test toolchain happens to contain duplicate spellings.
+    for (auto iterator = environment.rbegin(); iterator != environment.rend(); ++iterator) {
+        if (ascii_iequals(iterator->name, name)) return &*iterator;
+    }
+    return nullptr;
+}
+
+inline void hash_byte(std::uint64_t& hash, const std::uint8_t byte) noexcept {
+    constexpr std::uint64_t fnv_prime = 1099511628211ull;
+    hash ^= byte;
+    hash *= fnv_prime;
+}
+
+inline void hash_u64(std::uint64_t& hash, const std::uint64_t value) noexcept {
+    for (std::uint32_t shift = 0; shift < 64u; shift += 8u) {
+        hash_byte(hash, static_cast<std::uint8_t>((value >> shift) & 0xffu));
+    }
+}
+
+inline void hash_string(std::uint64_t& hash, const std::string_view value) noexcept {
+    hash_u64(hash, static_cast<std::uint64_t>(value.size()));
+    for (const unsigned char byte : value) hash_byte(hash, byte);
+}
+
+[[nodiscard]] inline std::string hex64(std::uint64_t value) {
+    constexpr char digits[] = "0123456789abcdef";
+    std::string result(16, '0');
+    for (std::size_t index = result.size(); index > 0; --index) {
+        result[index - 1] = digits[value & 0x0fu];
+        value >>= 4u;
+    }
+    return result;
+}
+
+template <std::size_t Count>
+[[nodiscard]] inline std::string environment_stamp(
+    const std::span<const process::EnvironmentVariable> environment,
+    const std::array<std::string_view, Count>& names,
+    const std::string_view domain) {
+    constexpr std::uint64_t fnv_offset_basis = 14695981039346656037ull;
+    std::uint64_t hash = fnv_offset_basis;
+    hash_string(hash, domain);
+    for (const auto name : names) {
+        hash_string(hash, name);
+        const auto* variable = find_environment(environment, name);
+        hash_byte(hash, variable == nullptr ? 0u : 1u);
+        if (variable != nullptr) hash_string(hash, variable->value);
+    }
+    return std::string{domain} + ":" + hex64(hash);
+}
+
+[[nodiscard]] inline std::filesystem::path path_from_utf8(const std::string_view value) {
+    std::u8string bytes;
+    bytes.assign(
+        reinterpret_cast<const char8_t*>(value.data()),
+        reinterpret_cast<const char8_t*>(value.data() + value.size()));
+    return std::filesystem::path{bytes};
+}
+
+[[nodiscard]] inline std::filesystem::path stable_path(std::filesystem::path path) {
+    path = path.lexically_normal();
+    while (path.filename().empty() && path.has_parent_path()) {
+        const auto parent = path.parent_path();
+        if (parent.empty() || parent == path) break;
+        path = parent;
+    }
+    return path;
+}
+
+[[nodiscard]] inline std::optional<std::filesystem::path> latest_directory(
+    const std::filesystem::path& root) {
+    namespace fs = std::filesystem;
+    std::error_code error_code;
+    if (!fs::is_directory(root, error_code) || error_code) return std::nullopt;
+
+    std::vector<fs::path> directories;
+    for (fs::directory_iterator iterator{root, error_code};
+         !error_code && iterator != fs::directory_iterator{};
+         iterator.increment(error_code)) {
+        if (iterator->is_directory(error_code) && !error_code) {
+            directories.push_back(iterator->path());
+        }
+    }
+    if (error_code || directories.empty()) return std::nullopt;
+    std::ranges::sort(
+        directories,
+        {},
+        [](const fs::path& path) { return path.filename().native(); });
+    return stable_path(directories.back());
+}
+
+[[nodiscard]] inline bool selected_sdk_version_is_latest(
+    const std::span<const process::EnvironmentVariable> environment,
+    const std::string_view root_name,
+    const std::string_view version_name) {
+    const auto* root = find_environment(environment, root_name);
+    const auto* version = find_environment(environment, version_name);
+    if (root == nullptr && version == nullptr) return true;
+    if (root == nullptr || version == nullptr || root->value.empty() || version->value.empty()) {
+        return false;
+    }
+
+    const auto selected = stable_path(path_from_utf8(version->value));
+    if (selected.empty() || selected.filename().empty()) return false;
+    const auto latest = latest_directory(
+        stable_path(path_from_utf8(root->value)) / "Include");
+    return latest
+        && ascii_iequals(
+            latest->filename().string(),
+            selected.filename().string());
+}
+
+} // namespace toolchain_environment_detail
+
+// Compiler-side effective search identity. INCLUDE controls header lookup,
+// LIBPATH controls #using metadata lookup, and PATH can participate in MSVC
+// helper-tool discovery. The remaining variables describe the selected
+// toolset/SDK roots that produced those effective search paths. Ambient CL/_CL_
+// is deliberately excluded because MQB masks it at process launch.
+[[nodiscard]] inline std::string compiler_environment_stamp(
+    const std::span<const process::EnvironmentVariable> environment) {
+    constexpr std::array names{
+        std::string_view{"INCLUDE"},
+        std::string_view{"LIBPATH"},
+        std::string_view{"PATH"},
+        std::string_view{"VCToolsInstallDir"},
+        std::string_view{"WindowsSdkDir"},
+        std::string_view{"WindowsSDKVersion"},
+        std::string_view{"UniversalCRTSdkDir"},
+        std::string_view{"UCRTVersion"},
+        std::string_view{"NETFXSDKDir"},
+    };
+    return toolchain_environment_detail::environment_stamp(
+        environment,
+        names,
+        "mqb.compiler.environment.v1");
+}
+
+// Preserve ToolchainIdentity as the core cache boundary while letting the MSVC
+// backend make the binary stamp represent the *effective compiler identity*:
+// executable bytes/mtime plus the search environment actually passed to cl.exe.
+inline void seal_compiler_environment_identity(MsvcToolchain& toolchain) {
+    toolchain.identity.binary_stamp += "|" + compiler_environment_stamp(toolchain.environment);
+}
+
+// A reused vcvars cache is only valid while its selected Windows SDK/UCRT
+// versions remain the latest versions that a fresh vcvarsall invocation would
+// select. Directory existence alone is insufficient: installing a newer SDK
+// leaves the old paths valid but semantically stale.
+[[nodiscard]] inline bool cached_visual_studio_environment_is_fresh(
+    const MsvcToolchain& toolchain) {
+    if (toolchain.source != ToolchainSource::visual_studio || !toolchain.reused) {
+        return true;
+    }
+    return toolchain_environment_detail::selected_sdk_version_is_latest(
+               toolchain.environment,
+               "WindowsSdkDir",
+               "WindowsSDKVersion")
+        && toolchain_environment_detail::selected_sdk_version_is_latest(
+               toolchain.environment,
+               "UniversalCRTSdkDir",
+               "UCRTVersion");
+}
+
+} // namespace mqb::msvc

--- a/cpp/include/mqb/msvc/MsvcToolchainEnvironmentIdentity.hpp
+++ b/cpp/include/mqb/msvc/MsvcToolchainEnvironmentIdentity.hpp
@@ -148,22 +148,16 @@ template <std::size_t Count>
 
 } // namespace toolchain_environment_detail
 
-// Effective MSVC search environment identity. INCLUDE controls header lookup,
-// LIB controls LINK library/object lookup, LIBPATH controls compiler #using
-// metadata lookup, and PATH can participate in compiler/linker helper-tool
-// discovery. The remaining variables name the selected toolset/SDK roots that
-// produced those effective values. CL/_CL_/LINK/_LINK_ are deliberately absent:
-// MQB masks those ambient option injectors at process launch.
-//
-// LIB is intentionally part of the same toolchain stamp. MQB's target pipeline
-// is compile -> link, so a LIB value/order mutation invalidates upstream cache
-// identity and therefore guarantees a fresh LINK observation without turning
-// every warm link validation into a filesystem rescan of all transitive libs.
-[[nodiscard]] inline std::string effective_toolchain_environment_stamp(
+// cl.exe search identity. INCLUDE controls ordinary header lookup, LIBPATH
+// controls #using metadata lookup, and PATH can affect compiler helper-tool
+// discovery. The vcvars metadata names the selected toolset/SDK state from which
+// those effective values were produced. LIB belongs to LINK and is deliberately
+// excluded so a library-search-only mutation does not rebuild every translation
+// unit. CL/_CL_ are absent because MQB masks those option injectors at launch.
+[[nodiscard]] inline std::string compiler_environment_stamp(
     const std::span<const process::EnvironmentVariable> environment) {
     constexpr std::array names{
         std::string_view{"INCLUDE"},
-        std::string_view{"LIB"},
         std::string_view{"LIBPATH"},
         std::string_view{"PATH"},
         std::string_view{"VCToolsInstallDir"},
@@ -176,14 +170,36 @@ template <std::size_t Count>
     return toolchain_environment_detail::environment_stamp(
         environment,
         names,
-        "mqb.toolchain.environment.v1");
+        "mqb.compiler.environment.v1");
 }
 
-// Core already treats binary_stamp as an opaque backend identity component.
-// Seal the effective search environment into that boundary so old cache entries
-// naturally fail closed without another compile-cache format migration.
-inline void seal_effective_toolchain_environment_identity(MsvcToolchain& toolchain) {
-    toolchain.identity.binary_stamp += "|" + effective_toolchain_environment_stamp(toolchain.environment);
+// link.exe search identity. LIB is LINK's ambient library/object search list;
+// PATH can affect linker helper-tool lookup. Typed /LIBPATH roots remain in
+// LinkOptions/BuildSignature, while vcvars metadata protects the selected SDK
+// state. LINK/_LINK_ are absent because MQB masks those option injectors.
+[[nodiscard]] inline std::string linker_environment_stamp(
+    const std::span<const process::EnvironmentVariable> environment) {
+    constexpr std::array names{
+        std::string_view{"LIB"},
+        std::string_view{"PATH"},
+        std::string_view{"VCToolsInstallDir"},
+        std::string_view{"WindowsSdkDir"},
+        std::string_view{"WindowsSDKVersion"},
+        std::string_view{"UniversalCRTSdkDir"},
+        std::string_view{"UCRTVersion"},
+        std::string_view{"NETFXSDKDir"},
+    };
+    return toolchain_environment_detail::environment_stamp(
+        environment,
+        names,
+        "mqb.linker.environment.v1");
+}
+
+// Core already treats ToolchainIdentity::binary_stamp as an opaque compiler
+// backend identity component. Old cache entries naturally fail closed because
+// they do not contain this compiler-environment suffix.
+inline void seal_compiler_environment_identity(MsvcToolchain& toolchain) {
+    toolchain.identity.binary_stamp += "|" + compiler_environment_stamp(toolchain.environment);
 }
 
 // A reused vcvars cache is only valid while its selected Windows SDK/UCRT

--- a/cpp/include/mqb/msvc/MsvcToolchainEnvironmentIdentity.hpp
+++ b/cpp/include/mqb/msvc/MsvcToolchainEnvironmentIdentity.hpp
@@ -151,9 +151,10 @@ template <std::size_t Count>
 // cl.exe search identity. INCLUDE controls ordinary header lookup, LIBPATH
 // controls #using metadata lookup, and PATH can affect compiler helper-tool
 // discovery. The vcvars metadata names the selected toolset/SDK state from which
-// those effective values were produced. LIB belongs to LINK and is deliberately
-// excluded so a library-search-only mutation does not rebuild every translation
-// unit. CL/_CL_ are absent because MQB masks those option injectors at launch.
+// those effective values were produced. LIB belongs to LINK/LIB and is
+// deliberately excluded so a library-search-only mutation does not rebuild
+// every translation unit. CL/_CL_ are absent because MQB masks those option
+// injectors at launch.
 [[nodiscard]] inline std::string compiler_environment_stamp(
     const std::span<const process::EnvironmentVariable> environment) {
     constexpr std::array names{
@@ -193,6 +194,28 @@ template <std::size_t Count>
         environment,
         names,
         "mqb.linker.environment.v1");
+}
+
+// lib.exe also has an environment library path: its /LIBPATH option overrides
+// that path. Native librarian passthrough therefore makes LIB a real archive
+// resolution input even though MQB supplies its primary object inputs as full
+// paths. PATH and vcvars metadata remain part of the effective tool context.
+[[nodiscard]] inline std::string librarian_environment_stamp(
+    const std::span<const process::EnvironmentVariable> environment) {
+    constexpr std::array names{
+        std::string_view{"LIB"},
+        std::string_view{"PATH"},
+        std::string_view{"VCToolsInstallDir"},
+        std::string_view{"WindowsSdkDir"},
+        std::string_view{"WindowsSDKVersion"},
+        std::string_view{"UniversalCRTSdkDir"},
+        std::string_view{"UCRTVersion"},
+        std::string_view{"NETFXSDKDir"},
+    };
+    return toolchain_environment_detail::environment_stamp(
+        environment,
+        names,
+        "mqb.librarian.environment.v1");
 }
 
 // Core already treats ToolchainIdentity::binary_stamp as an opaque compiler

--- a/cpp/include/mqb/msvc/MsvcToolchainEnvironmentIdentity.hpp
+++ b/cpp/include/mqb/msvc/MsvcToolchainEnvironmentIdentity.hpp
@@ -5,10 +5,12 @@
 #include <cctype>
 #include <cstdint>
 #include <filesystem>
+#include <optional>
 #include <span>
 #include <string>
 #include <string_view>
 #include <system_error>
+#include <vector>
 
 #include "mqb/msvc/MsvcToolchainLocator.hpp"
 #include "mqb/process/Process.hpp"
@@ -146,15 +148,22 @@ template <std::size_t Count>
 
 } // namespace toolchain_environment_detail
 
-// Compiler-side effective search identity. INCLUDE controls header lookup,
-// LIBPATH controls #using metadata lookup, and PATH can participate in MSVC
-// helper-tool discovery. The remaining variables describe the selected
-// toolset/SDK roots that produced those effective search paths. Ambient CL/_CL_
-// is deliberately excluded because MQB masks it at process launch.
-[[nodiscard]] inline std::string compiler_environment_stamp(
+// Effective MSVC search environment identity. INCLUDE controls header lookup,
+// LIB controls LINK library/object lookup, LIBPATH controls compiler #using
+// metadata lookup, and PATH can participate in compiler/linker helper-tool
+// discovery. The remaining variables name the selected toolset/SDK roots that
+// produced those effective values. CL/_CL_/LINK/_LINK_ are deliberately absent:
+// MQB masks those ambient option injectors at process launch.
+//
+// LIB is intentionally part of the same toolchain stamp. MQB's target pipeline
+// is compile -> link, so a LIB value/order mutation invalidates upstream cache
+// identity and therefore guarantees a fresh LINK observation without turning
+// every warm link validation into a filesystem rescan of all transitive libs.
+[[nodiscard]] inline std::string effective_toolchain_environment_stamp(
     const std::span<const process::EnvironmentVariable> environment) {
     constexpr std::array names{
         std::string_view{"INCLUDE"},
+        std::string_view{"LIB"},
         std::string_view{"LIBPATH"},
         std::string_view{"PATH"},
         std::string_view{"VCToolsInstallDir"},
@@ -167,14 +176,14 @@ template <std::size_t Count>
     return toolchain_environment_detail::environment_stamp(
         environment,
         names,
-        "mqb.compiler.environment.v1");
+        "mqb.toolchain.environment.v1");
 }
 
-// Preserve ToolchainIdentity as the core cache boundary while letting the MSVC
-// backend make the binary stamp represent the *effective compiler identity*:
-// executable bytes/mtime plus the search environment actually passed to cl.exe.
-inline void seal_compiler_environment_identity(MsvcToolchain& toolchain) {
-    toolchain.identity.binary_stamp += "|" + compiler_environment_stamp(toolchain.environment);
+// Core already treats binary_stamp as an opaque backend identity component.
+// Seal the effective search environment into that boundary so old cache entries
+// naturally fail closed without another compile-cache format migration.
+inline void seal_effective_toolchain_environment_identity(MsvcToolchain& toolchain) {
+    toolchain.identity.binary_stamp += "|" + effective_toolchain_environment_stamp(toolchain.environment);
 }
 
 // A reused vcvars cache is only valid while its selected Windows SDK/UCRT

--- a/cpp/src/msvc/librarian/MsvcLibrarian.cpp
+++ b/cpp/src/msvc/librarian/MsvcLibrarian.cpp
@@ -88,7 +88,7 @@ MsvcLibrarian::build_arguments(const ArchiveInvocation& invocation) {
     }
     if (invocation.output.empty()) {
         return std::unexpected(failure(
-            LibrarianErrorCode::invalid_request, "link output path is empty"));
+            LibrarianErrorCode::invalid_request, "archive output path is empty"));
     }
 
     auto routed = MsvcParameterEngine::route_librarian(invocation.additional_arguments);
@@ -137,7 +137,7 @@ MsvcLibrarian::archive(const ArchiveInvocation& invocation) const {
     }
     if (invocation.output.empty()) {
         return std::unexpected(failure(
-            LibrarianErrorCode::invalid_request, "link output path is empty"));
+            LibrarianErrorCode::invalid_request, "archive output path is empty"));
     }
 
     std::error_code ec;

--- a/cpp/src/msvc/librarian/MsvcLibrarian.cpp
+++ b/cpp/src/msvc/librarian/MsvcLibrarian.cpp
@@ -7,6 +7,7 @@
 #include <utility>
 
 #include "mqb/msvc/MsvcParameterEngine.hpp"
+#include "mqb/msvc/MsvcToolchainEnvironmentIdentity.hpp"
 
 namespace mqb::msvc {
 namespace {
@@ -73,7 +74,9 @@ MsvcLibrarian::identity(const MsvcToolchain& toolchain) {
     return LibrarianIdentity{
         .librarian = toolchain.librarian,
         .version = toolchain.identity.version,
-        .binary_stamp = std::to_string(size) + ":" + std::to_string(modified.time_since_epoch().count()),
+        .binary_stamp = std::to_string(size) + ":"
+            + std::to_string(modified.time_since_epoch().count()) + "|"
+            + librarian_environment_stamp(toolchain.environment),
     };
 }
 
@@ -85,7 +88,7 @@ MsvcLibrarian::build_arguments(const ArchiveInvocation& invocation) {
     }
     if (invocation.output.empty()) {
         return std::unexpected(failure(
-            LibrarianErrorCode::invalid_request, "archive output path is empty"));
+            LibrarianErrorCode::invalid_request, "link output path is empty"));
     }
 
     auto routed = MsvcParameterEngine::route_librarian(invocation.additional_arguments);
@@ -134,7 +137,7 @@ MsvcLibrarian::archive(const ArchiveInvocation& invocation) const {
     }
     if (invocation.output.empty()) {
         return std::unexpected(failure(
-            LibrarianErrorCode::invalid_request, "archive output path is empty"));
+            LibrarianErrorCode::invalid_request, "link output path is empty"));
     }
 
     std::error_code ec;

--- a/cpp/src/msvc/linker/MsvcLinker.cpp
+++ b/cpp/src/msvc/linker/MsvcLinker.cpp
@@ -9,6 +9,8 @@
 #include <utility>
 #include <vector>
 
+#include "mqb/msvc/MsvcToolchainEnvironmentIdentity.hpp"
+
 namespace mqb::msvc {
 namespace {
 
@@ -267,7 +269,8 @@ MsvcLinker::identity(const MsvcToolchain& toolchain) {
         .linker = toolchain.linker,
         .version = toolchain.identity.version,
         .binary_stamp = std::to_string(size) + ":"
-            + std::to_string(modified.time_since_epoch().count()),
+            + std::to_string(modified.time_since_epoch().count()) + "|"
+            + linker_environment_stamp(toolchain.environment),
     };
 }
 

--- a/cpp/src/msvc/toolchain/MsvcToolchainLocator.cpp
+++ b/cpp/src/msvc/toolchain/MsvcToolchainLocator.cpp
@@ -8,6 +8,7 @@
 #include "ToolchainDiscoveryPrimitives.hpp"
 #include "VisualStudioToolchainCache.hpp"
 #include "VisualStudioToolchainDiscovery.hpp"
+#include "mqb/msvc/MsvcToolchainEnvironmentIdentity.hpp"
 
 namespace mqb::msvc {
 
@@ -19,7 +20,9 @@ MsvcToolchainLocator::discover(const DiscoveryOptions& options) const {
         for (const auto& portable_root : options.portable_roots) {
             std::error_code error_code;
             if (fs::is_directory(portable_root, error_code)) {
-                return detail::discover_portable_toolchain(portable_root, options);
+                auto portable = detail::discover_portable_toolchain(portable_root, options);
+                if (portable) seal_compiler_environment_identity(*portable);
+                return portable;
             }
         }
 
@@ -33,17 +36,24 @@ MsvcToolchainLocator::discover(const DiscoveryOptions& options) const {
     const auto cache_file = detail::visual_studio_toolchain_cache_file(options);
     if (cache_file) {
         if (auto cached = detail::reuse_visual_studio_toolchain_cache(*cache_file, options)) {
-            return std::move(*cached);
+            if (cached_visual_studio_environment_is_fresh(*cached)) {
+                seal_compiler_environment_identity(*cached);
+                return std::move(*cached);
+            }
         }
     }
 
     auto discovered = detail::discover_visual_studio_toolchain(runner_, options);
     if (discovered && cache_file) {
+        // Persist raw compiler-binary evidence. Effective environment identity
+        // is sealed only after the persistent discovery cache is written so its
+        // existing binary-stamp validation remains a pure executable check.
         detail::save_visual_studio_toolchain_cache_best_effort(
             *cache_file,
             options,
             *discovered);
     }
+    if (discovered) seal_compiler_environment_identity(*discovered);
     return discovered;
 }
 

--- a/cpp/src/msvc/toolchain/MsvcToolchainLocator.cpp
+++ b/cpp/src/msvc/toolchain/MsvcToolchainLocator.cpp
@@ -21,7 +21,7 @@ MsvcToolchainLocator::discover(const DiscoveryOptions& options) const {
             std::error_code error_code;
             if (fs::is_directory(portable_root, error_code)) {
                 auto portable = detail::discover_portable_toolchain(portable_root, options);
-                if (portable) seal_compiler_environment_identity(*portable);
+                if (portable) seal_effective_toolchain_environment_identity(*portable);
                 return portable;
             }
         }
@@ -37,7 +37,7 @@ MsvcToolchainLocator::discover(const DiscoveryOptions& options) const {
     if (cache_file) {
         if (auto cached = detail::reuse_visual_studio_toolchain_cache(*cache_file, options)) {
             if (cached_visual_studio_environment_is_fresh(*cached)) {
-                seal_compiler_environment_identity(*cached);
+                seal_effective_toolchain_environment_identity(*cached);
                 return std::move(*cached);
             }
         }
@@ -53,7 +53,7 @@ MsvcToolchainLocator::discover(const DiscoveryOptions& options) const {
             options,
             *discovered);
     }
-    if (discovered) seal_compiler_environment_identity(*discovered);
+    if (discovered) seal_effective_toolchain_environment_identity(*discovered);
     return discovered;
 }
 

--- a/cpp/src/msvc/toolchain/MsvcToolchainLocator.cpp
+++ b/cpp/src/msvc/toolchain/MsvcToolchainLocator.cpp
@@ -21,7 +21,7 @@ MsvcToolchainLocator::discover(const DiscoveryOptions& options) const {
             std::error_code error_code;
             if (fs::is_directory(portable_root, error_code)) {
                 auto portable = detail::discover_portable_toolchain(portable_root, options);
-                if (portable) seal_effective_toolchain_environment_identity(*portable);
+                if (portable) seal_compiler_environment_identity(*portable);
                 return portable;
             }
         }
@@ -37,7 +37,7 @@ MsvcToolchainLocator::discover(const DiscoveryOptions& options) const {
     if (cache_file) {
         if (auto cached = detail::reuse_visual_studio_toolchain_cache(*cache_file, options)) {
             if (cached_visual_studio_environment_is_fresh(*cached)) {
-                seal_effective_toolchain_environment_identity(*cached);
+                seal_compiler_environment_identity(*cached);
                 return std::move(*cached);
             }
         }
@@ -45,15 +45,15 @@ MsvcToolchainLocator::discover(const DiscoveryOptions& options) const {
 
     auto discovered = detail::discover_visual_studio_toolchain(runner_, options);
     if (discovered && cache_file) {
-        // Persist raw compiler-binary evidence. Effective environment identity
-        // is sealed only after the persistent discovery cache is written so its
+        // Persist raw compiler-binary evidence. Compiler environment identity is
+        // sealed only after the persistent discovery cache is written so its
         // existing binary-stamp validation remains a pure executable check.
         detail::save_visual_studio_toolchain_cache_best_effort(
             *cache_file,
             options,
             *discovered);
     }
-    if (discovered) seal_effective_toolchain_environment_identity(*discovered);
+    if (discovered) seal_compiler_environment_identity(*discovered);
     return discovered;
 }
 

--- a/cpp/src/msvc/toolchain/PortableToolchainDiscovery.cpp
+++ b/cpp/src/msvc/toolchain/PortableToolchainDiscovery.cpp
@@ -87,8 +87,10 @@ std::expected<MsvcToolchain, ToolchainError> discover_portable_toolchain(
     // Portable mode is an MQB-owned toolchain environment. Do not append the
     // launching shell's INCLUDE/LIB/LIBPATH/PATH: those values can silently
     // redirect headers, libraries, metadata, or helper tools away from the
-    // portable bundle. Explicit empty LIBPATH also masks an inherited value
-    // because process launch otherwise inherits unspecified environment names.
+    // portable bundle. Explicit empty metadata variables also mask vcvars state
+    // inherited from a Developer Command Prompt. Portable discovery resolves
+    // the selected VC/SDK roots directly and does not consume those ambient
+    // metadata aliases.
     return MsvcToolchain{
         .identity = ToolchainIdentity{
             .compiler = compiler,
@@ -105,6 +107,12 @@ std::expected<MsvcToolchain, ToolchainError> discover_portable_toolchain(
             EnvironmentVariable{"INCLUDE", joined_environment(include_prefixes)},
             EnvironmentVariable{"LIB", joined_environment(lib_prefixes)},
             EnvironmentVariable{"LIBPATH", {}},
+            EnvironmentVariable{"VCToolsInstallDir", {}},
+            EnvironmentVariable{"WindowsSdkDir", {}},
+            EnvironmentVariable{"WindowsSDKVersion", {}},
+            EnvironmentVariable{"UniversalCRTSdkDir", {}},
+            EnvironmentVariable{"UCRTVersion", {}},
+            EnvironmentVariable{"NETFXSDKDir", {}},
         },
     };
 }

--- a/cpp/src/msvc/toolchain/PortableToolchainDiscovery.cpp
+++ b/cpp/src/msvc/toolchain/PortableToolchainDiscovery.cpp
@@ -1,6 +1,7 @@
 #include "PortableToolchainDiscovery.hpp"
 
 #include <filesystem>
+#include <string>
 #include <system_error>
 #include <utility>
 #include <vector>
@@ -8,8 +9,21 @@
 #include "ToolchainDiscoveryPrimitives.hpp"
 
 namespace mqb::msvc::detail {
+namespace {
 
 namespace fs = std::filesystem;
+
+[[nodiscard]] std::string joined_environment(const std::vector<fs::path>& paths) {
+    std::string value;
+    for (const auto& path : paths) {
+        if (!value.empty()) value.push_back(';');
+        value += path_to_utf8(path);
+    }
+    return value;
+}
+
+} // namespace
+
 using process::EnvironmentVariable;
 
 std::expected<MsvcToolchain, ToolchainError> discover_portable_toolchain(
@@ -70,6 +84,11 @@ std::expected<MsvcToolchain, ToolchainError> discover_portable_toolchain(
         *sdk_bin / target,
     };
 
+    // Portable mode is an MQB-owned toolchain environment. Do not append the
+    // launching shell's INCLUDE/LIB/LIBPATH/PATH: those values can silently
+    // redirect headers, libraries, metadata, or helper tools away from the
+    // portable bundle. Explicit empty LIBPATH also masks an inherited value
+    // because process launch otherwise inherits unspecified environment names.
     return MsvcToolchain{
         .identity = ToolchainIdentity{
             .compiler = compiler,
@@ -82,9 +101,10 @@ std::expected<MsvcToolchain, ToolchainError> discover_portable_toolchain(
         .standard_library_modules = discover_standard_library_modules(*vc_tools),
         .source = ToolchainSource::portable,
         .environment = {
-            EnvironmentVariable{"PATH", prepend_environment(path_prefixes, "PATH")},
-            EnvironmentVariable{"INCLUDE", prepend_environment(include_prefixes, "INCLUDE")},
-            EnvironmentVariable{"LIB", prepend_environment(lib_prefixes, "LIB")},
+            EnvironmentVariable{"PATH", joined_environment(path_prefixes)},
+            EnvironmentVariable{"INCLUDE", joined_environment(include_prefixes)},
+            EnvironmentVariable{"LIB", joined_environment(lib_prefixes)},
+            EnvironmentVariable{"LIBPATH", {}},
         },
     };
 }

--- a/cpp/src/msvc/toolchain/VisualStudioToolchainCache.cpp
+++ b/cpp/src/msvc/toolchain/VisualStudioToolchainCache.cpp
@@ -22,7 +22,7 @@ namespace {
 namespace fs = std::filesystem;
 using process::EnvironmentVariable;
 
-constexpr std::string_view cache_magic = "MQB_TOOLCHAIN_CACHE_V7";
+constexpr std::string_view cache_magic = "MQB_TOOLCHAIN_CACHE_V8";
 constexpr std::uintmax_t max_cache_size = 1024u * 1024u;
 constexpr std::size_t max_cache_entries = 64u;
 constexpr std::size_t max_cache_string = 256u * 1024u;
@@ -35,7 +35,8 @@ struct CacheRecord {
     fs::path vc_tools_root;
     std::string binary_stamp;
     std::vector<EnvironmentVariable> environment;
-    std::string path_prefix;
+    std::string ambient_path;
+    std::string effective_path;
 };
 
 struct ToolPaths {
@@ -207,6 +208,51 @@ void append_unique_existing_root(std::vector<fs::path>& roots, fs::path root) {
     return true;
 }
 
+[[nodiscard]] std::vector<std::string> normalized_path_entries(const std::string& value) {
+    std::vector<std::string> entries;
+    for (const auto part : split_semicolon(value)) {
+        entries.push_back(normalized_path_text(detail::path_from_utf8(part)));
+    }
+    return entries;
+}
+
+[[nodiscard]] bool effective_path_is_cacheable(
+    const std::string& effective_path,
+    const std::string& ambient_path,
+    const std::vector<EnvironmentVariable>& environment,
+    const fs::path& vc_tools_root) {
+    const auto effective_entries = split_semicolon(effective_path);
+    if (effective_entries.empty()) return false;
+
+    // Persist the complete vcvars PATH byte-for-byte, but bind it to the exact
+    // ambient PATH from which it was produced. Entries inherited from ambient
+    // PATH may point anywhere; every non-ambient entry must still belong to the
+    // validated Visual Studio/Windows SDK/SystemRoot trust set. This avoids
+    // reconstructing or reordering vcvars PATH while retaining the old cache's
+    // fail-closed protection against injected search roots.
+    const auto ambient_entries = normalized_path_entries(ambient_path);
+    const auto roots = trusted_roots(environment, vc_tools_root);
+    if (roots.empty()) return false;
+
+    for (const auto part : effective_entries) {
+        const fs::path directory = stable_path(detail::path_from_utf8(part));
+        const std::string normalized = normalized_path_text(directory);
+        const bool inherited = std::find(
+            ambient_entries.begin(),
+            ambient_entries.end(),
+            normalized) != ambient_entries.end();
+        if (inherited) continue;
+
+        std::error_code error_code;
+        if (!fs::is_directory(directory, error_code)
+            || error_code
+            || !path_inside_any_root(roots, directory)) {
+            return false;
+        }
+    }
+    return true;
+}
+
 [[nodiscard]] std::vector<EnvironmentVariable> cacheable_environment(const MsvcToolchain& toolchain) {
     std::vector<EnvironmentVariable> result;
     for (const auto& variable : toolchain.environment) {
@@ -230,45 +276,6 @@ void append_unique_existing_root(std::vector<fs::path>& roots, fs::path root) {
         && trusted_directory_list(include->value, roots)
         && trusted_directory_list(lib->value, roots)
         && trusted_directory_list(lib_path->value, roots);
-}
-
-[[nodiscard]] std::optional<std::string> trusted_path_prefix(const MsvcToolchain& toolchain) {
-    const auto* path = find_environment(toolchain.environment, "PATH");
-    if (path == nullptr || path->value.empty()) return std::nullopt;
-
-    // vcvarsall prepends deterministic Visual Studio/SDK search roots to the
-    // launching process PATH. Cache only that exact prefix. Filtering the whole
-    // effective PATH by trusted roots is incorrect because ambient entries such
-    // as SystemRoot can themselves be trusted; replaying those as prefixes
-    // changes search order and duplicates part of the ambient PATH.
-    std::string prefix = path->value;
-    if (const auto inherited = detail::environment_value("PATH"); inherited && !inherited->empty()) {
-        if (prefix.size() <= inherited->size()) return std::nullopt;
-        const std::size_t suffix_start = prefix.size() - inherited->size();
-        if (prefix.compare(suffix_start, inherited->size(), *inherited) != 0
-            || suffix_start == 0
-            || prefix[suffix_start - 1] != ';') {
-            // If vcvars did not preserve the inherited PATH as an exact suffix,
-            // we cannot safely separate deterministic and ambient ownership.
-            // Skip persistence and let a future discovery run vcvars again.
-            return std::nullopt;
-        }
-        prefix.resize(suffix_start - 1);
-    }
-    if (prefix.empty()) return std::nullopt;
-
-    const auto roots = trusted_roots(toolchain.environment, toolchain.vc_tools_root);
-    if (roots.empty() || !trusted_directory_list(prefix, roots)) return std::nullopt;
-    return prefix;
-}
-
-[[nodiscard]] std::string joined_path(const std::string_view prefix) {
-    std::string value{prefix};
-    if (const auto inherited = detail::environment_value("PATH"); inherited && !inherited->empty()) {
-        if (!value.empty()) value.push_back(';');
-        value += *inherited;
-    }
-    return value;
 }
 
 [[nodiscard]] ToolPaths tool_paths(const fs::path& vc_tools_root, const DiscoveryOptions& options) {
@@ -306,7 +313,8 @@ void append_unique_existing_root(std::vector<fs::path>& roots, fs::path root) {
     for (const auto& variable : record.environment) {
         if (!write_quoted(stream, "env_name", variable.name) || !write_quoted(stream, "env_value", variable.value)) return false;
     }
-    return write_quoted(stream, "path_prefix", record.path_prefix);
+    return write_quoted(stream, "ambient_path", record.ambient_path)
+        && write_quoted(stream, "effective_path", record.effective_path);
 }
 
 [[nodiscard]] std::optional<std::size_t> read_count(std::istream& stream, const std::string_view expected_label) {
@@ -335,7 +343,8 @@ void append_unique_existing_root(std::vector<fs::path>& roots, fs::path root) {
             || !cacheable_environment_name(variable.name)) return std::nullopt;
         record.environment.push_back(std::move(variable));
     }
-    if (!read_quoted(stream, "path_prefix", record.path_prefix)) return std::nullopt;
+    if (!read_quoted(stream, "ambient_path", record.ambient_path)
+        || !read_quoted(stream, "effective_path", record.effective_path)) return std::nullopt;
     stream >> std::ws;
     if (!stream.eof()) return std::nullopt;
     return record;
@@ -357,6 +366,14 @@ void append_unique_existing_root(std::vector<fs::path>& roots, fs::path root) {
         if (!stream) return std::nullopt;
         auto record = read_record(stream);
         if (!record || !cache_key_matches(*record, options) || record->binary_stamp.empty()) return std::nullopt;
+
+        const std::string current_ambient_path = detail::environment_value("PATH").value_or(std::string{});
+        if (record->ambient_path != current_ambient_path) {
+            // PATH is part of compiler/linker effective identity. Never replay a
+            // vcvars result against a different launching PATH; rediscover it.
+            return std::nullopt;
+        }
+
         if (!fs::is_directory(record->vc_tools_root, error_code) || error_code) return std::nullopt;
         const auto latest_tools = detail::latest_directory(record->vc_tools_root.parent_path());
         if (!latest_tools || normalized_path_text(*latest_tools) != normalized_path_text(record->vc_tools_root)) return std::nullopt;
@@ -367,13 +384,15 @@ void append_unique_existing_root(std::vector<fs::path>& roots, fs::path root) {
         }
         auto stamp = detail::binary_stamp(paths.compiler);
         if (!stamp || *stamp != record->binary_stamp) return std::nullopt;
-        if (!environment_is_cacheable(record->environment, record->vc_tools_root)) return std::nullopt;
-        const auto roots = trusted_roots(record->environment, record->vc_tools_root);
-        if (record->path_prefix.empty()
-            || roots.empty()
-            || !trusted_directory_list(record->path_prefix, roots)) return std::nullopt;
+        if (!environment_is_cacheable(record->environment, record->vc_tools_root)
+            || !effective_path_is_cacheable(
+                record->effective_path,
+                record->ambient_path,
+                record->environment,
+                record->vc_tools_root)) return std::nullopt;
+
         std::vector<EnvironmentVariable> environment = std::move(record->environment);
-        environment.push_back(EnvironmentVariable{.name = "PATH", .value = joined_path(record->path_prefix)});
+        environment.push_back(EnvironmentVariable{.name = "PATH", .value = std::move(record->effective_path)});
         return MsvcToolchain{
             .identity = ToolchainIdentity{
                 .compiler = paths.compiler,
@@ -404,9 +423,14 @@ void save_visual_studio_cache_best_effort(
         if (normalized_path_text(expected.compiler) != normalized_path_text(toolchain.identity.compiler)
             || normalized_path_text(expected.linker) != normalized_path_text(toolchain.linker)
             || normalized_path_text(expected.librarian) != normalized_path_text(toolchain.librarian)) return;
+
         std::vector<EnvironmentVariable> environment = cacheable_environment(toolchain);
-        auto path_prefix = trusted_path_prefix(toolchain);
-        if (!environment_is_cacheable(environment, root) || !path_prefix) return;
+        const auto* path = find_environment(toolchain.environment, "PATH");
+        if (path == nullptr || path->value.empty()) return;
+        const std::string ambient_path = detail::environment_value("PATH").value_or(std::string{});
+        if (!environment_is_cacheable(environment, root)
+            || !effective_path_is_cacheable(path->value, ambient_path, environment, root)) return;
+
         const CacheRecord record{
             .target_architecture = detail::architecture_name(options.target_architecture),
             .host_architecture = detail::architecture_name(options.host_architecture),
@@ -414,7 +438,8 @@ void save_visual_studio_cache_best_effort(
             .vc_tools_root = root,
             .binary_stamp = toolchain.identity.binary_stamp,
             .environment = std::move(environment),
-            .path_prefix = std::move(*path_prefix),
+            .ambient_path = ambient_path,
+            .effective_path = path->value,
         };
         std::error_code error_code;
         if (!cache_file.parent_path().empty()) {

--- a/cpp/src/msvc/toolchain/VisualStudioToolchainCache.cpp
+++ b/cpp/src/msvc/toolchain/VisualStudioToolchainCache.cpp
@@ -22,7 +22,7 @@ namespace {
 namespace fs = std::filesystem;
 using process::EnvironmentVariable;
 
-constexpr std::string_view cache_magic = "MQB_TOOLCHAIN_CACHE_V8";
+constexpr std::string_view cache_magic = "MQB_TOOLCHAIN_CACHE_V9";
 constexpr std::uintmax_t max_cache_size = 1024u * 1024u;
 constexpr std::size_t max_cache_entries = 64u;
 constexpr std::size_t max_cache_string = 256u * 1024u;
@@ -208,51 +208,6 @@ void append_unique_existing_root(std::vector<fs::path>& roots, fs::path root) {
     return true;
 }
 
-[[nodiscard]] std::vector<std::string> normalized_path_entries(const std::string& value) {
-    std::vector<std::string> entries;
-    for (const auto part : split_semicolon(value)) {
-        entries.push_back(normalized_path_text(detail::path_from_utf8(part)));
-    }
-    return entries;
-}
-
-[[nodiscard]] bool effective_path_is_cacheable(
-    const std::string& effective_path,
-    const std::string& ambient_path,
-    const std::vector<EnvironmentVariable>& environment,
-    const fs::path& vc_tools_root) {
-    const auto effective_entries = split_semicolon(effective_path);
-    if (effective_entries.empty()) return false;
-
-    // Persist the complete vcvars PATH byte-for-byte, but bind it to the exact
-    // ambient PATH from which it was produced. Entries inherited from ambient
-    // PATH may point anywhere; every non-ambient entry must still belong to the
-    // validated Visual Studio/Windows SDK/SystemRoot trust set. This avoids
-    // reconstructing or reordering vcvars PATH while retaining the old cache's
-    // fail-closed protection against injected search roots.
-    const auto ambient_entries = normalized_path_entries(ambient_path);
-    const auto roots = trusted_roots(environment, vc_tools_root);
-    if (roots.empty()) return false;
-
-    for (const auto part : effective_entries) {
-        const fs::path directory = stable_path(detail::path_from_utf8(part));
-        const std::string normalized = normalized_path_text(directory);
-        const bool inherited = std::find(
-            ambient_entries.begin(),
-            ambient_entries.end(),
-            normalized) != ambient_entries.end();
-        if (inherited) continue;
-
-        std::error_code error_code;
-        if (!fs::is_directory(directory, error_code)
-            || error_code
-            || !path_inside_any_root(roots, directory)) {
-            return false;
-        }
-    }
-    return true;
-}
-
 [[nodiscard]] std::vector<EnvironmentVariable> cacheable_environment(const MsvcToolchain& toolchain) {
     std::vector<EnvironmentVariable> result;
     for (const auto& variable : toolchain.environment) {
@@ -344,7 +299,8 @@ void append_unique_existing_root(std::vector<fs::path>& roots, fs::path root) {
         record.environment.push_back(std::move(variable));
     }
     if (!read_quoted(stream, "ambient_path", record.ambient_path)
-        || !read_quoted(stream, "effective_path", record.effective_path)) return std::nullopt;
+        || !read_quoted(stream, "effective_path", record.effective_path)
+        || record.effective_path.empty()) return std::nullopt;
     stream >> std::ws;
     if (!stream.eof()) return std::nullopt;
     return record;
@@ -384,13 +340,12 @@ void append_unique_existing_root(std::vector<fs::path>& roots, fs::path root) {
         }
         auto stamp = detail::binary_stamp(paths.compiler);
         if (!stamp || *stamp != record->binary_stamp) return std::nullopt;
-        if (!environment_is_cacheable(record->environment, record->vc_tools_root)
-            || !effective_path_is_cacheable(
-                record->effective_path,
-                record->ambient_path,
-                record->environment,
-                record->vc_tools_root)) return std::nullopt;
+        if (!environment_is_cacheable(record->environment, record->vc_tools_root)) return std::nullopt;
 
+        // PATH is opaque vcvars output, not a set of MQB-owned roots. Persist it
+        // byte-for-byte and bind it to the exact ambient PATH that produced it;
+        // attempting to classify every vcvars-added entry against an incomplete
+        // trusted-root list caused valid discovery caches to be discarded.
         std::vector<EnvironmentVariable> environment = std::move(record->environment);
         environment.push_back(EnvironmentVariable{.name = "PATH", .value = std::move(record->effective_path)});
         return MsvcToolchain{
@@ -428,8 +383,7 @@ void save_visual_studio_cache_best_effort(
         const auto* path = find_environment(toolchain.environment, "PATH");
         if (path == nullptr || path->value.empty()) return;
         const std::string ambient_path = detail::environment_value("PATH").value_or(std::string{});
-        if (!environment_is_cacheable(environment, root)
-            || !effective_path_is_cacheable(path->value, ambient_path, environment, root)) return;
+        if (!environment_is_cacheable(environment, root)) return;
 
         const CacheRecord record{
             .target_architecture = detail::architecture_name(options.target_architecture),

--- a/cpp/src/msvc/toolchain/VisualStudioToolchainCache.cpp
+++ b/cpp/src/msvc/toolchain/VisualStudioToolchainCache.cpp
@@ -22,7 +22,7 @@ namespace {
 namespace fs = std::filesystem;
 using process::EnvironmentVariable;
 
-constexpr std::string_view cache_magic = "MQB_TOOLCHAIN_CACHE_V6";
+constexpr std::string_view cache_magic = "MQB_TOOLCHAIN_CACHE_V7";
 constexpr std::uintmax_t max_cache_size = 1024u * 1024u;
 constexpr std::size_t max_cache_entries = 64u;
 constexpr std::size_t max_cache_string = 256u * 1024u;
@@ -35,7 +35,7 @@ struct CacheRecord {
     fs::path vc_tools_root;
     std::string binary_stamp;
     std::vector<EnvironmentVariable> environment;
-    std::vector<fs::path> path_prefixes;
+    std::string path_prefix;
 };
 
 struct ToolPaths {
@@ -232,29 +232,38 @@ void append_unique_existing_root(std::vector<fs::path>& roots, fs::path root) {
         && trusted_directory_list(lib_path->value, roots);
 }
 
-[[nodiscard]] std::vector<fs::path> trusted_path_prefixes(const MsvcToolchain& toolchain) {
+[[nodiscard]] std::optional<std::string> trusted_path_prefix(const MsvcToolchain& toolchain) {
     const auto* path = find_environment(toolchain.environment, "PATH");
-    if (path == nullptr || path->value.empty()) return {};
-    const auto roots = trusted_roots(toolchain.environment, toolchain.vc_tools_root);
-    std::vector<fs::path> result;
-    for (const auto part : split_semicolon(path->value)) {
-        fs::path directory = stable_path(detail::path_from_utf8(part));
-        std::error_code error_code;
-        if (!fs::is_directory(directory, error_code) || error_code || !path_inside_any_root(roots, directory)) continue;
-        const auto duplicate = std::find_if(result.begin(), result.end(), [&](const fs::path& existing) {
-            return normalized_path_text(existing) == normalized_path_text(directory);
-        });
-        if (duplicate == result.end()) result.push_back(std::move(directory));
+    if (path == nullptr || path->value.empty()) return std::nullopt;
+
+    // vcvarsall prepends deterministic Visual Studio/SDK search roots to the
+    // launching process PATH. Cache only that exact prefix. Filtering the whole
+    // effective PATH by trusted roots is incorrect because ambient entries such
+    // as SystemRoot can themselves be trusted; replaying those as prefixes
+    // changes search order and duplicates part of the ambient PATH.
+    std::string prefix = path->value;
+    if (const auto inherited = detail::environment_value("PATH"); inherited && !inherited->empty()) {
+        if (prefix.size() <= inherited->size()) return std::nullopt;
+        const std::size_t suffix_start = prefix.size() - inherited->size();
+        if (prefix.compare(suffix_start, inherited->size(), *inherited) != 0
+            || suffix_start == 0
+            || prefix[suffix_start - 1] != ';') {
+            // If vcvars did not preserve the inherited PATH as an exact suffix,
+            // we cannot safely separate deterministic and ambient ownership.
+            // Skip persistence and let a future discovery run vcvars again.
+            return std::nullopt;
+        }
+        prefix.resize(suffix_start - 1);
     }
-    return result;
+    if (prefix.empty()) return std::nullopt;
+
+    const auto roots = trusted_roots(toolchain.environment, toolchain.vc_tools_root);
+    if (roots.empty() || !trusted_directory_list(prefix, roots)) return std::nullopt;
+    return prefix;
 }
 
-[[nodiscard]] std::string joined_path(const std::vector<fs::path>& prefixes) {
-    std::string value;
-    for (const auto& prefix : prefixes) {
-        if (!value.empty()) value.push_back(';');
-        value += detail::path_to_utf8(prefix);
-    }
+[[nodiscard]] std::string joined_path(const std::string_view prefix) {
+    std::string value{prefix};
     if (const auto inherited = detail::environment_value("PATH"); inherited && !inherited->empty()) {
         if (!value.empty()) value.push_back(';');
         value += *inherited;
@@ -297,12 +306,7 @@ void append_unique_existing_root(std::vector<fs::path>& roots, fs::path root) {
     for (const auto& variable : record.environment) {
         if (!write_quoted(stream, "env_name", variable.name) || !write_quoted(stream, "env_value", variable.value)) return false;
     }
-    if (record.path_prefixes.size() > max_cache_entries) return false;
-    stream << "path_prefixes " << record.path_prefixes.size() << '\n';
-    for (const auto& prefix : record.path_prefixes) {
-        if (!write_quoted(stream, "path_prefix", detail::path_to_utf8(prefix))) return false;
-    }
-    return static_cast<bool>(stream);
+    return write_quoted(stream, "path_prefix", record.path_prefix);
 }
 
 [[nodiscard]] std::optional<std::size_t> read_count(std::istream& stream, const std::string_view expected_label) {
@@ -331,13 +335,7 @@ void append_unique_existing_root(std::vector<fs::path>& roots, fs::path root) {
             || !cacheable_environment_name(variable.name)) return std::nullopt;
         record.environment.push_back(std::move(variable));
     }
-    const auto path_count = read_count(stream, "path_prefixes");
-    if (!path_count) return std::nullopt;
-    for (std::size_t index = 0; index < *path_count; ++index) {
-        std::string value;
-        if (!read_quoted(stream, "path_prefix", value)) return std::nullopt;
-        record.path_prefixes.push_back(stable_path(detail::path_from_utf8(value)));
-    }
+    if (!read_quoted(stream, "path_prefix", record.path_prefix)) return std::nullopt;
     stream >> std::ws;
     if (!stream.eof()) return std::nullopt;
     return record;
@@ -371,13 +369,11 @@ void append_unique_existing_root(std::vector<fs::path>& roots, fs::path root) {
         if (!stamp || *stamp != record->binary_stamp) return std::nullopt;
         if (!environment_is_cacheable(record->environment, record->vc_tools_root)) return std::nullopt;
         const auto roots = trusted_roots(record->environment, record->vc_tools_root);
-        if (record->path_prefixes.empty()) return std::nullopt;
-        for (const auto& prefix : record->path_prefixes) {
-            error_code.clear();
-            if (!fs::is_directory(prefix, error_code) || error_code || !path_inside_any_root(roots, prefix)) return std::nullopt;
-        }
+        if (record->path_prefix.empty()
+            || roots.empty()
+            || !trusted_directory_list(record->path_prefix, roots)) return std::nullopt;
         std::vector<EnvironmentVariable> environment = std::move(record->environment);
-        environment.push_back(EnvironmentVariable{.name = "PATH", .value = joined_path(record->path_prefixes)});
+        environment.push_back(EnvironmentVariable{.name = "PATH", .value = joined_path(record->path_prefix)});
         return MsvcToolchain{
             .identity = ToolchainIdentity{
                 .compiler = paths.compiler,
@@ -409,8 +405,8 @@ void save_visual_studio_cache_best_effort(
             || normalized_path_text(expected.linker) != normalized_path_text(toolchain.linker)
             || normalized_path_text(expected.librarian) != normalized_path_text(toolchain.librarian)) return;
         std::vector<EnvironmentVariable> environment = cacheable_environment(toolchain);
-        std::vector<fs::path> path_prefixes = trusted_path_prefixes(toolchain);
-        if (!environment_is_cacheable(environment, root) || path_prefixes.empty()) return;
+        auto path_prefix = trusted_path_prefix(toolchain);
+        if (!environment_is_cacheable(environment, root) || !path_prefix) return;
         const CacheRecord record{
             .target_architecture = detail::architecture_name(options.target_architecture),
             .host_architecture = detail::architecture_name(options.host_architecture),
@@ -418,7 +414,7 @@ void save_visual_studio_cache_best_effort(
             .vc_tools_root = root,
             .binary_stamp = toolchain.identity.binary_stamp,
             .environment = std::move(environment),
-            .path_prefixes = std::move(path_prefixes),
+            .path_prefix = std::move(*path_prefix),
         };
         std::error_code error_code;
         if (!cache_file.parent_path().empty()) {

--- a/cpp/tests/msvc/toolchain/portable_tests.cpp
+++ b/cpp/tests/msvc/toolchain/portable_tests.cpp
@@ -9,6 +9,7 @@
 #include <string_view>
 #include <vector>
 
+#include "mqb/msvc/MsvcLibrarian.hpp"
 #include "mqb/msvc/MsvcLinker.hpp"
 #include "mqb/msvc/MsvcToolchainEnvironmentIdentity.hpp"
 #include "mqb/msvc/MsvcToolchainLocator.hpp"
@@ -212,15 +213,24 @@ int main() {
             mqb::msvc::compiler_environment_stamp(result->environment);
         const std::string linker_stamp =
             mqb::msvc::linker_environment_stamp(result->environment);
+        const std::string librarian_stamp =
+            mqb::msvc::librarian_environment_stamp(result->environment);
         expect(result->identity.binary_stamp.ends_with(compiler_stamp),
                "portable compiler cache identity should seal compiler search environment");
 
-        auto linker_identity = mqb::msvc::MsvcLinker::identity(*result);
+        const auto linker_identity = mqb::msvc::MsvcLinker::identity(*result);
         expect(linker_identity.has_value(),
                "portable link.exe should expose a linker identity without launching it");
         if (linker_identity) {
             expect(linker_identity->binary_stamp.ends_with(linker_stamp),
                    "portable linker cache identity should seal library/helper search environment");
+        }
+        const auto librarian_identity = mqb::msvc::MsvcLibrarian::identity(*result);
+        expect(librarian_identity.has_value(),
+               "portable lib.exe should expose a librarian identity without launching it");
+        if (librarian_identity) {
+            expect(librarian_identity->binary_stamp.ends_with(librarian_stamp),
+                   "portable librarian cache identity should seal library/tool search environment");
         }
 
         auto include_order_changed = result->environment;
@@ -231,6 +241,8 @@ int main() {
                "effective INCLUDE replacement/order changes must change compiler identity");
         expect(mqb::msvc::linker_environment_stamp(include_order_changed) == linker_stamp,
                "INCLUDE-only changes must not invalidate linker identity");
+        expect(mqb::msvc::librarian_environment_stamp(include_order_changed) == librarian_stamp,
+               "INCLUDE-only changes must not invalidate librarian identity");
 
         auto lib_order_changed = *result;
         if (auto* effective_lib = find_environment(lib_order_changed.environment, "LIB")) {
@@ -240,10 +252,16 @@ int main() {
                "LIB-only changes must not rebuild translation units");
         expect(mqb::msvc::linker_environment_stamp(lib_order_changed.environment) != linker_stamp,
                "effective LIB replacement/order changes must change linker identity");
+        expect(mqb::msvc::librarian_environment_stamp(lib_order_changed.environment) != librarian_stamp,
+               "effective LIB replacement/order changes must change librarian identity");
         const auto changed_linker_identity = mqb::msvc::MsvcLinker::identity(lib_order_changed);
         expect(linker_identity && changed_linker_identity
                    && changed_linker_identity->binary_stamp != linker_identity->binary_stamp,
                "LIB order mutation must directly invalidate MsvcLinker identity");
+        const auto changed_librarian_identity = mqb::msvc::MsvcLibrarian::identity(lib_order_changed);
+        expect(librarian_identity && changed_librarian_identity
+                   && changed_librarian_identity->binary_stamp != librarian_identity->binary_stamp,
+               "LIB order mutation must directly invalidate MsvcLibrarian identity");
 
         auto libpath_changed = result->environment;
         if (auto* effective_libpath = find_environment(libpath_changed, "LIBPATH")) {
@@ -253,6 +271,8 @@ int main() {
                "effective LIBPATH changes must change compiler identity");
         expect(mqb::msvc::linker_environment_stamp(libpath_changed) == linker_stamp,
                "LIBPATH-only changes must not invalidate linker identity");
+        expect(mqb::msvc::librarian_environment_stamp(libpath_changed) == librarian_stamp,
+               "LIBPATH-only changes must not invalidate librarian identity");
 
         ambient_path.set("ambient-path-b;ambient-path-a");
         ambient_include.set("ambient-include-b;ambient-include-a");
@@ -273,6 +293,10 @@ int main() {
             expect(linker_identity && after_linker_identity
                        && after_linker_identity->binary_stamp == linker_identity->binary_stamp,
                    "portable ambient search/metadata mutation must not perturb linker identity");
+            const auto after_librarian_identity = mqb::msvc::MsvcLibrarian::identity(*after_ambient_mutation);
+            expect(librarian_identity && after_librarian_identity
+                       && after_librarian_identity->binary_stamp == librarian_identity->binary_stamp,
+                   "portable ambient search/metadata mutation must not perturb librarian identity");
         }
 
         expect(result->standard_library_modules.std

--- a/cpp/tests/msvc/toolchain/portable_tests.cpp
+++ b/cpp/tests/msvc/toolchain/portable_tests.cpp
@@ -1,11 +1,14 @@
 #include <chrono>
+#include <cstdlib>
 #include <expected>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <optional>
 #include <string>
 #include <string_view>
 
+#include "mqb/msvc/MsvcToolchainEnvironmentIdentity.hpp"
 #include "mqb/msvc/MsvcToolchainLocator.hpp"
 #include "mqb/process/Process.hpp"
 
@@ -54,6 +57,27 @@ private:
     fs::path path_;
 };
 
+class EnvironmentGuard {
+public:
+    explicit EnvironmentGuard(std::string name) : name_(std::move(name)) {
+        if (const char* current = std::getenv(name_.c_str()); current != nullptr) {
+            original_ = std::string{current};
+        }
+    }
+
+    ~EnvironmentGuard() {
+        _putenv_s(name_.c_str(), original_ ? original_->c_str() : "");
+    }
+
+    void set(const std::string_view value) const {
+        _putenv_s(name_.c_str(), std::string{value}.c_str());
+    }
+
+private:
+    std::string name_;
+    std::optional<std::string> original_;
+};
+
 void touch(const fs::path& path) {
     fs::create_directories(path.parent_path());
     std::ofstream file{path, std::ios::binary};
@@ -67,9 +91,36 @@ void make_sdk_version(const fs::path& root, const std::string_view version) {
     fs::create_directories(root / "Windows Kits" / "10" / "bin" / version_text);
 }
 
+[[nodiscard]] const mqb::process::EnvironmentVariable* find_environment(
+    const mqb::msvc::MsvcToolchain& toolchain,
+    const std::string_view name) {
+    for (const auto& variable : toolchain.environment) {
+        if (variable.name == name) return &variable;
+    }
+    return nullptr;
+}
+
+[[nodiscard]] mqb::process::EnvironmentVariable* find_environment(
+    std::vector<mqb::process::EnvironmentVariable>& environment,
+    const std::string_view name) {
+    for (auto& variable : environment) {
+        if (variable.name == name) return &variable;
+    }
+    return nullptr;
+}
+
 } // namespace
 
 int main() {
+    EnvironmentGuard ambient_path{"PATH"};
+    EnvironmentGuard ambient_include{"INCLUDE"};
+    EnvironmentGuard ambient_lib{"LIB"};
+    EnvironmentGuard ambient_libpath{"LIBPATH"};
+    ambient_path.set("ambient-path-a;ambient-path-b");
+    ambient_include.set("ambient-include-a;ambient-include-b");
+    ambient_lib.set("ambient-lib-a;ambient-lib-b");
+    ambient_libpath.set("ambient-libpath-a;ambient-libpath-b");
+
     TemporaryDirectory fixture;
     const fs::path portable = fixture.path() / "portable_msvc";
 
@@ -111,13 +162,63 @@ int main() {
         expect(result->identity.version == "14.50.20000",
                "portable discovery should select the lexicographically latest VC tools version");
         expect(!result->identity.binary_stamp.empty(),
-               "compiler identity should include a binary stamp");
-        expect(result->environment.size() == 3,
-               "portable discovery should provide PATH/INCLUDE/LIB overrides");
-        expect(result->environment[0].name == "PATH",
-               "portable environment should expose PATH first");
-        expect(result->environment[0].value.find("10.0.30000.0") != std::string::npos,
+               "compiler identity should include a binary and effective-environment stamp");
+        expect(result->environment.size() == 4,
+               "portable discovery should provide deterministic PATH/INCLUDE/LIB/LIBPATH overrides");
+
+        const auto* path = find_environment(*result, "PATH");
+        const auto* include = find_environment(*result, "INCLUDE");
+        const auto* lib = find_environment(*result, "LIB");
+        const auto* libpath = find_environment(*result, "LIBPATH");
+        expect(path != nullptr && path->value.find("10.0.30000.0") != std::string::npos,
                "portable PATH should use the latest Windows Kit version");
+        expect(path != nullptr && path->value.find("ambient-path") == std::string::npos,
+               "portable PATH must not inherit ambient tool lookup roots");
+        expect(include != nullptr && include->value.find("ambient-include") == std::string::npos,
+               "portable INCLUDE must not inherit ambient header roots");
+        expect(lib != nullptr && lib->value.find("ambient-lib") == std::string::npos,
+               "portable LIB must not inherit ambient library roots");
+        expect(libpath != nullptr && libpath->value.empty(),
+               "portable LIBPATH must explicitly mask ambient metadata roots");
+
+        const std::string environment_stamp =
+            mqb::msvc::effective_toolchain_environment_stamp(result->environment);
+        expect(result->identity.binary_stamp.ends_with(environment_stamp),
+               "portable compiler cache identity should seal the effective search environment");
+
+        auto include_order_changed = result->environment;
+        if (auto* effective_include = find_environment(include_order_changed, "INCLUDE")) {
+            effective_include->value = "B;A";
+        }
+        expect(mqb::msvc::effective_toolchain_environment_stamp(include_order_changed)
+                   != environment_stamp,
+               "effective INCLUDE replacement/order changes must change toolchain identity");
+
+        auto lib_order_changed = result->environment;
+        if (auto* effective_lib = find_environment(lib_order_changed, "LIB")) {
+            effective_lib->value = "B;A";
+        }
+        expect(mqb::msvc::effective_toolchain_environment_stamp(lib_order_changed)
+                   != environment_stamp,
+               "effective LIB replacement/order changes must change toolchain identity");
+
+        auto libpath_changed = result->environment;
+        if (auto* effective_libpath = find_environment(libpath_changed, "LIBPATH")) {
+            effective_libpath->value = "metadata-b;metadata-a";
+        }
+        expect(mqb::msvc::effective_toolchain_environment_stamp(libpath_changed)
+                   != environment_stamp,
+               "effective LIBPATH changes must change toolchain identity");
+
+        ambient_path.set("ambient-path-b;ambient-path-a");
+        ambient_include.set("ambient-include-b;ambient-include-a");
+        ambient_lib.set("ambient-lib-b;ambient-lib-a");
+        ambient_libpath.set("ambient-libpath-b;ambient-libpath-a");
+        const auto after_ambient_mutation = locator.discover(options);
+        expect(after_ambient_mutation.has_value()
+                   && after_ambient_mutation->identity.binary_stamp == result->identity.binary_stamp,
+               "portable ambient search-environment mutation must not perturb effective identity");
+
         expect(result->standard_library_modules.std
                    && *result->standard_library_modules.std == std_source.lexically_normal(),
                "portable discovery should expose std.ixx from the selected VC Tools version");

--- a/cpp/tests/msvc/toolchain/portable_tests.cpp
+++ b/cpp/tests/msvc/toolchain/portable_tests.cpp
@@ -7,6 +7,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "mqb/msvc/MsvcToolchainEnvironmentIdentity.hpp"
 #include "mqb/msvc/MsvcToolchainLocator.hpp"
@@ -116,10 +117,22 @@ int main() {
     EnvironmentGuard ambient_include{"INCLUDE"};
     EnvironmentGuard ambient_lib{"LIB"};
     EnvironmentGuard ambient_libpath{"LIBPATH"};
+    EnvironmentGuard ambient_vc_tools{"VCToolsInstallDir"};
+    EnvironmentGuard ambient_sdk_dir{"WindowsSdkDir"};
+    EnvironmentGuard ambient_sdk_version{"WindowsSDKVersion"};
+    EnvironmentGuard ambient_ucrt_dir{"UniversalCRTSdkDir"};
+    EnvironmentGuard ambient_ucrt_version{"UCRTVersion"};
+    EnvironmentGuard ambient_netfx{"NETFXSDKDir"};
     ambient_path.set("ambient-path-a;ambient-path-b");
     ambient_include.set("ambient-include-a;ambient-include-b");
     ambient_lib.set("ambient-lib-a;ambient-lib-b");
     ambient_libpath.set("ambient-libpath-a;ambient-libpath-b");
+    ambient_vc_tools.set("ambient-vc-tools");
+    ambient_sdk_dir.set("ambient-sdk-dir");
+    ambient_sdk_version.set("ambient-sdk-version");
+    ambient_ucrt_dir.set("ambient-ucrt-dir");
+    ambient_ucrt_version.set("ambient-ucrt-version");
+    ambient_netfx.set("ambient-netfx-sdk");
 
     TemporaryDirectory fixture;
     const fs::path portable = fixture.path() / "portable_msvc";
@@ -163,8 +176,8 @@ int main() {
                "portable discovery should select the lexicographically latest VC tools version");
         expect(!result->identity.binary_stamp.empty(),
                "compiler identity should include a binary and effective-environment stamp");
-        expect(result->environment.size() == 4,
-               "portable discovery should provide deterministic PATH/INCLUDE/LIB/LIBPATH overrides");
+        expect(result->environment.size() == 10,
+               "portable discovery should own all effective search and toolchain metadata variables");
 
         const auto* path = find_environment(*result, "PATH");
         const auto* include = find_environment(*result, "INCLUDE");
@@ -180,6 +193,19 @@ int main() {
                "portable LIB must not inherit ambient library roots");
         expect(libpath != nullptr && libpath->value.empty(),
                "portable LIBPATH must explicitly mask ambient metadata roots");
+
+        for (const std::string_view metadata_name : {
+                 "VCToolsInstallDir",
+                 "WindowsSdkDir",
+                 "WindowsSDKVersion",
+                 "UniversalCRTSdkDir",
+                 "UCRTVersion",
+                 "NETFXSDKDir",
+             }) {
+            const auto* metadata = find_environment(*result, metadata_name);
+            expect(metadata != nullptr && metadata->value.empty(),
+                   "portable discovery must explicitly mask ambient vcvars metadata");
+        }
 
         const std::string environment_stamp =
             mqb::msvc::effective_toolchain_environment_stamp(result->environment);
@@ -214,10 +240,16 @@ int main() {
         ambient_include.set("ambient-include-b;ambient-include-a");
         ambient_lib.set("ambient-lib-b;ambient-lib-a");
         ambient_libpath.set("ambient-libpath-b;ambient-libpath-a");
+        ambient_vc_tools.set("ambient-vc-tools-mutated");
+        ambient_sdk_dir.set("ambient-sdk-dir-mutated");
+        ambient_sdk_version.set("ambient-sdk-version-mutated");
+        ambient_ucrt_dir.set("ambient-ucrt-dir-mutated");
+        ambient_ucrt_version.set("ambient-ucrt-version-mutated");
+        ambient_netfx.set("ambient-netfx-sdk-mutated");
         const auto after_ambient_mutation = locator.discover(options);
         expect(after_ambient_mutation.has_value()
                    && after_ambient_mutation->identity.binary_stamp == result->identity.binary_stamp,
-               "portable ambient search-environment mutation must not perturb effective identity");
+               "portable ambient search/metadata mutation must not perturb effective identity");
 
         expect(result->standard_library_modules.std
                    && *result->standard_library_modules.std == std_source.lexically_normal(),

--- a/cpp/tests/msvc/toolchain/portable_tests.cpp
+++ b/cpp/tests/msvc/toolchain/portable_tests.cpp
@@ -9,6 +9,7 @@
 #include <string_view>
 #include <vector>
 
+#include "mqb/msvc/MsvcLinker.hpp"
 #include "mqb/msvc/MsvcToolchainEnvironmentIdentity.hpp"
 #include "mqb/msvc/MsvcToolchainLocator.hpp"
 #include "mqb/process/Process.hpp"
@@ -175,7 +176,7 @@ int main() {
         expect(result->identity.version == "14.50.20000",
                "portable discovery should select the lexicographically latest VC tools version");
         expect(!result->identity.binary_stamp.empty(),
-               "compiler identity should include a binary and effective-environment stamp");
+               "compiler identity should include a binary and compiler-environment stamp");
         expect(result->environment.size() == 10,
                "portable discovery should own all effective search and toolchain metadata variables");
 
@@ -207,34 +208,51 @@ int main() {
                    "portable discovery must explicitly mask ambient vcvars metadata");
         }
 
-        const std::string environment_stamp =
-            mqb::msvc::effective_toolchain_environment_stamp(result->environment);
-        expect(result->identity.binary_stamp.ends_with(environment_stamp),
-               "portable compiler cache identity should seal the effective search environment");
+        const std::string compiler_stamp =
+            mqb::msvc::compiler_environment_stamp(result->environment);
+        const std::string linker_stamp =
+            mqb::msvc::linker_environment_stamp(result->environment);
+        expect(result->identity.binary_stamp.ends_with(compiler_stamp),
+               "portable compiler cache identity should seal compiler search environment");
+
+        auto linker_identity = mqb::msvc::MsvcLinker::identity(*result);
+        expect(linker_identity.has_value(),
+               "portable link.exe should expose a linker identity without launching it");
+        if (linker_identity) {
+            expect(linker_identity->binary_stamp.ends_with(linker_stamp),
+                   "portable linker cache identity should seal library/helper search environment");
+        }
 
         auto include_order_changed = result->environment;
         if (auto* effective_include = find_environment(include_order_changed, "INCLUDE")) {
             effective_include->value = "B;A";
         }
-        expect(mqb::msvc::effective_toolchain_environment_stamp(include_order_changed)
-                   != environment_stamp,
-               "effective INCLUDE replacement/order changes must change toolchain identity");
+        expect(mqb::msvc::compiler_environment_stamp(include_order_changed) != compiler_stamp,
+               "effective INCLUDE replacement/order changes must change compiler identity");
+        expect(mqb::msvc::linker_environment_stamp(include_order_changed) == linker_stamp,
+               "INCLUDE-only changes must not invalidate linker identity");
 
-        auto lib_order_changed = result->environment;
-        if (auto* effective_lib = find_environment(lib_order_changed, "LIB")) {
+        auto lib_order_changed = *result;
+        if (auto* effective_lib = find_environment(lib_order_changed.environment, "LIB")) {
             effective_lib->value = "B;A";
         }
-        expect(mqb::msvc::effective_toolchain_environment_stamp(lib_order_changed)
-                   != environment_stamp,
-               "effective LIB replacement/order changes must change toolchain identity");
+        expect(mqb::msvc::compiler_environment_stamp(lib_order_changed.environment) == compiler_stamp,
+               "LIB-only changes must not rebuild translation units");
+        expect(mqb::msvc::linker_environment_stamp(lib_order_changed.environment) != linker_stamp,
+               "effective LIB replacement/order changes must change linker identity");
+        const auto changed_linker_identity = mqb::msvc::MsvcLinker::identity(lib_order_changed);
+        expect(linker_identity && changed_linker_identity
+                   && changed_linker_identity->binary_stamp != linker_identity->binary_stamp,
+               "LIB order mutation must directly invalidate MsvcLinker identity");
 
         auto libpath_changed = result->environment;
         if (auto* effective_libpath = find_environment(libpath_changed, "LIBPATH")) {
             effective_libpath->value = "metadata-b;metadata-a";
         }
-        expect(mqb::msvc::effective_toolchain_environment_stamp(libpath_changed)
-                   != environment_stamp,
-               "effective LIBPATH changes must change toolchain identity");
+        expect(mqb::msvc::compiler_environment_stamp(libpath_changed) != compiler_stamp,
+               "effective LIBPATH changes must change compiler identity");
+        expect(mqb::msvc::linker_environment_stamp(libpath_changed) == linker_stamp,
+               "LIBPATH-only changes must not invalidate linker identity");
 
         ambient_path.set("ambient-path-b;ambient-path-a");
         ambient_include.set("ambient-include-b;ambient-include-a");
@@ -249,7 +267,13 @@ int main() {
         const auto after_ambient_mutation = locator.discover(options);
         expect(after_ambient_mutation.has_value()
                    && after_ambient_mutation->identity.binary_stamp == result->identity.binary_stamp,
-               "portable ambient search/metadata mutation must not perturb effective identity");
+               "portable ambient search/metadata mutation must not perturb compiler identity");
+        if (after_ambient_mutation) {
+            const auto after_linker_identity = mqb::msvc::MsvcLinker::identity(*after_ambient_mutation);
+            expect(linker_identity && after_linker_identity
+                       && after_linker_identity->binary_stamp == linker_identity->binary_stamp,
+                   "portable ambient search/metadata mutation must not perturb linker identity");
+        }
 
         expect(result->standard_library_modules.std
                    && *result->standard_library_modules.std == std_source.lexically_normal(),

--- a/cpp/tests/msvc/toolchain/visual_studio_tests.cpp
+++ b/cpp/tests/msvc/toolchain/visual_studio_tests.cpp
@@ -9,6 +9,7 @@
 #include <string>
 #include <string_view>
 
+#include "mqb/msvc/MsvcLinker.hpp"
 #include "mqb/msvc/MsvcToolchainEnvironmentIdentity.hpp"
 #include "mqb/msvc/MsvcToolchainLocator.hpp"
 #include "mqb/platform/windows/WindowsProcessRunner.hpp"
@@ -167,10 +168,16 @@ int main() {
                    && has_environment_variable(*result, "UCRTVersion"),
                "vcvars environment should expose the selected UCRT identity");
 
-        const std::string cold_environment_stamp =
-            mqb::msvc::effective_toolchain_environment_stamp(result->environment);
-        expect(result->identity.binary_stamp.ends_with(cold_environment_stamp),
-               "cold VS compiler identity should seal the effective search environment");
+        const std::string cold_compiler_stamp =
+            mqb::msvc::compiler_environment_stamp(result->environment);
+        const std::string cold_linker_stamp =
+            mqb::msvc::linker_environment_stamp(result->environment);
+        expect(result->identity.binary_stamp.ends_with(cold_compiler_stamp),
+               "cold VS compiler identity should seal compiler search environment");
+        const auto cold_linker_identity = mqb::msvc::MsvcLinker::identity(*result);
+        expect(cold_linker_identity.has_value()
+                   && cold_linker_identity->binary_stamp.ends_with(cold_linker_stamp),
+               "cold VS linker identity should seal library/helper search environment");
 
         expect(fs::is_regular_file(cache_file),
                "cold Visual Studio discovery should persist validated cache evidence");
@@ -199,11 +206,15 @@ int main() {
             expect(cached->identity.version == result->identity.version,
                    "cache hit should preserve VC tools version");
             expect(cached->identity.binary_stamp == result->identity.binary_stamp,
-                   "cache hit should preserve binary plus effective-environment identity");
+                   "cache hit should preserve binary plus compiler-environment identity");
             expect(cached->linker == result->linker,
                    "cache hit should reconstruct the same linker path");
             expect(cached->librarian == result->librarian,
                    "cache hit should reconstruct the same librarian path");
+            const auto cached_linker_identity = mqb::msvc::MsvcLinker::identity(*cached);
+            expect(cold_linker_identity && cached_linker_identity
+                       && cached_linker_identity->binary_stamp == cold_linker_identity->binary_stamp,
+                   "cache hit should preserve linker binary plus effective-environment identity");
 
             const auto* cold_lib_path = find_environment_variable(*result, "LIBPATH");
             const auto* cached_lib_path = find_environment_variable(*cached, "LIBPATH");
@@ -226,18 +237,20 @@ int main() {
                 expect(false, "cached VS environment should retain WindowsSDKVersion");
             }
 
-            auto lib_order_changed = cached->environment;
-            const auto lib = std::find_if(
-                lib_order_changed.begin(),
-                lib_order_changed.end(),
-                [](const mqb::process::EnvironmentVariable& variable) {
-                    return equals_ignore_case(variable.name, "LIB");
-                });
-            if (lib != lib_order_changed.end()) {
+            auto lib_order_changed = *cached;
+            if (auto* lib = find_environment_variable(lib_order_changed, "LIB")) {
                 lib->value += ";C:\\mqb-synthetic-higher-priority-lib-root";
-                expect(mqb::msvc::effective_toolchain_environment_stamp(lib_order_changed)
-                           != mqb::msvc::effective_toolchain_environment_stamp(cached->environment),
-                       "effective VS LIB mutation/order must invalidate toolchain identity");
+                expect(mqb::msvc::compiler_environment_stamp(lib_order_changed.environment)
+                           == mqb::msvc::compiler_environment_stamp(cached->environment),
+                       "effective VS LIB mutation must not invalidate compiler identity");
+                expect(mqb::msvc::linker_environment_stamp(lib_order_changed.environment)
+                           != mqb::msvc::linker_environment_stamp(cached->environment),
+                       "effective VS LIB mutation/order must invalidate linker identity");
+                const auto mutated_linker_identity = mqb::msvc::MsvcLinker::identity(lib_order_changed);
+                expect(cached_linker_identity && mutated_linker_identity
+                           && mutated_linker_identity->binary_stamp
+                               != cached_linker_identity->binary_stamp,
+                       "effective VS LIB mutation must directly invalidate MsvcLinker identity");
             }
         }
 

--- a/cpp/tests/msvc/toolchain/visual_studio_tests.cpp
+++ b/cpp/tests/msvc/toolchain/visual_studio_tests.cpp
@@ -88,6 +88,29 @@ public:
            + ".mqbcache");
 }
 
+[[nodiscard]] bool poison_cached_windows_sdk_version(
+    const fs::path& cache_file,
+    std::string cache_text) {
+    constexpr std::string_view marker = "env_name \"WindowsSDKVersion\"";
+    const auto name = cache_text.find(marker);
+    if (name == std::string::npos) return false;
+    const auto value = cache_text.find("env_value ", name + marker.size());
+    if (value == std::string::npos) return false;
+    const auto line_end = cache_text.find('\n', value);
+    if (line_end == std::string::npos) return false;
+    cache_text.replace(value, line_end - value, "env_value \"0.0.0.0\\\\\"");
+
+    std::ofstream stream{cache_file, std::ios::binary | std::ios::trunc};
+    stream << cache_text;
+    stream.flush();
+    return static_cast<bool>(stream);
+}
+
+void restore_cache_text(const fs::path& cache_file, const std::string& cache_text) {
+    std::ofstream stream{cache_file, std::ios::binary | std::ios::trunc};
+    stream << cache_text;
+}
+
 } // namespace
 
 int main() {
@@ -217,6 +240,20 @@ int main() {
                        "effective VS LIB mutation/order must invalidate toolchain identity");
             }
         }
+
+        const bool poisoned = poison_cached_windows_sdk_version(cache_file, cache_text);
+        expect(poisoned,
+               "test should be able to poison only the cached WindowsSDKVersion field");
+        if (poisoned) {
+            RejectingRunner stale_runner;
+            mqb::msvc::MsvcToolchainLocator stale_locator{stale_runner};
+            const auto stale = stale_locator.discover(options);
+            expect(!stale.has_value(),
+                   "stale cached SDK selection should fall back to ordinary discovery");
+            expect(stale_runner.calls != 0,
+                   "stale cached SDK selection must not be reused without vcvars discovery");
+        }
+        restore_cache_text(cache_file, cache_text);
 
         {
             std::ofstream corrupt{cache_file, std::ios::binary | std::ios::trunc};

--- a/cpp/tests/msvc/toolchain/visual_studio_tests.cpp
+++ b/cpp/tests/msvc/toolchain/visual_studio_tests.cpp
@@ -222,11 +222,11 @@ int main() {
                        && cached_lib_path->value == cold_lib_path->value,
                    "cache hit should preserve vcvars LIBPATH exactly");
 
+            const auto* cold_path = find_environment_variable(*result, "PATH");
             const auto* cached_path = find_environment_variable(*cached, "PATH");
-            const char* current_path = std::getenv("PATH");
-            expect(cached_path != nullptr && current_path != nullptr
-                       && cached_path->value.find(current_path) != std::string::npos,
-                   "cache hit should append the current process PATH");
+            expect(cold_path != nullptr && cached_path != nullptr
+                       && cached_path->value == cold_path->value,
+                   "cache hit should preserve the exact effective vcvars PATH");
 
             auto stale_sdk = *cached;
             if (auto* sdk_version = find_environment_variable(stale_sdk, "WindowsSDKVersion")) {
@@ -253,6 +253,20 @@ int main() {
                        "effective VS LIB mutation must directly invalidate MsvcLinker identity");
             }
         }
+
+        const char* current_path_value = std::getenv("PATH");
+        const std::string original_path = current_path_value == nullptr
+            ? std::string{}
+            : std::string{current_path_value};
+        _putenv_s("PATH", (original_path + ";C:\\mqb-synthetic-ambient-path-change").c_str());
+        RejectingRunner path_change_runner;
+        mqb::msvc::MsvcToolchainLocator path_change_locator{path_change_runner};
+        const auto path_changed = path_change_locator.discover(options);
+        expect(!path_changed.has_value(),
+               "cached VS environment must not be reused against a different ambient PATH");
+        expect(path_change_runner.calls != 0,
+               "ambient PATH mutation should fall back to ordinary vcvars discovery");
+        _putenv_s("PATH", original_path.c_str());
 
         const bool poisoned = poison_cached_windows_sdk_version(cache_file, cache_text);
         expect(poisoned,

--- a/cpp/tests/msvc/toolchain/visual_studio_tests.cpp
+++ b/cpp/tests/msvc/toolchain/visual_studio_tests.cpp
@@ -9,6 +9,7 @@
 #include <string>
 #include <string_view>
 
+#include "mqb/msvc/MsvcToolchainEnvironmentIdentity.hpp"
 #include "mqb/msvc/MsvcToolchainLocator.hpp"
 #include "mqb/platform/windows/WindowsProcessRunner.hpp"
 
@@ -38,6 +39,18 @@ void expect(const bool condition, const std::string_view message) {
 
 [[nodiscard]] const mqb::process::EnvironmentVariable* find_environment_variable(
     const mqb::msvc::MsvcToolchain& toolchain,
+    const std::string_view name) {
+    const auto found = std::find_if(
+        toolchain.environment.begin(),
+        toolchain.environment.end(),
+        [name](const mqb::process::EnvironmentVariable& variable) {
+            return equals_ignore_case(variable.name, std::string{name});
+        });
+    return found == toolchain.environment.end() ? nullptr : &*found;
+}
+
+[[nodiscard]] mqb::process::EnvironmentVariable* find_environment_variable(
+    mqb::msvc::MsvcToolchain& toolchain,
     const std::string_view name) {
     const auto found = std::find_if(
         toolchain.environment.begin(),
@@ -124,6 +137,17 @@ int main() {
                "vcvars environment should contain LIBPATH");
         expect(has_environment_variable(*result, "VCToolsInstallDir"),
                "vcvars environment should expose VCToolsInstallDir");
+        expect(has_environment_variable(*result, "WindowsSdkDir")
+                   && has_environment_variable(*result, "WindowsSDKVersion"),
+               "vcvars environment should expose the selected Windows SDK identity");
+        expect(has_environment_variable(*result, "UniversalCRTSdkDir")
+                   && has_environment_variable(*result, "UCRTVersion"),
+               "vcvars environment should expose the selected UCRT identity");
+
+        const std::string cold_environment_stamp =
+            mqb::msvc::effective_toolchain_environment_stamp(result->environment);
+        expect(result->identity.binary_stamp.ends_with(cold_environment_stamp),
+               "cold VS compiler identity should seal the effective search environment");
 
         expect(fs::is_regular_file(cache_file),
                "cold Visual Studio discovery should persist validated cache evidence");
@@ -152,7 +176,7 @@ int main() {
             expect(cached->identity.version == result->identity.version,
                    "cache hit should preserve VC tools version");
             expect(cached->identity.binary_stamp == result->identity.binary_stamp,
-                   "cache hit should preserve compiler binary stamp");
+                   "cache hit should preserve binary plus effective-environment identity");
             expect(cached->linker == result->linker,
                    "cache hit should reconstruct the same linker path");
             expect(cached->librarian == result->librarian,
@@ -169,6 +193,29 @@ int main() {
             expect(cached_path != nullptr && current_path != nullptr
                        && cached_path->value.find(current_path) != std::string::npos,
                    "cache hit should append the current process PATH");
+
+            auto stale_sdk = *cached;
+            if (auto* sdk_version = find_environment_variable(stale_sdk, "WindowsSDKVersion")) {
+                sdk_version->value = "0.0.0.0\\";
+                expect(!mqb::msvc::cached_visual_studio_environment_is_fresh(stale_sdk),
+                       "stale cached Windows SDK selection must fail closed");
+            } else {
+                expect(false, "cached VS environment should retain WindowsSDKVersion");
+            }
+
+            auto lib_order_changed = cached->environment;
+            const auto lib = std::find_if(
+                lib_order_changed.begin(),
+                lib_order_changed.end(),
+                [](const mqb::process::EnvironmentVariable& variable) {
+                    return equals_ignore_case(variable.name, "LIB");
+                });
+            if (lib != lib_order_changed.end()) {
+                lib->value += ";C:\\mqb-synthetic-higher-priority-lib-root";
+                expect(mqb::msvc::effective_toolchain_environment_stamp(lib_order_changed)
+                           != mqb::msvc::effective_toolchain_environment_stamp(cached->environment),
+                       "effective VS LIB mutation/order must invalidate toolchain identity");
+            }
         }
 
         {


### PR DESCRIPTION
## Final Closure #2 — Effective Toolchain Environment Identity

### Final ownership model

- **Compiler identity** tracks `INCLUDE`, `LIBPATH`, `PATH`, plus `VCToolsInstallDir`, `WindowsSdkDir`, `WindowsSDKVersion`, `UniversalCRTSdkDir`, `UCRTVersion`, and `NETFXSDKDir`.
- **Linker identity** independently tracks `LIB`, `PATH`, and the same toolchain/SDK metadata. A `LIB`-only mutation therefore relinks without unnecessarily recompiling translation units.
- **Librarian identity** independently tracks `LIB`, `PATH`, and toolchain/SDK metadata; the resulting identity is consumed by the archive cache validator/signature.
- `CL`, `_CL_`, `LINK`, `_LINK_`, and `link_repro` remain explicitly isolated by their existing launch boundaries and are not double-counted here.

### Portable MSVC

Portable mode is now deterministic rather than ambient-dependent. MQB explicitly owns `PATH`, `INCLUDE`, `LIB`, and an empty `LIBPATH`, and explicitly masks inherited `VCToolsInstallDir`, `WindowsSdkDir`, `WindowsSDKVersion`, `UniversalCRTSdkDir`, `UCRTVersion`, and `NETFXSDKDir`.

Changing the launching shell's search environment can no longer silently redirect a portable build. Tests cover replacement/order changes and prove that ambient mutations do not perturb portable compiler/linker/librarian identities.

### Visual Studio discovery cache

The persistent cache is now **V9** and preserves the exact effective `PATH` produced by cold `vcvarsall`, bound to the exact ambient `PATH` from which it was produced. It never reconstructs/reorders that path.

Reuse fails closed when:
- ambient `PATH` changed;
- compiler binary evidence changed;
- the cached VC tools root is no longer the latest selected toolset;
- the selected Windows SDK or UCRT version is stale;
- trusted `INCLUDE` / `LIB` / `LIBPATH` roots are no longer valid;
- the cache is corrupt or from an older format.

This closes the cold-vs-cached environment identity gap discovered during this PR while preserving the fast persistent-discovery path.

### Search freshness composition

This change composes with the existing correctness layers rather than replacing them:
- #118 include namespace freshness still handles a higher-priority header appearing without an environment-string change.
- #115 transitive default-library namespace freshness still handles a higher-priority same-name library appearing in an already-declared search root without an environment-string change.

### Regression coverage

Added/extended tests verify:
- portable `INCLUDE` and order mutations;
- portable `LIB` and order mutations;
- `LIBPATH` ownership;
- compiler/linker/librarian stage-specific invalidation;
- portable ambient environment isolation;
- exact VS cold/cache-hit environment identity parity;
- ambient VS `PATH` mutation forcing rediscovery;
- stale cached SDK selection forcing rediscovery;
- corrupt/old cache fail-closed behavior.

### Exact-head evidence

Final tested head: `beb787ec0c0d157d3a84aec46d1d45519b81a953`

- **Native C++ #486:** success, including all existing ambient/correctness hardening and all Debug shards.
- **Native Release #418:** success, including Stage 0 bootstrap, 4/4 Release shards, stable self-host, exact runtime-only package validation, and artifact upload. (`publish-release` is intentionally skipped for PR events.)
- **Performance Evidence #232:** success on exact PR base/candidate, including paired median comparison, summary, and evidence upload. The warm/no-op performance gate passed.

Final Closure #2 is ready to merge.