### PR TITLE
fix: close librarian native UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,4 +318,4 @@ mqb <source...> [options]
 
 ## License
 
-Apache License 2.0（SPDX: `Apache-2.0`）。完整条款见 [`LICENSE`](LICENSE）。
+Apache License 2.0（SPDX: `Apache-2.0`）。完整条款见 [`LICENSE`](LICENSE)。

--- a/README.md
+++ b/README.md
@@ -142,6 +142,34 @@ mqb build math.cpp vector.cpp --type static -o math
 
 支持 `exe`、`dll`、`static`。`mqb run` 只适用于 executable target。
 
+### 原生 linker / librarian 参数
+
+Executable / DLL 构建使用 `/link` 把其后的 build argv 交给 `link.exe`：
+
+```powershell
+mqb build foo.cpp /O2 /link /DEBUG:FULL /STACK:8388608
+```
+
+Static target 使用独立的 `/lib` boundary，把其后的参数交给 `lib.exe`：
+
+```powershell
+mqb build foo.cpp --type static /lib /WX /EXPORT:foo
+```
+
+`/lib` 是 **static librarian boundary 的唯一公开拼写**（`/LIB` 同样接受）；`-lib` / `-LIB` 明确拒绝，以免与 MQB 的 `-l <name>` / `-l<name>` library shorthand 冲突。Librarian policy 也可以配置：
+
+```json
+{
+  "version": 1,
+  "build": {
+    "type": "static",
+    "librarian_args": ["/WX", "/EXPORT:foo"]
+  }
+}
+```
+
+`librarian_args` 与其他 list policy 一样按 base config → selected profile → CLI `/lib` 顺序追加；它只允许用于 static target，并进入 archive recipe/cache identity。
+
 ## 核心能力
 
 - `mqb build` / `mqb run` 项目命令与 fail-closed 默认入口解析。
@@ -154,7 +182,7 @@ mqb build math.cpp vector.cpp --type static -o math
 - `-j / --jobs` 有界并行 scan/compile。
 - `exe` / `dll` / `static` typed targets。
 - typed runtime、LTCG、subsystem policy。
-- 原生 MSVC compiler/linker 参数与 `/link` 分界。
+- 原生 MSVC compiler/linker/librarian 参数，以及 `/link` / `/lib` 明确分界。
 - project-local named modules 与 header units。
 - external/prebuilt named-module IFC providers。
 - MSVC toolchain-owned `import std` / `import std.compat`。
@@ -193,11 +221,24 @@ MQB 从执行目录向上查找最近的 `mqb.json`。该文件所在目录成�
 }
 ```
 
+静态库可以声明 librarian policy：
+
+```json
+{
+  "version": 1,
+  "build": {
+    "entry": "src/math.cpp",
+    "type": "static",
+    "librarian_args": ["/WX"]
+  }
+}
+```
+
 `build.entry` 相对 `mqb.json` 解析，仅在 `mqb build` / `mqb run` 没有显式 positional source 时使用。若未设置，MQB 只在 project root 与 `src/` 中寻找 conventional `main.{c,cpp,cc,cxx}`；必须恰好命中一个，否则明确报错。
 
 `build.pch` 可为非空 header 路径或 `false`。配置/profile 中的 PCH 路径相对 `mqb.json`；CLI `--pch` 路径相对 invocation directory。Profile 可覆盖或用 `pch: false` 关闭 base PCH，CLI `--pch` / `--no-pch` 再覆盖 profile。
 
-Named profile 也声明在同一配置文件中，并用 `--profile <name>` 显式选择。Profile 内路径同样相对 `mqb.json`，native compiler/linker arguments 仍经过统一的 MSVC Parameter Engine；profile 名本身不是额外 cache 维度，最终生效的构建语义才决定 cache identity。
+Named profile 也声明在同一配置文件中，并用 `--profile <name>` 显式选择。Profile 内路径同样相对 `mqb.json`，native compiler/linker/librarian arguments 仍经过统一的 MSVC Parameter Engine；profile 名本身不是额外 cache 维度，最终生效的构建语义才决定 cache identity。
 
 External/prebuilt module IFC 也可在配置中声明：
 
@@ -243,6 +284,7 @@ mqb <source...> [options]
 | `-l <name>` / `--lib <name>` | library |
 | `/option` / `-option` | 原生 MSVC compiler 参数 |
 | `/link <...>` | 后续 build 参数路由到 linker |
+| `/lib <...>` | static target：后续 build 参数路由到 librarian；`-lib` 不支持 |
 | `--compiler-arg <arg>` | 原样 compiler argv element |
 | `--linker-arg <arg>` | 原样 linker argv element |
 | `--env <auto|vs|portable>` | toolchain selection |
@@ -276,4 +318,4 @@ mqb <source...> [options]
 
 ## License
 
-Apache License 2.0（SPDX: `Apache-2.0`）。完整条款见 [`LICENSE`](LICENSE)。
+Apache License 2.0（SPDX: `Apache-2.0`）。完整条款见 [`LICENSE`](LICENSE）。

--- a/cpp/src/app/cli/Cli.cpp
+++ b/cpp/src/app/cli/Cli.cpp
@@ -601,6 +601,11 @@ parse_arguments(const std::span<const std::string_view> arguments) {
             options.libraries.emplace_back(*value);
             continue;
         }
+        if (argument == "-lib" || argument == "-LIB") {
+            return std::unexpected(error(
+                "'-lib' is not a librarian separator; use '/lib' for static-target librarian options, "
+                "or '-l <name>' / '-l<name>' for a link library"));
+        }
         if (argument == "-I" || argument.starts_with("-I")) {
             auto value = attached_or_next(arguments, index, argument, "-I");
             if (!value) return std::unexpected(value.error());
@@ -621,11 +626,6 @@ parse_arguments(const std::span<const std::string_view> arguments) {
             if (value->empty()) return std::unexpected(error("empty library directory"));
             options.library_directories.emplace_back(std::string{*value});
             continue;
-        }
-        if (argument == "-lib" || argument == "-LIB") {
-            return std::unexpected(error(
-                "'-lib' is not a librarian separator; use '/lib' for static-target librarian options, "
-                "or '-l <name>' / '-l<name>' for a link library"));
         }
         if (argument == "-l" || argument.starts_with("-l")) {
             auto value = attached_or_next(arguments, index, argument, "-l");

--- a/cpp/src/app/cli/Cli.cpp
+++ b/cpp/src/app/cli/Cli.cpp
@@ -261,6 +261,8 @@ parse_arguments(const std::span<const std::string_view> arguments) {
 
     bool native_linker_tail = false;
     bool native_linker_tail_has_argument = false;
+    bool native_librarian_tail = false;
+    bool native_librarian_tail_has_argument = false;
 
     for (std::size_t index = first_argument; index < arguments.size(); ++index) {
         const std::string_view argument = arguments[index];
@@ -270,6 +272,19 @@ parse_arguments(const std::span<const std::string_view> arguments) {
                 options.build.run_arguments.emplace_back(arguments[index]);
             }
             break;
+        }
+        if (native_librarian_tail) {
+            if (argument == "/lib" || argument == "/LIB") {
+                return std::unexpected(error("duplicate native MSVC /lib separator"));
+            }
+            if (argument.starts_with("--")) {
+                return std::unexpected(error(
+                    "MQB option '" + std::string{argument}
+                    + "' must appear before native MSVC /lib"));
+            }
+            options.librarian_arguments.emplace_back(argument);
+            native_librarian_tail_has_argument = true;
+            continue;
         }
         if (native_linker_tail) {
             if (argument == "/link" || argument == "-link") {
@@ -282,6 +297,14 @@ parse_arguments(const std::span<const std::string_view> arguments) {
             }
             options.linker_arguments.emplace_back(argument);
             native_linker_tail_has_argument = true;
+            continue;
+        }
+        if (argument == "/lib" || argument == "/LIB") {
+            if (options.build.sources.empty() && options.command == Command::direct) {
+                return std::unexpected(error(
+                    "native MSVC /lib must appear after at least one source file"));
+            }
+            native_librarian_tail = true;
             continue;
         }
         if (argument == "/link" || argument == "-link") {
@@ -635,6 +658,9 @@ parse_arguments(const std::span<const std::string_view> arguments) {
     if (native_linker_tail && !native_linker_tail_has_argument) {
         return std::unexpected(error("native MSVC /link requires at least one linker option"));
     }
+    if (native_librarian_tail && !native_librarian_tail_has_argument) {
+        return std::unexpected(error("native MSVC /lib requires at least one librarian option"));
+    }
     if (!options.show_help
         && options.build.sources.empty()
         && options.command == Command::direct) {
@@ -744,17 +770,17 @@ PCH structural switches remain in the parameter engine's MQB-owned/unsupported d
 
 Native MSVC compiler switches may use '/' or a single '-' prefix. MQB '--long' options remain
 in the MQB namespace. `/link` (or `-link`) is a one-way compiler-to-linker boundary for build
-arguments; `/lib` is the librarian boundary for static-library builds. The librarian separator
-uses the slash spelling only (case-insensitive for `/lib` and `/LIB`); `-lib`/`-LIB` is rejected
-so it cannot collide with MQB's `-l` library shorthand. MQB options must appear before either
-native boundary. The outer `--` delimiter still ends build parsing and starts executable argv.
-`mqb run ... /link ... -- child-args` and the legacy source-first `--run` form remain supported.
-Native switches and @response syntax are not semantically reimplemented by the CLI: they flow
-through the same ownership, normalization, conflict, and cache-identity rules as
---compiler-arg/--linker-arg and build.librarian_args. For direct native compiler syntax the CLI
-asks the parameter engine for each option's token shape before treating a following bare token
-as a source. Exact split forms such as `/I dir`, `/D NAME`, `/U NAME`, and `/external:I dir` keep
-their option and operand as ordered raw compiler argv; attached spellings consume no extra token.
+arguments; `/lib` is the one-way compiler-to-librarian boundary for static-library builds. The
+librarian separator accepts the lowercase `/lib` and uppercase `/LIB` spellings; `-lib`/`-LIB`
+is rejected so it cannot collide with MQB's `-l` library shorthand. MQB options must appear
+before either native boundary. The outer `--` delimiter still ends build parsing and starts
+executable argv. `mqb run ... /link ... -- child-args` and the legacy source-first `--run` form
+remain supported. Native switches and @response syntax are not semantically reimplemented by
+the CLI: they flow through the same ownership, normalization, conflict, and cache-identity rules
+as --compiler-arg/--linker-arg and build.librarian_args. For direct native compiler syntax the
+CLI asks the parameter engine for each option's token shape before treating a following bare
+token as a source. Exact split forms such as `/I dir`, `/D NAME`, `/U NAME`, and `/external:I dir`
+keep their option and operand as ordered raw compiler argv; attached spellings consume no extra token.
 
 Static libraries are produced by MSVC lib.exe from the compiled object set. Native librarian
 policy can be supplied with `mqb build foo.cpp --type static /lib ...` or through

--- a/cpp/src/app/cli/Cli.cpp
+++ b/cpp/src/app/cli/Cli.cpp
@@ -599,6 +599,11 @@ parse_arguments(const std::span<const std::string_view> arguments) {
             options.library_directories.emplace_back(std::string{*value});
             continue;
         }
+        if (argument == "-lib" || argument == "-LIB") {
+            return std::unexpected(error(
+                "'-lib' is not a librarian separator; use '/lib' for static-target librarian options, "
+                "or '-l <name>' / '-l<name>' for a link library"));
+        }
         if (argument == "-l" || argument.starts_with("-l")) {
             auto value = attached_or_next(arguments, index, argument, "-l");
             if (!value) return std::unexpected(value.error());
@@ -647,6 +652,7 @@ std::string_view usage() noexcept {
     return "MQB " MQB_VERSION " - MSVC Quick Build (C++ refactor)\n\n"
 R"(Usage:
   mqb build [entry.cpp] [options] [MSVC-compiler-options] [/link linker-options...]
+  mqb build [source...] --type static [options] [MSVC-compiler-options] [/lib librarian-options...]
   mqb run [entry.cpp] [options] [MSVC-compiler-options] [/link linker-options...] [-- program-args...]
   mqb <entry.cpp> [options] [MSVC-compiler-options] [/link linker-options...] [-- program-args...]
   mqb <source.cpp> <more-sources...|module.ixx...> [options] [MSVC-compiler-options] [/link linker-options...] [-- program-args...]
@@ -720,6 +726,8 @@ Options:
   --lib <name>            Link a library
   /option, -option        Route a native MSVC compiler switch through the parameter engine
   /link <link-options...> Route the remaining build argv to native linker options
+  /lib <librarian-options...>
+                           Route the remaining static-target build argv to native lib.exe options
   --compiler-arg <arg>    Append one raw cl.exe argument
   --linker-arg <arg>      Append one raw link.exe argument
   --env <auto|vs|portable>
@@ -736,22 +744,27 @@ PCH structural switches remain in the parameter engine's MQB-owned/unsupported d
 
 Native MSVC compiler switches may use '/' or a single '-' prefix. MQB '--long' options remain
 in the MQB namespace. `/link` (or `-link`) is a one-way compiler-to-linker boundary for build
-arguments; MQB options must appear before it. The outer `--` delimiter still ends build parsing
-and starts executable argv. `mqb run ... /link ... -- child-args` and the legacy source-first
-`--run` form remain supported. Native switches and @response syntax are not semantically
-reimplemented by the CLI: they flow through the same ownership, normalization, conflict, and
-cache-identity rules as --compiler-arg/--linker-arg. For direct native syntax the CLI asks the
-parameter engine for each option's token shape before treating a following bare token as a
-source. Exact split forms such as `/I dir`, `/D NAME`, `/U NAME`, and `/external:I dir` keep
+arguments; `/lib` is the librarian boundary for static-library builds. The librarian separator
+uses the slash spelling only (case-insensitive for `/lib` and `/LIB`); `-lib`/`-LIB` is rejected
+so it cannot collide with MQB's `-l` library shorthand. MQB options must appear before either
+native boundary. The outer `--` delimiter still ends build parsing and starts executable argv.
+`mqb run ... /link ... -- child-args` and the legacy source-first `--run` form remain supported.
+Native switches and @response syntax are not semantically reimplemented by the CLI: they flow
+through the same ownership, normalization, conflict, and cache-identity rules as
+--compiler-arg/--linker-arg and build.librarian_args. For direct native compiler syntax the CLI
+asks the parameter engine for each option's token shape before treating a following bare token
+as a source. Exact split forms such as `/I dir`, `/D NAME`, `/U NAME`, and `/external:I dir` keep
 their option and operand as ordered raw compiler argv; attached spellings consume no extra token.
 
-Static libraries are produced by MSVC lib.exe from the compiled object set. Linker-only policy
-(libraries, library search paths, subsystem, and raw linker arguments) is rejected for static
-targets. Typed LTCG remains valid for static targets and couples /GL compilation with lib.exe
-/LTCG archive policy.
+Static libraries are produced by MSVC lib.exe from the compiled object set. Native librarian
+policy can be supplied with `mqb build foo.cpp --type static /lib ...` or through
+`build.librarian_args`; config/profile/CLI list values append in base -> profile -> CLI order.
+Librarian arguments are rejected for non-static targets. Linker-only policy (libraries, library
+search paths, subsystem, and raw linker arguments) is rejected for static targets. Typed LTCG
+remains valid for static targets and couples /GL compilation with lib.exe /LTCG archive policy.
 
-Raw compiler/linker arguments preserve argv element boundaries; MQB does not split a quoted
-string into multiple switches. Project config entries are applied first, selected profile
+Raw compiler/linker/librarian arguments preserve argv element boundaries; MQB does not split a
+quoted string into multiple switches. Project config entries are applied first, selected profile
 entries append/override next, and CLI entries apply last. Typed runtime/LTCG/PCH policy and
 structured artifact routing are emitted after raw arguments so the BuildPlan remains authoritative.
 

--- a/cpp/src/app/project/ProjectSetup.cpp
+++ b/cpp/src/app/project/ProjectSetup.cpp
@@ -50,42 +50,6 @@ template <typename T>
     return message;
 }
 
-[[nodiscard]] bool is_native_librarian_boundary(const std::string_view argument) noexcept {
-    return argument == "/lib" || argument == "/LIB";
-}
-
-[[nodiscard]] std::expected<void, std::string> extract_native_librarian_tail(
-    mqb::config::BuildOverrides& build,
-    const std::string_view layer) {
-    std::optional<std::size_t> boundary;
-    for (std::size_t index = 0; index < build.compiler_arguments.size(); ++index) {
-        if (!is_native_librarian_boundary(build.compiler_arguments[index])) {
-            continue;
-        }
-        if (boundary) {
-            return std::unexpected(
-                std::string{layer} + " contains a duplicate native MSVC /lib separator");
-        }
-        boundary = index;
-    }
-    if (!boundary) {
-        return {};
-    }
-    if (*boundary + 1 == build.compiler_arguments.size()) {
-        return std::unexpected(
-            std::string{layer} + " native MSVC /lib requires at least one librarian option");
-    }
-
-    build.librarian_arguments.insert(
-        build.librarian_arguments.end(),
-        std::make_move_iterator(build.compiler_arguments.begin() + *boundary + 1),
-        std::make_move_iterator(build.compiler_arguments.end()));
-    build.compiler_arguments.erase(
-        build.compiler_arguments.begin() + *boundary,
-        build.compiler_arguments.end());
-    return {};
-}
-
 [[nodiscard]] std::expected<void, std::string> append_linker_file_input(
     std::vector<mqb::msvc::LinkerFileInput>& inputs,
     mqb::msvc::LinkerFileInput input,
@@ -320,13 +284,6 @@ prepare_project(
     cli_overrides.build.librarian_arguments = options.librarian_arguments;
     cli_overrides.discovery.enabled = options.discovery_override;
     cli_overrides.modules.external_providers = options.external_module_providers;
-
-    if (auto extracted = extract_native_librarian_tail(cli_overrides.build, "CLI"); !extracted) {
-        return std::unexpected(ProjectSetupError{
-            .message = extracted.error(),
-            .config_error = std::nullopt,
-        });
-    }
 
     std::vector<fs::path> native_include_directories;
     // This app-layer vector exists only while resolving config/profile/CLI so

--- a/cpp/src/app/project/ProjectSetup.cpp
+++ b/cpp/src/app/project/ProjectSetup.cpp
@@ -51,8 +51,7 @@ template <typename T>
 }
 
 [[nodiscard]] bool is_native_librarian_boundary(const std::string_view argument) noexcept {
-    return argument == "/lib" || argument == "-lib"
-        || argument == "/LIB" || argument == "-LIB";
+    return argument == "/lib" || argument == "/LIB";
 }
 
 [[nodiscard]] std::expected<void, std::string> extract_native_librarian_tail(

--- a/cpp/tests/app/cli/build_policy_cli_tests.cpp
+++ b/cpp/tests/app/cli/build_policy_cli_tests.cpp
@@ -2,6 +2,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <string>
 #include <string_view>
 #include <system_error>
 #include <vector>
@@ -93,25 +94,26 @@ int main() {
             "/WX"sv,
         };
         auto parsed = mqb::cli::parse_arguments(arguments);
-        expect(parsed.has_value(), "native /lib boundary should parse as native argv before project setup");
+        expect(parsed.has_value(), "native /lib boundary should enter a one-way librarian tail");
         if (parsed) {
-            expect(parsed->compiler_arguments.size() == 4
-                       && parsed->compiler_arguments[0] == "/W4"
-                       && parsed->compiler_arguments[1] == "/lib"
-                       && parsed->compiler_arguments[2] == "/EXPORT:mqb_export"
-                       && parsed->compiler_arguments[3] == "/WX",
-                   "CLI parser should preserve /lib and its tail until ownership routing");
+            expect(parsed->compiler_arguments.size() == 1
+                       && parsed->compiler_arguments[0] == "/W4",
+                   "compiler argv before /lib should remain compiler-owned at the CLI boundary");
+            expect(parsed->librarian_arguments.size() == 2
+                       && parsed->librarian_arguments[0] == "/EXPORT:mqb_export"
+                       && parsed->librarian_arguments[1] == "/WX",
+                   "every argv element after /lib should be captured as ordered librarian policy");
 
             auto project = mqb::app::prepare_project(*parsed, tree.root);
-            expect(project.has_value(), "project setup should split and route native /lib policy");
+            expect(project.has_value(), "project setup should route CLI librarian policy");
             if (project) {
                 expect(parsed->compiler_arguments.size() == 1
                            && parsed->compiler_arguments[0] == "/W4",
-                       "compiler argv before /lib should remain compiler-owned");
+                       "project setup must preserve compiler argv that preceded /lib");
                 expect(parsed->librarian_arguments.size() == 2
                            && parsed->librarian_arguments[0] == "/EXPORT:mqb_export"
                            && parsed->librarian_arguments[1] == "/WX",
-                       "every native option after /lib should become routed librarian policy in order");
+                       "routed librarian policy should preserve CLI tail order");
                 expect(project->effective.target_kind == mqb::TargetKind::static_library,
                        "native librarian policy should coexist with the typed static target kind");
             }
@@ -124,16 +126,14 @@ int main() {
             "/WX"sv,
         };
         auto uppercase = mqb::cli::parse_arguments(uppercase_arguments);
-        expect(uppercase.has_value(), "uppercase /LIB boundary should parse before ownership routing");
+        expect(uppercase.has_value(), "uppercase /LIB should be accepted as the librarian boundary");
         if (uppercase) {
+            expect(uppercase->compiler_arguments.empty()
+                       && uppercase->librarian_arguments.size() == 1
+                       && uppercase->librarian_arguments.front() == "/WX",
+                   "uppercase /LIB should route its tail exclusively to librarian argv");
             auto project = mqb::app::prepare_project(*uppercase, tree.root);
-            expect(project.has_value(), "uppercase /LIB should be accepted as the librarian boundary");
-            if (project) {
-                expect(uppercase->compiler_arguments.empty()
-                           && uppercase->librarian_arguments.size() == 1
-                           && uppercase->librarian_arguments.front() == "/WX",
-                       "uppercase /LIB should route its tail exclusively to librarian argv");
-            }
+            expect(project.has_value(), "uppercase /LIB librarian policy should survive project setup");
         }
 
         const std::vector shorthand_arguments{
@@ -148,6 +148,24 @@ int main() {
                        && shorthand->libraries[0] == "kernel32"
                        && shorthand->libraries[1] == "user32",
                    "-l separated and attached forms must retain library shorthand semantics");
+        }
+
+        const std::vector tail_shorthand_arguments{
+            "main.cpp"sv,
+            "--type"sv, "static"sv,
+            "/lib"sv,
+            "-luser32"sv,
+        };
+        auto tail_shorthand = mqb::cli::parse_arguments(tail_shorthand_arguments);
+        expect(tail_shorthand.has_value(), "-l after /lib should remain inside the librarian tail");
+        if (tail_shorthand) {
+            expect(tail_shorthand->libraries.empty()
+                       && tail_shorthand->librarian_arguments.size() == 1
+                       && tail_shorthand->librarian_arguments.front() == "-luser32",
+                   "/lib must be one-way and prevent later -l text from becoming MQB library shorthand");
+            auto project = mqb::app::prepare_project(*tail_shorthand, tree.root);
+            expect(!project,
+                   "link-library shorthand text after /lib should fail librarian classification rather than leak back to MQB parsing");
         }
 
         for (const auto rejected : {"-lib"sv, "-LIB"sv}) {
@@ -179,18 +197,29 @@ int main() {
                    "raw -lib must not regain librarian-boundary semantics inside ProjectSetup");
         }
 
+        const std::vector option_after_boundary_arguments{
+            "main.cpp"sv,
+            "--type"sv, "static"sv,
+            "/lib"sv,
+            "/WX"sv,
+            "--verbose"sv,
+        };
+        auto option_after_boundary = mqb::cli::parse_arguments(option_after_boundary_arguments);
+        expect(!option_after_boundary,
+               "MQB long options after /lib should fail instead of escaping the one-way librarian tail");
+        if (!option_after_boundary) {
+            expect(option_after_boundary.error().message.find("must appear before native MSVC /lib") != std::string::npos,
+                   "post-/lib MQB option error should explain the boundary ordering rule");
+        }
+
         const std::vector empty_tail_arguments{
             "main.cpp"sv,
             "--type"sv, "static"sv,
             "/lib"sv,
         };
         auto empty_tail = mqb::cli::parse_arguments(empty_tail_arguments);
-        expect(empty_tail.has_value(), "bare /lib should remain syntactically parseable at CLI stage");
-        if (empty_tail) {
-            auto project = mqb::app::prepare_project(*empty_tail, tree.root);
-            expect(!project && project.error().message.find("requires at least one librarian option") != std::string::npos,
-                   "bare /lib should fail closed at ownership routing");
-        }
+        expect(!empty_tail && empty_tail.error().message.find("requires at least one librarian option") != std::string::npos,
+               "bare /lib should fail closed at the CLI boundary");
 
         const std::vector owned_output_arguments{
             "main.cpp"sv,
@@ -229,20 +258,20 @@ int main() {
             "/EXPORT:duplicate"sv,
         };
         auto duplicate_boundary = mqb::cli::parse_arguments(duplicate_boundary_arguments);
-        expect(duplicate_boundary.has_value(), "duplicate /lib boundary should parse before routing");
-        if (duplicate_boundary) {
-            auto project = mqb::app::prepare_project(*duplicate_boundary, tree.root);
-            expect(!project && project.error().message.find("duplicate native MSVC /lib separator") != std::string::npos,
-                   "duplicate /lib boundary should be rejected deterministically");
-        }
+        expect(!duplicate_boundary
+                   && duplicate_boundary.error().message.find("duplicate native MSVC /lib separator") != std::string::npos,
+               "duplicate /lib boundary should be rejected deterministically by the CLI state machine");
 
         const std::string_view help = mqb::cli::usage();
         expect(help.find("/lib <librarian-options...>") != std::string_view::npos,
                "--help contract should expose the native /lib librarian boundary");
-        expect(help.find("-lib`/`-LIB` is rejected") != std::string_view::npos,
+        expect(help.find("-lib`/`-LIB`") != std::string_view::npos
+                   && help.find("is rejected") != std::string_view::npos,
                "--help contract should expose the chosen dash -lib rejection policy");
         expect(help.find("build.librarian_args") != std::string_view::npos,
                "--help contract should expose the librarian config surface");
