### PR TITLE
perf: reduce cold-build toolchain discovery overhead

### DIFF
--- a/cpp/src/msvc/toolchain/MsvcToolchainLocator.cpp
+++ b/cpp/src/msvc/toolchain/MsvcToolchainLocator.cpp
@@ -43,6 +43,17 @@ MsvcToolchainLocator::discover(const DiscoveryOptions& options) const {
         }
     }
 
+    if (auto ambient = detail::adopt_ambient_visual_studio_toolchain(runner_, options)) {
+        if (cache_file) {
+            detail::save_visual_studio_toolchain_cache_best_effort(
+                *cache_file,
+                options,
+                *ambient);
+        }
+        seal_compiler_environment_identity(*ambient);
+        return std::move(*ambient);
+    }
+
     auto discovered = detail::discover_visual_studio_toolchain(runner_, options);
     if (discovered && cache_file) {
         // Persist raw compiler-binary evidence. Compiler environment identity is

--- a/cpp/src/msvc/toolchain/VisualStudioToolchainCache.cpp
+++ b/cpp/src/msvc/toolchain/VisualStudioToolchainCache.cpp
@@ -15,6 +15,8 @@
 #include <vector>
 
 #include "ToolchainDiscoveryPrimitives.hpp"
+#include "VisualStudioToolchainDiscovery.hpp"
+#include "mqb/msvc/MsvcToolchainEnvironmentIdentity.hpp"
 #include "mqb/platform/windows/PathIdentity.hpp"
 
 namespace mqb::msvc::detail {
@@ -157,13 +159,29 @@ void append_unique_existing_root(std::vector<fs::path>& roots, fs::path root) {
     const fs::path& vc_tools_root) {
     std::vector<fs::path> roots;
     append_unique_existing_root(roots, visual_studio_root(vc_tools_root));
+
+    wchar_t windows_directory[MAX_PATH]{};
+    const UINT windows_directory_size = ::GetWindowsDirectoryW(
+        windows_directory,
+        MAX_PATH);
+    if (windows_directory_size == 0
+        || windows_directory_size >= MAX_PATH) {
+        return roots;
+    }
+    append_unique_existing_root(roots, fs::path{windows_directory});
+    const fs::path windows_kits_root = stable_path(
+        fs::path{windows_directory}.root_path()
+        / "Program Files (x86)"
+        / "Windows Kits");
     for (const auto name : {"WindowsSdkDir", "UniversalCRTSdkDir", "NETFXSDKDir"}) {
         if (const auto* variable = find_environment(environment, name);
             variable != nullptr && !variable->value.empty()) {
-            append_unique_existing_root(roots, detail::path_from_utf8(variable->value));
+            fs::path sdk_root = stable_path(detail::path_from_utf8(variable->value));
+            if (path_inside_root(windows_kits_root, sdk_root)) {
+                append_unique_existing_root(roots, std::move(sdk_root));
+            }
         }
     }
-    if (const auto system_root = detail::environment_path("SystemRoot")) append_unique_existing_root(roots, *system_root);
     return roots;
 }
 
@@ -426,6 +444,128 @@ void save_visual_studio_cache_best_effort(
     }
 }
 
+[[nodiscard]] std::optional<MsvcToolchain> try_adopt_ambient_visual_studio_toolchain(
+    process::ProcessRunner& runner,
+    const DiscoveryOptions& options) {
+    try {
+        if (options.preference == ToolchainPreference::portable
+            || options.vswhere_path
+            || options.cmd_path) {
+            return std::nullopt;
+        }
+
+        const auto target_marker = detail::environment_value("VSCMD_ARG_TGT_ARCH");
+        const auto host_marker = detail::environment_value("VSCMD_ARG_HOST_ARCH");
+        if (!target_marker || target_marker->empty()
+            || !environment_name_equal(
+                *target_marker,
+                detail::architecture_name(options.target_architecture))
+            || !host_marker || host_marker->empty()
+            || !environment_name_equal(
+                *host_marker,
+                detail::architecture_name(options.host_architecture))) {
+            return std::nullopt;
+        }
+
+        const auto tools_path = detail::environment_path("VCToolsInstallDir");
+        if (!tools_path || tools_path->empty()) {
+            return std::nullopt;
+        }
+
+        fs::path vc_tools_root = stable_path(*tools_path);
+        std::error_code error_code;
+        if (!fs::is_directory(vc_tools_root, error_code) || error_code) {
+            return std::nullopt;
+        }
+
+        const std::string vc_tools_version = detail::path_to_utf8(vc_tools_root.filename());
+        if (vc_tools_version.empty()) {
+            return std::nullopt;
+        }
+
+        auto installation = detail::locate_visual_studio_installation(runner, options);
+        if (!installation) {
+            return std::nullopt;
+        }
+        const auto latest_tools = detail::latest_directory(
+            stable_path(*installation) / "VC" / "Tools" / "MSVC");
+        if (!latest_tools || !same_path(*latest_tools, vc_tools_root)) {
+            return std::nullopt;
+        }
+
+        const ToolPaths paths = tool_paths(vc_tools_root, options);
+        for (const auto& file : {paths.compiler, paths.linker, paths.librarian}) {
+            error_code.clear();
+            if (!fs::is_regular_file(file, error_code) || error_code) {
+                return std::nullopt;
+            }
+        }
+
+        const auto path_val = detail::environment_value("PATH");
+        if (!path_val || path_val->empty()) {
+            return std::nullopt;
+        }
+
+        std::vector<EnvironmentVariable> environment;
+        for (const auto name : {
+                 "INCLUDE",
+                 "LIB",
+                 "LIBPATH",
+                 "VCToolsInstallDir",
+                 "WindowsSdkDir",
+                 "WindowsSDKVersion",
+                 "UniversalCRTSdkDir",
+                 "UCRTVersion",
+                 "NETFXSDKDir",
+             }) {
+            if (const auto val = detail::environment_value(name)) {
+                environment.push_back(EnvironmentVariable{.name = name, .value = *val});
+            }
+        }
+
+        if (!environment_is_cacheable(environment, vc_tools_root)) {
+            return std::nullopt;
+        }
+
+        auto stamp = detail::binary_stamp(paths.compiler);
+        if (!stamp) {
+            return std::nullopt;
+        }
+
+        environment.push_back(EnvironmentVariable{.name = "PATH", .value = *path_val});
+
+        MsvcToolchain toolchain{
+            .identity = ToolchainIdentity{
+                .compiler = paths.compiler,
+                .version = vc_tools_version,
+                .binary_stamp = std::move(*stamp),
+            },
+            .linker = paths.linker,
+            .librarian = paths.librarian,
+            .vc_tools_root = vc_tools_root,
+            .standard_library_modules = detail::discover_standard_library_modules(vc_tools_root),
+            .source = ToolchainSource::visual_studio,
+            .environment = std::move(environment),
+            .reused = false,
+        };
+
+        if (!toolchain_environment_detail::selected_sdk_version_is_latest(
+                toolchain.environment,
+                "WindowsSdkDir",
+                "WindowsSDKVersion")
+            || !toolchain_environment_detail::selected_sdk_version_is_latest(
+                toolchain.environment,
+                "UniversalCRTSdkDir",
+                "UCRTVersion")) {
+            return std::nullopt;
+        }
+
+        return toolchain;
+    } catch (...) {
+        return std::nullopt;
+    }
+}
+
 } // namespace
 
 std::optional<std::filesystem::path>
