### PR TITLE
perf: isolate benchmarks and optimize invocation warm path

### DIFF
--- a/cpp/src/app/cli/Invocation.cpp
+++ b/cpp/src/app/cli/Invocation.cpp
@@ -6,11 +6,13 @@
 #include <string>
 #include <string_view>
 #include <system_error>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
 #include "Diagnostics.hpp"
 #include "mqb/core/TranslationUnitClassifier.hpp"
+#include "mqb/platform/windows/PathIdentity.hpp"
 
 namespace mqb::app {
 namespace {
@@ -114,6 +116,8 @@ resolve_invocation(mqb::cli::Options& options) {
 
     std::vector<fs::path> requested_sources;
     requested_sources.reserve(options.build.sources.size());
+    std::unordered_set<std::string> requested_source_keys;
+    requested_source_keys.reserve(options.build.sources.size());
     for (const auto& requested_source : options.build.sources) {
         auto source = absolute_path_from(invocation_directory, requested_source, "source file");
         if (!source) {
@@ -123,13 +127,12 @@ resolve_invocation(mqb::cli::Options& options) {
         if (!validated) {
             return std::unexpected(validated.error());
         }
-        for (const auto& previous : requested_sources) {
-            error_code.clear();
-            if (fs::equivalent(previous, *validated, error_code) && !error_code) {
-                return std::unexpected(
-                    "source file was provided more than once: "
-                    + diagnostics::path_text(*validated));
-            }
+        const std::string identity =
+            mqb::platform::windows::path_identity_key(*validated);
+        if (!requested_source_keys.insert(identity).second) {
+            return std::unexpected(
+                "source file was provided more than once: "
+                + diagnostics::path_text(*validated));
         }
         requested_sources.push_back(std::move(*validated));
     }

--- a/cpp/tests/app/cli/mqb_native_msvc_cli_e2e_tests.cpp
+++ b/cpp/tests/app/cli/mqb_native_msvc_cli_e2e_tests.cpp
@@ -350,6 +350,19 @@ void verify_native_candidate_e2e(const fs::path& mqb_executable) {
         "int main() { std::printf(\"native=%d\\n\", NATIVE_VALUE); return NATIVE_VALUE == 7 ? 0 : 1; }\n");
 
     mqb::platform::windows::WindowsProcessRunner runner;
+    auto duplicate_source = run_process(
+        runner,
+        mqb_executable,
+        tree.root,
+        {"main.cpp", "MAIN.CPP", "--no-discover"});
+    expect(duplicate_source.has_value(), "duplicate source validation should launch");
+    if (duplicate_source) {
+        expect(duplicate_source->exit_code == 2
+                   && duplicate_source->stderr_text.find("source file was provided more than once")
+                       != std::string::npos,
+               "Windows path-identity aliases should be rejected as duplicate sources");
+    }
+
     const fs::path map_file = tree.root / "native.map";
     auto build = run_process(
         runner,

--- a/docs/20260826-172358-benchmark-environment-isolation/implementation_plan.md
+++ b/docs/20260826-172358-benchmark-environment-isolation/implementation_plan.md
@@ -1,0 +1,122 @@
+# Benchmark environment correction and evidence-driven optimization
+
+## Decision
+
+Use a staged correction. First remove only confirmed stale global MSVC/SDK
+entries after exporting a registry backup. Then make the benchmark construct a
+clean process-local x64 MSVC environment and verify MQB cache transitions from
+its JSON timings. Rerun the formal benchmark before selecting any product-code
+optimization.
+
+This is preferred over two alternatives:
+
+- changing only the local machine would leave the public harness vulnerable on
+  other developer machines and CI images;
+- immediately tuning MQB would optimize data produced by a contaminated test
+  environment and could hide a correctness regression.
+
+## Contract
+
+Objective: produce a trustworthy 100-TU comparison, then reduce a remaining
+measured MQB product bottleneck without weakening incremental correctness.
+
+Gap: the machine has persistent paths for removed VS2022/SDK installations, and
+the harness layers VS18 on top of those values without asserting cache behavior.
+
+Scope: Windows environment cleanup, benchmark environment isolation and timing
+evidence, one evidence-selected MQB optimization, focused tests, documentation,
+and full native verification.
+
+Done when: stale persistent values are backed up and an administrator cleanup
+script is ready for the machine-level values that this process cannot remove; the harness proves
+the expected transition counts; corrected 100-TU x 5 before/after reports exist;
+the selected optimization has a semantic regression test plus retained
+before/after performance evidence; all relevant native and documentation gates
+pass.
+
+## Stage 1: recoverable machine correction
+
+Export the machine and user environment registry keys to the task outputs. Remove
+only nonexistent MSVC/SDK/Lua values from machine `INCLUDE`, `LIB`,
+`VCINSTALLDIR`, and the three confirmed stale compiler/SDK `PATH` entries. Remove
+the one nonexistent Qt CMake entry from user `PATH`. Do not add version-pinned
+MSVC paths globally; Visual Studio developer environments remain the authority.
+
+Verify the registry no longer contains those paths. Existing processes may keep
+their inherited copy until restarted, so later tests must not depend on the app
+being relaunched.
+
+## Stage 2: benchmark red/green correction
+
+Extend the harness to capture MQB `--timings=json` data for every sample and
+validate transition semantics. The first red run will execute under a deliberately
+poisoned launching environment and demonstrate that the current harness accepts
+unexpected no-op rebuilds.
+
+The minimal implementation will snapshot relevant process variables, clear stale
+MSVC metadata before calling `VsDevCmd.bat`, import one x64 environment, and
+restore the caller's process variables in `finally`. Both MQB and Ninja continue
+to receive the same effective environment.
+
+Expected transition contracts:
+
+- ordinary no-op: all TUs compile-hit and link-hit;
+- ordinary single-TU: exactly one compile miss;
+- ordinary public-header: every ordinary TU that includes the header misses;
+- PCH no-op: creator and consumers hit and link hits;
+- PCH single-TU: exactly one consumer miss;
+- PCH header: creator and consumers rebuild.
+
+The report will preserve raw timing/cache evidence without introducing wall-time
+performance thresholds.
+
+## Stage 3: corrected measurement
+
+Build the current Release MQB from `main`, run the 8-TU correctness fixture, then
+run 100 TUs, five iterations, and eight workers. Keep exact tool hashes,
+environment metadata, raw samples, transition evidence, and comparison medians.
+Treat the earlier contaminated report as diagnostic evidence, not a baseline for
+product claims.
+
+## Stage 4: product optimization
+
+Use the corrected MQB timing breakdown to select the largest repeatable product
+cost. Add the smallest semantic regression test around the optimized path-identity
+contract, preserve deterministic before/after timing reports as the performance
+regression evidence, implement one focused change, and rerun the same measurement.
+Do not combine unrelated cleanup or relax freshness checks to gain benchmark time.
+
+Likely candidates are persistent toolchain-cache startup validation or per-TU
+warm-cache filesystem work, but the corrected report decides; neither is assumed
+in advance.
+
+## Validation and rollback
+
+Validation proceeds from focused PowerShell harness checks to the corrected
+formal benchmark, current-MQB self-build, selected native tests, full native test
+suite, bilingual documentation parity, and git diff/status audit.
+
+Machine rollback uses the exported registry files. Repository rollback is a
+single focused branch diff. No merge, push, pull request, or release is authorized
+by this plan.
+
+## Execution result
+
+Stages 2-4 completed. The harness now filters inherited Visual Studio/SDK paths
+and MSVC option-injection variables, imports and verifies one selected x64
+toolchain, restores its process environment, captures MQB JSON timing records,
+and fails on incorrect cache transitions. A deliberately poisoned PATH/CL/LINK
+launch passed all eight scenarios and restored the caller environment. Corrected,
+same-policy before/after 100-TU x 5 reports were retained.
+
+The selected product optimization is duplicate-source validation in invocation
+resolution: an O(n²) sequence of physical filesystem comparisons was replaced
+with O(n) membership in the shared Windows path-identity domain. A case-alias
+duplicate-source E2E contract covers the user-visible rejection behavior.
+
+For Stage 1, registry backups were exported. The stale user Qt CMake path was
+removed and verified. The current process could not write the machine environment
+key without elevation, so the task output includes an administrator cleanup
+script that re-exports backups and removes only the confirmed nonexistent
+machine entries. Repository and benchmark verification do not depend on running
+that script because they establish a clean process-local environment.

--- a/docs/20260826-172358-benchmark-environment-isolation/issue.md
+++ b/docs/20260826-172358-benchmark-environment-isolation/issue.md
@@ -1,0 +1,88 @@
+# Benchmark environment isolation and cache-transition evidence
+
+## Original intent
+
+Continue the merged build-system comparison work by collecting a publishable
+`100 TU x 5 iterations` local data set, locating MQB's cold/PCH bottlenecks,
+and optimizing only after the measurements identify a reproducible cause.
+
+The user subsequently authorized correcting the persistent Windows environment,
+rerunning the formal measurement, and optimizing MQB product code against the
+corrected evidence.
+
+## Observed problem
+
+The first local report is internally correct but not yet suitable as a product
+performance conclusion. The launching shell contains MSVC metadata from an
+older VS2022 environment plus a custom include directory. The benchmark then
+imports VS18 on top of that ambient state.
+
+On this machine the layered environment prevents MQB's persistent Visual Studio
+toolchain cache from being reused. Every invocation repeats vcvars discovery.
+For the flat generated fixture, the discovery path also changes the directory
+used as quoted-include freshness evidence, so the 100 translation units that
+include `common.hpp` are rebuilt on a nominal no-op invocation.
+
+Reproduction evidence:
+
+- original 100-TU no-op median: about 2.0 seconds;
+- repeated polluted-environment invocation: 1 compile hit / 100 misses;
+- the only source without an include (`main.cpp`) remains a hit;
+- with clean MSVC metadata and the same MQB binary/source set: 101 compile hits,
+  one link hit, and about 102 milliseconds wall time;
+- moving active `.mqb` state outside the watched source directory also prevents
+  the false invalidation, confirming the interaction between repeated toolchain
+  discovery and include-directory freshness.
+
+## Goal
+
+Make the comparison harness establish one clean, explicit x64 MSVC environment
+for both MQB and CMake/Ninja, and make each measured MQB transition prove its
+expected cache behavior rather than accepting a correct executable after an
+unexpected rebuild.
+
+## Acceptance criteria
+
+1. A poisoned launching shell cannot leak stale MSVC include/library metadata
+   into the benchmark's effective toolchain environment.
+2. Both build systems still run under the same imported x64 MSVC environment.
+3. MQB timing evidence is captured for every sample.
+4. `ordinary-no-op` and `pch-no-op` have zero compile misses and a link hit.
+5. A single-TU mutation rebuilds only the intended ordinary consumer set.
+6. Shared-header and PCH-header transitions rebuild the expected dependent set.
+7. The 8-TU correctness fixture and the formal 100-TU x 5 run both complete,
+   execute every output program successfully, and retain raw JSON evidence.
+8. Existing bilingual methodology remains aligned with the actual harness.
+
+## Non-goals
+
+- Do not tune MQB product code before the corrected benchmark identifies a
+  remaining product bottleneck.
+- Do not add performance pass/fail thresholds based on hosted-runner wall time.
+- Do not claim MQB universally outperforms CMake/Ninja.
+- Do not change compiler/linker policy, TU contents, or the comparison matrix.
+
+## Constraints
+
+- Windows x64 and MSVC only.
+- Keep CMake configure time separate and keep timed Ninja invocation direct.
+- Preserve alternating execution order and identical source trees.
+- Use a small, reviewable change set with regression evidence before and after.
+
+## Resolution evidence
+
+- The 8-TU red run failed at `ordinary-no-op` with eight unexpected compile misses.
+- After process-local MSVC isolation, all eight scenarios satisfied their exact
+  compile/link hit and miss contracts.
+- The corrected 100-TU baseline exposed about 78 ms in duplicate-source
+  resolution. The implementation compared every source with every previous
+  source through `std::filesystem::equivalent()`.
+- Replacing that quadratic physical probe with the repository's authoritative
+  Windows path-identity key reduced invocation resolution to about 1.3 ms.
+- In the final five-iteration run, ordinary no-op improved from 102.73 ms to
+  28.41 ms and ordinary single-TU rebuild improved from 169.74 ms to 97.38 ms.
+- Debug self-build and all four isolated native-test shards passed (77/77).
+
+Cold and PCH-header builds remain slower than direct Ninja build timings. The
+reports keep that result visible; this change does not claim those gaps are
+resolved or that MQB is universally faster.

--- a/docs/20260826-172358-benchmark-environment-isolation/walkthrough.md
+++ b/docs/20260826-172358-benchmark-environment-isolation/walkthrough.md
@@ -1,0 +1,102 @@
+# Benchmark environment isolation and invocation warm-path walkthrough
+
+## Outcome
+
+The benchmark harness now resolves the requested tools before isolation,
+filters inherited Visual Studio/Windows SDK paths and MSVC option-injection
+variables, imports one verified x64 Visual Studio environment, records the
+selected compiler/linker paths, asserts exact MQB cache transitions, and restores
+the caller environment.
+
+The product change replaces quadratic duplicate-source filesystem equivalence
+checks with linear membership in the shared Windows path-identity domain. The
+user-visible case-alias duplicate rejection remains covered by a native CLI E2E
+test.
+
+## Changed source files
+
+- `cpp/src/app/cli/Invocation.cpp`
+- `cpp/tests/app/cli/mqb_native_msvc_cli_e2e_tests.cpp`
+- `tests/native/benchmark_build_systems.ps1`
+- `docs/BUILD_SYSTEM_BENCHMARK.md`
+- `docs/BUILD_SYSTEM_BENCHMARK_ZH.md`
+- `docs/20260826-172358-benchmark-environment-isolation/issue.md`
+- `docs/20260826-172358-benchmark-environment-isolation/implementation_plan.md`
+- `docs/20260826-172358-benchmark-environment-isolation/walkthrough.md`
+
+## Environment evidence
+
+After running the administrator cleanup script on 2026-08-26, a fresh registry
+and process audit reported zero stale matches in machine `PATH`, `INCLUDE`,
+`LIB`, and `VCINSTALLDIR`, zero stale matches in user `PATH`, and zero stale
+matches in the current Codex process `PATH`.
+
+The post-cleanup benchmark smoke report verified:
+
+```text
+Visual Studio: C:\Program Files\Microsoft Visual Studio\18\Community
+MSVC tools:    14.51.36231
+Windows SDK:   10.0.26100.0
+```
+
+## Native build and test evidence
+
+The current Debug MQB was rebuilt from the repository source with MQB. The
+successful verification output included:
+
+```text
+C++ responsibility layout contract passed.
+Verified project manifest: 73 production translation units
+[up-to-date] cpp/src/app/cli/Invocation.cpp
+[up-to-date] mqb.exe
+output: ...\native-out\verification\mqb-debug.exe
+```
+
+All eight deterministic Debug native subshards ran against that candidate and
+the verified shared product library:
+
+```text
+MQB-native shard 0/8:  8/8 selected tests passed.
+MQB-native shard 1/8:  9/9 selected tests passed.
+MQB-native shard 2/8:  9/9 selected tests passed.
+MQB-native shard 3/8:  9/9 selected tests passed.
+MQB-native shard 4/8:  9/9 selected tests passed.
+MQB-native shard 5/8: 11/11 selected tests passed.
+MQB-native shard 6/8: 11/11 selected tests passed.
+MQB-native shard 7/8: 11/11 selected tests passed.
+```
+
+Total: **77/77 native tests passed** without CMake or CTest. The shard containing
+`mqb_native_msvc_cli_e2e_tests.cpp` passed, including the new case-alias
+duplicate-source contract.
+
+## Benchmark evidence
+
+The corrected 100-TU, five-iteration before/after reports retain 80 raw samples
+each (eight scenarios, two systems, five iterations). Product warm-path medians
+changed as follows:
+
+| Scenario | Before | After | Reduction |
+| --- | ---: | ---: | ---: |
+| ordinary no-op | 104.31 ms | 26.59 ms | 74.5% |
+| ordinary single TU | 172.67 ms | 103.18 ms | 40.2% |
+| PCH no-op | 107.04 ms | 33.14 ms | 69.0% |
+| PCH single TU | 175.52 ms | 97.41 ms | 44.5% |
+
+A fresh post-cleanup 8-TU smoke run completed all ordinary and PCH cold, no-op,
+single-TU, and header transitions. The harness rejected no sample, so every MQB
+sample matched its exact compile/link cache contract.
+
+Cold builds and PCH-header rebuilds remain explicit follow-up optimization
+targets; they are not claimed as improved by this change.
+
+## Documentation and diff evidence
+
+```text
+Bilingual documentation parity check passed for 17 maintained pairs.
+PowerShell parse and git diff checks passed.
+```
+
+An independent read-only review found no blocking issues after the environment
+isolation follow-up fixes. No commit, push, pull request, merge, or release was
+performed while producing this evidence.

--- a/docs/BUILD_SYSTEM_BENCHMARK.md
+++ b/docs/BUILD_SYSTEM_BENCHMARK.md
@@ -33,7 +33,7 @@ C++ Modules and Header Units are deliberately outside the first comparison matri
 The harness is intentionally conservative about what it calls comparable:
 
 1. **Same physical source tree per iteration.** MQB state lives in `.mqb/`; CMake/Ninja state lives in `cmake-build/`.
-2. **Same MSVC environment.** If `cl.exe` is not already available, the harness imports the latest x64 Visual Studio developer environment with `vswhere` + `VsDevCmd.bat` before running either system.
+2. **Same clean MSVC environment.** The harness first resolves the requested benchmark tools, snapshots the caller's process environment, removes inherited Visual Studio/Windows SDK `PATH` entries plus `CL`/`LINK` option-injection variables, imports the latest x64 Visual Studio developer environment with `vswhere` + `VsDevCmd.bat`, and restores the caller's environment in `finally`. It also verifies that `cl.exe` and `link.exe` resolve from the selected Visual Studio installation.
 3. **Same explicit parallel ceiling.** `-Jobs N` becomes MQB `-j N` and Ninja `-j N`.
 4. **Aligned release compiler/linker policy.** The generated CMake target uses the same core MSVC release flags used by MQB for this fixture: `/utf-8`, `/W3`, `/EHsc`, `/permissive-`, `/Zc:__cplusplus`, `/Zc:preprocessor`, `/diagnostics:column`, `/O2`, `/Oi`, `/MD`, `/Z7`, `/DNDEBUG`, and `/std:c++23preview`; release link policy uses `/INCREMENTAL:NO`, `/OPT:REF`, `/OPT:ICF`, x64, and console subsystem.
 5. **Build-system dependency work remains visible.** CMake/Ninja may add its own dependency-tracking arguments and MQB may use its own metadata paths. Those are part of the systems being compared and are not manually removed.
@@ -66,7 +66,7 @@ Requirements:
 - Ninja;
 - the MQB executable under test.
 
-If the terminal is not already a Visual Studio developer shell, the script attempts to import the latest installed x64 MSVC environment automatically.
+The script deliberately filters inherited Visual Studio/Windows SDK paths and MSVC option-injection variables before importing one fresh x64 MSVC environment. This prevents removed or mixed installations, or unequal `CL`/`LINK` flags, from contaminating either build path.
 
 Use `-KeepWorktree` when debugging the generated fixtures. Otherwise the temporary fixture tree is removed after the run.
 
@@ -78,7 +78,7 @@ The JSON report records:
 - tool version strings where available;
 - Windows / PowerShell / CPU-width / MSVC environment metadata;
 - translation-unit count, iterations, jobs, architecture, and configuration;
-- every raw build sample with execution order;
+- every raw build sample with execution order, plus MQB phase timings and compile/link cache counters;
 - CMake configure samples and medians, separately from build time;
 - per-scenario MQB and CMake/Ninja medians;
 - MQB absolute and percentage deltas relative to CMake/Ninja;
@@ -90,6 +90,6 @@ For `mqb_delta_pct_vs_cmake_ninja`, a negative value means the MQB sample had lo
 
 `.github/workflows/build-system-evidence.yml` runs a small correctness-sized fixture on relevant pull requests. It builds the current MQB product from the repository, runs one comparison iteration with a small TU count, and uploads the JSON report.
 
-That workflow proves that the comparison harness remains executable and that both build paths produce correct programs. It is **not** a stable performance leaderboard: hosted runner placement, system load, antivirus state, filesystem caches, and VM noise can materially move wall-clock numbers.
+That workflow proves that the comparison harness remains executable, both build paths produce correct programs, and every MQB scenario performs the expected cold/no-op/incremental cache transition. It is **not** a stable performance leaderboard: hosted runner placement, system load, antivirus state, filesystem caches, and VM noise can materially move wall-clock numbers.
 
 For publishable measurements, run multiple iterations on a named physical machine, keep the full JSON, and report the machine and toolchain alongside the medians.

--- a/docs/BUILD_SYSTEM_BENCHMARK_ZH.md
+++ b/docs/BUILD_SYSTEM_BENCHMARK_ZH.md
@@ -33,7 +33,7 @@ C++ Modules 与 Header Units 有意不放进第一版对比矩阵。它们的支
 脚本对“可比较”的定义采取偏保守策略：
 
 1. **每次 iteration 使用同一份物理源码树。** MQB 状态放在 `.mqb/`；CMake/Ninja 状态放在 `cmake-build/`。
-2. **使用同一个 MSVC 环境。** 如果当前终端没有 `cl.exe`，脚本会先通过 `vswhere` + `VsDevCmd.bat` 导入最新安装的 x64 Visual Studio 开发环境，再运行两套系统。
+2. **使用同一个干净的 MSVC 环境。** 脚本先解析指定的测量工具并保存调用者的进程环境，移除继承的 Visual Studio/Windows SDK `PATH` 项及 `CL`/`LINK` 选项注入变量，再通过 `vswhere` + `VsDevCmd.bat` 导入最新安装的 x64 Visual Studio 开发环境；两套系统完成后，脚本会在 `finally` 中恢复调用者环境。脚本还会验证 `cl.exe` 和 `link.exe` 确实来自选中的 Visual Studio 安装。
 3. **显式使用同一并行上限。** `-Jobs N` 分别映射为 MQB `-j N` 与 Ninja `-j N`。
 4. **对齐 Release 编译/链接策略。** 生成的 CMake target 使用与本 fixture 中 MQB 相同的核心 MSVC Release 参数：`/utf-8`、`/W3`、`/EHsc`、`/permissive-`、`/Zc:__cplusplus`、`/Zc:preprocessor`、`/diagnostics:column`、`/O2`、`/Oi`、`/MD`、`/Z7`、`/DNDEBUG`、`/std:c++23preview`；Release link 策略使用 `/INCREMENTAL:NO`、`/OPT:REF`、`/OPT:ICF`、x64 与 console subsystem。
 5. **构建系统自己的 dependency 工作保留在测量中。** CMake/Ninja 可能加入自己的依赖跟踪参数，MQB 也会使用自己的 metadata 路径；这些属于被比较系统本身，不会人为移除。
@@ -66,7 +66,7 @@ C++ Modules 与 Header Units 有意不放进第一版对比矩阵。它们的支
 - Ninja；
 - 待测的 MQB executable。
 
-如果当前终端不是 Visual Studio Developer Shell，脚本会尝试自动导入最新安装的 x64 MSVC 环境。
+脚本会先过滤继承的 Visual Studio/Windows SDK 路径及 MSVC 选项注入变量，再全新导入一次 x64 MSVC 环境，避免已卸载或混合版本的安装，以及不对等的 `CL`/`LINK` 参数污染任一构建路径。
 
 调试生成 fixture 时可使用 `-KeepWorktree`。否则运行结束后会删除临时 fixture 树。
 
@@ -78,7 +78,7 @@ JSON 报告记录：
 - 可取得的工具版本字符串；
 - Windows / PowerShell / CPU width / MSVC 环境信息；
 - translation unit 数、iterations、jobs、architecture 与 configuration；
-- 每一个原始 build sample 及其 execution order；
+- 每一个原始 build sample 及其 execution order，以及 MQB 的阶段计时和 compile/link cache 计数；
 - 与 build 时间分离记录的 CMake configure samples 和 median；
 - 每个场景下 MQB 与 CMake/Ninja 的 median；
 - MQB 相对 CMake/Ninja 的绝对差值与百分比差值；
@@ -90,6 +90,6 @@ JSON 报告记录：
 
 `.github/workflows/build-system-evidence.yml` 会在相关 pull request 上运行一个小规模 correctness fixture。它从当前仓库源码构建 MQB，使用较小 TU 数执行一次对比，并上传 JSON 报告。
 
-这个 workflow 证明对比 harness 仍可执行，而且两条构建路径都能产生正确程序。它**不是**稳定的性能排行榜：hosted runner 的 VM 分配、系统负载、杀毒状态、文件系统缓存等都会明显影响 wall-clock 数字。
+这个 workflow 证明对比 harness 仍可执行、两条构建路径都能产生正确程序，并且 MQB 的每个 cold/no-op/incremental 场景都发生了预期的 cache transition。它**不是**稳定的性能排行榜：hosted runner 的 VM 分配、系统负载、杀毒状态、文件系统缓存等都会明显影响 wall-clock 数字。
 
 真正用于公开引用的测量，应在明确说明的物理机器上运行多次，保留完整 JSON，并把机器与 toolchain 信息和 median 一起发布。

--- a/tests/native/benchmark_build_systems.ps1
+++ b/tests/native/benchmark_build_systems.ps1
@@ -64,12 +64,65 @@ function Invoke-CapturedProcess {
     }
 }
 
-function Import-MsvcX64Environment {
-    $cl = Get-Command cl.exe -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
-    if ($null -ne $cl -and ([string]::IsNullOrWhiteSpace($env:VSCMD_ARG_TGT_ARCH) -or $env:VSCMD_ARG_TGT_ARCH -eq 'x64')) {
-        return $false
+function Get-ProcessEnvironmentSnapshot {
+    $snapshot = @{}
+    foreach ($entry in [Environment]::GetEnvironmentVariables('Process').GetEnumerator()) {
+        $snapshot[[string]$entry.Key] = [string]$entry.Value
+    }
+    return $snapshot
+}
+
+function Restore-ProcessEnvironmentSnapshot {
+    param([Parameter(Mandatory = $true)][hashtable]$Snapshot)
+
+    foreach ($key in @([Environment]::GetEnvironmentVariables('Process').Keys)) {
+        if (-not $Snapshot.ContainsKey([string]$key)) {
+            [Environment]::SetEnvironmentVariable([string]$key, $null, 'Process')
+        }
+    }
+    foreach ($entry in $Snapshot.GetEnumerator()) {
+        [Environment]::SetEnvironmentVariable([string]$entry.Key, [string]$entry.Value, 'Process')
+    }
+}
+
+function Clear-MsvcProcessEnvironment {
+    $names = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+    foreach ($name in @(
+        'INCLUDE', 'LIB', 'LIBPATH', 'CL', '_CL_', 'LINK', '_LINK_',
+        'VCToolsInstallDir', 'VCToolsVersion',
+        'WindowsSdkDir', 'WindowsSDKVersion', 'WindowsSdkBinPath', 'WindowsSdkVerBinPath',
+        'UniversalCRTSdkDir', 'UCRTVersion',
+        'NETFXSDKDir', 'VSINSTALLDIR', 'VCINSTALLDIR', 'VisualStudioVersion', 'DevEnvDir',
+        'ExtensionSdkDir', 'FrameworkDir', 'FrameworkVersion', 'FrameworkVersion32',
+        'Framework40Version', 'WindowsLibPath', '__VSCMD_PREINIT_PATH', 'CommandPromptType'
+    )) {
+        [void]$names.Add($name)
     }
 
+    foreach ($key in @([Environment]::GetEnvironmentVariables('Process').Keys)) {
+        $name = [string]$key
+        if ($name -match '^(?i:VSCMD_)' -or $name -match '(?i)^VS\d+COMNTOOLS$') {
+            [void]$names.Add($name)
+        }
+    }
+
+    foreach ($name in $names) {
+        [Environment]::SetEnvironmentVariable($name, $null, 'Process')
+    }
+
+    $filteredPath = @(
+        ([Environment]::GetEnvironmentVariable('PATH', 'Process') -split ';') |
+            Where-Object {
+                -not [string]::IsNullOrWhiteSpace($_) -and
+                $_ -notmatch '(?i)[\\/]Microsoft Visual Studio[\\/]' -and
+                $_ -notmatch '(?i)[\\/]Windows Kits[\\/]' -and
+                $_ -notmatch '(?i)[\\/]Microsoft SDKs[\\/]Windows[\\/]'
+            }
+    ) -join ';'
+    [Environment]::SetEnvironmentVariable('PATH', $filteredPath, 'Process')
+}
+
+function Import-MsvcX64Environment {
     $candidates = [System.Collections.Generic.List[string]]::new()
     $programFilesX86 = [Environment]::GetEnvironmentVariable('ProgramFiles(x86)')
     if (-not [string]::IsNullOrWhiteSpace($programFilesX86)) {
@@ -81,7 +134,7 @@ function Import-MsvcX64Environment {
 
     $vswhere = $candidates | Where-Object { Test-Path -LiteralPath $_ -PathType Leaf } | Select-Object -First 1
     if ([string]::IsNullOrWhiteSpace($vswhere)) {
-        throw 'cl.exe is not available and vswhere.exe could not be found.'
+        throw 'vswhere.exe could not be found.'
     }
 
     $installationPath = @(
@@ -109,11 +162,32 @@ function Import-MsvcX64Environment {
         [Environment]::SetEnvironmentVariable($Matches[1], $Matches[2], 'Process')
     }
 
-    $cl = Get-Command cl.exe -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
-    if ($null -eq $cl) {
-        throw 'VsDevCmd.bat completed but cl.exe is still unavailable.'
+    $toolRoot = [System.IO.Path]::GetFullPath(([string]$installationPath)).TrimEnd('\', '/') + [System.IO.Path]::DirectorySeparatorChar
+    $toolPaths = @{}
+    foreach ($toolName in @('cl.exe', 'link.exe')) {
+        $tool = Get-Command $toolName -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
+        if ($null -eq $tool) {
+            throw "VsDevCmd.bat completed but $toolName is still unavailable."
+        }
+        $toolPath = [System.IO.Path]::GetFullPath($tool.Source)
+        if (-not $toolPath.StartsWith($toolRoot, [StringComparison]::OrdinalIgnoreCase)) {
+            throw "$toolName did not resolve from the selected Visual Studio installation: $toolPath"
+        }
+        $toolPaths[$toolName] = $toolPath
     }
-    return $true
+
+    foreach ($name in @('CL', '_CL_', 'LINK', '_LINK_')) {
+        if (-not [string]::IsNullOrEmpty([Environment]::GetEnvironmentVariable($name, 'Process'))) {
+            throw "MSVC option injection variable remained set after isolation: $name"
+        }
+    }
+
+    return [PSCustomObject]@{
+        imported = $true
+        installation_path = [string]$installationPath
+        cl_path = [string]$toolPaths['cl.exe']
+        link_path = [string]$toolPaths['link.exe']
+    }
 }
 
 function Get-FirstOutputLine {
@@ -346,11 +420,62 @@ function Invoke-MqbBuild {
     if ($UsePch) {
         $arguments += @('--pch', 'pch.hpp')
     }
+    $arguments += '--timings=json'
 
     $result = Invoke-CapturedProcess -FilePath $MqbExe -Arguments $arguments -WorkingDirectory $Root -Measure
     $executable = Resolve-MqbExecutableOutput -Root $Root -Target $Target
     Assert-ExecutableRuns -Executable $executable -WorkingDirectory $Root
-    return $result.elapsed_ms
+
+    $timingLines = @($result.output | Where-Object { $_ -match '^\{"type":"mqb\.timings"' })
+    if ($timingLines.Count -ne 1) {
+        throw "Expected exactly one MQB JSON timing record, found $($timingLines.Count)."
+    }
+    try {
+        $timing = $timingLines[0] | ConvertFrom-Json -ErrorAction Stop
+    }
+    catch {
+        throw "Failed to parse MQB JSON timing record: $($_.Exception.Message)"
+    }
+
+    return [PSCustomObject]@{
+        elapsed_ms = $result.elapsed_ms
+        timing = $timing
+    }
+}
+
+function Assert-MqbCacheTransition {
+    param(
+        [Parameter(Mandatory = $true)][string]$Scenario,
+        [Parameter(Mandatory = $true)][object]$Timing,
+        [Parameter(Mandatory = $true)][int]$TranslationUnitCount
+    )
+
+    $ordinarySources = $TranslationUnitCount + 1
+    $pchSources = $TranslationUnitCount + 2
+    $expected = switch ($Scenario) {
+        'ordinary-cold' { @($ordinarySources, 0, 1, 0) }
+        'ordinary-no-op' { @(0, $ordinarySources, 0, 1) }
+        'ordinary-single-tu' { @(1, ($ordinarySources - 1), 1, 0) }
+        'ordinary-public-header' { @($TranslationUnitCount, 1, 1, 0) }
+        'pch-cold' { @($pchSources, 0, 1, 0) }
+        'pch-no-op' { @(0, $pchSources, 0, 1) }
+        'pch-single-tu' { @(1, ($pchSources - 1), 1, 0) }
+        'pch-header' { @($pchSources, 0, 1, 0) }
+        default { throw "Unknown MQB cache-transition scenario: $Scenario" }
+    }
+
+    $actual = @(
+        [int]$Timing.cache.compile.misses,
+        [int]$Timing.cache.compile.hits,
+        [int]$Timing.cache.link.misses,
+        [int]$Timing.cache.link.hits
+    )
+    $labels = @('compile misses', 'compile hits', 'link misses', 'link hits')
+    for ($index = 0; $index -lt $expected.Count; ++$index) {
+        if ($actual[$index] -ne $expected[$index]) {
+            throw "MQB cache-transition mismatch for '$Scenario': expected $($labels[$index])=$($expected[$index]), got $($actual[$index])."
+        }
+    }
 }
 
 function Invoke-NinjaBuild {
@@ -385,11 +510,14 @@ if (-not [string]::IsNullOrWhiteSpace($OutputPath)) {
     $OutputPath = Get-FullPath $OutputPath
 }
 
-$vsEnvironmentImported = Import-MsvcX64Environment
 $MqbPath = Resolve-ApplicationPath $MqbPath
 $CMakePath = Resolve-ApplicationPath $CMakePath
 $NinjaPath = Resolve-ApplicationPath $NinjaPath
-$clPath = Resolve-ApplicationPath 'cl.exe'
+$processEnvironmentSnapshot = Get-ProcessEnvironmentSnapshot
+try {
+    Clear-MsvcProcessEnvironment
+    $vsEnvironment = Import-MsvcX64Environment
+    $clPath = $vsEnvironment.cl_path
 
 $cmakeVersionLine = Get-FirstOutputLine -FilePath $CMakePath -Arguments @('--version')
 $ninjaVersionLine = Get-FirstOutputLine -FilePath $NinjaPath -Arguments @('--version')
@@ -410,7 +538,11 @@ $environment = [PSCustomObject]@{
     processor_identifier = [string]$env:PROCESSOR_IDENTIFIER
     logical_processors = [Environment]::ProcessorCount
     physical_memory_bytes = $computerMemory
-    vsdevcmd_imported = $vsEnvironmentImported
+    msvc_environment_isolated = $true
+    vsdevcmd_imported = $vsEnvironment.imported
+    visual_studio_installation = $vsEnvironment.installation_path
+    cl_path_verified = $vsEnvironment.cl_path
+    link_path_verified = $vsEnvironment.link_path
     vctools_version = [string]$env:VCToolsVersion
     windows_sdk_version = [string]$env:WindowsSDKVersion
 }
@@ -487,14 +619,21 @@ try {
                     $system = [string]$order[$orderIndex]
                     Write-Host ("[{0}] iteration {1}/{2}: {3}" -f $system, $iteration, $Iterations, $scenario)
 
+                    $mqbTiming = $null
                     $elapsed = if ($system -eq 'mqb') {
-                        Invoke-MqbBuild `
+                        $measurement = Invoke-MqbBuild `
                             -MqbExe $MqbPath `
                             -Root $root `
                             -Sources $sources `
                             -Target $fixture.target `
                             -JobCount $Jobs `
                             -UsePch $fixture.use_pch
+                        Assert-MqbCacheTransition `
+                            -Scenario $scenario `
+                            -Timing $measurement.timing `
+                            -TranslationUnitCount $TranslationUnits
+                        $mqbTiming = $measurement.timing
+                        $measurement.elapsed_ms
                     } else {
                         Invoke-NinjaBuild `
                             -NinjaExe $NinjaPath `
@@ -510,6 +649,7 @@ try {
                         system = $system
                         execution_order = $orderIndex + 1
                         elapsed_ms = [double]$elapsed
+                        mqb_timing = $mqbTiming
                     })
                 }
             }
@@ -608,4 +748,8 @@ finally {
     } else {
         Remove-Item -LiteralPath $benchmarkRoot -Recurse -Force -ErrorAction SilentlyContinue
     }
+}
+}
+finally {
+    Restore-ProcessEnvironmentSnapshot -Snapshot $processEnvironmentSnapshot
 }


### PR DESCRIPTION
## Summary

- isolate the benchmark from inherited Visual Studio/Windows SDK paths and `CL`/`LINK` option injection
- verify the selected `cl.exe` and `link.exe`, capture per-sample MQB timing/cache evidence, and enforce exact cache-transition counts
- replace quadratic duplicate-source filesystem equivalence checks with linear Windows path-identity set membership
- add native CLI E2E coverage and update the bilingual benchmark methodology

## Performance evidence

100 TUs, 5 iterations, 8 workers; lower is better:

| Scenario | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| ordinary no-op | 104.31 ms | 26.59 ms | 74.5% |
| ordinary single TU | 172.67 ms | 103.18 ms | 40.2% |
| PCH no-op | 107.04 ms | 33.14 ms | 69.0% |
| PCH single TU | 175.52 ms | 97.41 ms | 44.5% |

Cold builds and PCH-header rebuilds remain explicit follow-up optimization targets; this PR does not claim improvement there. CMake configure time remains separately measured and excluded from build medians.

## Validation

- Debug MQB self-build passed (73 production translation units)
- complete native test graph passed: 77/77 across 8 deterministic shards
- post-cleanup 8-TU benchmark smoke passed all ordinary/PCH cold, no-op, single-TU, and header transitions
- deliberately poisoned PATH/CL/LINK benchmark regression passed and restored the caller environment
- bilingual documentation parity passed for 17 maintained pairs
- PowerShell parsing, C++ layout contract, and `git diff --check` passed
- independent read-only review found no blocking issues

Detailed issue, plan, and walkthrough evidence is under `docs/20260826-172358-benchmark-environment-isolation/`.