### PR TITLE
fix: integrate first-class PCH with smart discovery

### DIFF
--- a/cpp/src/app/Application.cpp
+++ b/cpp/src/app/Application.cpp
@@ -222,6 +222,12 @@ int Application::run(const std::span<const std::string_view> arguments) {
             diagnostics::print_error(forced_includes.error().message);
             return 2;
         }
+        // First-class PCH remains typed MQB policy. Project only the compiler-visible
+        // forced-include semantic into discovery after raw /FI operands, matching
+        // the final cl.exe argument order without leaking /Yc, /Yu, or /Fp ownership.
+        if (effective.precompiled_header) {
+            forced_includes->push_back(effective.precompiled_header->lexically_normal());
+        }
 
         const fs::path& entry = requested_sources.front();
         const bool project_scoped = inside_project(project_root, entry);

--- a/cpp/tests/e2e/mqb_pch_e2e_tests.cpp
+++ b/cpp/tests/e2e/mqb_pch_e2e_tests.cpp
@@ -197,6 +197,224 @@ int main(const int argc, char* argv[]) {
         expect(fs::is_regular_file(pch_file), "repair should restore the owned .pch artifact");
     }
 
+    // Final Closure #4: smart discovery must observe the effective first-class
+    // PCH as compiler-visible forced-include semantics before source selection.
+    {
+        TempTree discovery_tree{
+            .root = fs::temp_directory_path()
+                / ("mqb_pch_discovery_e2e_" + std::to_string(unique)),
+        };
+        fs::create_directories(discovery_tree.root);
+
+        write_text(
+            discovery_tree.root / "pch.hpp",
+            "#pragma once\n"
+            "#include \"widget.hpp\"\n"
+            "#include \"nested/root.hpp\"\n");
+        write_text(discovery_tree.root / "widget.hpp", "#pragma once\nint widget_value();\n");
+        write_text(discovery_tree.root / "widget.cpp", "int widget_value() { return 20; }\n");
+        write_text(
+            discovery_tree.root / "nested/root.hpp",
+            "#pragma once\n"
+            "#include \"impl/deep.hpp\"\n");
+        write_text(
+            discovery_tree.root / "nested/impl/deep.hpp",
+            "#pragma once\nint deep_value();\n");
+        write_text(
+            discovery_tree.root / "nested/impl/deep.cpp",
+            "int deep_value() { return 22; }\n");
+        write_text(
+            discovery_tree.root / "unrelated.cpp",
+            "int unrelated_pch_discovery_value() { return 99; }\n");
+        write_text(
+            discovery_tree.root / "main.cpp",
+            "int main() { return widget_value() + deep_value() == 42 ? 0 : 1; }\n");
+
+        auto pch_only_reachable = run_process(
+            runner,
+            mqb_executable,
+            discovery_tree.root,
+            {"build", "main.cpp", "--env", "vs", "--debug",
+             "--pch", "pch.hpp", "--verbose", "-o", "pch_discovery"});
+        expect(pch_only_reachable.has_value(),
+               "PCH-aware smart-discovery build should launch");
+        if (pch_only_reachable) {
+            if (pch_only_reachable->exit_code != 0) dump_failure(*pch_only_reachable);
+            expect(pch_only_reachable->exit_code == 0,
+                   "PCH-only reachable implementation sources should build successfully");
+            expect(contains(*pch_only_reachable, "[discover] 3 translation units"),
+                   "PCH root plus nested include should select exactly main, widget, and deep TUs");
+            expect(contains(*pch_only_reachable, "widget.cpp"),
+                   "direct PCH-only header ownership should select widget.cpp");
+            expect(contains(*pch_only_reachable, "deep.cpp"),
+                   "nested include reachable only through PCH should select deep.cpp");
+            expect(!contains(*pch_only_reachable, "unrelated.cpp"),
+                   "PCH discovery root must not turn the indexed project into a global source hub");
+        }
+
+        write_text(discovery_tree.root / "alpha.hpp", "#pragma once\nint alpha_value();\n");
+        write_text(discovery_tree.root / "alpha.cpp", "int alpha_value() { return 1; }\n");
+        write_text(discovery_tree.root / "beta.hpp", "#pragma once\nint beta_value();\n");
+        write_text(discovery_tree.root / "beta.cpp", "int beta_value() { return 2; }\n");
+        write_text(discovery_tree.root / "raw.hpp", "#pragma once\nint raw_value();\n");
+        write_text(discovery_tree.root / "raw.cpp", "int raw_value() { return 3; }\n");
+        write_text(
+            discovery_tree.root / "base_pch.hpp",
+            "#pragma once\n#include \"alpha.hpp\"\n");
+        write_text(
+            discovery_tree.root / "profile_pch.hpp",
+            "#pragma once\n#include \"beta.hpp\"\n");
+        write_text(discovery_tree.root / "identity_main.cpp", "int main() { return 0; }\n");
+        write_text(
+            discovery_tree.root / "mqb.json",
+            R"json({
+  "version": 1,
+  "build": {
+    "pch": "base_pch.hpp"
+  },
+  "profiles": {
+    "alternate": {
+      "build": {
+        "pch": "profile_pch.hpp"
+      }
+    }
+  }
+})json");
+
+        auto base_discovery = run_process(
+            runner,
+            mqb_executable,
+            discovery_tree.root,
+            {"build", "identity_main.cpp", "--env", "vs", "--debug",
+             "--verbose", "-o", "pch_discovery_base"});
+        expect(base_discovery.has_value(), "base PCH discovery build should launch");
+        if (base_discovery) {
+            if (base_discovery->exit_code != 0) dump_failure(*base_discovery);
+            expect(base_discovery->exit_code == 0, "base PCH discovery build should succeed");
+            expect(contains(*base_discovery, "[discover] 2 translation units")
+                       && contains(*base_discovery, "alpha.cpp")
+                       && !contains(*base_discovery, "beta.cpp"),
+                   "base PCH should project alpha.hpp ownership, and only alpha.cpp, into discovery");
+        }
+
+        rewrite_after_tick(
+            discovery_tree.root / "base_pch.hpp",
+            "#pragma once\n#include \"beta.hpp\"\n");
+        auto changed_pch_discovery = run_process(
+            runner,
+            mqb_executable,
+            discovery_tree.root,
+            {"build", "identity_main.cpp", "--env", "vs", "--debug",
+             "--verbose", "-o", "pch_discovery_changed"});
+        expect(changed_pch_discovery.has_value(), "changed PCH discovery build should launch");
+        if (changed_pch_discovery) {
+            if (changed_pch_discovery->exit_code != 0) dump_failure(*changed_pch_discovery);
+            expect(changed_pch_discovery->exit_code == 0,
+                   "changing PCH include graph should rediscover successfully");
+            expect(contains(*changed_pch_discovery, "beta.cpp")
+                       && !contains(*changed_pch_discovery, "alpha.cpp"),
+                   "PCH content changes must alter selected source closure");
+        }
+
+        rewrite_after_tick(
+            discovery_tree.root / "base_pch.hpp",
+            "#pragma once\n#include \"alpha.hpp\"\n");
+        auto resealed_base_discovery = run_process(
+            runner,
+            mqb_executable,
+            discovery_tree.root,
+            {"build", "identity_main.cpp", "--env", "vs", "--debug",
+             "--verbose", "-o", "pch_discovery_resealed_base"});
+        expect(resealed_base_discovery.has_value(), "resealed base PCH discovery should launch");
+        if (resealed_base_discovery) {
+            if (resealed_base_discovery->exit_code != 0) dump_failure(*resealed_base_discovery);
+            expect(resealed_base_discovery->exit_code == 0
+                       && contains(*resealed_base_discovery, "alpha.cpp")
+                       && !contains(*resealed_base_discovery, "beta.cpp"),
+                   "base PCH closure should be resealed before path-identity regression check");
+        }
+
+        auto profile_discovery = run_process(
+            runner,
+            mqb_executable,
+            discovery_tree.root,
+            {"build", "identity_main.cpp", "--env", "vs", "--debug",
+             "--profile", "alternate", "--verbose", "-o", "pch_discovery_profile"});
+        expect(profile_discovery.has_value(), "profile PCH discovery build should launch");
+        if (profile_discovery) {
+            if (profile_discovery->exit_code != 0) dump_failure(*profile_discovery);
+            expect(profile_discovery->exit_code == 0, "profile PCH discovery build should succeed");
+            expect(contains(*profile_discovery, "beta.cpp")
+                       && !contains(*profile_discovery, "alpha.cpp"),
+                   "profile PCH overlay must change discovery and invalidate base-PCH cache identity");
+        }
+
+        auto no_pch_discovery = run_process(
+            runner,
+            mqb_executable,
+            discovery_tree.root,
+            {"build", "identity_main.cpp", "--env", "vs", "--debug",
+             "--profile", "alternate", "--no-pch", "--verbose",
+             "-o", "pch_discovery_off"});
+        expect(no_pch_discovery.has_value(), "--no-pch discovery build should launch");
+        if (no_pch_discovery) {
+            if (no_pch_discovery->exit_code != 0) dump_failure(*no_pch_discovery);
+            expect(no_pch_discovery->exit_code == 0, "--no-pch discovery build should succeed");
+            expect(contains(*no_pch_discovery, "[discover] 1 translation units")
+                       && !contains(*no_pch_discovery, "alpha.cpp")
+                       && !contains(*no_pch_discovery, "beta.cpp"),
+                   "CLI --no-pch must remove the inherited/profile forced discovery root");
+        }
+
+        auto raw_and_pch_discovery = run_process(
+            runner,
+            mqb_executable,
+            discovery_tree.root,
+            {"build", "identity_main.cpp", "--env", "vs", "--debug",
+             "--pch", "base_pch.hpp", "/FIraw.hpp", "--verbose",
+             "-o", "pch_discovery_raw_and_typed"});
+        expect(raw_and_pch_discovery.has_value(), "raw /FI + typed PCH discovery build should launch");
+        if (raw_and_pch_discovery) {
+            if (raw_and_pch_discovery->exit_code != 0) dump_failure(*raw_and_pch_discovery);
+            expect(raw_and_pch_discovery->exit_code == 0,
+                   "raw /FI and first-class PCH should coexist through smart discovery");
+            expect(contains(*raw_and_pch_discovery, "[discover] 3 translation units")
+                       && contains(*raw_and_pch_discovery, "alpha.cpp")
+                       && contains(*raw_and_pch_discovery, "raw.cpp"),
+                   "discovery must union raw /FI and MQB-owned PCH forced roots");
+        }
+    }
+
+    {
+        TempTree ordinary_tree{
+            .root = fs::temp_directory_path()
+                / ("mqb_no_pch_discovery_e2e_" + std::to_string(unique)),
+        };
+        fs::create_directories(ordinary_tree.root);
+        write_text(
+            ordinary_tree.root / "main.cpp",
+            "#include \"ordinary.hpp\"\nint main() { return ordinary_value() == 7 ? 0 : 1; }\n");
+        write_text(ordinary_tree.root / "ordinary.hpp", "#pragma once\nint ordinary_value();\n");
+        write_text(ordinary_tree.root / "ordinary.cpp", "int ordinary_value() { return 7; }\n");
+        write_text(ordinary_tree.root / "unrelated.cpp", "int unrelated_value() { return 0; }\n");
+
+        auto ordinary_discovery = run_process(
+            runner,
+            mqb_executable,
+            ordinary_tree.root,
+            {"build", "main.cpp", "--env", "vs", "--debug",
+             "--verbose", "-o", "ordinary_discovery"});
+        expect(ordinary_discovery.has_value(), "ordinary no-PCH discovery build should launch");
+        if (ordinary_discovery) {
+            if (ordinary_discovery->exit_code != 0) dump_failure(*ordinary_discovery);
+            expect(ordinary_discovery->exit_code == 0, "ordinary no-PCH discovery should remain valid");
+            expect(contains(*ordinary_discovery, "[discover] 2 translation units")
+                       && contains(*ordinary_discovery, "ordinary.cpp")
+                       && !contains(*ordinary_discovery, "unrelated.cpp"),
+                   "ordinary smart-discovery behavior must remain unchanged without PCH");
+        }
+    }
+
     // Exercise the project/profile/CLI scalar precedence through the real
     // candidate binary from a nested invocation directory. Config/profile PCH
     // paths must remain config-relative while CLI PCH paths remain invocation-relative.