@@ -438,6 +578,13 @@ reuse_visual_studio_toolchain_cache(
     const std::filesystem::path& cache_file,
     const DiscoveryOptions& options) {
     return try_reuse_visual_studio_cache(cache_file, options);
+}
+
+std::optional<MsvcToolchain>
+adopt_ambient_visual_studio_toolchain(
+    process::ProcessRunner& runner,
+    const DiscoveryOptions& options) {
+    return try_adopt_ambient_visual_studio_toolchain(runner, options);
 }
 
 void save_visual_studio_toolchain_cache_best_effort(

--- a/cpp/src/msvc/toolchain/VisualStudioToolchainCache.hpp
+++ b/cpp/src/msvc/toolchain/VisualStudioToolchainCache.hpp
@@ -15,6 +15,11 @@ reuse_visual_studio_toolchain_cache(
     const std::filesystem::path& cache_file,
     const DiscoveryOptions& options);
 
+[[nodiscard]] std::optional<MsvcToolchain>
+adopt_ambient_visual_studio_toolchain(
+    process::ProcessRunner& runner,
+    const DiscoveryOptions& options);
+
 void save_visual_studio_toolchain_cache_best_effort(
     const std::filesystem::path& cache_file,
     const DiscoveryOptions& options,

--- a/cpp/src/msvc/toolchain/VisualStudioToolchainDiscovery.cpp
+++ b/cpp/src/msvc/toolchain/VisualStudioToolchainDiscovery.cpp
@@ -1,5 +1,10 @@
 #include "VisualStudioToolchainDiscovery.hpp"
 
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+
 #include <filesystem>
 #include <optional>
 #include <string>
@@ -18,21 +23,27 @@ namespace fs = std::filesystem;
 using process::ProcessSpec;
 
 [[nodiscard]] std::optional<fs::path> default_vswhere_path() {
-    if (const auto program_files_x86 = environment_path("ProgramFiles(x86)")) {
-        return *program_files_x86 / "Microsoft Visual Studio" / "Installer" / "vswhere.exe";
-    }
-    return std::nullopt;
+    wchar_t windows_directory[MAX_PATH]{};
+    const UINT size = ::GetWindowsDirectoryW(windows_directory, MAX_PATH);
+    if (size == 0 || size >= MAX_PATH) return std::nullopt;
+    return fs::path{windows_directory}.root_path()
+        / "Program Files (x86)"
+        / "Microsoft Visual Studio"
+        / "Installer"
+        / "vswhere.exe";
 }
 
 [[nodiscard]] std::vector<fs::path> visual_studio_fallbacks() {
     std::vector<fs::path> candidates;
-    const auto program_files = environment_path("ProgramFiles");
-    if (!program_files) return candidates;
+    wchar_t windows_directory[MAX_PATH]{};
+    const UINT size = ::GetWindowsDirectoryW(windows_directory, MAX_PATH);
+    if (size == 0 || size >= MAX_PATH) return candidates;
+    const fs::path program_files = fs::path{windows_directory}.root_path() / "Program Files";
 
     for (const std::string_view version : {"18", "2022"}) {
         for (const std::string_view edition : {"Community", "Professional", "Enterprise", "BuildTools"}) {
             candidates.push_back(
-                *program_files
+                program_files
                 / "Microsoft Visual Studio"
                 / std::string{version}
                 / std::string{edition});
@@ -41,7 +52,9 @@ using process::ProcessSpec;
     return candidates;
 }
 
-[[nodiscard]] std::expected<fs::path, ToolchainError> locate_visual_studio(
+} // namespace
+
+std::expected<fs::path, ToolchainError> locate_visual_studio_installation(
     process::ProcessRunner& runner,
     const DiscoveryOptions& options) {
     std::optional<fs::path> vswhere = options.vswhere_path;
@@ -80,12 +93,10 @@ using process::ProcessSpec;
         "no Visual Studio installation was found"));
 }
 
-} // namespace
-
 std::expected<MsvcToolchain, ToolchainError> discover_visual_studio_toolchain(
     process::ProcessRunner& runner,
     const DiscoveryOptions& options) {
-    auto installation = locate_visual_studio(runner, options);
+    auto installation = locate_visual_studio_installation(runner, options);
     if (!installation) return std::unexpected(installation.error());
 
     const fs::path vcvarsall = *installation / "VC" / "Auxiliary" / "Build" / "vcvarsall.bat";

--- a/cpp/src/msvc/toolchain/VisualStudioToolchainDiscovery.hpp
+++ b/cpp/src/msvc/toolchain/VisualStudioToolchainDiscovery.hpp
@@ -1,10 +1,16 @@
 #pragma once
 
 #include <expected>
+#include <filesystem>
 
 #include "mqb/msvc/MsvcToolchainLocator.hpp"
 
 namespace mqb::msvc::detail {
+
+[[nodiscard]] std::expected<std::filesystem::path, ToolchainError>
+locate_visual_studio_installation(
+    process::ProcessRunner& runner,
+    const DiscoveryOptions& options);
 
 [[nodiscard]] std::expected<MsvcToolchain, ToolchainError>
 discover_visual_studio_toolchain(

--- a/cpp/tests/msvc/toolchain/visual_studio_tests.cpp
+++ b/cpp/tests/msvc/toolchain/visual_studio_tests.cpp
@@ -9,6 +9,8 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <utility>
+#include <vector>
 
 #include "mqb/msvc/MsvcLinker.hpp"
 #include "mqb/msvc/MsvcToolchainEnvironmentIdentity.hpp"
@@ -82,6 +84,81 @@ public:
 
     std::size_t calls{};
 };
+
+class VswhereOnlyRunner final : public mqb::process::ProcessRunner {
+public:
+    explicit VswhereOnlyRunner(fs::path installation)
+        : installation_(std::move(installation)) {}
+
+    [[nodiscard]] std::expected<mqb::process::ProcessResult, mqb::process::ProcessError>
+    run(const mqb::process::ProcessSpec&) override {
+        ++calls;
+        if (calls != 1) {
+            return std::unexpected(mqb::process::ProcessError{
+                .code = mqb::process::ProcessErrorCode::launch_failed,
+                .message = "ambient adoption attempted more than vswhere validation",
+            });
+        }
+        return mqb::process::ProcessResult{
+            .exit_code = 0,
+            .stdout_text = installation_.string() + "\n",
+        };
+    }
+
+    std::size_t calls{};
+
+private:
+    fs::path installation_;
+};
+
+class ScopedEnvironment final {
+public:
+    ScopedEnvironment() = default;
+    ~ScopedEnvironment() {
+        for (auto iterator = originals_.rbegin(); iterator != originals_.rend(); ++iterator) {
+            _putenv_s(iterator->first.c_str(), iterator->second ? iterator->second->c_str() : "");
+        }
+    }
+
+    ScopedEnvironment(const ScopedEnvironment&) = delete;
+    ScopedEnvironment& operator=(const ScopedEnvironment&) = delete;
+
+    void set(const std::string& name, const std::string& value) {
+        remember(name);
+        _putenv_s(name.c_str(), value.c_str());
+    }
+
+    void unset(const std::string& name) {
+        remember(name);
+        _putenv_s(name.c_str(), "");
+    }
+
+private:
+    void remember(const std::string& name) {
+        const auto existing = std::find_if(originals_.begin(), originals_.end(), [&](const auto& entry) {
+            return equals_ignore_case(entry.first, name);
+        });
+        if (existing != originals_.end()) return;
+        const char* value = std::getenv(name.c_str());
+        originals_.push_back({
+            name,
+            value == nullptr ? std::nullopt : std::optional<std::string>{value},
+        });
+    }
+
+    std::vector<std::pair<std::string, std::optional<std::string>>> originals_;
+};
+
+[[nodiscard]] fs::path visual_studio_installation_from_tools_root(fs::path tools_root) {
+    tools_root = tools_root.lexically_normal();
+    while (tools_root.filename().empty() && tools_root.has_parent_path()) {
+        tools_root = tools_root.parent_path();
+    }
+    for (int level = 0; level < 4 && tools_root.has_parent_path(); ++level) {
+        tools_root = tools_root.parent_path();
+    }
+    return tools_root;
+}
 
 [[nodiscard]] fs::path unique_cache_file() {
     return fs::temp_directory_path()
@@ -361,6 +438,212 @@ int main() {
     }
     cleanup_error.clear();
     fs::remove_all(default_cache_root, cleanup_error);
+
+    // Verify ambient Visual Studio toolchain adoption on cold builds:
+    // when ambient environment contains valid, trusted MSVC environment,
+    // it must be adopted directly without subprocess calls (RejectingRunner).
+    if (result) {
+        const auto* tools_env = find_environment_variable(*result, "VCToolsInstallDir");
+        const auto* include_env = find_environment_variable(*result, "INCLUDE");
+        const auto* lib_env = find_environment_variable(*result, "LIB");
+        const auto* libpath_env = find_environment_variable(*result, "LIBPATH");
+        const auto* path_env = find_environment_variable(*result, "PATH");
+        if (tools_env && include_env && lib_env && libpath_env && path_env) {
+            ScopedEnvironment ambient_environment;
+            for (const auto name : {
+                     "INCLUDE", "LIB", "LIBPATH", "PATH", "VCToolsInstallDir",
+                     "WindowsSdkDir", "WindowsSDKVersion", "UniversalCRTSdkDir",
+                     "UCRTVersion", "NETFXSDKDir",
+                 }) {
+                if (const auto* variable = find_environment_variable(*result, name)) {
+                    ambient_environment.set(variable->name, variable->value);
+                } else {
+                    ambient_environment.unset(name);
+                }
+            }
+            ambient_environment.set("VSCMD_ARG_TGT_ARCH", "x64");
+            ambient_environment.set("VSCMD_ARG_HOST_ARCH", "x64");
+
+            const fs::path ambient_cache_file = unique_cache_file();
+            fs::remove(ambient_cache_file, cleanup_error);
+
+            mqb::msvc::DiscoveryOptions ambient_options;
+            ambient_options.preference = mqb::msvc::ToolchainPreference::visual_studio;
+            ambient_options.target_architecture = mqb::Architecture::x64;
+            ambient_options.host_architecture = mqb::Architecture::x64;
+            ambient_options.cache_file = ambient_cache_file;
+
+            VswhereOnlyRunner ambient_runner{
+                visual_studio_installation_from_tools_root(tools_env->value)};
+            mqb::msvc::MsvcToolchainLocator ambient_locator{ambient_runner};
+            const auto ambient_result = ambient_locator.discover(ambient_options);
+            expect(ambient_result.has_value(),
+                   "ambient Visual Studio toolchain should be adopted when valid environment is present");
+            expect(ambient_runner.calls == 1,
+                   "ambient Visual Studio adoption should run only vswhere validation");
+            if (ambient_result) {
+                expect(ambient_result->source == mqb::msvc::ToolchainSource::visual_studio,
+                       "ambient adoption should have visual_studio source");
+                expect(fs::is_regular_file(ambient_cache_file),
+                       "ambient adoption should persist validated project toolchain cache");
+
+                // Verify the cache written by ambient adoption is reusable
+                RejectingRunner cached_runner;
+                mqb::msvc::MsvcToolchainLocator cached_ambient_locator{cached_runner};
+                const auto cached_result = cached_ambient_locator.discover(ambient_options);
+                expect(cached_result.has_value() && cached_result->reused,
+                       "cache written by ambient adoption should be reusable");
+                expect(cached_runner.calls == 0,
+                       "cache hit after ambient adoption must not execute subprocesses");
+            }
+            fs::remove(ambient_cache_file, cleanup_error);
+
+            // Mismatched target architecture in ambient environment must fall back to discovery
+            ambient_environment.set("VSCMD_ARG_TGT_ARCH", "x86");
+            RejectingRunner arch_mismatch_runner;
+            mqb::msvc::MsvcToolchainLocator arch_mismatch_locator{arch_mismatch_runner};
+            mqb::msvc::DiscoveryOptions no_cache_options = ambient_options;
+            no_cache_options.cache_file = fs::path{};
+            const auto arch_mismatch = arch_mismatch_locator.discover(no_cache_options);
+            expect(!arch_mismatch.has_value(),
+                   "mismatched ambient target architecture must reject ambient adoption");
+            expect(arch_mismatch_runner.calls != 0,
+                   "mismatched ambient target architecture must fall back to subprocess discovery");
+            ambient_environment.set("VSCMD_ARG_TGT_ARCH", "x64");
+
+            ambient_environment.unset("VSCMD_ARG_TGT_ARCH");
+            RejectingRunner missing_arch_runner;
+            mqb::msvc::MsvcToolchainLocator missing_arch_locator{missing_arch_runner};
+            const auto missing_arch = missing_arch_locator.discover(no_cache_options);
+            expect(!missing_arch.has_value(),
+                   "ambient adoption must require an explicit target-architecture marker");
+            expect(missing_arch_runner.calls != 0,
+                   "missing target-architecture marker must fall back to discovery");
+            ambient_environment.set("VSCMD_ARG_TGT_ARCH", "x64");
+
+            ambient_environment.set("VSCMD_ARG_HOST_ARCH", "x86");
+            RejectingRunner host_mismatch_runner;
+            mqb::msvc::MsvcToolchainLocator host_mismatch_locator{host_mismatch_runner};
+            const auto host_mismatch = host_mismatch_locator.discover(no_cache_options);
+            expect(!host_mismatch.has_value(),
+                   "mismatched ambient host architecture must reject ambient adoption");
+            expect(host_mismatch_runner.calls != 0,
+                   "mismatched ambient host architecture must fall back to discovery");
+            ambient_environment.set("VSCMD_ARG_HOST_ARCH", "x64");
+
+            ambient_environment.unset("VSCMD_ARG_HOST_ARCH");
+            RejectingRunner missing_host_runner;
+            mqb::msvc::MsvcToolchainLocator missing_host_locator{missing_host_runner};
+            const auto missing_host = missing_host_locator.discover(no_cache_options);
+            expect(!missing_host.has_value(),
+                   "ambient adoption must require an explicit host-architecture marker");
+            expect(missing_host_runner.calls != 0,
+                   "missing host-architecture marker must fall back to discovery");
+            ambient_environment.set("VSCMD_ARG_HOST_ARCH", "x64");
+
+            mqb::msvc::DiscoveryOptions explicit_override_options = no_cache_options;
+            explicit_override_options.vswhere_path = fs::path{"C:\\mqb-explicit-missing-vswhere.exe"};
+            RejectingRunner explicit_override_runner;
+            mqb::msvc::MsvcToolchainLocator explicit_override_locator{explicit_override_runner};
+            const auto explicit_override = explicit_override_locator.discover(explicit_override_options);
+            expect(!explicit_override.has_value(),
+                   "explicit discovery override must remain authoritative over ambient adoption");
+            expect(explicit_override_runner.calls == 0,
+                   "missing explicit vswhere path should fail before a subprocess launch");
+
+            mqb::msvc::DiscoveryOptions explicit_cmd_options = no_cache_options;
+            explicit_cmd_options.cmd_path = fs::path{"C:\\mqb-explicit-missing-cmd.exe"};
+            RejectingRunner explicit_cmd_runner;
+            mqb::msvc::MsvcToolchainLocator explicit_cmd_locator{explicit_cmd_runner};
+            const auto explicit_cmd = explicit_cmd_locator.discover(explicit_cmd_options);
+            expect(!explicit_cmd.has_value(),
+                   "explicit command-processor override must remain authoritative over ambient adoption");
+            expect(explicit_cmd_runner.calls != 0,
+                   "explicit command-processor override must force ordinary discovery");
+
+            // Untrusted include directory in ambient environment must fall back to discovery
+            const std::string original_include = include_env->value;
+            ambient_environment.set("INCLUDE", "C:\\mqb-untrusted-arbitrary-include-root");
+            RejectingRunner untrusted_runner;
+            mqb::msvc::MsvcToolchainLocator untrusted_locator{untrusted_runner};
+            const auto untrusted = untrusted_locator.discover(no_cache_options);
+            expect(!untrusted.has_value(),
+                   "untrusted ambient include root must reject ambient adoption");
+            expect(untrusted_runner.calls != 0,
+                   "untrusted ambient environment must fall back to subprocess discovery");
+            ambient_environment.set("INCLUDE", original_include);
+
+            const fs::path fake_sdk = unique_cache_root() / "Windows Kits/10";
+            const fs::path fake_sdk_include = fake_sdk / "Include/99.0.0.0/ucrt";
+            fs::create_directories(fake_sdk_include, cleanup_error);
+            ambient_environment.set("WindowsSdkDir", fake_sdk.string());
+            ambient_environment.set("WindowsSDKVersion", "99.0.0.0\\");
+            ambient_environment.set("INCLUDE", fake_sdk_include.string());
+            RejectingRunner fake_sdk_runner;
+            mqb::msvc::MsvcToolchainLocator fake_sdk_locator{fake_sdk_runner};
+            const auto fake_sdk_result = fake_sdk_locator.discover(no_cache_options);
+            expect(!fake_sdk_result.has_value(),
+                   "ambient environment must not establish its own Windows SDK trust root");
+            expect(fake_sdk_runner.calls != 0,
+                   "unregistered fake Windows SDK root must fall back to discovery");
+            ambient_environment.set("INCLUDE", original_include);
+            if (const auto* variable = find_environment_variable(*result, "WindowsSdkDir")) {
+                ambient_environment.set(variable->name, variable->value);
+            } else {
+                ambient_environment.unset("WindowsSdkDir");
+            }
+            if (const auto* variable = find_environment_variable(*result, "WindowsSDKVersion")) {
+                ambient_environment.set(variable->name, variable->value);
+            } else {
+                ambient_environment.unset("WindowsSDKVersion");
+            }
+            fs::remove_all(fake_sdk.parent_path().parent_path(), cleanup_error);
+
+            const fs::path fake_installation = unique_cache_root() / "FakeVisualStudio";
+            const fs::path fake_tools = fake_installation / "VC/Tools/MSVC/14.50.00000";
+            const fs::path fake_bin = fake_tools / "bin/Hostx64/x64";
+            for (const auto& directory : {
+                     fake_bin,
+                     fake_installation / "include",
+                     fake_installation / "lib/x64",
+                     fake_installation / "libpath",
+                 }) {
+                fs::create_directories(directory, cleanup_error);
+            }
+            for (const auto name : {"cl.exe", "link.exe", "lib.exe"}) {
+                std::ofstream{fake_bin / name, std::ios::binary} << "not a Microsoft tool";
+            }
+            ambient_environment.set("VCToolsInstallDir", fake_tools.string());
+            ambient_environment.set("INCLUDE", (fake_installation / "include").string());
+            ambient_environment.set("LIB", (fake_installation / "lib/x64").string());
+            ambient_environment.set("LIBPATH", (fake_installation / "libpath").string());
+            ambient_environment.set("PATH", fake_bin.string());
+            ambient_environment.unset("WindowsSdkDir");
+            ambient_environment.unset("WindowsSDKVersion");
+            ambient_environment.unset("UniversalCRTSdkDir");
+            ambient_environment.unset("UCRTVersion");
+            ambient_environment.unset("NETFXSDKDir");
+            RejectingRunner fake_root_runner;
+            mqb::msvc::MsvcToolchainLocator fake_root_locator{fake_root_runner};
+            const auto fake_root = fake_root_locator.discover(no_cache_options);
+            expect(!fake_root.has_value(),
+                   "ambient environment must not establish its own Visual Studio trust root");
+            expect(fake_root_runner.calls != 0,
+                   "unregistered fake Visual Studio root must fall back to discovery");
+
+            fs::create_directories(
+                fake_installation / "VC/Tools/MSVC/14.51.00000",
+                cleanup_error);
+            VswhereOnlyRunner stale_tools_runner{fake_installation};
+            mqb::msvc::MsvcToolchainLocator stale_tools_locator{stale_tools_runner};
+            const auto stale_tools = stale_tools_locator.discover(no_cache_options);
+            expect(!stale_tools.has_value(),
+                   "ambient adoption must reject a non-latest registered MSVC toolset");
+            expect(stale_tools_runner.calls > 1,
+                   "stale ambient MSVC toolset must fall back to ordinary discovery");
+            fs::remove_all(fake_installation.parent_path(), cleanup_error);
+        }
+    }
 
     if (failures != 0) {
         std::cerr << failures << " test(s) failed\n";

--- a/docs/20260826-195200-cold-build-overhead/benchmark-after.json
+++ b/docs/20260826-195200-cold-build-overhead/benchmark-after.json
@@ -1,0 +1,1969 @@
+{
+  "schema_version": 1,
+  "generated_utc": "2026-08-26T13:02:08.8662748Z",
+  "methodology": {
+    "translation_units": 100,
+    "iterations": 5,
+    "jobs": 32,
+    "target_architecture": "x64",
+    "build_configuration": "release",
+    "cpp_standard_flag": "/std:c++23preview",
+    "same_source_tree_per_iteration": true,
+    "alternating_execution_order": true,
+    "cmake_generator": "Ninja",
+    "cmake_configure_excluded_from_build_timings": true,
+    "ninja_invoked_directly": true,
+    "pch_uses_native_build_system_mechanism": true,
+    "note": "This is machine-specific reproducible evidence, not a universal performance claim."
+  },
+  "environment": {
+    "os_version": "Microsoft Windows NT 10.0.22631.0",
+    "powershell": "7.6.0",
+    "processor_identifier": "Intel64 Family 6 Model 183 Stepping 1, GenuineIntel",
+    "logical_processors": 32,
+    "physical_memory_bytes": 16894455808,
+    "msvc_environment_isolated": true,
+    "vsdevcmd_imported": true,
+    "visual_studio_installation": "C:\\Program Files\\Microsoft Visual Studio\\18\\Community",
+    "cl_path_verified": "C:\\Program Files\\Microsoft Visual Studio\\18\\Community\\VC\\Tools\\MSVC\\14.51.36231\\bin\\HostX64\\x64\\cl.exe",
+    "link_path_verified": "C:\\Program Files\\Microsoft Visual Studio\\18\\Community\\VC\\Tools\\MSVC\\14.51.36231\\bin\\HostX64\\x64\\link.exe",
+    "vctools_version": "14.51.36231",
+    "windows_sdk_version": "10.0.26100.0\\"
+  },
+  "tools": {
+    "mqb": {
+      "path": "D:\\program\\build项目\\native-dev\\release\\mqb.exe",
+      "sha256": "64433520634730b64be54145a2ddf608361f0e6ab888fb6656b0715147765b52",
+      "file_version": "",
+      "product_version": ""
+    },
+    "cmake": {
+      "identity": {
+        "path": "C:\\Program Files\\CMake\\bin\\cmake.exe",
+        "sha256": "bce3d4c9e2bb3eab0c90eae3fe7ea9626d9dc35263194adc9132cf5349d628a3",
+        "file_version": "4.1.2",
+        "product_version": "4.1.2"
+      },
+      "version": "cmake version 4.1.2"
+    },
+    "ninja": {
+      "identity": {
+        "path": "C:\\Users\\Iviesever\\AppData\\Local\\Microsoft\\WinGet\\Packages\\Ninja-build.Ninja_Microsoft.Winget.Source_8wekyb3d8bbwe\\ninja.exe",
+        "sha256": "2df494116decdae84d74c02373119176bbfc4797a6f49a6c709d85d961d6a0d8",
+        "file_version": "",
+        "product_version": ""
+      },
+      "version": "1.13.1"
+    },
+    "cl": {
+      "identity": {
+        "path": "C:\\Program Files\\Microsoft Visual Studio\\18\\Community\\VC\\Tools\\MSVC\\14.51.36231\\bin\\HostX64\\x64\\cl.exe",
+        "sha256": "dc8426b8760d92cf757df3d10b9f0244a95b454ff43194a58161568a0ec70d53",
+        "file_version": "19.51.36248.0",
+        "product_version": "14.51.36248.0"
+      },
+      "version": "用法: cl [ 选项... ] 文件名... [ /link 链接选项... ]"
+    }
+  },
+  "cmake_configure_samples": [
+    {
+      "iteration": 1,
+      "fixture": "ordinary",
+      "elapsed_ms": 1209.946
+    },
+    {
+      "iteration": 1,
+      "fixture": "pch",
+      "elapsed_ms": 887.27
+    },
+    {
+      "iteration": 2,
+      "fixture": "ordinary",
+      "elapsed_ms": 862.371
+    },
+    {
+      "iteration": 2,
+      "fixture": "pch",
+      "elapsed_ms": 887.126
+    },
+    {
+      "iteration": 3,
+      "fixture": "ordinary",
+      "elapsed_ms": 877.896
+    },
+    {
+      "iteration": 3,
+      "fixture": "pch",
+      "elapsed_ms": 888.442
+    },
+    {
+      "iteration": 4,
+      "fixture": "ordinary",
+      "elapsed_ms": 876.011
+    },
+    {
+      "iteration": 4,
+      "fixture": "pch",
+      "elapsed_ms": 824.793
+    },
+    {
+      "iteration": 5,
+      "fixture": "ordinary",
+      "elapsed_ms": 849.737
+    },
+    {
+      "iteration": 5,
+      "fixture": "pch",
+      "elapsed_ms": 842.584
+    }
+  ],
+  "cmake_configure_summary": [
+    {
+      "fixture": "ordinary",
+      "samples": 5,
+      "median_ms": 876.011
+    },
+    {
+      "fixture": "pch",
+      "samples": 5,
+      "median_ms": 887.126
+    }
+  ],
+  "samples": [
+    {
+      "iteration": 1,
+      "scenario": "ordinary-cold",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 815.201,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 1,
+      "scenario": "ordinary-cold",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 693.638,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.711,
+          "compile": 541.542,
+          "link": 55.163,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 684.21
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 101
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 1,
+      "scenario": "ordinary-no-op",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 28.47,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.548,
+          "compile": 10.303,
+          "link": 3.067,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 22.869
+        },
+        "cache": {
+          "compile": {
+            "hits": 101,
+            "misses": 0
+          },
+          "link": {
+            "hits": 1,
+            "misses": 0
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 1,
+      "scenario": "ordinary-no-op",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 25.067,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 1,
+      "scenario": "ordinary-single-tu",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 118.314,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 1,
+      "scenario": "ordinary-single-tu",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 93.416,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.571,
+          "compile": 43.837,
+          "link": 34.317,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 88.198
+        },
+        "cache": {
+          "compile": {
+            "hits": 100,
+            "misses": 1
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 1,
+      "scenario": "ordinary-public-header",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 490.885,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.534,
+          "compile": 430.025,
+          "link": 45.409,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 485.772
+        },
+        "cache": {
+          "compile": {
+            "hits": 1,
+            "misses": 100
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 1,
+      "scenario": "ordinary-public-header",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 753.634,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 1,
+      "scenario": "pch-cold",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 1012.758,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 1,
+      "scenario": "pch-cold",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 1018.694,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.474,
+          "compile": 879.413,
+          "link": 42.645,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 1011.52
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 102
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 1,
+      "scenario": "pch-no-op",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 29.416,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.476,
+          "compile": 12.888,
+          "link": 2.885,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 25.239
+        },
+        "cache": {
+          "compile": {
+            "hits": 102,
+            "misses": 0
+          },
+          "link": {
+            "hits": 1,
+            "misses": 0
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 1,
+      "scenario": "pch-no-op",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 41.1,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 1,
+      "scenario": "pch-single-tu",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 127.458,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 1,
+      "scenario": "pch-single-tu",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 103.762,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.531,
+          "compile": 45.556,
+          "link": 43.039,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 98.505
+        },
+        "cache": {
+          "compile": {
+            "hits": 101,
+            "misses": 1
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 1,
+      "scenario": "pch-header",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 915.627,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.51,
+          "compile": 851.071,
+          "link": 50.188,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 911.057
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 102
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 1,
+      "scenario": "pch-header",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 1107.442,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 2,
+      "scenario": "ordinary-cold",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 657.799,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.519,
+          "compile": 511.565,
+          "link": 50.484,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 651.919
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 101
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 2,
+      "scenario": "ordinary-cold",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 760.461,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 2,
+      "scenario": "ordinary-no-op",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 33.193,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 2,
+      "scenario": "ordinary-no-op",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 26.97,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.539,
+          "compile": 10.115,
+          "link": 2.922,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 22.711
+        },
+        "cache": {
+          "compile": {
+            "hits": 101,
+            "misses": 0
+          },
+          "link": {
+            "hits": 1,
+            "misses": 0
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 2,
+      "scenario": "ordinary-single-tu",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 93.885,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.527,
+          "compile": 39.696,
+          "link": 40.452,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 89.55
+        },
+        "cache": {
+          "compile": {
+            "hits": 100,
+            "misses": 1
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 2,
+      "scenario": "ordinary-single-tu",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 126.607,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 2,
+      "scenario": "ordinary-public-header",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 764.07,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 2,
+      "scenario": "ordinary-public-header",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 543.275,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.532,
+          "compile": 486.34,
+          "link": 41.541,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 538.1
+        },
+        "cache": {
+          "compile": {
+            "hits": 1,
+            "misses": 100
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 2,
+      "scenario": "pch-cold",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 1013.84,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.509,
+          "compile": 872.249,
+          "link": 45.339,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 1009.547
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 102
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 2,
+      "scenario": "pch-cold",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 904.81,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 2,
+      "scenario": "pch-no-op",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 34.477,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 2,
+      "scenario": "pch-no-op",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 32.953,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.494,
+          "compile": 15.385,
+          "link": 3.085,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 28.349
+        },
+        "cache": {
+          "compile": {
+            "hits": 102,
+            "misses": 0
+          },
+          "link": {
+            "hits": 1,
+            "misses": 0
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 2,
+      "scenario": "pch-single-tu",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 99.424,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.486,
+          "compile": 44.978,
+          "link": 40.445,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 95.436
+        },
+        "cache": {
+          "compile": {
+            "hits": 101,
+            "misses": 1
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 2,
+      "scenario": "pch-single-tu",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 143.819,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 2,
+      "scenario": "pch-header",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 948.022,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 2,
+      "scenario": "pch-header",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 896.307,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.479,
+          "compile": 833.126,
+          "link": 48.224,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 891.374
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 102
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 3,
+      "scenario": "ordinary-cold",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 764.579,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 3,
+      "scenario": "ordinary-cold",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 709.162,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.532,
+          "compile": 570.855,
+          "link": 45.428,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 704.574
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 101
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 3,
+      "scenario": "ordinary-no-op",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 25.961,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.569,
+          "compile": 8.431,
+          "link": 2.886,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 21.871
+        },
+        "cache": {
+          "compile": {
+            "hits": 101,
+            "misses": 0
+          },
+          "link": {
+            "hits": 1,
+            "misses": 0
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 3,
+      "scenario": "ordinary-no-op",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 46.135,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 3,
+      "scenario": "ordinary-single-tu",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 117.47,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 3,
+      "scenario": "ordinary-single-tu",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 98.629,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.589,
+          "compile": 42.343,
+          "link": 42.415,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 94.33
+        },
+        "cache": {
+          "compile": {
+            "hits": 100,
+            "misses": 1
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 3,
+      "scenario": "ordinary-public-header",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 580.22,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.531,
+          "compile": 521.004,
+          "link": 43.632,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 574.684
+        },
+        "cache": {
+          "compile": {
+            "hits": 1,
+            "misses": 100
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 3,
+      "scenario": "ordinary-public-header",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 764.726,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 3,
+      "scenario": "pch-cold",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 1002.276,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 3,
+      "scenario": "pch-cold",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 1042.032,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.51,
+          "compile": 902.031,
+          "link": 45.332,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 1036.836
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 102
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 3,
+      "scenario": "pch-no-op",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 30.661,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.488,
+          "compile": 12.291,
+          "link": 3.713,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 26.318
+        },
+        "cache": {
+          "compile": {
+            "hits": 102,
+            "misses": 0
+          },
+          "link": {
+            "hits": 1,
+            "misses": 0
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 3,
+      "scenario": "pch-no-op",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 39.154,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 3,
+      "scenario": "pch-single-tu",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 117.768,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 3,
+      "scenario": "pch-single-tu",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 98.436,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.562,
+          "compile": 41.837,
+          "link": 42.951,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 94.341
+        },
+        "cache": {
+          "compile": {
+            "hits": 101,
+            "misses": 1
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 3,
+      "scenario": "pch-header",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 882.072,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.492,
+          "compile": 813.432,
+          "link": 53.95,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 877.019
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 102
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 3,
+      "scenario": "pch-header",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 936.732,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 4,
+      "scenario": "ordinary-cold",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 685.998,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.54,
+          "compile": 536.33,
+          "link": 45.846,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 679.132
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 101
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 4,
+      "scenario": "ordinary-cold",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 832.129,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 4,
+      "scenario": "ordinary-no-op",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 40.288,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 4,
+      "scenario": "ordinary-no-op",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 25.554,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.505,
+          "compile": 9.432,
+          "link": 2.899,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 21.803
+        },
+        "cache": {
+          "compile": {
+            "hits": 101,
+            "misses": 0
+          },
+          "link": {
+            "hits": 1,
+            "misses": 0
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 4,
+      "scenario": "ordinary-single-tu",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 97.956,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.529,
+          "compile": 42.457,
+          "link": 42.001,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 93.907
+        },
+        "cache": {
+          "compile": {
+            "hits": 100,
+            "misses": 1
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 4,
+      "scenario": "ordinary-single-tu",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 124.78,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 4,
+      "scenario": "ordinary-public-header",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 771.815,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 4,
+      "scenario": "ordinary-public-header",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 523.741,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.539,
+          "compile": 463.999,
+          "link": 44.735,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 518.849
+        },
+        "cache": {
+          "compile": {
+            "hits": 1,
+            "misses": 100
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 4,
+      "scenario": "pch-cold",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 1031.959,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.491,
+          "compile": 890.266,
+          "link": 44.577,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 1027.292
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 102
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 4,
+      "scenario": "pch-cold",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 996.738,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 4,
+      "scenario": "pch-no-op",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 32.378,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 4,
+      "scenario": "pch-no-op",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 30.582,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.453,
+          "compile": 12.905,
+          "link": 2.983,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 26.433
+        },
+        "cache": {
+          "compile": {
+            "hits": 102,
+            "misses": 0
+          },
+          "link": {
+            "hits": 1,
+            "misses": 0
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 4,
+      "scenario": "pch-single-tu",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 98.979,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.506,
+          "compile": 45.657,
+          "link": 39.387,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 94.649
+        },
+        "cache": {
+          "compile": {
+            "hits": 101,
+            "misses": 1
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 4,
+      "scenario": "pch-single-tu",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 119.417,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 4,
+      "scenario": "pch-header",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 968.682,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 4,
+      "scenario": "pch-header",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 879.597,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.542,
+          "compile": 818.317,
+          "link": 46.264,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 874.582
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 102
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 5,
+      "scenario": "ordinary-cold",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 792.068,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 5,
+      "scenario": "ordinary-cold",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 685.761,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.594,
+          "compile": 542.816,
+          "link": 46.999,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 680.68
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 101
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 5,
+      "scenario": "ordinary-no-op",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 27.758,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.59,
+          "compile": 9.412,
+          "link": 3.313,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 22.813
+        },
+        "cache": {
+          "compile": {
+            "hits": 101,
+            "misses": 0
+          },
+          "link": {
+            "hits": 1,
+            "misses": 0
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 5,
+      "scenario": "ordinary-no-op",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 34.455,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 5,
+      "scenario": "ordinary-single-tu",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 128.33,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 5,
+      "scenario": "ordinary-single-tu",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 97.55,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.536,
+          "compile": 42.369,
+          "link": 41.528,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 93.546
+        },
+        "cache": {
+          "compile": {
+            "hits": 100,
+            "misses": 1
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 5,
+      "scenario": "ordinary-public-header",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 522.76,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.528,
+          "compile": 460.178,
+          "link": 47.97,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 517.683
+        },
+        "cache": {
+          "compile": {
+            "hits": 1,
+            "misses": 100
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 5,
+      "scenario": "ordinary-public-header",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 802.651,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 5,
+      "scenario": "pch-cold",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 923.539,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 5,
+      "scenario": "pch-cold",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 981.221,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.473,
+          "compile": 844.237,
+          "link": 43.666,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 976.583
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 102
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 5,
+      "scenario": "pch-no-op",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 30.304,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.505,
+          "compile": 12.924,
+          "link": 3.039,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 25.79
+        },
+        "cache": {
+          "compile": {
+            "hits": 102,
+            "misses": 0
+          },
+          "link": {
+            "hits": 1,
+            "misses": 0
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 5,
+      "scenario": "pch-no-op",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 32.314,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 5,
+      "scenario": "pch-single-tu",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 116.434,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 5,
+      "scenario": "pch-single-tu",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 97.635,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.458,
+          "compile": 44.666,
+          "link": 39.348,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 93.486
+        },
+        "cache": {
+          "compile": {
+            "hits": 101,
+            "misses": 1
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 5,
+      "scenario": "pch-header",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 893.197,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.523,
+          "compile": 831.534,
+          "link": 47.273,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 888.316
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 102
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 5,
+      "scenario": "pch-header",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 953.66,
+      "mqb_timing": null
+    }
+  ],
+  "comparison": [
+    {
+      "scenario": "ordinary-cold",
+      "samples_per_system": 5,
+      "mqb_median_ms": 685.998,
+      "cmake_ninja_median_ms": 792.068,
+      "mqb_delta_ms_vs_cmake_ninja": -106.07,
+      "mqb_delta_pct_vs_cmake_ninja": -13.39,
+      "cmake_ninja_over_mqb_ratio": 1.155
+    },
+    {
+      "scenario": "ordinary-no-op",
+      "samples_per_system": 5,
+      "mqb_median_ms": 26.97,
+      "cmake_ninja_median_ms": 34.455,
+      "mqb_delta_ms_vs_cmake_ninja": -7.485,
+      "mqb_delta_pct_vs_cmake_ninja": -21.72,
+      "cmake_ninja_over_mqb_ratio": 1.278
+    },
+    {
+      "scenario": "ordinary-single-tu",
+      "samples_per_system": 5,
+      "mqb_median_ms": 97.55,
+      "cmake_ninja_median_ms": 124.78,
+      "mqb_delta_ms_vs_cmake_ninja": -27.23,
+      "mqb_delta_pct_vs_cmake_ninja": -21.82,
+      "cmake_ninja_over_mqb_ratio": 1.279
+    },
+    {
+      "scenario": "ordinary-public-header",
+      "samples_per_system": 5,
+      "mqb_median_ms": 523.741,
+      "cmake_ninja_median_ms": 764.726,
+      "mqb_delta_ms_vs_cmake_ninja": -240.985,
+      "mqb_delta_pct_vs_cmake_ninja": -31.51,
+      "cmake_ninja_over_mqb_ratio": 1.46
+    },
+    {
+      "scenario": "pch-cold",
+      "samples_per_system": 5,
+      "mqb_median_ms": 1018.694,
+      "cmake_ninja_median_ms": 996.738,
+      "mqb_delta_ms_vs_cmake_ninja": 21.956,
+      "mqb_delta_pct_vs_cmake_ninja": 2.2,
+      "cmake_ninja_over_mqb_ratio": 0.978
+    },
+    {
+      "scenario": "pch-no-op",
+      "samples_per_system": 5,
+      "mqb_median_ms": 30.582,
+      "cmake_ninja_median_ms": 34.477,
+      "mqb_delta_ms_vs_cmake_ninja": -3.895,
+      "mqb_delta_pct_vs_cmake_ninja": -11.3,
+      "cmake_ninja_over_mqb_ratio": 1.127
+    },
+    {
+      "scenario": "pch-single-tu",
+      "samples_per_system": 5,
+      "mqb_median_ms": 98.979,
+      "cmake_ninja_median_ms": 119.417,
+      "mqb_delta_ms_vs_cmake_ninja": -20.438,
+      "mqb_delta_pct_vs_cmake_ninja": -17.11,
+      "cmake_ninja_over_mqb_ratio": 1.206
+    },
+    {
+      "scenario": "pch-header",
+      "samples_per_system": 5,
+      "mqb_median_ms": 893.197,
+      "cmake_ninja_median_ms": 953.66,
+      "mqb_delta_ms_vs_cmake_ninja": -60.463,
+      "mqb_delta_pct_vs_cmake_ninja": -6.34,
+      "cmake_ninja_over_mqb_ratio": 1.068
+    }
+  ],
+  "retained_worktree": null
+}

--- a/docs/20260826-195200-cold-build-overhead/benchmark-before.json
+++ b/docs/20260826-195200-cold-build-overhead/benchmark-before.json
@@ -1,0 +1,1969 @@
+{
+  "schema_version": 1,
+  "generated_utc": "2026-08-26T11:51:14.8147664Z",
+  "methodology": {
+    "translation_units": 100,
+    "iterations": 5,
+    "jobs": 32,
+    "target_architecture": "x64",
+    "build_configuration": "release",
+    "cpp_standard_flag": "/std:c++23preview",
+    "same_source_tree_per_iteration": true,
+    "alternating_execution_order": true,
+    "cmake_generator": "Ninja",
+    "cmake_configure_excluded_from_build_timings": true,
+    "ninja_invoked_directly": true,
+    "pch_uses_native_build_system_mechanism": true,
+    "note": "This is machine-specific reproducible evidence, not a universal performance claim."
+  },
+  "environment": {
+    "os_version": "Microsoft Windows NT 10.0.22631.0",
+    "powershell": "7.6.0",
+    "processor_identifier": "Intel64 Family 6 Model 183 Stepping 1, GenuineIntel",
+    "logical_processors": 32,
+    "physical_memory_bytes": 16894455808,
+    "msvc_environment_isolated": true,
+    "vsdevcmd_imported": true,
+    "visual_studio_installation": "C:\\Program Files\\Microsoft Visual Studio\\18\\Community",
+    "cl_path_verified": "C:\\Program Files\\Microsoft Visual Studio\\18\\Community\\VC\\Tools\\MSVC\\14.51.36231\\bin\\HostX64\\x64\\cl.exe",
+    "link_path_verified": "C:\\Program Files\\Microsoft Visual Studio\\18\\Community\\VC\\Tools\\MSVC\\14.51.36231\\bin\\HostX64\\x64\\link.exe",
+    "vctools_version": "14.51.36231",
+    "windows_sdk_version": "10.0.26100.0\\"
+  },
+  "tools": {
+    "mqb": {
+      "path": "C:\\Users\\Iviesever\\bin\\mqb.exe",
+      "sha256": "518efda21f50096b5f8eac8f3283bba112f313493baca199699441bb63e3b929",
+      "file_version": "",
+      "product_version": ""
+    },
+    "cmake": {
+      "identity": {
+        "path": "C:\\Program Files\\CMake\\bin\\cmake.exe",
+        "sha256": "bce3d4c9e2bb3eab0c90eae3fe7ea9626d9dc35263194adc9132cf5349d628a3",
+        "file_version": "4.1.2",
+        "product_version": "4.1.2"
+      },
+      "version": "cmake version 4.1.2"
+    },
+    "ninja": {
+      "identity": {
+        "path": "C:\\Users\\Iviesever\\AppData\\Local\\Microsoft\\WinGet\\Packages\\Ninja-build.Ninja_Microsoft.Winget.Source_8wekyb3d8bbwe\\ninja.exe",
+        "sha256": "2df494116decdae84d74c02373119176bbfc4797a6f49a6c709d85d961d6a0d8",
+        "file_version": "",
+        "product_version": ""
+      },
+      "version": "1.13.1"
+    },
+    "cl": {
+      "identity": {
+        "path": "C:\\Program Files\\Microsoft Visual Studio\\18\\Community\\VC\\Tools\\MSVC\\14.51.36231\\bin\\HostX64\\x64\\cl.exe",
+        "sha256": "dc8426b8760d92cf757df3d10b9f0244a95b454ff43194a58161568a0ec70d53",
+        "file_version": "19.51.36248.0",
+        "product_version": "14.51.36248.0"
+      },
+      "version": "Microsoft (R) C/C++ Optimizing Compiler Version 19.51.36248 for x64"
+    }
+  },
+  "cmake_configure_samples": [
+    {
+      "iteration": 1,
+      "fixture": "ordinary",
+      "elapsed_ms": 1163.841
+    },
+    {
+      "iteration": 1,
+      "fixture": "pch",
+      "elapsed_ms": 700.906
+    },
+    {
+      "iteration": 2,
+      "fixture": "ordinary",
+      "elapsed_ms": 762.856
+    },
+    {
+      "iteration": 2,
+      "fixture": "pch",
+      "elapsed_ms": 743.503
+    },
+    {
+      "iteration": 3,
+      "fixture": "ordinary",
+      "elapsed_ms": 818.748
+    },
+    {
+      "iteration": 3,
+      "fixture": "pch",
+      "elapsed_ms": 845.853
+    },
+    {
+      "iteration": 4,
+      "fixture": "ordinary",
+      "elapsed_ms": 780.411
+    },
+    {
+      "iteration": 4,
+      "fixture": "pch",
+      "elapsed_ms": 851.445
+    },
+    {
+      "iteration": 5,
+      "fixture": "ordinary",
+      "elapsed_ms": 787.848
+    },
+    {
+      "iteration": 5,
+      "fixture": "pch",
+      "elapsed_ms": 808.416
+    }
+  ],
+  "cmake_configure_summary": [
+    {
+      "fixture": "ordinary",
+      "samples": 5,
+      "median_ms": 787.848
+    },
+    {
+      "fixture": "pch",
+      "samples": 5,
+      "median_ms": 808.416
+    }
+  ],
+  "samples": [
+    {
+      "iteration": 1,
+      "scenario": "ordinary-cold",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 769.71,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 1,
+      "scenario": "ordinary-cold",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 2424.3,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.519,
+          "compile": 537.48,
+          "link": 38.397,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 2411.186
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 101
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 1,
+      "scenario": "ordinary-no-op",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 105.036,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.523,
+          "compile": 8.535,
+          "link": 2.809,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 99.886
+        },
+        "cache": {
+          "compile": {
+            "hits": 101,
+            "misses": 0
+          },
+          "link": {
+            "hits": 1,
+            "misses": 0
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 1,
+      "scenario": "ordinary-no-op",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 24.924,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 1,
+      "scenario": "ordinary-single-tu",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 117.016,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 1,
+      "scenario": "ordinary-single-tu",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 173.63,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.499,
+          "compile": 46.038,
+          "link": 36.558,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 168.074
+        },
+        "cache": {
+          "compile": {
+            "hits": 100,
+            "misses": 1
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 1,
+      "scenario": "ordinary-public-header",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 641.5,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.561,
+          "compile": 507.342,
+          "link": 42.432,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 635.827
+        },
+        "cache": {
+          "compile": {
+            "hits": 1,
+            "misses": 100
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 1,
+      "scenario": "ordinary-public-header",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 662.562,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 1,
+      "scenario": "pch-cold",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 848.976,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 1,
+      "scenario": "pch-cold",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 2829.923,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.507,
+          "compile": 996.776,
+          "link": 37.882,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 2818.516
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 102
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 1,
+      "scenario": "pch-no-op",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 108.619,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.483,
+          "compile": 13.497,
+          "link": 2.873,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 100.042
+        },
+        "cache": {
+          "compile": {
+            "hits": 102,
+            "misses": 0
+          },
+          "link": {
+            "hits": 1,
+            "misses": 0
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 1,
+      "scenario": "pch-no-op",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 28.271,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 1,
+      "scenario": "pch-single-tu",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 129.389,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 1,
+      "scenario": "pch-single-tu",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 168.83,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.548,
+          "compile": 43.031,
+          "link": 36.575,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 163.663
+        },
+        "cache": {
+          "compile": {
+            "hits": 101,
+            "misses": 1
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 1,
+      "scenario": "pch-header",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 1050.842,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.508,
+          "compile": 918.071,
+          "link": 42.494,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 1045.274
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 102
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 1,
+      "scenario": "pch-header",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 842.516,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 2,
+      "scenario": "ordinary-cold",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 2347.167,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.511,
+          "compile": 528.82,
+          "link": 40.659,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 2334.987
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 101
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 2,
+      "scenario": "ordinary-cold",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 704.064,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 2,
+      "scenario": "ordinary-no-op",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 24.45,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 2,
+      "scenario": "ordinary-no-op",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 104.351,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.507,
+          "compile": 10.661,
+          "link": 2.717,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 96.656
+        },
+        "cache": {
+          "compile": {
+            "hits": 101,
+            "misses": 0
+          },
+          "link": {
+            "hits": 1,
+            "misses": 0
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 2,
+      "scenario": "ordinary-single-tu",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 177.358,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.504,
+          "compile": 53.018,
+          "link": 34.628,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 171.545
+        },
+        "cache": {
+          "compile": {
+            "hits": 100,
+            "misses": 1
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 2,
+      "scenario": "ordinary-single-tu",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 105.349,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 2,
+      "scenario": "ordinary-public-header",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 633.505,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 2,
+      "scenario": "ordinary-public-header",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 601.942,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.529,
+          "compile": 462.077,
+          "link": 45.343,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 593.853
+        },
+        "cache": {
+          "compile": {
+            "hits": 1,
+            "misses": 100
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 2,
+      "scenario": "pch-cold",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 2820.888,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.515,
+          "compile": 958.971,
+          "link": 44.999,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 2815.271
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 102
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 2,
+      "scenario": "pch-cold",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 904.306,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 2,
+      "scenario": "pch-no-op",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 22.497,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 2,
+      "scenario": "pch-no-op",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 107.856,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.484,
+          "compile": 14.127,
+          "link": 2.793,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 99.495
+        },
+        "cache": {
+          "compile": {
+            "hits": 102,
+            "misses": 0
+          },
+          "link": {
+            "hits": 1,
+            "misses": 0
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 2,
+      "scenario": "pch-single-tu",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 173.055,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.488,
+          "compile": 45.546,
+          "link": 39.59,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 167.993
+        },
+        "cache": {
+          "compile": {
+            "hits": 101,
+            "misses": 1
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 2,
+      "scenario": "pch-single-tu",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 123.214,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 2,
+      "scenario": "pch-header",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 1021.821,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 2,
+      "scenario": "pch-header",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 1118.754,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.517,
+          "compile": 975.291,
+          "link": 49.403,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 1111.689
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 102
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 3,
+      "scenario": "ordinary-cold",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 754.207,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 3,
+      "scenario": "ordinary-cold",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 2524.791,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.551,
+          "compile": 598.244,
+          "link": 47.362,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 2516.753
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 101
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 3,
+      "scenario": "ordinary-no-op",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 102.415,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.51,
+          "compile": 9.743,
+          "link": 2.88,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 97.594
+        },
+        "cache": {
+          "compile": {
+            "hits": 101,
+            "misses": 0
+          },
+          "link": {
+            "hits": 1,
+            "misses": 0
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 3,
+      "scenario": "ordinary-no-op",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 24.842,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 3,
+      "scenario": "ordinary-single-tu",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 111.902,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 3,
+      "scenario": "ordinary-single-tu",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 182.391,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.527,
+          "compile": 49.151,
+          "link": 37.183,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 176.513
+        },
+        "cache": {
+          "compile": {
+            "hits": 100,
+            "misses": 1
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 3,
+      "scenario": "ordinary-public-header",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 649.546,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.544,
+          "compile": 488.146,
+          "link": 66.954,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 644.099
+        },
+        "cache": {
+          "compile": {
+            "hits": 1,
+            "misses": 100
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 3,
+      "scenario": "ordinary-public-header",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 697.165,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 3,
+      "scenario": "pch-cold",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 842.346,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 3,
+      "scenario": "pch-cold",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 2853.426,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.511,
+          "compile": 963.774,
+          "link": 42.195,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 2845.945
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 102
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 3,
+      "scenario": "pch-no-op",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 105.61,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.567,
+          "compile": 11.703,
+          "link": 2.875,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 101.996
+        },
+        "cache": {
+          "compile": {
+            "hits": 102,
+            "misses": 0
+          },
+          "link": {
+            "hits": 1,
+            "misses": 0
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 3,
+      "scenario": "pch-no-op",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 40.324,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 3,
+      "scenario": "pch-single-tu",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 123.613,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 3,
+      "scenario": "pch-single-tu",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 175.669,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.527,
+          "compile": 45.093,
+          "link": 39.549,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 171.341
+        },
+        "cache": {
+          "compile": {
+            "hits": 101,
+            "misses": 1
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 3,
+      "scenario": "pch-header",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 1047.804,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.503,
+          "compile": 913.317,
+          "link": 42.982,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 1043.286
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 102
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 3,
+      "scenario": "pch-header",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 945.642,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 4,
+      "scenario": "ordinary-cold",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 2503.64,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.513,
+          "compile": 572.737,
+          "link": 49.894,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 2499.644
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 101
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 4,
+      "scenario": "ordinary-cold",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 731.716,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 4,
+      "scenario": "ordinary-no-op",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 27.096,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 4,
+      "scenario": "ordinary-no-op",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 103.926,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.572,
+          "compile": 9.82,
+          "link": 2.837,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 99.829
+        },
+        "cache": {
+          "compile": {
+            "hits": 101,
+            "misses": 0
+          },
+          "link": {
+            "hits": 1,
+            "misses": 0
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 4,
+      "scenario": "ordinary-single-tu",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 181.731,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.542,
+          "compile": 44.1,
+          "link": 44.943,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 177.568
+        },
+        "cache": {
+          "compile": {
+            "hits": 100,
+            "misses": 1
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 4,
+      "scenario": "ordinary-single-tu",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 116.479,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 4,
+      "scenario": "ordinary-public-header",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 814.24,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 4,
+      "scenario": "ordinary-public-header",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 688.392,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.52,
+          "compile": 548.192,
+          "link": 46.74,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 683.114
+        },
+        "cache": {
+          "compile": {
+            "hits": 1,
+            "misses": 100
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 4,
+      "scenario": "pch-cold",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 2934.874,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.516,
+          "compile": 1032.155,
+          "link": 44.881,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 2930.312
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 102
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 4,
+      "scenario": "pch-cold",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 1007.054,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 4,
+      "scenario": "pch-no-op",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 32.846,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 4,
+      "scenario": "pch-no-op",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 108.717,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.514,
+          "compile": 13.885,
+          "link": 3.066,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 104.694
+        },
+        "cache": {
+          "compile": {
+            "hits": 102,
+            "misses": 0
+          },
+          "link": {
+            "hits": 1,
+            "misses": 0
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 4,
+      "scenario": "pch-single-tu",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 178.605,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.511,
+          "compile": 46.71,
+          "link": 39.149,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 173.008
+        },
+        "cache": {
+          "compile": {
+            "hits": 101,
+            "misses": 1
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 4,
+      "scenario": "pch-single-tu",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 118.65,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 4,
+      "scenario": "pch-header",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 949.318,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 4,
+      "scenario": "pch-header",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 1148.166,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.485,
+          "compile": 1008.612,
+          "link": 45.369,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 1139.368
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 102
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 5,
+      "scenario": "ordinary-cold",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 800.668,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 5,
+      "scenario": "ordinary-cold",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 2550.077,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.517,
+          "compile": 594.232,
+          "link": 48.652,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 2543.092
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 101
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 5,
+      "scenario": "ordinary-no-op",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 107.844,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.567,
+          "compile": 6.318,
+          "link": 3.156,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 102.066
+        },
+        "cache": {
+          "compile": {
+            "hits": 101,
+            "misses": 0
+          },
+          "link": {
+            "hits": 1,
+            "misses": 0
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 5,
+      "scenario": "ordinary-no-op",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 19.748,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 5,
+      "scenario": "ordinary-single-tu",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 131.366,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 5,
+      "scenario": "ordinary-single-tu",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 185.648,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.536,
+          "compile": 46.772,
+          "link": 41.944,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 180.174
+        },
+        "cache": {
+          "compile": {
+            "hits": 100,
+            "misses": 1
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 5,
+      "scenario": "ordinary-public-header",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 599.356,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.536,
+          "compile": 467.357,
+          "link": 42.815,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 594.218
+        },
+        "cache": {
+          "compile": {
+            "hits": 1,
+            "misses": 100
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 5,
+      "scenario": "ordinary-public-header",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 750.264,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 5,
+      "scenario": "pch-cold",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 932.323,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 5,
+      "scenario": "pch-cold",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 3268.232,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.508,
+          "compile": 1138.776,
+          "link": 61.671,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 3258.843
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 102
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 5,
+      "scenario": "pch-no-op",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 119.797,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.484,
+          "compile": 13.193,
+          "link": 3.138,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 110.889
+        },
+        "cache": {
+          "compile": {
+            "hits": 102,
+            "misses": 0
+          },
+          "link": {
+            "hits": 1,
+            "misses": 0
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 5,
+      "scenario": "pch-no-op",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 35.141,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 5,
+      "scenario": "pch-single-tu",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 137.946,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 5,
+      "scenario": "pch-single-tu",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 177.998,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.526,
+          "compile": 43.824,
+          "link": 39.442,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 171.443
+        },
+        "cache": {
+          "compile": {
+            "hits": 101,
+            "misses": 1
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 5,
+      "scenario": "pch-header",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 1092.349,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.505,
+          "compile": 958.617,
+          "link": 45.917,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 1086.273
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 102
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 5,
+      "scenario": "pch-header",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 941.349,
+      "mqb_timing": null
+    }
+  ],
+  "comparison": [
+    {
+      "scenario": "ordinary-cold",
+      "samples_per_system": 5,
+      "mqb_median_ms": 2503.64,
+      "cmake_ninja_median_ms": 754.207,
+      "mqb_delta_ms_vs_cmake_ninja": 1749.433,
+      "mqb_delta_pct_vs_cmake_ninja": 231.96,
+      "cmake_ninja_over_mqb_ratio": 0.301
+    },
+    {
+      "scenario": "ordinary-no-op",
+      "samples_per_system": 5,
+      "mqb_median_ms": 104.351,
+      "cmake_ninja_median_ms": 24.842,
+      "mqb_delta_ms_vs_cmake_ninja": 79.509,
+      "mqb_delta_pct_vs_cmake_ninja": 320.06,
+      "cmake_ninja_over_mqb_ratio": 0.238
+    },
+    {
+      "scenario": "ordinary-single-tu",
+      "samples_per_system": 5,
+      "mqb_median_ms": 181.731,
+      "cmake_ninja_median_ms": 116.479,
+      "mqb_delta_ms_vs_cmake_ninja": 65.252,
+      "mqb_delta_pct_vs_cmake_ninja": 56.02,
+      "cmake_ninja_over_mqb_ratio": 0.641
+    },
+    {
+      "scenario": "ordinary-public-header",
+      "samples_per_system": 5,
+      "mqb_median_ms": 641.5,
+      "cmake_ninja_median_ms": 697.165,
+      "mqb_delta_ms_vs_cmake_ninja": -55.665,
+      "mqb_delta_pct_vs_cmake_ninja": -7.98,
+      "cmake_ninja_over_mqb_ratio": 1.087
+    },
+    {
+      "scenario": "pch-cold",
+      "samples_per_system": 5,
+      "mqb_median_ms": 2853.426,
+      "cmake_ninja_median_ms": 904.306,
+      "mqb_delta_ms_vs_cmake_ninja": 1949.12,
+      "mqb_delta_pct_vs_cmake_ninja": 215.54,
+      "cmake_ninja_over_mqb_ratio": 0.317
+    },
+    {
+      "scenario": "pch-no-op",
+      "samples_per_system": 5,
+      "mqb_median_ms": 108.619,
+      "cmake_ninja_median_ms": 32.846,
+      "mqb_delta_ms_vs_cmake_ninja": 75.773,
+      "mqb_delta_pct_vs_cmake_ninja": 230.69,
+      "cmake_ninja_over_mqb_ratio": 0.302
+    },
+    {
+      "scenario": "pch-single-tu",
+      "samples_per_system": 5,
+      "mqb_median_ms": 175.669,
+      "cmake_ninja_median_ms": 123.613,
+      "mqb_delta_ms_vs_cmake_ninja": 52.056,
+      "mqb_delta_pct_vs_cmake_ninja": 42.11,
+      "cmake_ninja_over_mqb_ratio": 0.704
+    },
+    {
+      "scenario": "pch-header",
+      "samples_per_system": 5,
+      "mqb_median_ms": 1092.349,
+      "cmake_ninja_median_ms": 945.642,
+      "mqb_delta_ms_vs_cmake_ninja": 146.707,
+      "mqb_delta_pct_vs_cmake_ninja": 15.51,
+      "cmake_ninja_over_mqb_ratio": 0.866
+    }
+  ],
+  "retained_worktree": null
+}

--- a/docs/20260826-195200-cold-build-overhead/implementation_plan.md
+++ b/docs/20260826-195200-cold-build-overhead/implementation_plan.md
@@ -1,0 +1,79 @@
+# Implementation Plan - Reduce Ordinary and PCH Cold-Build Overhead
+
+## Decision
+
+Implement ambient Visual Studio toolchain adoption in `MsvcToolchainLocator`. When a cold build runs in an environment where a valid Visual Studio developer toolset is already active, MQB validates it with one `vswhere.exe` query and adopts it without rerunning `vcvarsall.bat`. Adoption requires matching host and target architecture markers, the latest registered MSVC toolset, verified binaries, and machine-owned SDK/MSVC roots.
+
+## Contract
+
+- **Objective**: Eliminate ~1.8 s of redundant `vcvarsall.bat` startup overhead on cold builds in active MSVC developer environments without weakening cache identity or security validation.
+- **Scope**:
+  1. `cpp/src/msvc/toolchain/VisualStudioToolchainDiscovery.hpp` & `.cpp`: Expose registered-installation resolution and derive default discovery locations from the Windows installation rather than mutable `ProgramFiles` variables.
+  2. `cpp/src/msvc/toolchain/VisualStudioToolchainCache.hpp` & `.cpp`: Validate and materialize ambient toolchain evidence using the same cache/freshness authority.
+  3. `cpp/src/msvc/toolchain/MsvcToolchainLocator.cpp`: Query ambient adoption if project cache is absent/misses, before falling back to `discover_visual_studio_toolchain`.
+  4. `cpp/tests/msvc/toolchain/visual_studio_tests.cpp`: Add deterministic tests for adoption, host/target mismatch, missing markers, explicit overrides, stale toolsets, untrusted VS/SDK roots, and cache emission.
+  5. Retain corrected before/after 100-TU x 5 raw reports and run the complete release gates.
+
+## Proposed Changes
+
+### Toolchain Discovery Layer
+
+#### [MODIFY] `cpp/src/msvc/toolchain/VisualStudioToolchainCache.hpp` and `.cpp`
+- Implement `adopt_ambient_visual_studio_toolchain(process::ProcessRunner&, const DiscoveryOptions&)`:
+  - Inspect `environment_path("VCToolsInstallDir")`.
+  - Require exact `VSCMD_ARG_HOST_ARCH` and `VSCMD_ARG_TGT_ARCH` matches.
+  - Reject ambient adoption when an explicit `vswhere_path` or `cmd_path` is supplied.
+  - Validate `vc_tools_root` as the latest toolset beneath the installation returned by `vswhere`.
+  - Verify compiler, linker, and librarian exist at `tool_paths(vc_tools_root, options)`.
+  - Validate required environment variables (`INCLUDE`, `LIB`, `LIBPATH`, `PATH`) are present and non-empty.
+  - Validate include/library paths against the registered Visual Studio root plus Windows and Windows Kits roots derived from the operating system, not from ambient trust declarations.
+  - Compute `binary_stamp(compiler)`.
+  - Return a Visual Studio `MsvcToolchain` with `reused = false`.
+
+#### [MODIFY] `cpp/src/msvc/toolchain/VisualStudioToolchainDiscovery.hpp` and `.cpp`
+- Expose `locate_visual_studio_installation` for the ambient validation path.
+- Derive default `vswhere.exe` and Visual Studio fallback roots from `GetWindowsDirectoryW` rather than mutable process environment variables.
+
+#### [MODIFY] `cpp/src/msvc/toolchain/MsvcToolchainLocator.cpp`
+- In `MsvcToolchainLocator::discover`:
+  - After checking cache file reuse (if absent/miss), check `adopt_ambient_visual_studio_toolchain(runner_, options)`.
+  - If ambient toolchain is adopted:
+    - Save project toolchain cache if `cache_file` is specified (so subsequent warm runs use the cached record).
+    - Seal compiler environment identity and return.
+  - If ambient adoption is not available/valid, fall back to `discover_visual_studio_toolchain(runner_, options)`.
+
+### Test Layer
+
+#### [MODIFY] `cpp/tests/msvc/toolchain/visual_studio_tests.cpp`
+- Add tests verifying:
+  1. Valid ambient Visual Studio environment is adopted after exactly one `vswhere` validation call and does not invoke `vcvarsall.bat`.
+  2. Missing/mismatched host or target architecture markers fall back to ordinary discovery.
+  3. Explicit `vswhere_path` and `cmd_path` remain authoritative.
+  4. Unregistered VS roots, self-declared SDK roots, untrusted include roots, and stale MSVC toolsets are rejected.
+  5. Cache persistence after ambient adoption matches the expected cache format and is reusable with zero subprocesses.
+
+### Benchmark & Documentation Layer
+
+#### [MODIFY] `docs/BUILD_SYSTEM_BENCHMARK.md` and `docs/BUILD_SYSTEM_BENCHMARK_ZH.md`
+- Update cold-build performance evidence and analysis.
+
+## Verification Plan
+
+### Automated Tests
+1. Native visual studio toolchain tests:
+   ```powershell
+   & tests/native/develop.ps1
+   ```
+2. Sharded native test suites (all 77/77 tests across 8 shards):
+   ```powershell
+   & tests/native/run_native_tests.ps1 -BuilderMqbPath ... -TestMqbPath ... -RepoRoot .
+   ```
+3. C++ layout and bilingual docs validation:
+   ```powershell
+   & tests/native/assert_cpp_layout.ps1 -CppRoot cpp
+   & tests/docs/verify_bilingual_docs.ps1
+   ```
+4. Full 100-TU x 5 benchmark comparison:
+   ```powershell
+   pwsh -File tests/native/benchmark_build_systems.ps1 -MqbPath <built_mqb> -TranslationUnits 100 -Iterations 5 -OutputPath "$env:TEMP/bench_100_after.json"
+   ```

--- a/docs/20260826-195200-cold-build-overhead/issue.md
+++ b/docs/20260826-195200-cold-build-overhead/issue.md
@@ -1,0 +1,40 @@
+# Reduce ordinary and PCH cold-build overhead
+
+## Original intent
+
+Complete Issue #129: reduce MQB-owned overhead on ordinary and PCH cold builds without weakening correctness, freshness, dependency discovery, or artifact ownership.
+
+## Observed problem
+
+In the baseline 100-TU x 5 reproducible benchmark:
+- `ordinary-cold`: MQB median was 2503.64 ms vs CMake+Ninja median 754.21 ms (+1749.43 ms gap).
+- `pch-cold`: MQB median was 2853.43 ms vs CMake+Ninja median 904.31 ms (+1949.12 ms gap).
+
+Timing breakdown from MQB `--timings=json` on cold builds reveals:
+- `ordinary-cold`: compile phase was 537.48 ms (101 TUs compiled across 32 workers), link phase was 38.40 ms, total reported phase time was 576.40 ms, while overall invocation was 2411.19 ms.
+- `pch-cold`: compile phase was 996.78 ms, link phase was 37.88 ms, total reported phase time was 1035.17 ms, while overall invocation was 2818.52 ms.
+
+Approximately 1780-1835 ms (~65-76% of cold-build wall time) is spent before target compilation begins, in Visual Studio toolchain discovery (`MsvcToolchainLocator::discover`).
+
+On a cold build (fresh workspace or worktree without an existing `.mqb/cache/toolchain/` entry), `MsvcToolchainLocator::discover()` unconditionally invokes `cmd.exe /c vcvarsall.bat` even when the launching process environment already contains a complete Visual Studio developer environment. The optimization may skip that expensive recapture, but it must still validate the ambient toolset against a machine-registered Visual Studio installation.
+
+## Goal
+
+Enable `MsvcToolchainLocator` to recognize, validate, and adopt a trusted ambient Visual Studio environment for the requested host/target architecture. Retain one `vswhere.exe` installation validation, avoid redundant `vcvarsall.bat` process execution, and preserve all freshness, ownership, explicit-override, and fallback guarantees.
+
+## Acceptance criteria
+
+1. Retain a corrected 100-TU x 5 before report and a same-machine, same-tool-hash, same-environment after report.
+2. Record raw samples and MQB phase timings for ordinary-cold and PCH-cold scenarios.
+3. Identify the optimized MQB-owned phase with evidence; do not attribute MSVC compile time to MQB without proof.
+4. Add deterministic semantic/regression coverage for ambient toolchain adoption, architecture mismatch fallback, untrusted environment fallback, and cache persistence.
+5. The benchmark harness continues to enforce exact compile/link cache counts for all eight ordinary/PCH transitions.
+6. Debug and Release MQB self-builds, complete native test shards, self-host/package validation, C++ layout, and bilingual documentation gates pass.
+7. Document the achieved improvement and any remaining gap to direct Ninja without overstating the result.
+
+## Non-goals
+
+- Weakening dependency, toolchain, or include-freshness checks.
+- Bypassing validation of ambient environment variables (untrusted or corrupted environments must fail open to discovery).
+- Writing any user-global state outside project `.mqb/`.
+- Claiming cross-machine performance guarantees from one workstation.

--- a/docs/20260826-195200-cold-build-overhead/walkthrough.md
+++ b/docs/20260826-195200-cold-build-overhead/walkthrough.md
@@ -1,0 +1,74 @@
+# Walkthrough - Reduce Ordinary and PCH Cold-Build Overhead
+
+## Overview
+
+We addressed Issue #129 by optimizing cold-build toolchain discovery in MQB. MQB now validates an ambient Visual Studio developer environment with one `vswhere.exe` query and adopts it without rerunning `vcvarsall.bat`. This preserves installation trust, freshness, explicit discovery overrides, and cache identity while removing the dominant redundant cold-start cost.
+
+## Problem & Root Cause
+
+In the initial 100-TU x 5 baseline benchmark:
+- `ordinary-cold`: MQB took **2503.64 ms** (vs CMake+Ninja 754.21 ms).
+- `pch-cold`: MQB took **2853.43 ms** (vs CMake+Ninja 904.31 ms).
+
+Instrumentation via MQB `--timings=json` proved that:
+- In `ordinary-cold`, actual compilation of 101 translation units across 32 workers took only **537.48 ms**, and linking took **38.40 ms**.
+- The remaining **~1835 ms** (~76% of total wall time) was spent before compilation, dominated by `MsvcToolchainLocator::discover()` and its `vcvarsall.bat` environment capture. The final after report retains the same compiler/toolchain/harness identity and reduces that unaccounted startup portion without excluding it from MQB wall time.
+
+## Solution
+
+1. **Ambient Visual Studio Adoption (`adopt_ambient_visual_studio_toolchain`)**:
+   - When a project build runs in an active Visual Studio developer environment (such as Developer PowerShell, `VsDevCmd.bat`, VS Code terminal, CI runner, or the benchmark harness), `MsvcToolchainLocator::discover` checks whether the ambient environment is complete and trusted for the requested target architecture before spawning child processes.
+   - Rigorously validates:
+     - Directory existence and version name of `VCToolsInstallDir`.
+     - Exact host and target architecture markers (`VSCMD_ARG_HOST_ARCH` and `VSCMD_ARG_TGT_ARCH`).
+     - The ambient MSVC directory is the latest toolset under the Visual Studio installation returned by `vswhere.exe`.
+     - Required tools (`cl.exe`, `link.exe`, `lib.exe`) verified as existing regular files.
+     - `INCLUDE`, `LIB`, `LIBPATH`, `PATH` presence and cacheability.
+     - All include/lib paths are inside the registered Visual Studio root or OS-derived Windows/Windows Kits roots; ambient variables cannot declare their own trust roots.
+     - Windows SDK and UCRT version freshness against the machine's installed SDKs (`selected_sdk_version_is_latest`).
+   - Explicit `vswhere_path` and `cmd_path` remain authoritative and disable ambient adoption.
+   - If valid, adopts the ambient environment as `MsvcToolchain`, saves the project toolchain cache (`.mqb/cache/toolchain/msvc-vs-x64-x64.mqbcache`), and seals the compiler environment identity.
+   - If ambient environment is missing, invalid, or architecturally mismatched, safely falls back to standard `vswhere` + `vcvarsall.bat` discovery.
+
+2. **Deterministic Unit Test Coverage**:
+   - Added test cases in `cpp/tests/msvc/toolchain/visual_studio_tests.cpp`:
+     - Valid ambient Visual Studio environment performs exactly one `vswhere` validation and no `vcvarsall.bat` capture.
+     - Missing or mismatched host/target markers reject adoption.
+     - Explicit discovery overrides remain authoritative.
+     - Unregistered Visual Studio roots, fake SDK roots, untrusted include roots, and stale toolsets reject adoption.
+     - The emitted project cache is validated and reusable with zero subprocesses.
+
+## Benchmark Results (100-TU x 5 Iterations)
+
+Both runs were executed on the same machine under identical conditions with 100 translation units, 5 iterations, and full cache-transition verification:
+
+| Scenario | Before MQB Median | After MQB Median | After Ninja Median | MQB vs Ninja Delta | MQB Delta % | Improvement vs Before |
+|---|---|---|---|---|---|---|
+| `ordinary-cold` | 2503.64 ms | **686.00 ms** | 792.07 ms | **-106.07 ms** | **-13.39%** | **72.60%** (-1817.64 ms) |
+| `pch-cold` | 2853.43 ms | **1018.69 ms** | 996.74 ms | +21.96 ms | +2.20% | **64.30%** (-1834.73 ms) |
+| `ordinary-single-tu` | 181.73 ms | **97.55 ms** | 124.78 ms | **-27.23 ms** | **-21.82%** | **46.32%** |
+| `ordinary-public-header` | 641.50 ms | **523.74 ms** | 764.73 ms | **-240.99 ms** | **-31.51%** | **18.36%** |
+| `pch-single-tu` | 175.67 ms | **98.98 ms** | 119.42 ms | **-20.44 ms** | **-17.11%** | **43.66%** |
+| `pch-header` | 1092.35 ms | **893.20 ms** | 953.66 ms | **-60.46 ms** | **-6.34%** | **18.23%** |
+| `ordinary-no-op` | 104.35 ms | **26.97 ms** | 34.45 ms | **-7.49 ms** | **-21.72%** | **74.15%** |
+| `pch-no-op` | 108.62 ms | **30.58 ms** | 34.48 ms | **-3.90 ms** | **-11.30%** | **71.84%** |
+
+The full reports contain 80 raw samples each and exact cache-transition counters for all eight scenarios: [`benchmark-before.json`](benchmark-before.json) and [`benchmark-after.json`](benchmark-after.json). The external CMake, Ninja, `cl.exe`, Visual Studio, SDK, machine, and harness identities match. The candidate MQB hash differs by design. The remaining PCH-cold gap is 21.96 ms (2.20%) on this machine; no cross-machine performance guarantee is claimed.
+
+## Verification Gates
+
+1. **C++ Responsibility Layout**:
+   `tests/native/assert_cpp_layout.ps1 -CppRoot cpp` passed.
+2. **MQB Self-Builds**:
+   - Debug: `native-dev/debug/mqb.exe` built successfully.
+   - Release: `native-dev/release/mqb.exe` built successfully.
+3. **Full Native Test Suite**:
+   `develop.ps1` executed all 77 test suites with 77/77 tests passing.
+4. **Bilingual Documentation**:
+   `tests/docs/verify_bilingual_docs.ps1` verified 17 maintained documentation pairs.
+5. **Exact Cache Transition Enforcement**:
+   All 8 scenario transitions across 5 iterations in `benchmark_build_systems.ps1` verified exact compile/link cache counts.
+6. **MSVC Parameter Inventories**:
+   The exact inventory covered 309 compiler, 114 linker, and 21 librarian options (444 total); the semantic inventory covered 44 concrete high-risk variants across 7 risk classes.
+7. **Release Self-Host Closure**:
+   A clean Stage 0 -> Stage 1 -> Stage 2 Release self-host completed successfully. Runtime-only package staging and exact package validation remain enforced by the Native Release PR gate.

--- a/docs/BUILD_SYSTEM_BENCHMARK.md
+++ b/docs/BUILD_SYSTEM_BENCHMARK.md
@@ -86,6 +86,19 @@ The JSON report records:
 
 For `mqb_delta_pct_vs_cmake_ninja`, a negative value means the MQB sample had lower wall-clock time. The ratio is provided for convenience, but neither field should be quoted without the machine/tool/methodology metadata from the same report.
 
+## Issue #129 measured evidence
+
+Issue #129 used this contract for a same-machine 100-TU, 5-iteration, 32-worker before/after study. CMake 4.1.2, Ninja 1.13.1, MSVC 19.51.36248, the selected Visual Studio installation, Windows SDK, operating system, CPU width, and harness policy were unchanged. The MQB binary hash necessarily changed because the candidate contains the optimization.
+
+| Scenario | Before MQB median | After MQB median | After Ninja median | After MQB delta vs Ninja |
+|---|---:|---:|---:|---:|
+| `ordinary-cold` | 2503.64 ms | 686.00 ms | 792.07 ms | -13.39% |
+| `pch-cold` | 2853.43 ms | 1018.69 ms | 996.74 ms | +2.20% |
+
+The selected product change removes redundant `vcvarsall.bat` environment capture when the caller already has a complete developer environment. It still runs one `vswhere.exe` query to bind ambient paths to a registered Visual Studio installation. On this machine, ordinary cold time fell by 1817.64 ms (72.60%) and PCH cold time fell by 1834.73 ms (64.30%). PCH cold remained 21.96 ms slower than direct Ninja; this is retained as an honest remaining gap, not treated as a threshold failure or a cross-machine claim.
+
+The complete raw reports, including all 80 samples per report, MQB phase timings, tool hashes, and exact cache counters, are retained as [`benchmark-before.json`](20260826-195200-cold-build-overhead/benchmark-before.json) and [`benchmark-after.json`](20260826-195200-cold-build-overhead/benchmark-after.json).
+
 ## CI contract
 
 `.github/workflows/build-system-evidence.yml` runs a small correctness-sized fixture on relevant pull requests. It builds the current MQB product from the repository, runs one comparison iteration with a small TU count, and uploads the JSON report.

--- a/docs/BUILD_SYSTEM_BENCHMARK_ZH.md
+++ b/docs/BUILD_SYSTEM_BENCHMARK_ZH.md
@@ -86,6 +86,19 @@ JSON 报告记录：
 
 对于 `mqb_delta_pct_vs_cmake_ninja`，负值表示 MQB 的 wall-clock time 更低。Ratio 只是便于阅读；任何数字都不应脱离同一报告里的机器、工具链和方法信息单独引用。
 
+## Issue #129 实测证据
+
+Issue #129 按本契约完成了同机 100 TU、5 iterations、32 workers 的 before/after 测量。CMake 4.1.2、Ninja 1.13.1、MSVC 19.51.36248、选定的 Visual Studio 安装、Windows SDK、操作系统、CPU width 与 harness policy 均未变化。由于 candidate 包含本次优化，MQB binary hash 必然与 baseline 不同。
+
+| 场景 | Before MQB median | After MQB median | After Ninja median | After MQB 相对 Ninja 差值 |
+|---|---:|---:|---:|---:|
+| `ordinary-cold` | 2503.64 ms | 686.00 ms | 792.07 ms | -13.39% |
+| `pch-cold` | 2853.43 ms | 1018.69 ms | 996.74 ms | +2.20% |
+
+本次 product change 在调用者已有完整 developer environment 时移除重复的 `vcvarsall.bat` 环境捕获，但仍执行一次 `vswhere.exe` 查询，把 ambient path 绑定到已注册的 Visual Studio 安装。在本机上，ordinary cold 减少 1817.64 ms（72.60%），PCH cold 减少 1834.73 ms（64.30%）。PCH cold 仍比 direct Ninja 慢 21.96 ms；这里如实保留这个剩余差距，不把它当成 threshold failure，也不把单机结果外推成跨机器结论。
+
+完整 raw report 保留为 [`benchmark-before.json`](20260826-195200-cold-build-overhead/benchmark-before.json) 与 [`benchmark-after.json`](20260826-195200-cold-build-overhead/benchmark-after.json)，其中包含每份报告的全部 80 个样本、MQB phase timings、tool hashes 与 exact cache counters。
+
 ## CI 契约
 
 `.github/workflows/build-system-evidence.yml` 会在相关 pull request 上运行一个小规模 correctness fixture。它从当前仓库源码构建 MQB，使用较小 TU 数执行一次对比，并上传 JSON 报告。


### PR DESCRIPTION
## Summary

- validate and adopt an already-active Visual Studio developer environment without rerunning `vcvarsall.bat`
- preserve registered-installation, latest-toolset, SDK freshness, architecture-marker, explicit-override, and trusted-root checks
- add deterministic adoption, fallback, cache-reuse, stale-toolset, and untrusted-root coverage
- retain corrected 100-TU x 5 raw before/after reports and update the bilingual methodology

## Performance evidence

Same Windows/MSVC machine, 100 translation units, 5 iterations, 32 jobs:

| Scenario | Before MQB | After MQB | After Ninja | Improvement |
|---|---:|---:|---:|---:|
| ordinary cold | 2503.64 ms | 686.00 ms | 792.07 ms | 72.60% |
| PCH cold | 2853.43 ms | 1018.69 ms | 996.74 ms | 64.30% |

The remaining PCH-cold gap is 21.96 ms (2.20%) on this machine. No cross-machine claim is made. Both reports contain 80 raw samples and all eight exact cache transitions.

## Verification

- Debug and Release MQB self-builds
- focused Visual Studio toolchain tests
- full native Debug suite: 77/77 across 8 shards
- exact MSVC parameter inventory: 444 options
- semantic variant inventory: 44 variants across 7 risk classes
- clean Release Stage 0 -> Stage 1 -> Stage 2 self-host
- C++ layout contract
- bilingual documentation parity: 17 pairs
- 100-TU x 5 benchmark: all 80 samples passed

Closes #129