+        expect(help.find("one-way compiler-to-librarian boundary") != std::string_view::npos,
+               "--help contract should expose the one-way /lib boundary semantics");
     }
 
     {

--- a/cpp/tests/app/cli/build_policy_cli_tests.cpp
+++ b/cpp/tests/app/cli/build_policy_cli_tests.cpp
@@ -117,6 +117,68 @@ int main() {
             }
         }
 
+        const std::vector uppercase_arguments{
+            "main.cpp"sv,
+            "--type"sv, "static"sv,
+            "/LIB"sv,
+            "/WX"sv,
+        };
+        auto uppercase = mqb::cli::parse_arguments(uppercase_arguments);
+        expect(uppercase.has_value(), "uppercase /LIB boundary should parse before ownership routing");
+        if (uppercase) {
+            auto project = mqb::app::prepare_project(*uppercase, tree.root);
+            expect(project.has_value(), "uppercase /LIB should be accepted as the librarian boundary");
+            if (project) {
+                expect(uppercase->compiler_arguments.empty()
+                           && uppercase->librarian_arguments.size() == 1
+                           && uppercase->librarian_arguments.front() == "/WX",
+                       "uppercase /LIB should route its tail exclusively to librarian argv");
+            }
+        }
+
+        const std::vector shorthand_arguments{
+            "main.cpp"sv,
+            "-l"sv, "kernel32"sv,
+            "-luser32"sv,
+        };
+        auto shorthand = mqb::cli::parse_arguments(shorthand_arguments);
+        expect(shorthand.has_value(), "-l library shorthand must remain valid");
+        if (shorthand) {
+            expect(shorthand->libraries.size() == 2
+                       && shorthand->libraries[0] == "kernel32"
+                       && shorthand->libraries[1] == "user32",
+                   "-l separated and attached forms must retain library shorthand semantics");
+        }
+
+        for (const auto rejected : {"-lib"sv, "-LIB"sv}) {
+            const std::vector dash_arguments{
+                "main.cpp"sv,
+                "--type"sv, "static"sv,
+                rejected,
+                "/WX"sv,
+            };
+            auto dash = mqb::cli::parse_arguments(dash_arguments);
+            expect(!dash, "dash -lib spellings must be rejected instead of colliding with -l");
+            if (!dash) {
+                expect(dash.error().message.find("use '/lib'") != std::string::npos,
+                       "rejected -lib spelling should point users to the slash librarian boundary");
+            }
+        }
+
+        const std::vector raw_dash_arguments{
+            "main.cpp"sv,
+            "--type"sv, "static"sv,
+            "--compiler-arg"sv, "-lib"sv,
+            "/WX"sv,
+        };
+        auto raw_dash = mqb::cli::parse_arguments(raw_dash_arguments);
+        expect(raw_dash.has_value(), "raw --compiler-arg should preserve -lib for parameter routing");
+        if (raw_dash) {
+            auto project = mqb::app::prepare_project(*raw_dash, tree.root);
+            expect(!project,
+                   "raw -lib must not regain librarian-boundary semantics inside ProjectSetup");
+        }
+
         const std::vector empty_tail_arguments{
             "main.cpp"sv,
             "--type"sv, "static"sv,
@@ -173,6 +235,14 @@ int main() {
             expect(!project && project.error().message.find("duplicate native MSVC /lib separator") != std::string::npos,
                    "duplicate /lib boundary should be rejected deterministically");
         }
+
+        const std::string_view help = mqb::cli::usage();
+        expect(help.find("/lib <librarian-options...>") != std::string_view::npos,
+               "--help contract should expose the native /lib librarian boundary");
+        expect(help.find("-lib`/`-LIB` is rejected") != std::string_view::npos,
+               "--help contract should expose the chosen dash -lib rejection policy");
+        expect(help.find("build.librarian_args") != std::string_view::npos,
+               "--help contract should expose the librarian config surface");
     }
 
     {

--- a/cpp/tests/e2e/mqb_static_library_e2e_tests.cpp
+++ b/cpp/tests/e2e/mqb_static_library_e2e_tests.cpp
@@ -331,6 +331,21 @@ int main() {
     expect(override_run.has_value() && override_run->exit_code == 43,
            "CLI-overridden LTCG executable should consume the existing static library");
 
+    auto invalid_librarian_policy = run_process(
+        runner, mqb_executable, tree.root,
+        {"consumer.cpp", "--no-discover", "--env", "vs", "--type", "exe",
+         "-o", "invalid_librarian", "/lib", "/WX"});
+    expect(invalid_librarian_policy.has_value(),
+           "non-static librarian-policy invocation should launch");
+    if (invalid_librarian_policy) {
+        expect(invalid_librarian_policy->exit_code == 2,
+               "non-static target should reject native librarian policy");
+        expect(invalid_librarian_policy->stderr_text.find(
+                   "native MSVC librarian policy is only valid for static-library targets")
+                   != std::string::npos,
+               "non-static librarian-policy failure should explain the static-only contract");
+    }
+
     auto invalid_policy = run_process(
         runner, mqb_executable, tree.root,
         {"math.cpp", "--type", "static", "--subsystem", "console"});

--- a/docs/MQB_CONFIG.md
+++ b/docs/MQB_CONFIG.md
@@ -49,7 +49,8 @@ profiles
     "library_dirs": ["third_party/lib"],
     "libraries": ["user32", "codec.lib"],
     "compiler_args": ["/W4"],
-    "linker_args": ["/OPT:NOREF"]
+    "linker_args": ["/OPT:NOREF"],
+    "librarian_args": []
   },
   "discovery": {
     "enabled": true,
@@ -104,7 +105,8 @@ profiles
 | `library_dirs` | string[] | library search path；static target 不接受 |
 | `libraries` | string[] | link libraries；static target 不接受 |
 | `compiler_args` | string[] | 按顺序传给 `cl.exe` 的原始 argv element |
-| `linker_args` | string[] | 按顺序传给 linker 的原始 argv element；static target 不接受 |
+| `linker_args` | string[] | 按顺序传给 `link.exe` 的原始 argv element；static target 不接受 |
+| `librarian_args` | string[] | 按顺序传给 `lib.exe` 的原始 argv element；只允许 static target |
 
 ### 默认入口
 
@@ -200,7 +202,7 @@ MQB 自己拥有 synthetic creator、`.pch`、配对 creator `.obj`、`/FI`、`/
 
 ### Typed policy
 
-`type`、`runtime`、`ltcg`、`subsystem`、`pch` 是 MQB 的强类型/结构化策略，不是字符串形式的 MSVC flag 别名。MQB 后端负责最终命令行拼写，冲突的 raw compiler/linker argument 不应被用来绕过 typed policy 或 MQB-owned artifact routing。
+`type`、`runtime`、`ltcg`、`subsystem`、`pch` 是 MQB 的强类型/结构化策略，不是字符串形式的 MSVC flag 别名。MQB 后端负责最终命令行拼写，冲突的 raw compiler/linker/librarian argument 不应被用来绕过 typed policy 或 MQB-owned artifact routing。
 
 `ltcg: true` 同时影响 compile 与 downstream target：
 
@@ -209,6 +211,30 @@ MQB 自己拥有 synthetic creator、`.pch`、配对 creator `.obj`、`/FI`、`/
 - static library：librarian `/LTCG`。
 
 DLL import library 与最终 DLL 一起位于 `.mqb/bin/`。Static target 使用独立的 `lib.exe` archive pipeline 和 archive cache。
+
+### Librarian policy
+
+Static library 的原生 librarian 参数可以直接写在配置中：
+
+```json
+{
+  "version": 1,
+  "build": {
+    "type": "static",
+    "librarian_args": ["/WX", "/EXPORT:math_entry"]
+  }
+}
+```
+
+CLI 对应形式是：
+
+```powershell
+mqb build math.cpp --type static /lib /WX /EXPORT:math_entry
+```
+
+`/lib` 是 librarian boundary 的唯一公开拼写；`/LIB` 也接受。`-lib` / `-LIB` 不作为 boundary，并在 CLI 上明确拒绝，因为 `-l <name>` / `-l<name>` 已属于 MQB 的 link-library shorthand。
+
+`/lib` 必须至少跟一个 librarian 参数，重复 `/lib` / `/LIB` 会 fail closed。其后的参数进入 `MsvcParameterEngine::route_librarian()`：MQB-owned `/OUT` 等 structural 参数不能覆盖 artifact ownership；错误工具的参数也会拒绝。最终 `librarian_args` 只允许 static target，exe / DLL 使用时 fail closed。
 
 ## 4. `discovery`
 
@@ -304,9 +330,11 @@ modules
   "version": 1,
   "build": {
     "entry": "src/main.cpp",
+    "type": "static",
     "standard": "23",
     "pch": "include/pch.hpp",
-    "defines": ["PROJECT=1"]
+    "defines": ["PROJECT=1"],
+    "librarian_args": ["/EXPORT:base_symbol"]
   },
   "profiles": {
     "dev": {
@@ -315,7 +343,8 @@ modules
         "runtime": "MDd",
         "pch": false,
         "defines": ["DEV=1"],
-        "compiler_args": ["/W4"]
+        "compiler_args": ["/W4"],
+        "librarian_args": ["/WX"]
       }
     },
     "release": {
@@ -351,7 +380,7 @@ mqb build --profile=release
 - `--profile` 需要项目存在 `mqb.json`；
 - 未找到 profile 时 fail closed，并列出可用 profile 名；
 - profile 中的 relative path（包括 `pch`）与 base config 一样，以 `mqb.json` 所在目录为基准；
-- profile 中的 `compiler_args` / `linker_args` 仍进入同一 MSVC Parameter Engine，semantic option 会先在 profile 自身层归一化，然后再由更高优先级 CLI 覆盖；
+- profile 中的 `compiler_args` / `linker_args` / `librarian_args` 仍进入同一 MSVC Parameter Engine，semantic option 会先在 profile 自身层归一化，然后再由更高优先级 CLI 覆盖；
 - profile 可以选择 `type` / `pch` 等 policy，因此最终 target 仍受同一 executable/static/DLL/PCH 合法性门禁约束。
 
 ## 7. 优先级
@@ -392,7 +421,13 @@ output
 base mqb.json entries -> selected profile entries -> CLI entries
 ```
 
-适用于 defines、include dirs、library dirs、libraries、compiler args、linker args，以及 discovery list corrections。
+适用于 defines、include dirs、library dirs、libraries、compiler args、linker args、**librarian args**，以及 discovery list corrections。对于 librarian，CLI list 来自 `/lib` tail；因此最终顺序为：
+
+```text
+build.librarian_args
+-> profiles.<name>.build.librarian_args
+-> CLI /lib <...>
+```
 
 External module provider registry 按 logical module name 合并；同名后层项定点覆盖前层项，而不是制造重复 provider。
 
@@ -467,6 +502,7 @@ PCH 的 identity 由最终 effective PCH header/artifact/role 与正常 compiler
 - `ltcg` 同时改变 compile 与 link/archive identity；
 - `subsystem` 只影响 link identity；
 - libraries / library dirs / linker args 改变 link identity；
+- **librarian args 改变 archive recipe/cache identity，并触发 static target 重新归档**；
 - `type` 改变 downstream target ownership；
 - discovery/profile corrections 通过最终 source set 影响参与构建的 TUs；
 - external/prebuilt IFC identity 改变会使依赖它的 consumer compile cache 失效；
@@ -483,6 +519,7 @@ PCH 的 identity 由最终 effective PCH header/artifact/role 与正常 compiler
 - ordinary C++ `exe` / `dll` / `static` 支持 first-class PCH；
 - first-class PCH 与 C TU 或 Modules/Header Units pipeline 组合时当前 fail closed；
 - static target 不接受 subsystem、library paths/libraries、linker args；
+- librarian args 只允许 static target；native librarian CLI 使用 `/lib` / `/LIB`，不支持 `-lib` / `-LIB`；
 - **需要 Modules/Header Units pipeline 的 static-library target 当前仍 fail closed**；
 - discovery correction 使用精确路径，不支持 glob；
 - default-entry conventional fallback 不递归、不使用 glob；

--- a/docs/MQB_CONFIG_EN.md
+++ b/docs/MQB_CONFIG_EN.md
@@ -49,7 +49,8 @@ profiles
     "library_dirs": ["third_party/lib"],
     "libraries": ["user32", "codec.lib"],
     "compiler_args": ["/W4"],
-    "linker_args": ["/OPT:NOREF"]
+    "linker_args": ["/OPT:NOREF"],
+    "librarian_args": []
   },
   "discovery": {
     "enabled": true,
@@ -105,6 +106,7 @@ profiles
 | `libraries` | string[] | link libraries; not accepted for static targets |
 | `compiler_args` | string[] | ordered raw argv elements passed to `cl.exe` |
 | `linker_args` | string[] | ordered raw linker argv elements; not accepted for static targets |
+| `librarian_args` | string[] | ordered raw `lib.exe` argv elements; accepted only for static targets |
 
 ### Default entry
 
@@ -200,7 +202,7 @@ First-class PCH currently supports ordinary C++ source sets for `exe` / `dll` / 
 
 ### Typed policy
 
-`type`, `runtime`, `ltcg`, `subsystem`, and `pch` are structured MQB policies, not string aliases for MSVC flags. The backend owns final command-line spelling; raw compiler/linker arguments should not bypass typed policy or MQB-owned artifact routing.
+`type`, `runtime`, `ltcg`, `subsystem`, and `pch` are structured MQB policies, not string aliases for MSVC flags. The backend owns final command-line spelling; raw compiler/linker/librarian arguments should not bypass typed policy or MQB-owned artifact routing.
 
 `ltcg: true` affects both compile and the downstream target:
 
@@ -209,6 +211,30 @@ First-class PCH currently supports ordinary C++ source sets for `exe` / `dll` / 
 - static library: librarian `/LTCG`.
 
 A DLL import library is placed beside the DLL under `.mqb/bin/`. Static targets use a dedicated `lib.exe` archive pipeline and archive cache.
+
+### Librarian policy
+
+Native librarian parameters for a static library can be configured directly:
+
+```json
+{
+  "version": 1,
+  "build": {
+    "type": "static",
+    "librarian_args": ["/WX", "/EXPORT:math_entry"]
+  }
+}
+```
+
+The CLI equivalent is:
+
+```powershell
+mqb build math.cpp --type static /lib /WX /EXPORT:math_entry
+```
+
+`/lib` is the only public librarian-boundary spelling; uppercase `/LIB` is accepted as well. `-lib` / `-LIB` are not boundaries and are rejected by the CLI because `-l <name>` / `-l<name>` already belong to MQB's link-library shorthand.
+
+A `/lib` boundary must be followed by at least one librarian option, and duplicate `/lib` / `/LIB` boundaries fail closed. The tail flows through `MsvcParameterEngine::route_librarian()`: MQB-owned structural switches such as `/OUT` cannot override artifact ownership, and wrong-tool switches are rejected. Effective `librarian_args` are valid only for static targets; using them with an executable or DLL fails closed.
 
 ## 4. `discovery`
 
@@ -304,9 +330,11 @@ Example:
   "version": 1,
   "build": {
     "entry": "src/main.cpp",
+    "type": "static",
     "standard": "23",
     "pch": "include/pch.hpp",
-    "defines": ["PROJECT=1"]
+    "defines": ["PROJECT=1"],
+    "librarian_args": ["/EXPORT:base_symbol"]
   },
   "profiles": {
     "dev": {
@@ -315,7 +343,8 @@ Example:
         "runtime": "MDd",
         "pch": false,
         "defines": ["DEV=1"],
-        "compiler_args": ["/W4"]
+        "compiler_args": ["/W4"],
+        "librarian_args": ["/WX"]
       }
     },
     "release": {
@@ -351,7 +380,7 @@ The current contract is deliberately small and deterministic:
 - `--profile` requires an `mqb.json` project configuration;
 - an unknown profile fails closed and reports the available profile names;
 - relative paths inside a profile, including `pch`, use the `mqb.json` directory as their base, exactly like root config paths;
-- profile `compiler_args` / `linker_args` still flow through the same MSVC Parameter Engine. Semantic native options are normalized within the profile layer before higher-precedence CLI policy is applied;
+- profile `compiler_args` / `linker_args` / `librarian_args` still flow through the same MSVC Parameter Engine. Semantic native options are normalized within the profile layer before higher-precedence CLI policy is applied;
 - a profile may select policy such as `type` and `pch`, so the final target still passes through the same executable/static/DLL/PCH validity gates.
 
 ## 7. Precedence
@@ -392,7 +421,13 @@ Ordinary list-like inputs append deterministically:
 base mqb.json entries -> selected profile entries -> CLI entries
 ```
 
-This applies to defines, include dirs, library dirs, libraries, compiler args, linker args, and discovery list corrections.
+This applies to defines, include dirs, library dirs, libraries, compiler args, linker args, **librarian args**, and discovery list corrections. For librarian policy, the CLI list is the `/lib` tail, so the effective order is:
+
+```text
+build.librarian_args
+-> profiles.<name>.build.librarian_args
+-> CLI /lib <...>
+```
 
 The external module provider registry merges by logical module name. A matching entry in a later layer replaces the earlier provider rather than creating a duplicate.
 
@@ -467,6 +502,7 @@ Typical effects:
 - `ltcg` changes compile and link/archive identity;
 - `subsystem` changes link identity only;
 - libraries, library dirs, and linker args change link identity;
+- **librarian args change archive recipe/cache identity and force a static target to rearchive**;
 - `type` changes downstream target ownership;
 - discovery/profile corrections affect participating TUs through the final source set;
 - changing an external/prebuilt IFC invalidates dependent consumer compile caches;
@@ -483,6 +519,7 @@ Missing recorded outputs invalidate the corresponding compile/link/archive/PCH c
 - ordinary C++ `exe` / `dll` / `static` targets support first-class PCH;
 - first-class PCH combined with a C translation unit or Modules/Header Unit pipeline currently fails closed;
 - static targets do not accept subsystem, library paths/libraries, or linker args;
+- librarian args are accepted only for static targets; native librarian CLI uses `/lib` or `/LIB`, while `-lib` / `-LIB` are rejected;
 - **static-library targets that require the Modules/Header Units pipeline still fail closed**;
 - discovery corrections use exact paths and do not support globs;
 - conventional default-entry fallback is non-recursive and does not use globs;

--- a/docs/MSVC_PARAMETER_ENGINE.md
+++ b/docs/MSVC_PARAMETER_ENGINE.md
@@ -15,7 +15,9 @@ MQB does not try to rename every MSVC switch into a second property system. Inst
 
 Ownership and availability are deliberately separate. An option can be structurally safe for MQB to pass through while only existing on part of the supported MSVC toolset range. Those options survive semantic routing and are admitted after MQB discovers the actual toolchain.
 
-Class C passthrough does not mean MQB must remain blind to every effect of an option. MQB may extract **non-owning semantic evidence** when another subsystem requires it, while keeping the original compiler/linker argv authoritative. Native `/I` and `/external:I` expose their include roots to smart discovery, but remain raw compiler argv and therefore retain their ordering relative to other native compiler options. Native `/D` is parsed as preprocessor metadata for the same reason but is likewise kept raw. Native `/FI` remains raw compiler argv/compile identity while its ordered forced-header operands are observed by smart discovery. `/FI` operands are not rewritten relative to a config/profile/CLI path base because MSVC gives them quoted-include semantics: discovery resolves them from the selected entry source directory and then the effective include search roots. When a native `/I` or `/external:I` path is relative, MQB resolves its payload against the supplying layer's path base (project root for config/profile, invocation directory for CLI) without moving the token in argv.
+Class C passthrough does not mean MQB must remain blind to every effect of an option. MQB may extract **non-owning semantic evidence** when another subsystem requires it, while keeping the original compiler/linker/librarian argv authoritative.
+
+Native `/I` and `/external:I` expose their include roots to smart discovery, but remain raw compiler argv and therefore retain their ordering relative to other native compiler options. Native `/D` is parsed as preprocessor metadata for the same reason but is likewise kept raw. Native `/FI` remains raw compiler argv/compile identity while its ordered forced-header operands are observed by smart discovery. `/FI` operands are not rewritten relative to a config/profile/CLI path base because MSVC gives them quoted-include semantics: discovery resolves them from the selected entry source directory and then the effective include search roots. When a native `/I` or `/external:I` path is relative, MQB resolves its payload against the supplying layer's path base (project root for config/profile, invocation directory for CLI) without moving the token in argv.
 
 Native linker `/DEF:<file>` follows the same evidence-without-ownership model. The raw LINK argument remains authoritative, but MQB resolves a relative definition-file payload inside the layer that supplied it and records the resolved file as a generic linker freshness input. Config/profile paths are based at project root; CLI paths are based at the invocation directory. The argument keeps its original argv position. Because LINK accepts one module-definition file for an invocation, a second effective `/DEF` is rejected before `link.exe` rather than relying on argv ordering.
 
@@ -44,6 +46,21 @@ The shape table follows the actual MSVC spelling contract rather than guessing f
 
 The current model does not invent a generic stateful/variadic mode. If a future MSVC syntax cannot be represented as `none` or `single`, it must receive an explicit shape extension before the CLI is allowed to interpret it.
 
+## Native linker and librarian boundaries
+
+The public CLI has explicit one-way boundaries for downstream native tools:
+
+```powershell
+mqb build foo.cpp /O2 /link /DEBUG:FULL /STACK:8388608
+mqb build foo.cpp --type static /O2 /lib /WX /EXPORT:foo
+```
+
+`/link` routes the remaining build argv to `link.exe`. Static targets use `/lib` to route the remaining build argv to `lib.exe`; uppercase `/LIB` is accepted too. The librarian boundary deliberately does **not** expose a single-dash alias. `-lib` and `-LIB` are rejected before the generic `-l...` shorthand so they cannot be interpreted as `-l ib`. MQB keeps `-l <name>` and `-l<name>` exclusively as link-library shorthand.
+
+The `/lib` tail must contain at least one librarian argument. A second `/lib` or `/LIB` is rejected. After extraction, the tail goes through `MsvcParameterEngine::route_librarian()` exactly like `build.librarian_args`; Class A structural ownership such as `/OUT` remains unavailable to users, Class B `/MACHINE` and `/LTCG` merge into typed policy, Class C options remain ordered passthrough, and unsupported/wrong-tool options fail closed.
+
+Librarian policy is valid only when the final target kind is `static`. Executable and DLL targets reject a non-empty effective librarian argument set before product execution. Conversely, static targets reject linker-only policy such as libraries, library directories, subsystem, and raw linker arguments.
+
 ## Toolchain lifecycle admission
 
 `ToolchainIdentity.version` records the discovered `VCToolsVersion` (for example `14.44.x` or `14.50.x`). `MsvcParameterCapabilities` uses that real toolset identity after discovery instead of baking a single forever-current answer into the ownership registry.
@@ -61,21 +78,34 @@ This two-stage design preserves the existing early config/profile/CLI normalizat
 
 Native parameters are normalized inside the layer that supplied them:
 
-1. `mqb.json` typed fields and `compiler_args` / `linker_args` are normalized together.
-2. A selected profile is normalized as its own overlay.
-3. CLI typed options and native/raw arguments are normalized together.
+1. `mqb.json` typed fields and `compiler_args` / `linker_args` / `librarian_args` are normalized together.
+2. A selected profile is normalized as its own overlay, including its own librarian arguments.
+3. CLI typed options and native/raw arguments are normalized together; a CLI `/lib` tail becomes CLI-layer librarian arguments before routing.
 4. Conflicting typed/native values inside one layer are errors; tracked file inputs obey their LINK semantics across effective layers (`/DEF` is single-instance, `/ORDER` and `/STUB` are last-wins, `/MANIFESTINPUT` is cumulative). Path-bearing `/DEFAULTLIB` declarations are normalized in the same supplying layer while remaining default-library argv.
-5. The project resolver then applies `built-ins < base mqb.json < selected profile < CLI`.
+5. The project resolver applies `built-ins < base mqb.json < selected profile < CLI`. List-valued librarian policy therefore appends in the exact order `build.librarian_args -> profile librarian_args -> CLI /lib tail`.
 6. Requirements or observations that depend on the **final merged linker argv** are derived after layering: `/MANIFESTINPUT` requires final `/MANIFEST:EMBED`, while user-explicit `/DEFAULTLIB` freshness is filtered by final `/NODEFAULTLIB` / `/NODEFAULTLIB:<name>` policy.
-7. After MSVC discovery, remaining raw arguments pass toolchain lifecycle admission.
+7. After MSVC discovery, remaining raw compiler, linker, and librarian arguments pass toolchain lifecycle admission.
 
-Relative path-bearing evidence is resolved before layers are merged: project configuration/profile values use project root, while CLI values use invocation directory. This prevents cwd-dependent cache identity and keeps the rewritten raw argv stable when the same project is invoked from a child directory.
+Relative path-bearing evidence is resolved before layers are merged: project configuration/profile values use project root, while CLI values use invocation directory. This prevents cwd-dependent cache identity and keeps rewritten raw argv stable when the same project is invoked from a child directory.
 
 This prevents argv ordering from becoming a second precedence system for typed semantic policy. Native passthrough options keep their own argv order rather than being silently converted into a reordered property list.
 
+## Archive cache identity
+
+Static-library freshness is defined by the complete effective archive recipe, not only by the object timestamps. The archive signature includes librarian/toolchain identity, target architecture, effective LTCG state, object set/output, and the final routed librarian argv.
+
+That makes librarian policy a first-class cache dimension:
+
+```text
+unchanged librarian argv -> warm archive cache may be reused
+changed librarian argv   -> archive_recipe_changed -> rearchive
+```
+
+`build.librarian_args`, profile librarian arguments, and the CLI `/lib` tail all converge on this same final recipe. The profile name or configuration-file timestamp is not itself a cache dimension; only the effective librarian semantics are.
+
 ## Tool semantics
 
-Compiler option names are treated with compiler spelling/case semantics. Linker and librarian option names are normalized case-insensitively.
+Compiler option names are treated with compiler spelling/case semantics. Linker and librarian option names are normalized case-insensitively by their parameter routers. The CLI boundary itself deliberately recognizes the documented public `/lib` and `/LIB` spellings only; this is separate from case normalization of options *after* the boundary.
 
 MQB compiles one TU per `cl.exe /c` invocation and owns concurrency, so `/MP` is rejected in favor of `-j/--jobs`. Compiler `/F` is also rejected: it asks `cl.exe` to control linker stack size, but MQB owns a separate `link.exe` invocation; use linker `/STACK` instead.
 
@@ -103,6 +133,12 @@ Other file-bearing linker modes beyond promoted `/DEF`, `/ORDER`, `/STUB`, `/MAN
 
 `cpp/tests/msvc/parameters/msvc_parameter_engine_tests.cpp` is the executable ownership and token-shape coverage matrix. It contains representative argv for every option family in the current Microsoft references used by the registry and requires each family to resolve to A, B, C, or D rather than `unregistered`. It also locks split-vs-attached compiler forms so a future registry expansion cannot silently consume a positional source.
 
+`cpp/tests/app/cli/build_policy_cli_tests.cpp` locks the librarian-facing UX contract: `/lib` and `/LIB` route a static-target tail, `-l` remains the link-library shorthand, `-lib` / `-LIB` are rejected with `/lib` guidance, empty and duplicate librarian boundaries fail, and MQB-owned/wrong-tool librarian options remain fail-closed. The same test also treats `mqb --help` text as part of the public contract.
+
+`cpp/tests/config/resolution/project_options_tests.cpp` proves librarian list precedence independently from CLI parsing: base `build.librarian_args`, selected-profile librarian arguments, and CLI overrides append in base -> profile -> CLI order without loss.
+
+`cpp/tests/orchestration/incremental/incremental_archive_coordinator_tests.cpp` proves archive cache identity: native librarian argv reaches the actual archive invocation, an unchanged recipe is reusable, and changing only librarian argv produces `archive_recipe_changed` and exactly one additional librarian invocation.
+
 `cpp/tests/core/cache/link_state_tests.cpp` locks the generic linker file-input execution evidence independently from object/library freshness: warm inputs reuse, while newer/missing/re-resolved inputs or lost metadata invalidate reuse and mark `file_inputs_changed` without contaminating `library_inputs_changed`.
 
 `cpp/tests/orchestration/incremental/incremental_link_coordinator_tests.cpp` locks `/ORDER` execution semantics: repeated order options preserve raw argv but track only the last effective file, malformed `/ORDER` fails before LINK, warm no-op skips LINK, effective order-file mutation invalidates freshness, and every actual `/ORDER` link appends authoritative `/INCREMENTAL:NO` after raw linker arguments.
@@ -115,7 +151,7 @@ Other file-bearing linker modes beyond promoted `/DEF`, `/ORDER`, `/STUB`, `/MAN
 
 `cpp/tests/msvc/linker/library_resolver_tests.cpp` locks explicit-vs-default library resolution policy. Structured libraries remain require-all, while user DEFAULTLIB evidence is available-only; the test also covers case-insensitive `/NODEFAULTLIB:<name>` suppression, optional `.lib` matching, path-bearing layer-base normalization, and shared library-search precedence.
 
-`cpp/tests/e2e/mqb_default_library_e2e_tests.cpp` proves the real user-explicit `/DEFAULTLIB` pipeline on Windows/MSVC. A consumer resolves a symbol only through raw DEFAULTLIB, an unchanged build becomes a zero-LINK cache hit, a default-library-only archive mutation leaves the TU up-to-date but relinks and changes runtime behavior, `/NODEFAULTLIB:<name>` suppresses the raw default library, and a structured explicit library retains priority over a competing DEFAULTLIB. The fixture also proves a suppressed missing DEFAULTLIB does not make MQB stricter than LINK and that project-root-relative `mqb.json` DEFAULTLIB paths remain correct when MQB is launched from a nested directory. The native graph contains 77 tests after this promotion.
+`cpp/tests/e2e/mqb_default_library_e2e_tests.cpp` proves the real user-explicit `/DEFAULTLIB` pipeline on Windows/MSVC. A consumer resolves a symbol only through raw DEFAULTLIB, an unchanged build becomes a zero-LINK cache hit, a default-library-only archive mutation leaves the TU up-to-date but relinks and changes runtime behavior, `/NODEFAULTLIB:<name>` suppresses the raw default library, and a structured explicit library retains priority over a competing DEFAULTLIB. The fixture also proves a suppressed missing DEFAULTLIB does not make MQB stricter than LINK and that project-root-relative `mqb.json` DEFAULTLIB paths remain correct when MQB is launched from a nested directory.
 
 `cpp/tests/app/cli/mqb_native_msvc_cli_e2e_tests.cpp` independently verifies the CLI boundary and native execution path: fixed operands stay in ordered compiler argv, attached forms do not consume the next source, and graph-aware native options such as `/FI` retain their split operand and rebuild behavior under the real candidate MQB/MSVC pipeline.
 


### PR DESCRIPTION
## Final Closure #6 — Librarian Native UX Closure

Closes the remaining product-surface and cross-stage parser ambiguity around native `lib.exe` arguments without reopening the librarian engine introduced in #117.

### Final public policy

- `/lib` is a **one-way compiler-to-librarian CLI boundary** for static targets; uppercase `/LIB` is accepted as well.
- once `/lib` is crossed, subsequent build argv stays librarian-owned; MQB long options must appear before the boundary.
- `-lib` / `-LIB` are **not** librarian boundaries and are rejected explicitly before MQB's `-L...` / `-l...` shorthands can consume them.
- `-l <name>` / `-l<name>` remain link-library shorthand before the boundary; text such as `-lfoo` after `/lib` remains downstream librarian argv instead of escaping back into MQB parsing.
- `/lib` with no tail fails closed; duplicate `/lib` / `/LIB` boundaries fail closed.
- the CLI writes the tail directly to `librarian_arguments`; `ProjectSetup` no longer scans raw compiler argv for hidden `/lib` boundaries.
- the librarian tail then passes through `MsvcParameterEngine::route_librarian()`, preserving Class A/B/C/D ownership semantics.
- effective librarian policy is static-only; executable/DLL targets fail closed before build execution.

### Regression coverage

- `/lib` and `/LIB` routing
- one-way `/lib` tail semantics
- MQB long options after `/lib` fail with an ordering diagnostic
- `-l` separated/attached shorthand remains intact before `/lib`
- `-l...` text after `/lib` stays librarian-owned and fails librarian classification instead of becoming MQB library input
- explicit `-lib` / `-LIB` rejection with `/lib` migration guidance, including protection against both `-l` and `-L` precedence collisions
- raw `--compiler-arg -lib` cannot regain hidden boundary semantics in `ProjectSetup`
- empty/duplicate librarian boundary fail-closed
- Class A `/OUT` and wrong-tool options remain rejected
- executable target + `/lib /WX` is exercised through the real candidate `mqb.exe` and must return exit 2 with the static-only diagnostic
- `mqb --help` contract exposes `/lib`, the dash-alias policy, `build.librarian_args`, and the one-way boundary rule

Existing correctness coverage from #117 remains authoritative for:

- base config -> selected profile -> CLI librarian list precedence
- archive recipe/cache identity and `archive_recipe_changed` when only librarian argv changes

### Documentation

Updated:

- `mqb --help`
- `README.md`
- `docs/MQB_CONFIG.md`
- `docs/MQB_CONFIG_EN.md`
- `docs/MSVC_PARAMETER_ENGINE.md`

The documented static form is now:

```powershell
mqb build foo.cpp --type static /lib /WX /EXPORT:foo
```

and configuration remains:

```json
{
  "build": {
    "librarian_args": ["/WX"]
  }
}
```

Validation continues through the repository's existing MQB self-host/native PowerShell test path; this closure does not introduce another build system.

This PR is the Final Closure #6 audit item, not a new feature tranche.