--- a/cpp/tests/e2e/mqb_pch_e2e_tests.cpp
+++ b/cpp/tests/e2e/mqb_pch_e2e_tests.cpp
@@ -371,7 +371,7 @@ int main(const int argc, char* argv[]) {
             mqb_executable,
             discovery_tree.root,
             {"build", "identity_main.cpp", "--env", "vs", "--debug",
-             "--pch", "base_pch.hpp", "/FIraw.hpp", "--verbose",
+             "--pch", "base_pch.hpp", "/I.", "/FIraw.hpp", "--verbose",
              "-o", "pch_discovery_raw_and_typed"});
         expect(raw_and_pch_discovery.has_value(), "raw /FI + typed PCH discovery build should launch");
         if (raw_and_pch_discovery) {


### PR DESCRIPTION
## What changed

- Project the resolved first-class PCH header into smart discovery as effective forced-include semantics.
- Keep PCH typed/MQB-owned: no `/Yc`, `/Yu`, `/Fp`, or synthetic raw compiler argument is introduced into user compiler args.
- Preserve final compiler order by appending the typed PCH root after routed raw `/FI` operands.
- Reuse discovery cache v3 identity instead of bumping the format: the existing ordered forced-include vector already persists the required semantic, so ordinary no-PCH warm caches are not globally invalidated.

## Root cause

`prepare_project()` resolved the effective PCH before discovery, including config/profile/CLI precedence and `--no-pch`, but `Application` only projected raw `/FI` operands into `SourceDiscovery::Request`. The actual compiler later injected the first-class PCH with MQB-owned `/FI`, so compile visibility and smart-discovery visibility diverged.

## Regression coverage

The existing Windows PCH E2E now checks:

1. PCH-only reachable implementation TU.
2. Nested include reachable only through the PCH.
3. PCH content change alters selected source closure.
4. PCH path/profile change invalidates persistent discovery identity by changing the restored closure.
5. `--no-pch` removes the forced discovery root.
6. Profile PCH overlay changes discovery correctly.
7. Raw `/FI` and first-class PCH coexist and both contribute roots.
8. Ordinary no-PCH smart discovery remains unchanged.

## Validation

GitHub Actions Windows CI is the executable validation environment for this branch; the local tool container has neither MSVC nor the GitHub CLI/network checkout path.