### PR TITLE
refactor: close Windows path identity authority

### DIFF
--- a/cpp/include/mqb/msvc/MsvcIncludeSearchFreshness.hpp
+++ b/cpp/include/mqb/msvc/MsvcIncludeSearchFreshness.hpp
@@ -19,9 +19,29 @@ namespace include_freshness_detail {
 
 namespace fs = std::filesystem;
 
-[[nodiscard]] inline bool same_path(const fs::path& left, const fs::path& right) {
+[[nodiscard]] inline bool same_path_identity(
+    const fs::path& left,
+    const fs::path& right) {
     return mqb::platform::windows::path_identity_key(left)
         == mqb::platform::windows::path_identity_key(right);
+}
+
+[[nodiscard]] inline bool same_existing_search_location(
+    const fs::path& left,
+    const fs::path& right) {
+    if (same_path_identity(left, right)) {
+        return true;
+    }
+
+    // Include-search freshness observes filesystem namespaces, not cache-key
+    // spelling. A compiler-reported header and a user search root can reach the
+    // same existing directory through a junction/symlink/canonical alias. Use
+    // equivalent() only as a physical-provenance probe for those existing
+    // locations; it never generates a path key and is not used by signatures,
+    // artifact ownership, or general path set membership.
+    std::error_code error_code;
+    const bool equivalent = fs::equivalent(left, right, error_code);
+    return equivalent && !error_code;
 }
 
 [[nodiscard]] inline bool ascii_iequals(
@@ -83,7 +103,7 @@ inline void append_unique(std::vector<fs::path>& paths, fs::path path) {
     if (path.empty()) return;
     path = path.lexically_normal();
     if (std::none_of(paths.begin(), paths.end(), [&](const fs::path& existing) {
-            return same_path(existing, path);
+            return same_existing_search_location(existing, path);
         })) {
         paths.push_back(std::move(path));
     }
@@ -119,7 +139,9 @@ inline void append_search_root(std::vector<fs::path>& roots, fs::path path) {
     const fs::path& root) {
     const fs::path relative = child.lexically_normal().lexically_relative(root.lexically_normal());
     if (relative.empty()) {
-        return same_path(child, root) ? std::optional<fs::path>{fs::path{}} : std::nullopt;
+        return same_path_identity(child, root)
+            ? std::optional<fs::path>{fs::path{}}
+            : std::nullopt;
     }
     if (relative.is_absolute()) return std::nullopt;
     for (const auto& component : relative) {
@@ -129,10 +151,10 @@ inline void append_search_root(std::vector<fs::path>& roots, fs::path path) {
 }
 
 // The compiler reports resolved dependency paths using filesystem spelling,
-// while a user-supplied /I root may differ only by Windows ASCII casing or a
-// lexically equivalent spelling. Fall back to an ancestor walk using the shared
-// Windows path-identity authority so include-relative suffix recovery cannot
-// establish a second equality rule.
+// while a user-supplied /I root may name the same existing search location
+// through a junction/symlink/canonical alias. Lexical Windows identity remains
+// authoritative first; the ancestor fallback uses physical equivalence only to
+// recover the include-relative suffix for that freshness observation.
 [[nodiscard]] inline std::optional<fs::path> relative_if_within(
     const fs::path& child,
     const fs::path& root) {
@@ -144,7 +166,7 @@ inline void append_search_root(std::vector<fs::path>& roots, fs::path path) {
     fs::path cursor = child.lexically_normal();
     fs::path suffix;
     while (!cursor.empty()) {
-        if (same_path(cursor, root)) {
+        if (same_existing_search_location(cursor, root)) {
             return suffix;
         }
         const fs::path filename = cursor.filename();

--- a/cpp/include/mqb/msvc/MsvcIncludeSearchFreshness.hpp
+++ b/cpp/include/mqb/msvc/MsvcIncludeSearchFreshness.hpp
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "mqb/core/CompilerOptions.hpp"
+#include "mqb/platform/windows/PathIdentity.hpp"
 #include "mqb/process/Process.hpp"
 
 namespace mqb::msvc {
@@ -19,11 +20,8 @@ namespace include_freshness_detail {
 namespace fs = std::filesystem;
 
 [[nodiscard]] inline bool same_path(const fs::path& left, const fs::path& right) {
-    if (left == right || left.lexically_normal() == right.lexically_normal()) {
-        return true;
-    }
-    std::error_code error_code;
-    return fs::equivalent(left, right, error_code) && !error_code;
+    return mqb::platform::windows::path_identity_key(left)
+        == mqb::platform::windows::path_identity_key(right);
 }
 
 [[nodiscard]] inline bool ascii_iequals(
@@ -94,7 +92,7 @@ inline void append_unique(std::vector<fs::path>& paths, fs::path path) {
 // Compiler search-root identity is an ordered argv/environment fact, not a
 // filesystem-equivalence set. Preserve each normalized spelling (including
 // duplicates) exactly as MSVC sees it. Besides being more faithful, this keeps
-// the warm path free of equivalent()/status syscalls while constructing roots.
+// the warm path free of filesystem identity/status syscalls while constructing roots.
 inline void append_search_root(std::vector<fs::path>& roots, fs::path path) {
     if (path.empty()) return;
     roots.push_back(path.lexically_normal());
@@ -131,9 +129,10 @@ inline void append_search_root(std::vector<fs::path>& roots, fs::path path) {
 }
 
 // The compiler reports resolved dependency paths using filesystem spelling,
-// while a user-supplied /I root may differ only by Windows casing or by an
-// equivalent path spelling. Fall back to an ancestor walk using equivalent()
-// so we still recover the include-relative suffix in those cases.
+// while a user-supplied /I root may differ only by Windows ASCII casing or a
+// lexically equivalent spelling. Fall back to an ancestor walk using the shared
+// Windows path-identity authority so include-relative suffix recovery cannot
+// establish a second equality rule.
 [[nodiscard]] inline std::optional<fs::path> relative_if_within(
     const fs::path& child,
     const fs::path& root) {

--- a/cpp/include/mqb/msvc/MsvcToolchainEnvironmentIdentity.hpp
+++ b/cpp/include/mqb/msvc/MsvcToolchainEnvironmentIdentity.hpp
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "mqb/msvc/MsvcToolchainLocator.hpp"
+#include "mqb/platform/windows/PathIdentity.hpp"
 #include "mqb/process/Process.hpp"
 
 namespace mqb::msvc {
@@ -118,6 +119,9 @@ template <std::size_t Count>
         }
     }
     if (error_code || directories.empty()) return std::nullopt;
+    // Version selection is deterministic ordering, not path equality. Keep the
+    // native case-preserving filename order here; identity comparisons below
+    // use the shared Windows path primitive.
     std::ranges::sort(
         directories,
         {},
@@ -141,9 +145,8 @@ template <std::size_t Count>
     const auto latest = latest_directory(
         stable_path(path_from_utf8(root->value)) / "Include");
     return latest
-        && ascii_iequals(
-            latest->filename().string(),
-            selected.filename().string());
+        && mqb::platform::windows::path_identity_key(latest->filename())
+            == mqb::platform::windows::path_identity_key(selected.filename());
 }
 
 } // namespace toolchain_environment_detail

--- a/cpp/include/mqb/platform/windows/PathIdentity.hpp
+++ b/cpp/include/mqb/platform/windows/PathIdentity.hpp
@@ -9,8 +9,22 @@ namespace mqb::platform::windows {
 // across ordinary ASCII case differences without routing non-ASCII path bytes
 // through the active narrow-character locale. Preserve UTF-8 bytes verbatim
 // and fold only ASCII A-Z after lexical normalization.
+//
+// std::filesystem::path::lexically_normal() preserves a trailing separator on
+// non-root paths. Windows path identity does not: `C:/sdk` and `C:/sdk/` name
+// the same path. Strip only redundant non-root trailing components here so all
+// callers share that rule instead of recreating local `stable_path()` helpers.
 [[nodiscard]] inline std::string path_identity_key(const std::filesystem::path& path) {
-    const std::u8string utf8 = path.lexically_normal().generic_u8string();
+    std::filesystem::path normalized = path.lexically_normal();
+    while (normalized.filename().empty() && normalized.has_parent_path()) {
+        const std::filesystem::path parent = normalized.parent_path();
+        if (parent.empty() || parent == normalized) {
+            break;
+        }
+        normalized = parent;
+    }
+
+    const std::u8string utf8 = normalized.generic_u8string();
     std::string key;
     key.reserve(utf8.size());
     for (const char8_t ch : utf8) {

--- a/cpp/src/core/cache/ArchiveCache.cpp
+++ b/cpp/src/core/cache/ArchiveCache.cpp
@@ -4,13 +4,16 @@
 #include <filesystem>
 #include <span>
 
+#include "mqb/platform/windows/PathIdentity.hpp"
+
 namespace mqb {
 namespace {
 
 [[nodiscard]] bool same_path(
     const std::filesystem::path& left,
     const std::filesystem::path& right) {
-    return left == right || left.lexically_normal() == right.lexically_normal();
+    return platform::windows::path_identity_key(left)
+        == platform::windows::path_identity_key(right);
 }
 
 [[nodiscard]] bool same_paths(

--- a/cpp/src/core/cache/CompileCache.cpp
+++ b/cpp/src/core/cache/CompileCache.cpp
@@ -5,13 +5,16 @@
 #include <optional>
 #include <span>
 
+#include "mqb/platform/windows/PathIdentity.hpp"
+
 namespace mqb {
 namespace {
 
 [[nodiscard]] bool same_path(
     const std::filesystem::path& left,
     const std::filesystem::path& right) {
-    return left == right || left.lexically_normal() == right.lexically_normal();
+    return platform::windows::path_identity_key(left)
+        == platform::windows::path_identity_key(right);
 }
 
 [[nodiscard]] bool same_toolchain(

--- a/cpp/src/core/cache/LinkCache.cpp
+++ b/cpp/src/core/cache/LinkCache.cpp
@@ -4,13 +4,16 @@
 #include <filesystem>
 #include <span>
 
+#include "mqb/platform/windows/PathIdentity.hpp"
+
 namespace mqb {
 namespace {
 
 [[nodiscard]] bool same_path(
     const std::filesystem::path& left,
     const std::filesystem::path& right) {
-    return left == right || left.lexically_normal() == right.lexically_normal();
+    return platform::windows::path_identity_key(left)
+        == platform::windows::path_identity_key(right);
 }
 
 [[nodiscard]] bool same_paths(

--- a/cpp/src/core/model/BuildSignature.cpp
+++ b/cpp/src/core/model/BuildSignature.cpp
@@ -10,6 +10,7 @@
 
 #include "mqb/core/Artifact.hpp"
 #include "mqb/core/TranslationUnitClassifier.hpp"
+#include "mqb/platform/windows/PathIdentity.hpp"
 
 namespace mqb {
 namespace {
@@ -38,11 +39,8 @@ public:
     }
 
     void add_path(const std::filesystem::path& value) noexcept {
-        const auto normalized = value.lexically_normal().generic_u8string();
-        add_u64(static_cast<std::uint64_t>(normalized.size()));
-        for (const char8_t byte : normalized) {
-            add_byte(static_cast<std::uint8_t>(byte));
-        }
+        const std::string identity = platform::windows::path_identity_key(value);
+        add_string(identity);
     }
 
     template <typename Enum>

--- a/cpp/src/core/planning/ProjectArtifactLayout.cpp
+++ b/cpp/src/core/planning/ProjectArtifactLayout.cpp
@@ -1,7 +1,5 @@
 #include "mqb/core/ProjectArtifactLayout.hpp"
 
-#include <algorithm>
-#include <cctype>
 #include <cstdint>
 #include <filesystem>
 #include <iomanip>
@@ -9,6 +7,8 @@
 #include <string>
 #include <string_view>
 #include <utility>
+
+#include "mqb/platform/windows/PathIdentity.hpp"
 
 namespace mqb {
 namespace {
@@ -41,18 +41,13 @@ namespace fs = std::filesystem;
     return canonical.lexically_normal();
 }
 
-[[nodiscard]] fs::path windows_identity_casefold(fs::path path) {
-#ifdef _WIN32
-    std::string value = path.generic_string();
-    std::transform(
-        value.begin(),
-        value.end(),
-        value.begin(),
-        [](const unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
-    return fs::path{value};
-#else
-    return path;
-#endif
+[[nodiscard]] fs::path identity_path(const fs::path& path) {
+    const std::string key = platform::windows::path_identity_key(path);
+    std::u8string utf8;
+    utf8.assign(
+        reinterpret_cast<const char8_t*>(key.data()),
+        reinterpret_cast<const char8_t*>(key.data() + key.size()));
+    return fs::path{utf8};
 }
 
 [[nodiscard]] bool safe_relative(const fs::path& relative) {
@@ -80,7 +75,7 @@ namespace fs = std::filesystem;
     while (!current.empty()) {
         error_code.clear();
         if (fs::equivalent(current, project_root, error_code) && !error_code) {
-            return windows_identity_casefold(relative.lexically_normal());
+            return identity_path(relative.lexically_normal());
         }
         const fs::path parent = current.parent_path();
         if (parent.empty() || parent == current) break;
@@ -94,8 +89,8 @@ namespace fs = std::filesystem;
     constexpr std::uint64_t offset = 14695981039346656037ull;
     constexpr std::uint64_t prime = 1099511628211ull;
     std::uint64_t hash = offset;
-    const auto bytes = windows_identity_casefold(path.lexically_normal()).generic_u8string();
-    for (const char8_t byte : bytes) {
+    const std::string identity = platform::windows::path_identity_key(path);
+    for (const unsigned char byte : identity) {
         hash ^= static_cast<std::uint8_t>(byte);
         hash *= prime;
     }
@@ -115,16 +110,13 @@ namespace fs = std::filesystem;
     }
 
     fs::path relative = normalized_source.lexically_relative(project_root);
-#ifdef _WIN32
-    relative = windows_identity_casefold(std::move(relative));
-#endif
     if (safe_relative(relative)) {
-        return relative;
+        return identity_path(relative);
     }
 
-    const fs::path identity = windows_identity_casefold(normalized_source);
+    const fs::path identity = identity_path(normalized_source);
     return fs::path{".external"}
-        / stable_path_hash(identity)
+        / stable_path_hash(normalized_source)
         / identity.filename();
 }
 

--- a/cpp/src/msvc/compiler/MsvcCompileExecutor.cpp
+++ b/cpp/src/msvc/compiler/MsvcCompileExecutor.cpp
@@ -13,6 +13,7 @@
 #include "mqb/msvc/MsvcCompiler.hpp"
 #include "mqb/msvc/MsvcIncludeSearchFreshness.hpp"
 #include "mqb/msvc/MsvcSourceDependenciesReader.hpp"
+#include "mqb/platform/windows/PathIdentity.hpp"
 
 namespace mqb::msvc {
 namespace {
@@ -44,21 +45,28 @@ namespace fs = std::filesystem;
     return found;
 }
 
-[[nodiscard]] bool same_existing_file(
+[[nodiscard]] bool same_path_identity(
     const fs::path& left,
     const fs::path& right) {
+    return mqb::platform::windows::path_identity_key(left)
+        == mqb::platform::windows::path_identity_key(right);
+}
+
+[[nodiscard]] bool same_existing_physical_file(
+    const fs::path& left,
+    const fs::path& right) {
+    if (same_path_identity(left, right)) {
+        return true;
+    }
+
+    // This is deliberately not a second path-identity primitive. The compiler
+    // can report an existing source through a junction/symlink/canonical alias;
+    // sourceDependencies provenance must prove that both spellings refer to the
+    // same physical filesystem object. Cache keys, dependency deduplication,
+    // and artifact ownership continue to use path_identity_key() exclusively.
     std::error_code error_code;
     const bool equivalent = fs::equivalent(left, right, error_code);
     return equivalent && !error_code;
-}
-
-[[nodiscard]] bool same_dependency_path(
-    const fs::path& left,
-    const fs::path& right) {
-    if (same_existing_file(left, right)) {
-        return true;
-    }
-    return left.lexically_normal() == right.lexically_normal();
 }
 
 [[nodiscard]] bool regular_file(const fs::path& path) {
@@ -73,7 +81,7 @@ void add_interface_dependency(
         dependencies.begin(),
         dependencies.end(),
         [&interface_file](const fs::path& dependency) {
-            return same_dependency_path(dependency, interface_file);
+            return same_path_identity(dependency, interface_file);
         });
     if (duplicate == dependencies.end()) {
         dependencies.push_back(interface_file.lexically_normal());
@@ -166,8 +174,9 @@ MsvcCompileExecutor::execute(const CompileExecutionRequest& request) const {
                 return std::unexpected(invalid_request(
                     "PCH creator must expose exactly one non-empty precompiled-header artifact"));
             }
-            if (pch_output->path.lexically_normal()
-                != request.options.precompiled_header->artifact.lexically_normal()) {
+            if (!same_path_identity(
+                    pch_output->path,
+                    request.options.precompiled_header->artifact)) {
                 return std::unexpected(invalid_request(
                     "PCH creator output must match the typed precompiled-header artifact path"));
             }
@@ -244,7 +253,7 @@ MsvcCompileExecutor::execute(const CompileExecutionRequest& request) const {
         });
     }
 
-    if (!same_existing_file(dependencies->source, request.unit.source)) {
+    if (!same_existing_physical_file(dependencies->source, request.unit.source)) {
         return std::unexpected(CompileExecutorError{
             .code = CompileExecutorErrorCode::dependency_metadata_failed,
             .message = "sourceDependencies metadata belongs to a different translation unit",

--- a/cpp/src/msvc/linker/MsvcLibraryResolver.cpp
+++ b/cpp/src/msvc/linker/MsvcLibraryResolver.cpp
@@ -11,6 +11,8 @@
 #include <utility>
 #include <vector>
 
+#include "mqb/platform/windows/PathIdentity.hpp"
+
 namespace mqb::msvc {
 namespace {
 
@@ -60,27 +62,13 @@ namespace fs = std::filesystem;
     return true;
 }
 
-[[nodiscard]] std::string windows_path_key(const fs::path& path) {
-    std::string value = path.lexically_normal().generic_string();
-    std::transform(
-        value.begin(),
-        value.end(),
-        value.begin(),
-        [](const unsigned char character) {
-            return static_cast<char>(std::tolower(character));
-        });
-    return value;
-}
-
-[[nodiscard]] bool same_windows_path(const fs::path& left, const fs::path& right) {
-    return windows_path_key(left) == windows_path_key(right);
-}
-
 [[nodiscard]] bool contains_windows_path(
     const std::vector<fs::path>& paths,
     const fs::path& expected) {
+    const std::string expected_key =
+        mqb::platform::windows::path_identity_key(expected);
     return std::any_of(paths.begin(), paths.end(), [&](const fs::path& path) {
-        return same_windows_path(path, expected);
+        return mqb::platform::windows::path_identity_key(path) == expected_key;
     });
 }
 

--- a/cpp/src/msvc/linker/MsvcLinker.cpp
+++ b/cpp/src/msvc/linker/MsvcLinker.cpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "mqb/msvc/MsvcToolchainEnvironmentIdentity.hpp"
+#include "mqb/platform/windows/PathIdentity.hpp"
 
 namespace mqb::msvc {
 namespace {
@@ -120,25 +121,13 @@ void suppress_ambient_linker_options(
     return std::string_view::npos;
 }
 
-[[nodiscard]] std::string windows_path_key(const fs::path& path) {
-    std::string key = path.lexically_normal().generic_string();
-    std::transform(
-        key.begin(),
-        key.end(),
-        key.begin(),
-        [](const unsigned char character) {
-            return static_cast<char>(std::tolower(character));
-        });
-    return key;
-}
-
 void add_unique_path(std::vector<fs::path>& paths, const fs::path& path) {
-    const std::string key = windows_path_key(path);
+    const std::string key = mqb::platform::windows::path_identity_key(path);
     const auto duplicate = std::find_if(
         paths.begin(),
         paths.end(),
         [&](const fs::path& existing) {
-            return windows_path_key(existing) == key;
+            return mqb::platform::windows::path_identity_key(existing) == key;
         });
     if (duplicate == paths.end()) {
         paths.push_back(path.lexically_normal());

--- a/cpp/src/msvc/toolchain/VisualStudioToolchainCache.cpp
+++ b/cpp/src/msvc/toolchain/VisualStudioToolchainCache.cpp
@@ -15,6 +15,7 @@
 #include <vector>
 
 #include "ToolchainDiscoveryPrimitives.hpp"
+#include "mqb/platform/windows/PathIdentity.hpp"
 
 namespace mqb::msvc::detail {
 namespace {
@@ -55,6 +56,11 @@ struct ToolPaths {
     return path;
 }
 
+[[nodiscard]] bool same_path(const fs::path& left, const fs::path& right) {
+    return mqb::platform::windows::path_identity_key(left)
+        == mqb::platform::windows::path_identity_key(right);
+}
+
 [[nodiscard]] int preference_value(const ToolchainPreference preference) noexcept {
     switch (preference) {
     case ToolchainPreference::automatic: return 0;
@@ -71,17 +77,6 @@ struct ToolPaths {
     case ToolchainPreference::portable: return "portable";
     }
     return "unknown";
-}
-
-[[nodiscard]] std::string lower_ascii(std::string value) {
-    std::transform(value.begin(), value.end(), value.begin(), [](const unsigned char ch) {
-        return static_cast<char>(std::tolower(ch));
-    });
-    return value;
-}
-
-[[nodiscard]] std::string normalized_path_text(const fs::path& path) {
-    return lower_ascii(detail::path_to_utf8(stable_path(path)));
 }
 
 [[nodiscard]] bool cache_key_matches(const CacheRecord& record, const DiscoveryOptions& options) {
@@ -146,11 +141,12 @@ struct ToolPaths {
     if (error_code) return false;
     const fs::path absolute_candidate = stable_path(fs::absolute(candidate, error_code));
     if (error_code) return false;
-    std::string root_text = normalized_path_text(absolute_root);
-    const std::string candidate_text = normalized_path_text(absolute_candidate);
-    if (candidate_text == root_text) return true;
-    if (!root_text.empty() && root_text.back() != '/') root_text.push_back('/');
-    return candidate_text.starts_with(root_text);
+    std::string root_key = mqb::platform::windows::path_identity_key(absolute_root);
+    const std::string candidate_key =
+        mqb::platform::windows::path_identity_key(absolute_candidate);
+    if (candidate_key == root_key) return true;
+    if (!root_key.empty() && root_key.back() != '/') root_key.push_back('/');
+    return candidate_key.starts_with(root_key);
 }
 
 void append_unique_existing_root(std::vector<fs::path>& roots, fs::path root) {
@@ -158,7 +154,7 @@ void append_unique_existing_root(std::vector<fs::path>& roots, fs::path root) {
     root = stable_path(std::move(root));
     if (!fs::is_directory(root, error_code) || error_code) return;
     const auto duplicate = std::find_if(roots.begin(), roots.end(), [&](const fs::path& existing) {
-        return normalized_path_text(existing) == normalized_path_text(root);
+        return same_path(existing, root);
     });
     if (duplicate == roots.end()) roots.push_back(std::move(root));
 }
@@ -225,7 +221,7 @@ void append_unique_existing_root(std::vector<fs::path>& roots, fs::path root) {
     const auto* tools = find_environment(environment, "VCToolsInstallDir");
     if (include == nullptr || lib == nullptr || lib_path == nullptr || tools == nullptr
         || include->value.empty() || lib->value.empty() || lib_path->value.empty() || tools->value.empty()) return false;
-    if (normalized_path_text(detail::path_from_utf8(tools->value)) != normalized_path_text(vc_tools_root)) return false;
+    if (!same_path(detail::path_from_utf8(tools->value), vc_tools_root)) return false;
     const auto roots = trusted_roots(environment, vc_tools_root);
     return !roots.empty()
         && trusted_directory_list(include->value, roots)
@@ -332,7 +328,7 @@ void append_unique_existing_root(std::vector<fs::path>& roots, fs::path root) {
 
         if (!fs::is_directory(record->vc_tools_root, error_code) || error_code) return std::nullopt;
         const auto latest_tools = detail::latest_directory(record->vc_tools_root.parent_path());
-        if (!latest_tools || normalized_path_text(*latest_tools) != normalized_path_text(record->vc_tools_root)) return std::nullopt;
+        if (!latest_tools || !same_path(*latest_tools, record->vc_tools_root)) return std::nullopt;
         const ToolPaths paths = tool_paths(record->vc_tools_root, options);
         for (const auto& file : {paths.compiler, paths.linker, paths.librarian}) {
             error_code.clear();
@@ -375,9 +371,9 @@ void save_visual_studio_cache_best_effort(
         if (toolchain.source != ToolchainSource::visual_studio || toolchain.reused) return;
         const fs::path root = stable_path(toolchain.vc_tools_root);
         const ToolPaths expected = tool_paths(root, options);
-        if (normalized_path_text(expected.compiler) != normalized_path_text(toolchain.identity.compiler)
-            || normalized_path_text(expected.linker) != normalized_path_text(toolchain.linker)
-            || normalized_path_text(expected.librarian) != normalized_path_text(toolchain.librarian)) return;
+        if (!same_path(expected.compiler, toolchain.identity.compiler)
+            || !same_path(expected.linker, toolchain.linker)
+            || !same_path(expected.librarian, toolchain.librarian)) return;
 
         std::vector<EnvironmentVariable> environment = cacheable_environment(toolchain);
         const auto* path = find_environment(toolchain.environment, "PATH");

--- a/cpp/src/orchestration/incremental/MsvcIncrementalCompileCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalCompileCoordinator.cpp
@@ -16,6 +16,7 @@
 #include "mqb/msvc/MsvcCompileExecutor.hpp"
 #include "mqb/msvc/MsvcIncludeSearchFreshness.hpp"
 #include "mqb/msvc/MsvcSourceDependenciesReader.hpp"
+#include "mqb/platform/windows/PathIdentity.hpp"
 
 #include "IncrementalFileSnapshot.hpp"
 
@@ -57,11 +58,8 @@ void add_reason_once(
 [[nodiscard]] bool same_path(
     const std::filesystem::path& left,
     const std::filesystem::path& right) {
-    if (left == right || left.lexically_normal() == right.lexically_normal()) {
-        return true;
-    }
-    std::error_code error_code;
-    return std::filesystem::equivalent(left, right, error_code) && !error_code;
+    return mqb::platform::windows::path_identity_key(left)
+        == mqb::platform::windows::path_identity_key(right);
 }
 
 [[nodiscard]] bool same_ordered_paths(

--- a/cpp/src/orchestration/incremental/MsvcIncrementalLinkCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalLinkCoordinator.cpp
@@ -1,7 +1,6 @@
 #include "mqb/orchestration/MsvcIncrementalLinkCoordinator.hpp"
 
 #include <algorithm>
-#include <cctype>
 #include <expected>
 #include <filesystem>
 #include <optional>
@@ -25,6 +24,7 @@
 #include "mqb/msvc/MsvcOpenMpPolicy.hpp"
 #include "mqb/msvc/MsvcParameterEngine.hpp"
 #include "mqb/msvc/MsvcWholeArchivePolicy.hpp"
+#include "mqb/platform/windows/PathIdentity.hpp"
 
 #include "IncrementalFileSnapshot.hpp"
 
@@ -66,30 +66,17 @@ void snapshot_inputs(
 }
 
 [[nodiscard]] bool same_path(const fs::path& left, const fs::path& right) {
-    return left == right || left.lexically_normal() == right.lexically_normal();
-}
-
-[[nodiscard]] std::string windows_path_key(const fs::path& path) {
-    std::string value = path.lexically_normal().generic_string();
-    std::transform(
-        value.begin(),
-        value.end(),
-        value.begin(),
-        [](const unsigned char character) {
-            return static_cast<char>(std::tolower(character));
-        });
-    return value;
-}
-
-[[nodiscard]] bool same_windows_path(const fs::path& left, const fs::path& right) {
-    return windows_path_key(left) == windows_path_key(right);
+    return mqb::platform::windows::path_identity_key(left)
+        == mqb::platform::windows::path_identity_key(right);
 }
 
 [[nodiscard]] bool contains_windows_path(
     const std::vector<fs::path>& paths,
     const fs::path& expected) {
+    const std::string expected_key =
+        mqb::platform::windows::path_identity_key(expected);
     return std::any_of(paths.begin(), paths.end(), [&](const fs::path& path) {
-        return same_windows_path(path, expected);
+        return mqb::platform::windows::path_identity_key(path) == expected_key;
     });
 }
 

--- a/cpp/tests/core/model/build_signature_tests.cpp
+++ b/cpp/tests/core/model/build_signature_tests.cpp
@@ -75,6 +75,20 @@ int main() {
     expect(mqb::BuildSignature::for_compile(normalized_unit, toolchain, options) == baseline,
            "lexically equivalent source paths should produce the same signature");
 
+    auto unicode_unit = unit;
+    unicode_unit.source = std::filesystem::path{u8"C:/项目/Source/Main.CPP"};
+    auto unicode_case_alias = unicode_unit;
+    unicode_case_alias.source = std::filesystem::path{u8"c:/项目/source/main.cpp"};
+    expect(mqb::BuildSignature::for_compile(unicode_case_alias, toolchain, options)
+               == mqb::BuildSignature::for_compile(unicode_unit, toolchain, options),
+           "Unicode source identity should fold ASCII path casing without narrowing non-ASCII bytes");
+
+    auto different_unicode_unit = unicode_unit;
+    different_unicode_unit.source = std::filesystem::path{u8"C:/項目/Source/Main.CPP"};
+    expect(mqb::BuildSignature::for_compile(different_unicode_unit, toolchain, options)
+               != mqb::BuildSignature::for_compile(unicode_unit, toolchain, options),
+           "distinct non-ASCII UTF-8 path bytes must remain distinct build identity");
+
     auto release_options = options;
     release_options.configuration = mqb::BuildConfiguration::release;
     expect(mqb::BuildSignature::for_compile(unit, toolchain, release_options) != baseline,
@@ -129,6 +143,14 @@ int main() {
     moved_ifc.outputs.back().path = "another-ifc/main.ifc";
     expect(mqb::BuildSignature::for_compile(moved_ifc, toolchain, options) != module_baseline,
            "planned compiled-module output path should participate in provider identity");
+
+    auto unicode_module = module_unit;
+    unicode_module.outputs.back().path = std::filesystem::path{u8"C:/项目/IFC/Math.IFC"};
+    auto unicode_module_alias = unicode_module;
+    unicode_module_alias.outputs.back().path = std::filesystem::path{u8"c:/项目/ifc/math.ifc"};
+    expect(mqb::BuildSignature::for_compile(unicode_module_alias, toolchain, options)
+               == mqb::BuildSignature::for_compile(unicode_module, toolchain, options),
+           "module provider artifact identity should share Windows ASCII-case folding");
 
     auto consumer = unit;
     consumer.module_references = {
@@ -215,6 +237,18 @@ int main() {
                != link_baseline,
            "enabling typed LTCG should invalidate downstream link identity");
 
+    const std::vector<std::filesystem::path> unicode_libraries{
+        std::filesystem::path{u8"C:/库/Runtime/Math.LIB"},
+    };
+    const std::vector<std::filesystem::path> unicode_library_aliases{
+        std::filesystem::path{u8"c:/库/runtime/math.lib"},
+    };
+    expect(mqb::BuildSignature::for_link(
+               objects, unicode_libraries, "bin/app.exe", linker, link_options)
+               == mqb::BuildSignature::for_link(
+                   objects, unicode_library_aliases, "bin/app.exe", linker, link_options),
+           "same resolved library path with different ASCII casing should keep one link recipe identity");
+
     const mqb::LibrarianIdentity librarian{
         .librarian = "toolchain/lib.exe",
         .version = "14.50.12345",
@@ -225,6 +259,13 @@ int main() {
     expect(mqb::BuildSignature::for_archive(objects, "bin/math.lib", librarian, true)
                != archive_baseline,
            "enabling typed LTCG should invalidate downstream archive identity");
+    const std::vector<std::filesystem::path> archive_case_alias{
+        std::filesystem::path{"BUILD/MAIN.OBJ"},
+    };
+    expect(mqb::BuildSignature::for_archive(
+               archive_case_alias, "BIN/MATH.LIB", librarian)
+               == archive_baseline,
+           "archive recipe identity should collapse ASCII path casing aliases");
 
     if (failures != 0) {
         std::cerr << failures << " test(s) failed\n";

--- a/cpp/tests/core/planning/project_artifact_layout_tests.cpp
+++ b/cpp/tests/core/planning/project_artifact_layout_tests.cpp
@@ -95,12 +95,13 @@ int main() {
 
 #ifdef _WIN32
     // Existing physical paths are normalized before deriving source identity.
-    // This prevents scanner/user aliases (case differences, 8.3/long-path or
-    // other canonical spellings) from splitting one source into two caches.
+    // The project root deliberately contains non-ASCII components: ASCII case
+    // aliases must collapse without feeding the UTF-8 bytes through tolower.
     const auto tick = std::chrono::steady_clock::now().time_since_epoch().count();
-    const fs::path physical_root = fs::temp_directory_path()
+    const fs::path unicode_parent = fs::temp_directory_path() / fs::path{u8"MQB_项目_テスト"};
+    const fs::path physical_root = unicode_parent
         / ("MqB_Artifact_Alias_" + std::to_string(tick));
-    const fs::path physical_header = physical_root / "Include" / "Util.hpp";
+    const fs::path physical_header = physical_root / fs::path{u8"Include/模块Util.hpp"};
     fs::create_directories(physical_header.parent_path());
     {
         std::ofstream file{physical_header, std::ios::binary | std::ios::trunc};
@@ -108,29 +109,29 @@ int main() {
     }
 
     auto physical_layout = mqb::ProjectArtifactLayout::create(physical_root);
-    expect(physical_layout.has_value(), "existing physical project root should create a layout");
+    expect(physical_layout.has_value(), "Unicode physical project root should create a layout");
     if (physical_layout) {
         std::string alias_component = physical_root.filename().string();
         for (auto& ch : alias_component) {
             if (ch >= 'A' && ch <= 'Z') ch = static_cast<char>(ch - 'A' + 'a');
         }
         const fs::path root_alias = physical_root.parent_path() / alias_component;
-        const fs::path source_alias = root_alias / "include" / "util.hpp";
+        const fs::path source_alias = root_alias / fs::path{u8"include/模块util.hpp"};
         auto real_artifacts = physical_layout->for_source(physical_header);
         auto alias_artifacts = physical_layout->for_source(source_alias);
         expect(real_artifacts.has_value() && alias_artifacts.has_value(),
-               "case aliases of an existing Windows source should map to artifacts");
+               "case aliases inside a Unicode Windows project should map to artifacts");
         if (real_artifacts && alias_artifacts) {
             expect(real_artifacts->object == alias_artifacts->object
                        && real_artifacts->dependencies == alias_artifacts->dependencies
                        && real_artifacts->module_dependencies == alias_artifacts->module_dependencies
                        && real_artifacts->module_interface == alias_artifacts->module_interface
                        && real_artifacts->compile_cache == alias_artifacts->compile_cache,
-                   "one physical Windows source must have one stable artifact identity across path aliases");
+                   "one Unicode Windows source must have one stable artifact identity across ASCII case aliases");
         }
     }
     std::error_code cleanup_error;
-    fs::remove_all(physical_root, cleanup_error);
+    fs::remove_all(unicode_parent, cleanup_error);
 #endif
 
     expect(!layout->for_target("../demo"), "target names with parent traversal must be rejected");

--- a/cpp/tests/msvc/linker/library_resolver_tests.cpp
+++ b/cpp/tests/msvc/linker/library_resolver_tests.cpp
@@ -13,6 +13,7 @@
 #include "mqb/msvc/MsvcLibraryResolver.hpp"
 #include "mqb/msvc/MsvcToolchainLocator.hpp"
 #include "mqb/msvc/MsvcWholeArchivePolicy.hpp"
+#include "mqb/platform/windows/PathIdentity.hpp"
 
 namespace {
 
@@ -102,6 +103,35 @@ int main() {
                && from_current->files.size() == 1
                && from_current->files.front() == (work / "local.lib").lexically_normal(),
            "working directory should be searched before toolchain LIB fallback");
+
+    const fs::path unicode_library_dir = tree.root / fs::path{u8"库目录/日本語Lib"};
+    const fs::path unicode_library = unicode_library_dir / "unicode.lib";
+    touch(unicode_library);
+    mqb::LinkOptions unicode_options;
+    unicode_options.library_directories = {unicode_library_dir};
+    unicode_options.libraries = {"unicode"};
+    const auto unicode_resolved = mqb::msvc::MsvcLibraryResolver::resolve(
+        toolchain, unicode_options, work);
+    expect(unicode_resolved.has_value()
+               && unicode_resolved->files.size() == 1
+               && mqb::platform::windows::path_identity_key(unicode_resolved->files.front())
+                   == mqb::platform::windows::path_identity_key(unicode_library),
+           "Unicode library directories should resolve without changing non-ASCII path bytes");
+
+#ifdef _WIN32
+    mqb::LinkOptions unicode_alias_options;
+    unicode_alias_options.library_directories = {
+        tree.root / fs::path{u8"库目录/日本語lib"},
+    };
+    unicode_alias_options.libraries = {"UNICODE.LIB"};
+    const auto unicode_alias_resolved = mqb::msvc::MsvcLibraryResolver::resolve(
+        toolchain, unicode_alias_options, work);
+    expect(unicode_alias_resolved.has_value()
+               && unicode_alias_resolved->files.size() == 1
+               && mqb::platform::windows::path_identity_key(unicode_alias_resolved->files.front())
+                   == mqb::platform::windows::path_identity_key(unicode_library),
+           "the same Unicode library path with different ASCII casing should keep one Windows identity");
+#endif
 
     mqb::LinkOptions missing_options;
     missing_options.libraries = {"does-not-exist"};

--- a/cpp/tests/msvc/linker/linker_arguments_tests.cpp
+++ b/cpp/tests/msvc/linker/linker_arguments_tests.cpp
@@ -7,6 +7,7 @@
 
 #include "mqb/core/LinkOptions.hpp"
 #include "mqb/msvc/MsvcLinker.hpp"
+#include "mqb/platform/windows/PathIdentity.hpp"
 
 namespace {
 
@@ -88,6 +89,26 @@ int main() {
            "Debug required side outputs should include the linker PDB");
     expect(!contains_path(debug_outputs, "bin/my app.exe.manifest"),
            "external manifest is conditional on LINK actually producing content and must not be required blindly");
+
+    const std::u8string observed_text =
+        u8"    Found C:\\项目\\Lib\\Math.LIB\n"
+        u8"    Found c:\\项目\\lib\\math.lib\n"
+        u8"    Found C:\\項目\\Lib\\Math.lib\n";
+    const auto observed_libraries = mqb::msvc::MsvcLinker::observed_library_paths(
+        std::string_view{
+            reinterpret_cast<const char*>(observed_text.data()),
+            observed_text.size()});
+    expect(observed_libraries.size() == 2,
+           "LINK library observation should deduplicate ASCII case aliases without collapsing distinct non-ASCII paths");
+    if (observed_libraries.size() == 2) {
+        expect(mqb::platform::windows::path_identity_key(observed_libraries[0])
+                   == mqb::platform::windows::path_identity_key(
+                       std::filesystem::path{u8"C:/项目/Lib/Math.LIB"}),
+               "observed Unicode library path should preserve non-ASCII UTF-8 bytes");
+        expect(mqb::platform::windows::path_identity_key(observed_libraries[0])
+                   != mqb::platform::windows::path_identity_key(observed_libraries[1]),
+               "different non-ASCII library components must remain distinct path identities");
+    }
 
     auto debug_none = invocation;
     debug_none.options.additional_arguments = {"/DEBUG:NONE"};

--- a/cpp/tests/msvc/toolchain/portable_tests.cpp
+++ b/cpp/tests/msvc/toolchain/portable_tests.cpp
@@ -137,7 +137,7 @@ int main() {
     ambient_netfx.set("ambient-netfx-sdk");
 
     TemporaryDirectory fixture;
-    const fs::path portable = fixture.path() / "portable_msvc";
+    const fs::path portable = fixture.path() / fs::path{u8"portable_msvc_工具链_テスト"};
 
     fs::create_directories(portable / "VC" / "Tools" / "MSVC" / "14.40.10000");
     const fs::path latest_vc = portable / "VC" / "Tools" / "MSVC" / "14.50.20000";
@@ -163,13 +163,13 @@ int main() {
     options.portable_roots = {portable};
 
     const auto result = locator.discover(options);
-    expect(result.has_value(), "automatic discovery should select an existing portable toolchain first");
+    expect(result.has_value(), "automatic discovery should select an existing Unicode portable toolchain first");
     expect(runner.calls == 0, "portable discovery should not invoke vswhere or cmd.exe");
     if (result) {
         expect(result->source == mqb::msvc::ToolchainSource::portable,
                "portable discovery should retain toolchain provenance");
         expect(result->identity.compiler == tool_bin / "cl.exe",
-               "portable discovery should resolve the requested host/target compiler");
+               "portable discovery should resolve the requested host/target compiler under a Unicode root");
         expect(result->linker == tool_bin / "link.exe",
                "portable discovery should resolve link.exe beside cl.exe");
         expect(result->librarian == tool_bin / "lib.exe",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -248,6 +248,20 @@ config path   -> directory containing mqb.json
 
 存在 `mqb.json` 时，它的目录是 project root 与 `.mqb/` root；否则 project root 由 invocation/source context 决定。
 
+### Windows path identity authority
+
+MQB 面向 Windows/MSVC，因此凡是判断**路径是否代表同一 Windows 路径**的逻辑，都只有一个 authority：
+
+```cpp
+mqb::platform::windows::path_identity_key(path)
+```
+
+它负责 lexical normalization，并只折叠 ASCII `A-Z`；non-ASCII UTF-8 bytes 原样保留，不允许经过 locale-sensitive narrow `std::tolower`。Discovery、artifact layout、module provider identity、compile/link/archive cache、`BuildSignature`、library resolver、LINK freshness/observation、Visual Studio/portable toolchain identity 都必须共享这一规则。
+
+以下操作不得自行重新实现 Windows path identity：path equality、dedup、set membership、case-insensitive key、root containment。`generic_string() + std::tolower`、自定义 `normalized_path_text()` / `same_windows_path()` 一类实现都不属于允许的 identity primitive。
+
+字符串**展示/序列化**、环境变量名比较、MSVC option parsing，以及“选择 latest version”所需的确定性**排序**不是路径 identity；这些场景可以保留各自规则，但代码应避免把 ordering/formatting helper 当作 equality authority。
+
 配置解析与 precedence 的完整行为见 [`MQB_CONFIG.md`](MQB_CONFIG.md)。
 
 ## 9. 源码物理结构
@@ -278,6 +292,7 @@ cpp/
 10. Correctness 优先于缓存命中率；unsupported/ambiguous state fail closed。
 11. `cpp/include`、`cpp/src`、`cpp/tests` 各自只有一个物理根。
 12. MQB 自身的开发、测试与发布构建以 MQB 为构建系统。
+13. Windows path equality / dedup / identity key 只能由 `path_identity_key()` 定义；其他层不得建立第二套 case-folding authority。
 
 ## 11. 当前边界
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -256,9 +256,11 @@ MQB 面向 Windows/MSVC，因此凡是判断**路径是否代表同一 Windows �
 mqb::platform::windows::path_identity_key(path)
 ```
 
-它负责 lexical normalization，并只折叠 ASCII `A-Z`；non-ASCII UTF-8 bytes 原样保留，不允许经过 locale-sensitive narrow `std::tolower`。Discovery、artifact layout、module provider identity、compile/link/archive cache、`BuildSignature`、library resolver、LINK freshness/observation、Visual Studio/portable toolchain identity 都必须共享这一规则。
+它负责 lexical normalization、消除非根路径的冗余尾分隔符，并只折叠 ASCII `A-Z`；non-ASCII UTF-8 bytes 原样保留，不允许经过 locale-sensitive narrow `std::tolower`。Discovery、artifact layout、module provider identity、compile/link/archive cache、`BuildSignature`、library resolver、LINK freshness/observation、Visual Studio/portable toolchain identity 都必须共享这一规则。
 
 以下操作不得自行重新实现 Windows path identity：path equality、dedup、set membership、case-insensitive key、root containment。`generic_string() + std::tolower`、自定义 `normalized_path_text()` / `same_windows_path()` 一类实现都不属于允许的 identity primitive。
+
+存在一个刻意收窄的不同语义：当 MQB 需要验证**两个已经存在的路径是否指向同一个物理 filesystem object**时，例如 `/sourceDependencies` 返回的 source provenance，或 include-search freshness 需要把 junction/symlink/canonical alias 视为同一个已存在搜索目录，可以在先比较 `path_identity_key()` 后使用 `std::filesystem::equivalent()` 作为 physical-provenance probe。它不得生成 identity key，也不得用于 `BuildSignature`、cache/artifact ownership、普通 path set membership，代码必须用明确的 `physical/provenance` 命名与注释说明该语义。
 
 字符串**展示/序列化**、环境变量名比较、MSVC option parsing，以及“选择 latest version”所需的确定性**排序**不是路径 identity；这些场景可以保留各自规则，但代码应避免把 ordering/formatting helper 当作 equality authority。
 
@@ -292,7 +294,7 @@ cpp/
 10. Correctness 优先于缓存命中率；unsupported/ambiguous state fail closed。
 11. `cpp/include`、`cpp/src`、`cpp/tests` 各自只有一个物理根。
 12. MQB 自身的开发、测试与发布构建以 MQB 为构建系统。
-13. Windows path equality / dedup / identity key 只能由 `path_identity_key()` 定义；其他层不得建立第二套 case-folding authority。
+13. Windows path equality / dedup / identity key 只能由 `path_identity_key()` 定义；`filesystem::equivalent()` 仅允许用于显式的已存在 physical-provenance/freshness probe，不能成为第二套 lexical/case-folding authority。
 
 ## 11. 当前边界
 

--- a/docs/ARCHITECTURE_EN.md
+++ b/docs/ARCHITECTURE_EN.md
@@ -256,9 +256,11 @@ MQB targets Windows/MSVC, so every decision asking whether two paths represent t
 mqb::platform::windows::path_identity_key(path)
 ```
 
-It performs lexical normalization and folds ASCII `A-Z` only. Non-ASCII UTF-8 bytes are preserved verbatim and must never be passed through locale-sensitive narrow `std::tolower`. Discovery, artifact layout, module-provider identity, compile/link/archive caches, `BuildSignature`, library resolution, LINK freshness/observation, and Visual Studio/portable toolchain identity all share this rule.
+It performs lexical normalization, removes redundant trailing separators from non-root paths, and folds ASCII `A-Z` only. Non-ASCII UTF-8 bytes are preserved verbatim and must never be passed through locale-sensitive narrow `std::tolower`. Discovery, artifact layout, module-provider identity, compile/link/archive caches, `BuildSignature`, library resolution, LINK freshness/observation, and Visual Studio/portable toolchain identity all share this rule.
 
 Path equality, deduplication, set membership, case-insensitive keys, and root containment must not reimplement Windows path identity. Patterns such as `generic_string() + std::tolower` or local `normalized_path_text()` / `same_windows_path()` helpers are not valid identity primitives.
+
+There is one deliberately narrow different semantic: when MQB must prove that **two already-existing paths refer to the same physical filesystem object**, for example `/sourceDependencies` source provenance or include-search freshness coalescing a junction/symlink/canonical alias to the same existing search directory, code may use `std::filesystem::equivalent()` after first checking `path_identity_key()`. That is a physical-provenance probe: it must not generate identity keys and must not be used for `BuildSignature`, cache/artifact ownership, or ordinary path-set membership. Such code must use explicit `physical/provenance` naming and comments.
 
 String **display/serialization**, environment-variable-name comparison, MSVC option parsing, and deterministic **ordering** used to select a latest version are not path identity. Those operations may retain purpose-specific rules, but ordering/formatting helpers must not become equality authorities.
 
@@ -292,7 +294,7 @@ Those roots are organized by responsibility such as `core / config / discovery /
 10. Correctness beats cache hit rate; unsupported or ambiguous states fail closed.
 11. `cpp/include`, `cpp/src`, and `cpp/tests` each have one physical root.
 12. MQB uses MQB as the build system for its own development, tests, and release builds.
-13. Windows path equality, deduplication, and identity keys are defined only by `path_identity_key()`; no other layer may establish a second case-folding authority.
+13. Windows path equality, deduplication, and identity keys are defined only by `path_identity_key()`; `filesystem::equivalent()` is restricted to explicit existing-object physical-provenance/freshness probes and may not become a second lexical/case-folding authority.
 
 ## 11. Current boundary
 

--- a/docs/ARCHITECTURE_EN.md
+++ b/docs/ARCHITECTURE_EN.md
@@ -248,6 +248,20 @@ config path   -> directory containing mqb.json
 
 When `mqb.json` exists, its directory is the project root and `.mqb/` root. Without it, the project root is derived from invocation/source context.
 
+### Windows path identity authority
+
+MQB targets Windows/MSVC, so every decision asking whether two paths represent the **same Windows path** has exactly one authority:
+
+```cpp
+mqb::platform::windows::path_identity_key(path)
+```
+
+It performs lexical normalization and folds ASCII `A-Z` only. Non-ASCII UTF-8 bytes are preserved verbatim and must never be passed through locale-sensitive narrow `std::tolower`. Discovery, artifact layout, module-provider identity, compile/link/archive caches, `BuildSignature`, library resolution, LINK freshness/observation, and Visual Studio/portable toolchain identity all share this rule.
+
+Path equality, deduplication, set membership, case-insensitive keys, and root containment must not reimplement Windows path identity. Patterns such as `generic_string() + std::tolower` or local `normalized_path_text()` / `same_windows_path()` helpers are not valid identity primitives.
+
+String **display/serialization**, environment-variable-name comparison, MSVC option parsing, and deterministic **ordering** used to select a latest version are not path identity. Those operations may retain purpose-specific rules, but ordering/formatting helpers must not become equality authorities.
+
 See [`MQB_CONFIG_EN.md`](MQB_CONFIG_EN.md) for full parsing and precedence behavior.
 
 ## 9. Physical source layout
@@ -278,6 +292,7 @@ Those roots are organized by responsibility such as `core / config / discovery /
 10. Correctness beats cache hit rate; unsupported or ambiguous states fail closed.
 11. `cpp/include`, `cpp/src`, and `cpp/tests` each have one physical root.
 12. MQB uses MQB as the build system for its own development, tests, and release builds.
+13. Windows path equality, deduplication, and identity keys are defined only by `path_identity_key()`; no other layer may establish a second case-folding authority.
 
 ## 11. Current boundary
 


### PR DESCRIPTION
## Final Closure #5 — Windows Path Identity Authority

Closes the productization audit gap where later correctness hardening reintroduced multiple Windows path-identity implementations after the shared `mqb::platform::windows::path_identity_key()` authority had already been established.

### Root cause

Later library freshness/toolchain/cache work added local equality/key rules such as `generic_string() + std::tolower`, `normalized_path_text()`, lexical-only `same_path()`, and filesystem-equivalence fallbacks. That split identity semantics across discovery/modules, library resolution, LINK observations, incremental freshness, caches/signatures, artifact layout, and toolchain reuse.

### Changes

- route compile/link/archive cache path equality through `path_identity_key()`
- route every path field hashed by `BuildSignature` through the same authority
- route project artifact source identity/hash through the same authority
- remove library resolver and LINK observation custom Windows path keys
- unify incremental LINK side-output/file-input membership and dedup
- unify incremental compile/include-search lexical path identity
- remove Visual Studio cache `normalized_path_text()` and use the shared authority for roots/tool paths/latest toolset checks
- use the shared authority for cached SDK-version path-component identity
- make the authority normalize redundant trailing separators on non-root paths (`C:/sdk` == `C:/sdk/`)
- retain purpose-specific ASCII parsing only for environment-variable names/MSVC options and deterministic version ordering as ordering, not equality
- retain `std::filesystem::equivalent()` only as an explicitly named existing-object physical-provenance probe for compiler source metadata/include-search junction/symlink/canonical aliases; it is not a cache/signature/artifact identity primitive
- document both the single authority and the narrow physical-provenance exception in the bilingual architecture docs

### Regression coverage

- Unicode project path + ASCII case alias artifact identity
- Unicode library directory
- Unicode library path with different ASCII casing
- Unicode portable toolchain root
- LINK `/VERBOSE:LIB` observation dedup across ASCII casing
- distinct non-ASCII path bytes remain distinct
- compile/link/archive/module-provider signatures share Windows path identity
- Visual Studio/toolchain paths with redundant trailing separators share one identity
- existing physical include/source aliases retain provenance/freshness correctness without becoming a second lexical identity authority

### Final-closure invariant

Windows path equality, deduplication, set membership, case-insensitive keys, and path-root containment have one lexical/case-folding authority: `mqb::platform::windows::path_identity_key()`.

`std::filesystem::equivalent()` is reserved for explicitly documented checks that ask a different question — whether two already-existing spellings resolve to the same physical filesystem object — and must not generate cache/signature/artifact identity.
