### PR TITLE
perf: close final cross-stage productization gaps

### DIFF
--- a/.github/workflows/final-closure-cross-stage.yml
+++ b/.github/workflows/final-closure-cross-stage.yml
@@ -1,0 +1,67 @@
+name: Final Closure Cross-Stage
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'cpp/**'
+      - 'tests/native/verify_final_closure_cross_stage.ps1'
+      - '.github/workflows/final-closure-cross-stage.yml'
+  pull_request:
+    paths:
+      - 'cpp/**'
+      - 'tests/native/verify_final_closure_cross_stage.ps1'
+      - '.github/workflows/final-closure-cross-stage.yml'
+
+concurrency:
+  group: final-closure-cross-stage-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Project state + Windows identity
+    runs-on: windows-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    env:
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Acquire pinned MQB seed
+        id: seed
+        shell: pwsh
+        run: |
+          $seed = & (Join-Path $PWD 'tests/native/acquire_seed.ps1') `
+            -RepoRoot $PWD `
+            -OutputRoot (Join-Path $PWD 'native-seed')
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          "path=$seed" >> $env:GITHUB_OUTPUT
+
+      - name: Build current Debug MQB with MQB
+        shell: pwsh
+        run: |
+          $version = (Get-Content -LiteralPath 'VERSION' -Raw).Trim()
+          $mqb = & (Join-Path $PWD 'tests/native/build_mqb.ps1') `
+            -BuilderMqbPath '${{ steps.seed.outputs.path }}' `
+            -RepoRoot $PWD `
+            -Version "$version-dev" `
+            -Configuration Debug `
+            -Clean `
+            -OutputPath (Join-Path $PWD 'native-out/debug/mqb.exe')
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          if (-not (Test-Path -LiteralPath $mqb -PathType Leaf)) {
+            throw "Debug MQB build output missing: $mqb"
+          }
+
+      - name: Verify Final Closure cross-stage invariants
+        shell: pwsh
+        run: |
+          & (Join-Path $PWD 'tests/native/verify_final_closure_cross_stage.ps1') `
+            -MqbPath (Join-Path $PWD 'native-out/debug/mqb.exe') `
+            -RepoRoot $PWD
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/cpp/include/mqb/msvc/MsvcToolchainLocator.hpp
+++ b/cpp/include/mqb/msvc/MsvcToolchainLocator.hpp
@@ -35,12 +35,13 @@ struct DiscoveryOptions {
     std::vector<std::filesystem::path> portable_roots;
     std::optional<std::filesystem::path> vswhere_path;
     std::optional<std::filesystem::path> cmd_path;
-    // Visual Studio discovery only. Persistent reuse is opt-in: the default
-    // engaged-but-empty path disables it. The MQB application supplies a cache
-    // path under the active project's .mqb tree; tests/embedders may supply an
-    // explicit path of their own. Custom vswhere/cmd overrides also disable
-    // reuse so explicit discovery remains authoritative.
-    std::optional<std::filesystem::path> cache_file{std::filesystem::path{}};
+    // Visual Studio discovery only. Standalone callers retain persistent reuse
+    // under the current working directory's .mqb tree. The MQB application
+    // replaces this with the active project root's .mqb cache path. An
+    // explicitly empty path disables reuse. Custom vswhere/cmd overrides also
+    // disable reuse so explicit discovery remains authoritative.
+    std::optional<std::filesystem::path> cache_file{
+        std::filesystem::path{".mqb"} / "cache" / "toolchain" / "vs.cache"};
 };
 
 struct MsvcToolchain {

--- a/cpp/include/mqb/msvc/MsvcToolchainLocator.hpp
+++ b/cpp/include/mqb/msvc/MsvcToolchainLocator.hpp
@@ -35,13 +35,13 @@ struct DiscoveryOptions {
     std::vector<std::filesystem::path> portable_roots;
     std::optional<std::filesystem::path> vswhere_path;
     std::optional<std::filesystem::path> cmd_path;
-    // Visual Studio discovery only. Standalone callers retain persistent reuse
-    // under the current working directory's .mqb tree. The MQB application
-    // replaces this with the active project root's .mqb cache path. An
-    // explicitly empty path disables reuse. Custom vswhere/cmd overrides also
-    // disable reuse so explicit discovery remains authoritative.
-    std::optional<std::filesystem::path> cache_file{
-        std::filesystem::path{".mqb"} / "cache" / "toolchain" / "vs.cache"};
+    // Visual Studio discovery only. nullopt uses the cache authority's default
+    // architecture-specific path under the current working directory's .mqb
+    // tree. The MQB application replaces it with the active project root's
+    // .mqb cache path. An explicitly empty path disables reuse. Custom
+    // vswhere/cmd overrides also disable reuse so explicit discovery remains
+    // authoritative.
+    std::optional<std::filesystem::path> cache_file;
 };
 
 struct MsvcToolchain {

--- a/cpp/include/mqb/msvc/MsvcToolchainLocator.hpp
+++ b/cpp/include/mqb/msvc/MsvcToolchainLocator.hpp
@@ -35,13 +35,13 @@ struct DiscoveryOptions {
     std::vector<std::filesystem::path> portable_roots;
     std::optional<std::filesystem::path> vswhere_path;
     std::optional<std::filesystem::path> cmd_path;
-    // Visual Studio discovery only. nullopt uses the cache authority's default
-    // architecture-specific path under the current working directory's .mqb
-    // tree. The MQB application replaces it with the active project root's
-    // .mqb cache path. An explicitly empty path disables reuse. Custom
-    // vswhere/cmd overrides also disable reuse so explicit discovery remains
-    // authoritative.
-    std::optional<std::filesystem::path> cache_file;
+    // Visual Studio discovery only. Standalone callers retain persistent reuse
+    // under the current working directory's .mqb tree. The MQB application
+    // replaces this with the active project root's architecture-specific .mqb
+    // cache path. An explicitly empty path disables reuse. Custom vswhere/cmd
+    // overrides also disable reuse so explicit discovery remains authoritative.
+    std::optional<std::filesystem::path> cache_file{
+        std::filesystem::path{".mqb"} / "cache" / "toolchain" / "vs.cache"};
 };
 
 struct MsvcToolchain {

--- a/cpp/include/mqb/msvc/MsvcToolchainLocator.hpp
+++ b/cpp/include/mqb/msvc/MsvcToolchainLocator.hpp
@@ -35,10 +35,12 @@ struct DiscoveryOptions {
     std::vector<std::filesystem::path> portable_roots;
     std::optional<std::filesystem::path> vswhere_path;
     std::optional<std::filesystem::path> cmd_path;
-    // Visual Studio discovery only. nullopt uses MQB's user-local cache under
-    // LOCALAPPDATA; an explicitly empty path disables persistent reuse. Custom
-    // vswhere/cmd overrides also disable reuse so explicit discovery remains authoritative.
-    std::optional<std::filesystem::path> cache_file;
+    // Visual Studio discovery only. Persistent reuse is opt-in: the default
+    // engaged-but-empty path disables it. The MQB application supplies a cache
+    // path under the active project's .mqb tree; tests/embedders may supply an
+    // explicit path of their own. Custom vswhere/cmd overrides also disable
+    // reuse so explicit discovery remains authoritative.
+    std::optional<std::filesystem::path> cache_file{std::filesystem::path{}};
 };
 
 struct MsvcToolchain {

--- a/cpp/include/mqb/platform/windows/PathIdentity.hpp
+++ b/cpp/include/mqb/platform/windows/PathIdentity.hpp
@@ -39,4 +39,25 @@ namespace mqb::platform::windows {
     return key;
 }
 
+// Root-containment decisions are identity decisions on Windows, not lexical
+// spelling decisions. Compare the same canonical keys used by caches,
+// discovery, library resolution, and toolchain identity, and require a path
+// separator at the boundary so `C:/project2` is not inside `C:/project`.
+[[nodiscard]] inline bool path_identity_contains(
+    const std::filesystem::path& root,
+    const std::filesystem::path& candidate) {
+    std::string root_key = path_identity_key(root);
+    const std::string candidate_key = path_identity_key(candidate);
+    if (root_key.empty() || candidate_key.empty()) {
+        return false;
+    }
+    if (candidate_key == root_key) {
+        return true;
+    }
+    if (root_key.back() != '/') {
+        root_key.push_back('/');
+    }
+    return candidate_key.starts_with(root_key);
+}
+
 } // namespace mqb::platform::windows

--- a/cpp/include/mqb/process/Process.hpp
+++ b/cpp/include/mqb/process/Process.hpp
@@ -4,9 +4,8 @@
 #include <cstdint>
 #include <expected>
 #include <filesystem>
-#include <span>
+#include <optional>
 #include <string>
-#include <string_view>
 #include <vector>
 
 namespace mqb::process {
@@ -22,10 +21,11 @@ struct EnvironmentVariable {
 struct ProcessSpec {
     std::filesystem::path executable;
     std::vector<std::string> arguments;
-    std::filesystem::path working_directory;
+    std::optional<std::filesystem::path> working_directory;
     std::vector<EnvironmentVariable> environment;
-    bool capture_stdout{false};
-    bool capture_stderr{false};
+    bool inherit_environment{true};
+    bool capture_stdout{true};
+    bool capture_stderr{true};
 };
 
 struct ProcessResult {
@@ -36,31 +36,26 @@ struct ProcessResult {
 };
 
 enum class ProcessErrorCode {
-    executable_not_found,
-    working_directory_not_found,
-    invalid_environment,
-    pipe_creation_failed,
-    process_creation_failed,
+    invalid_specification,
+    launch_failed,
     wait_failed,
-    read_failed,
+    io_failed,
 };
 
 struct ProcessError {
-    ProcessErrorCode code{ProcessErrorCode::process_creation_failed};
-    std::string message;
+    ProcessErrorCode code{ProcessErrorCode::launch_failed};
     std::uint32_t native_code{};
+    std::string message;
 };
 
 class ProcessRunner {
 public:
     virtual ~ProcessRunner() = default;
 
+    // Orchestration may call run() concurrently on the same runner instance.
+    // Implementations must keep per-launch state isolated.
     [[nodiscard]] virtual std::expected<ProcessResult, ProcessError>
     run(const ProcessSpec& spec) = 0;
 };
-
-[[nodiscard]] std::string format_command_for_display(
-    const std::filesystem::path& executable,
-    std::span<const std::string> arguments);
 
 } // namespace mqb::process

--- a/cpp/include/mqb/process/Process.hpp
+++ b/cpp/include/mqb/process/Process.hpp
@@ -4,8 +4,9 @@
 #include <cstdint>
 #include <expected>
 #include <filesystem>
-#include <optional>
+#include <span>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace mqb::process {
@@ -13,16 +14,18 @@ namespace mqb::process {
 struct EnvironmentVariable {
     std::string name;
     std::string value;
+    // Removal is distinct from assigning an empty string on Windows: some
+    // MSVC tools observe presence itself (for example LINK_REPRO).
+    bool remove{false};
 };
 
 struct ProcessSpec {
     std::filesystem::path executable;
     std::vector<std::string> arguments;
-    std::optional<std::filesystem::path> working_directory;
+    std::filesystem::path working_directory;
     std::vector<EnvironmentVariable> environment;
-    bool inherit_environment{true};
-    bool capture_stdout{true};
-    bool capture_stderr{true};
+    bool capture_stdout{false};
+    bool capture_stderr{false};
 };
 
 struct ProcessResult {
@@ -33,26 +36,31 @@ struct ProcessResult {
 };
 
 enum class ProcessErrorCode {
-    invalid_specification,
-    launch_failed,
+    executable_not_found,
+    working_directory_not_found,
+    invalid_environment,
+    pipe_creation_failed,
+    process_creation_failed,
     wait_failed,
-    io_failed,
+    read_failed,
 };
 
 struct ProcessError {
-    ProcessErrorCode code{ProcessErrorCode::launch_failed};
-    std::uint32_t native_code{};
+    ProcessErrorCode code{ProcessErrorCode::process_creation_failed};
     std::string message;
+    std::uint32_t native_code{};
 };
 
 class ProcessRunner {
 public:
     virtual ~ProcessRunner() = default;
 
-    // Orchestration may call run() concurrently on the same runner instance.
-    // Implementations must keep per-launch state isolated.
     [[nodiscard]] virtual std::expected<ProcessResult, ProcessError>
     run(const ProcessSpec& spec) = 0;
 };
+
+[[nodiscard]] std::string format_command_for_display(
+    const std::filesystem::path& executable,
+    std::span<const std::string> arguments);
 
 } // namespace mqb::process

--- a/cpp/src/app/Application.cpp
+++ b/cpp/src/app/Application.cpp
@@ -32,6 +32,7 @@
 #include "mqb/orchestration/MsvcIncrementalPchCoordinator.hpp"
 #include "mqb/orchestration/MsvcIncrementalTargetCoordinator.hpp"
 #include "mqb/orchestration/ParallelismPolicy.hpp"
+#include "mqb/platform/windows/PathIdentity.hpp"
 #include "mqb/platform/windows/WindowsProcessRunner.hpp"
 #include "mqb/process/Process.hpp"
 
@@ -55,7 +56,7 @@ namespace fs = std::filesystem;
 [[nodiscard]] bool inside_project(
     const fs::path& project_root,
     const fs::path& path) {
-    return safe_relative(path.lexically_normal().lexically_relative(project_root.lexically_normal()));
+    return mqb::platform::windows::path_identity_contains(project_root, path);
 }
 
 [[nodiscard]] fs::path display_source(
@@ -72,7 +73,14 @@ void add_portable_root_if_missing(
         return;
     }
     const fs::path normalized = candidate.lexically_normal();
-    if (std::find(roots.begin(), roots.end(), normalized) == roots.end()) {
+    const std::string candidate_key = mqb::platform::windows::path_identity_key(normalized);
+    const bool present = std::any_of(
+        roots.begin(),
+        roots.end(),
+        [&](const fs::path& root) {
+            return mqb::platform::windows::path_identity_key(root) == candidate_key;
+        });
+    if (!present) {
         roots.push_back(normalized);
     }
 }
@@ -314,6 +322,13 @@ int Application::run(const std::span<const std::string_view> arguments) {
     toolchain_discovery.host_architecture = mqb::Architecture::x64;
     toolchain_discovery.preference = options.toolchain_preference;
     toolchain_discovery.portable_roots = options.portable_roots;
+    std::string toolchain_cache_name = "vs-";
+    toolchain_cache_name += mqb::to_string(options.build.architecture);
+    toolchain_cache_name += ".cache";
+    toolchain_discovery.cache_file = layout->artifact_root()
+        / "cache"
+        / "toolchain"
+        / toolchain_cache_name;
 
     auto toolchain = locator.discover(toolchain_discovery);
     if (!toolchain) {

--- a/cpp/src/discovery/SourceDiscovery.cpp
+++ b/cpp/src/discovery/SourceDiscovery.cpp
@@ -278,34 +278,68 @@ SourceDiscovery::discover(const Request& request) {
     }
 
     result.sources.reserve(selection.selected_indices.size() + extra_sources.size());
-    result.sources.push_back(indexed->files[entry_it->second].path);
     for (const std::size_t index : selection.selected_indices) {
-        const fs::path& source = indexed->files[index].path;
-        if (index != entry_it->second) {
-            result.sources.push_back(source);
-        }
-        result.requires_module_pipeline = result.requires_module_pipeline
-            || detail::file_requires_module_pipeline(indexed->files[index]);
+        result.sources.push_back(indexed->files[index].path);
     }
+
+    bool extras_are_indexed = true;
     for (const auto& source : extra_sources) {
-        if (std::find_if(
-                result.sources.begin(),
-                result.sources.end(),
-                [&](const fs::path& existing) {
-                    return path_key(existing) == path_key(source);
-                }) == result.sources.end()) {
+        const std::string key = path_key(source);
+        if (!indexed->index_by_path.contains(key)) {
+            extras_are_indexed = false;
+        }
+        const auto duplicate = std::find_if(
+            result.sources.begin(),
+            result.sources.end(),
+            [&](const fs::path& existing) { return path_key(existing) == key; });
+        if (duplicate == result.sources.end()) {
             result.sources.push_back(source);
         }
     }
 
-    if (cache_file && indexed->cacheable) {
-        detail::DiscoveryCacheRecord record{
-            .request = cache_identity,
-            .result = result,
-            .files = std::move(indexed->file_snapshots),
-            .directories = std::move(indexed->directory_snapshots),
-        };
-        detail::save_discovery_cache_best_effort(*cache_file, record);
+    std::sort(
+        result.sources.begin(),
+        result.sources.end(),
+        [](const fs::path& left, const fs::path& right) {
+            return path_key(left) < path_key(right);
+        });
+    const std::string entry_key = path_key(entry);
+    const auto entry_position = std::find_if(
+        result.sources.begin(),
+        result.sources.end(),
+        [&](const fs::path& source) { return path_key(source) == entry_key; });
+    if (entry_position != result.sources.end() && entry_position != result.sources.begin()) {
+        std::rotate(result.sources.begin(), entry_position, entry_position + 1);
+    }
+
+    for (const auto& source : result.sources) {
+        const auto selected = indexed->index_by_path.find(path_key(source));
+        if (selected != indexed->index_by_path.end()
+            && detail::file_requires_module_pipeline(indexed->files[selected->second])) {
+            result.requires_module_pipeline = true;
+            break;
+        }
+    }
+
+    if (result.sources.empty() || path_key(result.sources.front()) != entry_key) {
+        return std::unexpected(failure(
+            ErrorCode::invalid_entry,
+            entry,
+            "source discovery did not retain the entry translation unit"));
+    }
+
+    if (cache_file
+        && indexed->cacheable
+        && extras_are_indexed
+        && result.warnings.empty()) {
+        detail::save_discovery_cache_best_effort(
+            *cache_file,
+            detail::DiscoveryCacheRecord{
+                .request = cache_identity,
+                .result = result,
+                .files = indexed->file_snapshots,
+                .directories = indexed->directory_snapshots,
+            });
     }
     return result;
 }

--- a/cpp/src/discovery/SourceDiscovery.cpp
+++ b/cpp/src/discovery/SourceDiscovery.cpp
@@ -166,7 +166,7 @@ SourceDiscovery::discover(const Request& request) {
         if (!source) {
             return std::unexpected(source.error());
         }
-        if (*source == entry) {
+        if (path_key(*source) == path_key(entry)) {
             return std::unexpected(failure(
                 ErrorCode::invalid_correction,
                 *source,
@@ -200,7 +200,7 @@ SourceDiscovery::discover(const Request& request) {
                     "discovery extra source must not be inside an excluded directory"));
             }
         }
-        if (*source != entry && extra_source_keys.insert(key).second) {
+        if (key != path_key(entry) && extra_source_keys.insert(key).second) {
             extra_sources.push_back(std::move(*source));
         }
     }
@@ -278,64 +278,34 @@ SourceDiscovery::discover(const Request& request) {
     }
 
     result.sources.reserve(selection.selected_indices.size() + extra_sources.size());
+    result.sources.push_back(indexed->files[entry_it->second].path);
     for (const std::size_t index : selection.selected_indices) {
-        result.sources.push_back(indexed->files[index].path);
-    }
-
-    bool extras_are_indexed = true;
-    for (const auto& source : extra_sources) {
-        const std::string key = path_key(source);
-        if (!indexed->index_by_path.contains(key)) {
-            extras_are_indexed = false;
+        const fs::path& source = indexed->files[index].path;
+        if (index != entry_it->second) {
+            result.sources.push_back(source);
         }
-        const auto duplicate = std::find_if(
-            result.sources.begin(),
-            result.sources.end(),
-            [&](const fs::path& existing) { return path_key(existing) == key; });
-        if (duplicate == result.sources.end()) {
+        result.requires_module_pipeline = result.requires_module_pipeline
+            || detail::file_requires_module_pipeline(indexed->files[index]);
+    }
+    for (const auto& source : extra_sources) {
+        if (std::find_if(
+                result.sources.begin(),
+                result.sources.end(),
+                [&](const fs::path& existing) {
+                    return path_key(existing) == path_key(source);
+                }) == result.sources.end()) {
             result.sources.push_back(source);
         }
     }
 
-    std::sort(
-        result.sources.begin(),
-        result.sources.end(),
-        [](const fs::path& left, const fs::path& right) {
-            return path_key(left) < path_key(right);
-        });
-    const auto entry_position = std::find(result.sources.begin(), result.sources.end(), entry);
-    if (entry_position != result.sources.end() && entry_position != result.sources.begin()) {
-        std::rotate(result.sources.begin(), entry_position, entry_position + 1);
-    }
-
-    for (const auto& source : result.sources) {
-        const auto selected = indexed->index_by_path.find(path_key(source));
-        if (selected != indexed->index_by_path.end()
-            && detail::file_requires_module_pipeline(indexed->files[selected->second])) {
-            result.requires_module_pipeline = true;
-            break;
-        }
-    }
-
-    if (result.sources.empty() || result.sources.front() != entry) {
-        return std::unexpected(failure(
-            ErrorCode::invalid_entry,
-            entry,
-            "source discovery did not retain the entry translation unit"));
-    }
-
-    if (cache_file
-        && indexed->cacheable
-        && extras_are_indexed
-        && result.warnings.empty()) {
-        detail::save_discovery_cache_best_effort(
-            *cache_file,
-            detail::DiscoveryCacheRecord{
-                .request = cache_identity,
-                .result = result,
-                .files = indexed->file_snapshots,
-                .directories = indexed->directory_snapshots,
-            });
+    if (cache_file && indexed->cacheable) {
+        detail::DiscoveryCacheRecord record{
+            .request = cache_identity,
+            .result = result,
+            .files = std::move(indexed->file_snapshots),
+            .directories = std::move(indexed->directory_snapshots),
+        };
+        detail::save_discovery_cache_best_effort(*cache_file, record);
     }
     return result;
 }

--- a/cpp/src/discovery/cache/DiscoveryCache.cpp
+++ b/cpp/src/discovery/cache/DiscoveryCache.cpp
@@ -299,11 +299,12 @@ private:
     const DiscoveryRequestIdentity& request) noexcept {
     if (record.request != request
         || record.result.sources.empty()
-        || record.result.sources.front().lexically_normal() != request.entry.lexically_normal()
+        || mqb::platform::windows::path_identity_key(record.result.sources.front())
+            != mqb::platform::windows::path_identity_key(request.entry)
         || record.result.indexed_files != record.files.size()
         || record.directories.empty()
-        || record.directories.front().path.lexically_normal()
-            != request.project_root.lexically_normal()) {
+        || mqb::platform::windows::path_identity_key(record.directories.front().path)
+            != mqb::platform::windows::path_identity_key(request.project_root)) {
         return false;
     }
     return true;

--- a/cpp/src/discovery/cache/DiscoveryCache.hpp
+++ b/cpp/src/discovery/cache/DiscoveryCache.hpp
@@ -7,6 +7,7 @@
 
 #include "mqb/core/FileSnapshot.hpp"
 #include "mqb/discovery/SourceDiscovery.hpp"
+#include "mqb/platform/windows/PathIdentity.hpp"
 
 namespace mqb::discovery::detail {
 
@@ -20,22 +21,31 @@ struct DiscoveryRequestIdentity {
     std::vector<std::filesystem::path> excluded_sources;
 
     [[nodiscard]] bool operator==(const DiscoveryRequestIdentity& other) const {
-        if (project_root != other.project_root
-            || entry != other.entry
-            || include_directories != other.include_directories
-            || excluded_directories != other.excluded_directories
-            || extra_sources != other.extra_sources
-            || excluded_sources != other.excluded_sources
-            || forced_includes.size() != other.forced_includes.size()) {
-            return false;
-        }
-        for (std::size_t index = 0; index < forced_includes.size(); ++index) {
-            if (forced_includes[index].lexically_normal()
-                != other.forced_includes[index].lexically_normal()) {
+        const auto same_path = [](const std::filesystem::path& left, const std::filesystem::path& right) {
+            return mqb::platform::windows::path_identity_key(left)
+                == mqb::platform::windows::path_identity_key(right);
+        };
+        const auto same_paths = [&](
+                                    const std::vector<std::filesystem::path>& left,
+                                    const std::vector<std::filesystem::path>& right) {
+            if (left.size() != right.size()) {
                 return false;
             }
-        }
-        return true;
+            for (std::size_t index = 0; index < left.size(); ++index) {
+                if (!same_path(left[index], right[index])) {
+                    return false;
+                }
+            }
+            return true;
+        };
+
+        return same_path(project_root, other.project_root)
+            && same_path(entry, other.entry)
+            && same_paths(include_directories, other.include_directories)
+            && same_paths(forced_includes, other.forced_includes)
+            && same_paths(excluded_directories, other.excluded_directories)
+            && same_paths(extra_sources, other.extra_sources)
+            && same_paths(excluded_sources, other.excluded_sources);
     }
 };
 

--- a/cpp/src/discovery/indexing/DiscoveryPath.hpp
+++ b/cpp/src/discovery/indexing/DiscoveryPath.hpp
@@ -41,20 +41,12 @@ namespace fs = std::filesystem;
 }
 
 [[nodiscard]] inline bool inside_root(const fs::path& root, const fs::path& path) {
-    const fs::path relative = path.lexically_normal().lexically_relative(root.lexically_normal());
-    if (relative.empty() || relative.is_absolute()) {
-        return false;
-    }
-    for (const auto& component : relative) {
-        if (component == "..") {
-            return false;
-        }
-    }
-    return true;
+    return path_key(root) != path_key(path)
+        && mqb::platform::windows::path_identity_contains(root, path);
 }
 
 [[nodiscard]] inline bool same_or_inside(const fs::path& root, const fs::path& path) {
-    return path.lexically_normal() == root.lexically_normal() || inside_root(root, path);
+    return mqb::platform::windows::path_identity_contains(root, path);
 }
 
 [[nodiscard]] inline std::string extension_lower(const fs::path& path) {

--- a/cpp/src/msvc/compiler/CompilerExecution.cpp
+++ b/cpp/src/msvc/compiler/CompilerExecution.cpp
@@ -27,10 +27,10 @@ void suppress_ambient_compiler_options(
     std::vector<process::EnvironmentVariable>& environment) {
     // cl.exe prepends CL and appends _CL_ to its explicit argv. Those hidden
     // arguments would bypass MQB's Parameter Engine, structured ownership, and
-    // compile identity. Empty overrides preserve the inherited vcvars environment
-    // while making the explicit MQB argv the complete compiler option surface.
-    environment.push_back(process::EnvironmentVariable{"CL", {}});
-    environment.push_back(process::EnvironmentVariable{"_CL_", {}});
+    // compile identity. Remove the variables entirely: an empty value is still
+    // a present environment variable and is not a general substitute for absence.
+    environment.push_back(process::EnvironmentVariable{"CL", {}, true});
+    environment.push_back(process::EnvironmentVariable{"_CL_", {}, true});
 }
 
 [[nodiscard]] std::expected<process::ProcessResult, CompilerError> run_compiler(

--- a/cpp/src/msvc/librarian/MsvcLibrarian.cpp
+++ b/cpp/src/msvc/librarian/MsvcLibrarian.cpp
@@ -44,10 +44,10 @@ void remove_if_present(const fs::path& path) noexcept {
 
 void suppress_ambient_librarian_repro(
     std::vector<process::EnvironmentVariable>& environment) {
-    // LINK/LIB honor the link_repro environment variable independently of the
+    // LINK/LIB honor the LINK_REPRO environment variable independently of the
     // explicit argv. Repro packages are diagnostic artifact trees outside the
     // archive cache identity, so ambient state must not enable them implicitly.
-    environment.push_back(process::EnvironmentVariable{"link_repro", {}});
+    environment.push_back(process::EnvironmentVariable{"LINK_REPRO", {}, true});
 }
 
 } // namespace

--- a/cpp/src/msvc/linker/MsvcLinker.cpp
+++ b/cpp/src/msvc/linker/MsvcLinker.cpp
@@ -71,12 +71,12 @@ namespace fs = std::filesystem;
 void suppress_ambient_linker_options(
     std::vector<process::EnvironmentVariable>& environment) {
     // link.exe prepends LINK and appends _LINK_ to its explicit argv. It also
-    // honors link_repro as an implicit diagnostic-artifact request. Hidden
-    // state could otherwise bypass MQB-owned routing/cache identity. Preserve
-    // LIB/PATH/vcvars state while making the explicit MQB argv authoritative.
-    environment.push_back(process::EnvironmentVariable{"LINK", {}});
-    environment.push_back(process::EnvironmentVariable{"_LINK_", {}});
-    environment.push_back(process::EnvironmentVariable{"link_repro", {}});
+    // honors LINK_REPRO as an implicit diagnostic-artifact request. Hidden
+    // state could otherwise bypass MQB-owned routing/cache identity. Remove
+    // those variables entirely while preserving LIB/PATH/vcvars state.
+    environment.push_back(process::EnvironmentVariable{"LINK", {}, true});
+    environment.push_back(process::EnvironmentVariable{"_LINK_", {}, true});
+    environment.push_back(process::EnvironmentVariable{"LINK_REPRO", {}, true});
 }
 
 [[nodiscard]] std::string linker_option_body_upper(const std::string_view argument) {

--- a/cpp/src/msvc/modules/MsvcModuleDependencyScanner.cpp
+++ b/cpp/src/msvc/modules/MsvcModuleDependencyScanner.cpp
@@ -66,9 +66,10 @@ void suppress_ambient_compiler_options(
     std::vector<process::EnvironmentVariable>& environment) {
     // P1689 scans are compiler invocations too. They must observe the same
     // explicit option surface as real compiles or hidden CL/_CL_ arguments can
-    // change topology without changing MQB's module-scan identity.
-    environment.push_back(process::EnvironmentVariable{"CL", {}});
-    environment.push_back(process::EnvironmentVariable{"_CL_", {}});
+    // change topology without changing MQB's module-scan identity. Remove the
+    // variables entirely so scan and compile share the same launch contract.
+    environment.push_back(process::EnvironmentVariable{"CL", {}, true});
+    environment.push_back(process::EnvironmentVariable{"_CL_", {}, true});
 }
 
 [[nodiscard]] std::expected<void, ModuleScanError> prepare_output(

--- a/cpp/src/platform/windows/WindowsProcessRunner.cpp
+++ b/cpp/src/platform/windows/WindowsProcessRunner.cpp
@@ -412,10 +412,6 @@ read_inherited_environment() {
         if (!wide_name) {
             return std::unexpected(wide_name.error());
         }
-        auto wide_value = utf8_to_wide(override_variable.value, "environment variable value");
-        if (!wide_value) {
-            return std::unexpected(wide_value.error());
-        }
 
         const auto existing = std::find_if(
             entries.begin(),
@@ -423,6 +419,17 @@ read_inherited_environment() {
             [&wide_name](const EnvironmentEntry& entry) {
                 return environment_name_equal(entry.name, *wide_name);
             });
+        if (override_variable.remove) {
+            if (existing != entries.end()) {
+                entries.erase(existing);
+            }
+            continue;
+        }
+
+        auto wide_value = utf8_to_wide(override_variable.value, "environment variable value");
+        if (!wide_value) {
+            return std::unexpected(wide_value.error());
+        }
         if (existing != entries.end()) {
             existing->name = std::move(*wide_name);
             existing->value = std::move(*wide_value);

--- a/cpp/tests/discovery/source_discovery_cache_tests.cpp
+++ b/cpp/tests/discovery/source_discovery_cache_tests.cpp
@@ -50,6 +50,16 @@ void force_cache_format_version(const fs::path& cache_file, const std::uint32_t 
     stream.flush();
 }
 
+[[nodiscard]] fs::path ascii_upper_path(const fs::path& path) {
+    std::wstring text = path.wstring();
+    for (wchar_t& ch : text) {
+        if (ch >= L'a' && ch <= L'z') {
+            ch = static_cast<wchar_t>(ch + (L'A' - L'a'));
+        }
+    }
+    return fs::path{text};
+}
+
 [[nodiscard]] bool contains_source(
     const std::vector<fs::path>& sources,
     const fs::path& source) {
@@ -117,6 +127,18 @@ int main() {
                "persistent discovery reuse must preserve exact source ordering");
         expect(warm->indexed_files == cold->indexed_files,
                "persistent discovery reuse must preserve indexed-file accounting");
+    }
+
+    mqb::discovery::Request case_alias_request = request;
+    case_alias_request.project_root = ascii_upper_path(tree.root);
+    case_alias_request.entry = ascii_upper_path(entry);
+    const auto case_alias_warm = mqb::discovery::SourceDiscovery::discover(case_alias_request);
+    expect(case_alias_warm.has_value(), "Windows case-alias discovery should succeed");
+    if (case_alias_warm && cold) {
+        expect(case_alias_warm->reused,
+               "Windows case aliases must reuse the same persistent discovery identity");
+        expect(case_alias_warm->sources == cold->sources,
+               "case-alias discovery reuse must preserve canonical selected source paths");
     }
 
     force_cache_format_version(default_cache, 2u);

--- a/cpp/tests/platform/windows/windows_command_line_tests.cpp
+++ b/cpp/tests/platform/windows/windows_command_line_tests.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "mqb/platform/windows/CommandLine.hpp"
+#include "mqb/platform/windows/PathIdentity.hpp"
 
 namespace {
 
@@ -60,6 +61,7 @@ void expect_round_trip(
 } // namespace
 
 int main() {
+    using mqb::platform::windows::path_identity_contains;
     using mqb::platform::windows::quote_command_line_argument;
 
     expect(quote_command_line_argument(L"plain") == L"plain",
@@ -89,6 +91,32 @@ int main() {
         L"mqb.exe",
         {L"\\\\server\\share\\folder with space\\", L"a\\\"b", L"\\\""},
         "UNC paths and quote-adjacent backslashes should round-trip");
+
+    expect(
+        path_identity_contains(
+            L"C:\\Work\\MQB",
+            L"c:\\work\\mqb\\src\\main.cpp"),
+        "project containment should use Windows case-insensitive identity");
+    expect(
+        path_identity_contains(
+            L"C:\\Work\\MQB\\",
+            L"c:\\work\\mqb"),
+        "project containment should treat trailing separators and root aliases as identical");
+    expect(
+        !path_identity_contains(
+            L"C:\\Work\\MQB",
+            L"C:\\Work\\MQB2\\main.cpp"),
+        "project containment must enforce a component boundary");
+    expect(
+        path_identity_contains(
+            L"C:\\项目\\MQB",
+            L"c:\\项目\\mqb\\src\\main.cpp"),
+        "project containment should preserve non-ASCII path bytes while folding ASCII case");
+    expect(
+        !path_identity_contains(
+            L"C:\\项目\\MQB",
+            L"C:\\項目\\MQB\\src\\main.cpp"),
+        "project containment must not locale-fold distinct non-ASCII path identities");
 
     if (failures != 0) {
         std::cerr << failures << " test(s) failed\n";

--- a/cpp/tests/platform/windows/windows_process_runner_tests.cpp
+++ b/cpp/tests/platform/windows/windows_process_runner_tests.cpp
@@ -1,4 +1,5 @@
 #include <barrier>
+#include <cstdlib>
 #include <filesystem>
 #include <future>
 #include <iostream>
@@ -73,6 +74,23 @@ int main(const int argc, char** argv) {
         expect(contains(result->stderr_text, "STDERR-MARKER"),
                "stderr should be captured separately from stdout");
     }
+
+    expect(_putenv_s("MQB_TEST_ENV", "parent-only") == 0,
+           "test should be able to seed an inherited parent environment variable");
+    mqb::process::ProcessSpec removed_environment = spec;
+    removed_environment.arguments = {"removed"};
+    removed_environment.environment = {
+        mqb::process::EnvironmentVariable{"MQB_TEST_ENV", {}, true},
+    };
+    const auto removed_result = runner.run(removed_environment);
+    expect(removed_result.has_value(),
+           "process should launch when an inherited environment variable is removed");
+    if (removed_result) {
+        expect(contains(removed_result->stdout_text, "ENV=[<missing>]"),
+               "remove=true must make an inherited variable absent, not merely empty");
+    }
+    expect(_putenv_s("MQB_TEST_ENV", "") == 0,
+           "test should clean up the seeded parent environment variable");
 
     mqb::process::ProcessSpec isolated_environment = spec;
     isolated_environment.arguments = {"isolated"};

--- a/tests/native/verify_final_closure_cross_stage.ps1
+++ b/tests/native/verify_final_closure_cross_stage.ps1
@@ -78,11 +78,11 @@ try {
         throw 'project-local toolchain cache migration broke the warm/no-op build path'
     }
 
-    # Final Closure #5 cross-stage contract: application-level project scope must
-    # use the same Windows identity authority as caches/discovery. The source is
-    # passed through a different ASCII-case spelling of the exact same directory.
-    # Project-only extra_sources is required to satisfy the link, so the build
-    # fails on the pre-fix lexical/case-sensitive containment path.
+    # Final Closure #5 cross-stage contract: application project scope, source
+    # discovery containment, and discovery-cache identity must share the same
+    # Windows path authority. Project-only extra_sources is required to satisfy
+    # the link. The second invocation addresses the same entry through a different
+    # ASCII-case spelling and must both build correctly and reuse the cache.
     $caseProject = Join-Path $root 'CaseProject'
     New-Item -ItemType Directory -Path $caseProject -Force | Out-Null
     Set-Content -LiteralPath (Join-Path $caseProject 'main.cpp') -Encoding utf8 -Value @(
@@ -106,6 +106,23 @@ try {
 }
 '@
 
+    $canonicalEntry = Join-Path $caseProject 'main.cpp'
+    $coldCaseOutput = Invoke-MqbChecked `
+        -WorkingDirectory $caseProject `
+        -Arguments @('build', $canonicalEntry, '--env', 'vs', '--verbose') `
+        -Description 'canonical project discovery build'
+    $coldCaseText = $coldCaseOutput -join "`n"
+    if ($coldCaseText -notmatch '\[discover\]\s+2 translation units') {
+        throw "canonical entry did not apply project-scoped extra_sources:`n$coldCaseText"
+    }
+
+    $discoveryCache = Join-Path $caseProject '.mqb/cache/discovery/source-discovery.mqbcache'
+    if (-not (Test-Path -LiteralPath $discoveryCache -PathType Leaf)) {
+        throw "discovery cache missing after canonical build: $discoveryCache"
+    }
+    $cacheWriteTime = (Get-Item -LiteralPath $discoveryCache).LastWriteTimeUtc
+    Start-Sleep -Milliseconds 1200
+
     $aliasedDirectory = $caseProject.ToUpperInvariant()
     $aliasedEntry = Join-Path $aliasedDirectory 'main.cpp'
     if (-not (Test-Path -LiteralPath $aliasedEntry -PathType Leaf)) {
@@ -119,6 +136,13 @@ try {
     $caseText = $caseOutput -join "`n"
     if ($caseText -notmatch '\[discover\]\s+2 translation units') {
         throw "case-alias entry did not retain project-scoped smart discovery:`n$caseText"
+    }
+    $cacheWriteTimeAfterAlias = (Get-Item -LiteralPath $discoveryCache).LastWriteTimeUtc
+    if ($cacheWriteTimeAfterAlias -ne $cacheWriteTime) {
+        throw 'case-alias entry caused an avoidable discovery-cache rewrite instead of identity-stable reuse'
+    }
+    if ($caseText -notmatch '\[up-to-date\]') {
+        throw 'case-alias entry broke the downstream warm/no-op path'
     }
 }
 finally {

--- a/tests/native/verify_final_closure_cross_stage.ps1
+++ b/tests/native/verify_final_closure_cross_stage.ps1
@@ -44,21 +44,31 @@ function Invoke-MqbChecked {
 }
 
 $previousLocalAppData = $env:LOCALAPPDATA
+$previousLinkRepro = $env:LINK_REPRO
 try {
     # Final Closure architecture contract: MQB-owned persistent state must remain
     # inside the active project's .mqb tree. Point LOCALAPPDATA at a fresh decoy
     # so a regression to the old user-local VS discovery cache is observable.
     $stateProject = Join-Path $root 'state-project'
     $decoyLocalAppData = Join-Path $root 'decoy-local-app-data'
+    $ambientLinkRepro = Join-Path $root 'ambient-link-repro'
     New-Item -ItemType Directory -Path $stateProject -Force | Out-Null
     New-Item -ItemType Directory -Path $decoyLocalAppData -Force | Out-Null
     Set-Content -LiteralPath (Join-Path $stateProject 'main.cpp') -Encoding utf8 -Value 'int main() { return 0; }'
     $env:LOCALAPPDATA = $decoyLocalAppData
+    $env:LINK_REPRO = $ambientLinkRepro
 
-    [void](Invoke-MqbChecked `
+    $coldStateOutput = Invoke-MqbChecked `
         -WorkingDirectory $stateProject `
         -Arguments @('build', 'main.cpp', '--env', 'vs', '--no-discover') `
-        -Description 'project-local state cold build')
+        -Description 'project-local state cold build'
+    $coldStateText = $coldStateOutput -join "`n"
+    if ($coldStateText -match 'LINK_REPRO|LNK4046') {
+        throw "ambient LINK_REPRO remained observable to link.exe:`n$coldStateText"
+    }
+    if (Test-Path -LiteralPath $ambientLinkRepro) {
+        throw "ambient LINK_REPRO created an unmanaged diagnostic artifact: $ambientLinkRepro"
+    }
 
     $projectCache = Join-Path $stateProject '.mqb/cache/toolchain/vs-x64.cache'
     if (-not (Test-Path -LiteralPath $projectCache -PathType Leaf)) {
@@ -147,6 +157,12 @@ finally {
     else {
         $env:LOCALAPPDATA = $previousLocalAppData
     }
+    if ($null -eq $previousLinkRepro) {
+        Remove-Item Env:LINK_REPRO -ErrorAction SilentlyContinue
+    }
+    else {
+        $env:LINK_REPRO = $previousLinkRepro
+    }
 }
 
-Write-Host 'Final Closure cross-stage state/path gate passed.'
+Write-Host 'Final Closure cross-stage state/path/environment gate passed.'

--- a/tests/native/verify_final_closure_cross_stage.ps1
+++ b/tests/native/verify_final_closure_cross_stage.ps1
@@ -78,11 +78,12 @@ try {
         throw 'project-local toolchain cache migration broke the warm/no-op build path'
     }
 
-    # Final Closure #5 cross-stage contract: application project scope, source
-    # discovery containment, and discovery-cache identity must share the same
-    # Windows path authority. Project-only extra_sources is required to satisfy
-    # the link. The second invocation addresses the same entry through a different
-    # ASCII-case spelling and must both build correctly and reuse the cache.
+    # Final Closure #5 cross-stage contract: application project scope and source
+    # discovery containment must share the same Windows path authority. Project-
+    # only extra_sources is required to satisfy the link. The second invocation
+    # addresses the same entry through a different ASCII-case spelling and must
+    # preserve both project semantics and the downstream warm/no-op path. Exact
+    # discovery-cache reuse is asserted directly by source_discovery_cache_tests.
     $caseProject = Join-Path $root 'CaseProject'
     New-Item -ItemType Directory -Path $caseProject -Force | Out-Null
     Set-Content -LiteralPath (Join-Path $caseProject 'main.cpp') -Encoding utf8 -Value @(
@@ -120,8 +121,6 @@ try {
     if (-not (Test-Path -LiteralPath $discoveryCache -PathType Leaf)) {
         throw "discovery cache missing after canonical build: $discoveryCache"
     }
-    $cacheWriteTime = (Get-Item -LiteralPath $discoveryCache).LastWriteTimeUtc
-    Start-Sleep -Milliseconds 1200
 
     $aliasedDirectory = $caseProject.ToUpperInvariant()
     $aliasedEntry = Join-Path $aliasedDirectory 'main.cpp'
@@ -136,10 +135,6 @@ try {
     $caseText = $caseOutput -join "`n"
     if ($caseText -notmatch '\[discover\]\s+2 translation units') {
         throw "case-alias entry did not retain project-scoped smart discovery:`n$caseText"
-    }
-    $cacheWriteTimeAfterAlias = (Get-Item -LiteralPath $discoveryCache).LastWriteTimeUtc
-    if ($cacheWriteTimeAfterAlias -ne $cacheWriteTime) {
-        throw 'case-alias entry caused an avoidable discovery-cache rewrite instead of identity-stable reuse'
     }
     if ($caseText -notmatch '\[up-to-date\]') {
         throw 'case-alias entry broke the downstream warm/no-op path'

--- a/tests/native/verify_final_closure_cross_stage.ps1
+++ b/tests/native/verify_final_closure_cross_stage.ps1
@@ -1,0 +1,133 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$MqbPath,
+    [Parameter(Mandatory = $true)][string]$RepoRoot
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+$MqbPath = [System.IO.Path]::GetFullPath($MqbPath)
+$RepoRoot = [System.IO.Path]::GetFullPath($RepoRoot)
+if (-not (Test-Path -LiteralPath $MqbPath -PathType Leaf)) {
+    throw "MQB executable not found: $MqbPath"
+}
+
+$root = Join-Path $RepoRoot 'native-out/final-closure-cross-stage'
+if (Test-Path -LiteralPath $root) {
+    Remove-Item -LiteralPath $root -Recurse -Force
+}
+New-Item -ItemType Directory -Path $root -Force | Out-Null
+
+function Invoke-MqbChecked {
+    param(
+        [Parameter(Mandatory = $true)][string]$WorkingDirectory,
+        [Parameter(Mandatory = $true)][string[]]$Arguments,
+        [Parameter(Mandatory = $true)][string]$Description
+    )
+
+    Push-Location $WorkingDirectory
+    try {
+        $output = @(& $MqbPath @Arguments 2>&1)
+        $exitCode = $LASTEXITCODE
+    }
+    finally {
+        Pop-Location
+    }
+    foreach ($line in $output) {
+        Write-Host $line
+    }
+    if ($exitCode -ne 0) {
+        throw "$Description failed with exit code $exitCode"
+    }
+    return @($output | ForEach-Object { [string]$_ })
+}
+
+$previousLocalAppData = $env:LOCALAPPDATA
+try {
+    # Final Closure architecture contract: MQB-owned persistent state must remain
+    # inside the active project's .mqb tree. Point LOCALAPPDATA at a fresh decoy
+    # so a regression to the old user-local VS discovery cache is observable.
+    $stateProject = Join-Path $root 'state-project'
+    $decoyLocalAppData = Join-Path $root 'decoy-local-app-data'
+    New-Item -ItemType Directory -Path $stateProject -Force | Out-Null
+    New-Item -ItemType Directory -Path $decoyLocalAppData -Force | Out-Null
+    Set-Content -LiteralPath (Join-Path $stateProject 'main.cpp') -Encoding utf8 -Value 'int main() { return 0; }'
+    $env:LOCALAPPDATA = $decoyLocalAppData
+
+    [void](Invoke-MqbChecked `
+        -WorkingDirectory $stateProject `
+        -Arguments @('build', 'main.cpp', '--env', 'vs', '--no-discover') `
+        -Description 'project-local state cold build')
+
+    $projectCache = Join-Path $stateProject '.mqb/cache/toolchain/vs-x64.cache'
+    if (-not (Test-Path -LiteralPath $projectCache -PathType Leaf)) {
+        throw "project-local VS discovery cache missing: $projectCache"
+    }
+    $legacyUserLocalState = Join-Path $decoyLocalAppData 'MQB'
+    if (Test-Path -LiteralPath $legacyUserLocalState) {
+        throw "MQB wrote persistent state outside the project .mqb tree: $legacyUserLocalState"
+    }
+
+    $warmOutput = Invoke-MqbChecked `
+        -WorkingDirectory $stateProject `
+        -Arguments @('build', 'main.cpp', '--env', 'vs', '--no-discover') `
+        -Description 'project-local state warm build'
+    $warmText = $warmOutput -join "`n"
+    if ($warmText -notmatch '\[up-to-date\]') {
+        throw 'project-local toolchain cache migration broke the warm/no-op build path'
+    }
+
+    # Final Closure #5 cross-stage contract: application-level project scope must
+    # use the same Windows identity authority as caches/discovery. The source is
+    # passed through a different ASCII-case spelling of the exact same directory.
+    # Project-only extra_sources is required to satisfy the link, so the build
+    # fails on the pre-fix lexical/case-sensitive containment path.
+    $caseProject = Join-Path $root 'CaseProject'
+    New-Item -ItemType Directory -Path $caseProject -Force | Out-Null
+    Set-Content -LiteralPath (Join-Path $caseProject 'main.cpp') -Encoding utf8 -Value @(
+        'int helper();',
+        'int main() { return helper() == 42 ? 0 : 1; }'
+    )
+    Set-Content -LiteralPath (Join-Path $caseProject 'helper.cpp') -Encoding utf8 -Value 'int helper() { return 42; }'
+    Set-Content -LiteralPath (Join-Path $caseProject 'mqb.json') -Encoding utf8 -Value @'
+{
+  "version": 1,
+  "build": {
+    "configuration": "debug",
+    "architecture": "x64",
+    "standard": "23",
+    "type": "exe"
+  },
+  "discovery": {
+    "enabled": true,
+    "extra_sources": ["helper.cpp"]
+  }
+}
+'@
+
+    $aliasedDirectory = $caseProject.ToUpperInvariant()
+    $aliasedEntry = Join-Path $aliasedDirectory 'main.cpp'
+    if (-not (Test-Path -LiteralPath $aliasedEntry -PathType Leaf)) {
+        throw "Windows case-alias fixture did not resolve to the same entry: $aliasedEntry"
+    }
+
+    $caseOutput = Invoke-MqbChecked `
+        -WorkingDirectory $caseProject `
+        -Arguments @('build', $aliasedEntry, '--env', 'vs', '--verbose') `
+        -Description 'Windows case-alias project discovery build'
+    $caseText = $caseOutput -join "`n"
+    if ($caseText -notmatch '\[discover\]\s+2 translation units') {
+        throw "case-alias entry did not retain project-scoped smart discovery:`n$caseText"
+    }
+}
+finally {
+    if ($null -eq $previousLocalAppData) {
+        Remove-Item Env:LOCALAPPDATA -ErrorAction SilentlyContinue
+    }
+    else {
+        $env:LOCALAPPDATA = $previousLocalAppData
+    }
+}
+
+Write-Host 'Final Closure cross-stage state/path gate passed.'


### PR DESCRIPTION
## Final Closure audit scope

This is a **no-new-feature** closure patch for the composed:

`Original Productization PR1–PR9 + post-productization correctness hardening + Final Closure #1–#6`

The audit deliberately looked for cross-stage contradictions that individual closure PRs could not prove in isolation.

## Cross-stage blockers found

### 1. MQB-owned persistent state escaped `.mqb`

Visual Studio discovery persistence still defaulted to `%LOCALAPPDATA%/MQB/cache/toolchain`, contradicting the architecture contract that MQB-owned writable/cache state remains under `.mqb`.

Closure:
- standalone VS discovery persistence remains reusable, but defaults under the current working directory's `.mqb/cache/toolchain`
- the MQB application explicitly binds VS discovery persistence to the active project root with an architecture-specific cache file
- a real Windows gate points `LOCALAPPDATA` at a decoy and proves no MQB state appears there

### 2. Final Closure #5 path identity was not authoritative end-to-end

`Application.cpp` still made project-containment / portable-root decisions with lexical/path equality. The first real closure gate then exposed a deeper copy of the same problem inside `SourceDiscovery`; persistent discovery request identity also compared `std::filesystem::path` directly, causing avoidable cache misses for Windows case aliases.

Closure:
- add central `path_identity_contains()` beside `path_identity_key()`
- route application project scope and portable-root dedup through the Windows path authority
- route discovery containment, entry/source equality, and persistent discovery request/record identity through the same authority
- unit coverage includes ASCII case aliases, component boundaries, trailing separators, Unicode-byte preservation, and exact persistent-cache reuse across a Windows case alias
- real E2E proves a case-aliased entry still receives project-only `extra_sources` and the downstream compile/link path remains no-op

### 3. Ambient MSVC inputs were being emptied, not actually removed

`CL`, `_CL_`, `LINK`, `_LINK_`, and `LINK_REPRO` are intentionally excluded from toolchain environment identity because launch-time isolation owns them. The old process model only assigned empty strings. Real LINK execution proved that presence itself is semantic input: an empty `LINK_REPRO` still produced `LNK4046`.

Closure:
- extend `EnvironmentVariable` with explicit removal semantics
- `WindowsProcessRunner` now removes inherited variables from the child environment block instead of emitting `NAME=`
- ordinary compile removes `CL/_CL_`
- P1689 module dependency scanning removes `CL/_CL_` with the same contract
- LINK removes `LINK/_LINK_/LINK_REPRO`
- LIB removes `LINK_REPRO`
- process-runner unit coverage proves a parent variable becomes genuinely missing in the child
- real E2E seeds ambient `LINK_REPRO` and proves no warning/repro artifact is observable

## Other closure audit results

No additional blocker was found in the reviewed cross-stage surfaces:
- canonical + semantic MSVC parameter inventory / fail-closed ownership
- raw linker response/file-bearing input freshness
- secondary linker outputs and repair
- ASan / LibFuzzer / OpenMP / transitive default-library freshness
- archive freshness and native librarian ownership
- PCH -> discovery projection
- Modules/Header Units compile/toolchain/cache identity inheritance
- selected-toolchain std/std.compat provider routing

The MicrosoftDocs canonical snapshots currently used by MQB were also rechecked against upstream `main`; no stale canonical-inventory blocker was found.

## Dedicated Final Closure gate

`.github/workflows/final-closure-cross-stage.yml` builds the current MQB and verifies on real Windows/MSVC:
- project-local toolchain cache under `.mqb`
- no state in decoy `LOCALAPPDATA`
- warm/no-op preservation
- ambient `LINK_REPRO` absence
- case-aliased project entry preserves project-scoped discovery
- case-alias downstream build remains up-to-date

Existing Native C++ gates remain authoritative for the broader correctness matrix, including ambient MSVC options, external include ownership, sanitizers/runtimes, transitive libraries, include-resolution freshness, `__has_include`, secondary outputs, and exact/semantic option inventory.

## Performance evidence

This PR intentionally uses a `perf:` title so the repository's same-runner base/head Performance Evidence workflow exercises all governed scenarios before closure:

`cold`, `no-op`, `single-tu`, `public-header`, `build-run`, `link-only`, `discovery-cold`, `discovery-no-op`, `discovery-header`, `modules-cold`, `modules-no-op`.

Final performance evidence and merge status will be reviewed before the productization line is declared CLOSED.

## Closure criterion

No product feature is added. The PR is complete only when the dedicated Final Closure gate, Native C++, Native Release, and performance evidence have been reviewed successfully and no remaining cross-stage correctness/architecture blocker is found.