### PR TITLE
perf: skip stale PCH consumer validation

### DIFF
--- a/cpp/src/orchestration/incremental/MsvcIncrementalCompileCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalCompileCoordinator.cpp
@@ -162,88 +162,92 @@ std::expected<IncrementalCompileResult, IncrementalCompileError>
 MsvcIncrementalCompileCoordinator::run(const IncrementalCompileRequest& request) const {
     IncrementalCompileResult result;
 
-    std::optional<CompileCacheEntry> cached_entry;
-    auto loaded_cache = CompileCacheFile::load(request.cache_file);
-    if (!loaded_cache) {
-        result.warnings.push_back(IncrementalCompileWarning{
-            .code = IncrementalCompileWarningCode::cache_load_failed,
-            .path = request.cache_file,
-            .message = loaded_cache.error().message,
-        });
+    // An upstream coordinator may already own the invalidation decision (for
+    // example, a successfully rebuilt MQB-owned PCH). In that case old cache
+    // state cannot make this unit reusable, so avoid probing it and reseal the
+    // normal compile cache from the compiler result below.
+    if (request.force_rebuild) {
+        result.validation.reasons.push_back(BuildReason::explicit_rebuild);
     } else {
-        cached_entry = std::move(*loaded_cache);
-    }
+        std::optional<CompileCacheEntry> cached_entry;
+        auto loaded_cache = CompileCacheFile::load(request.cache_file);
+        if (!loaded_cache) {
+            result.warnings.push_back(IncrementalCompileWarning{
+                .code = IncrementalCompileWarningCode::cache_load_failed,
+                .path = request.cache_file,
+                .message = loaded_cache.error().message,
+            });
+        } else {
+            cached_entry = std::move(*loaded_cache);
+        }
 
-    auto source_snapshot = detail::snapshot_regular_file(request.unit.source);
-    append_snapshot_warning(
-        result.warnings,
-        request.unit.source,
-        std::move(source_snapshot.failure));
-
-    std::vector<FileSnapshot> output_snapshots;
-    output_snapshots.reserve(request.unit.outputs.size());
-    for (const auto& output : request.unit.outputs) {
-        auto output_snapshot = detail::snapshot_regular_file(output.path);
+        auto source_snapshot = detail::snapshot_regular_file(request.unit.source);
         append_snapshot_warning(
             result.warnings,
-            output.path,
-            std::move(output_snapshot.failure));
-        output_snapshots.push_back(std::move(output_snapshot.snapshot));
-    }
+            request.unit.source,
+            std::move(source_snapshot.failure));
 
-    std::vector<FileSnapshot> dependency_snapshots;
-    if (cached_entry) {
-        dependency_snapshots.reserve(cached_entry->dependencies.size());
-        for (const auto& dependency : cached_entry->dependencies) {
-            auto dependency_snapshot = detail::snapshot_file_or_directory(dependency);
+        std::vector<FileSnapshot> output_snapshots;
+        output_snapshots.reserve(request.unit.outputs.size());
+        for (const auto& output : request.unit.outputs) {
+            auto output_snapshot = detail::snapshot_regular_file(output.path);
             append_snapshot_warning(
                 result.warnings,
-                dependency,
-                std::move(dependency_snapshot.failure));
-            dependency_snapshots.push_back(std::move(dependency_snapshot.snapshot));
+                output.path,
+                std::move(output_snapshot.failure));
+            output_snapshots.push_back(std::move(output_snapshot.snapshot));
         }
-    }
 
-    result.validation = CompileCacheValidator::validate(
-        request.unit,
-        toolchain_.identity,
-        request.options,
-        cached_entry,
-        source_snapshot.snapshot,
-        output_snapshots,
-        dependency_snapshots);
+        std::vector<FileSnapshot> dependency_snapshots;
+        if (cached_entry) {
+            dependency_snapshots.reserve(cached_entry->dependencies.size());
+            for (const auto& dependency : cached_entry->dependencies) {
+                auto dependency_snapshot = detail::snapshot_file_or_directory(dependency);
+                append_snapshot_warning(
+                    result.warnings,
+                    dependency,
+                    std::move(dependency_snapshot.failure));
+                dependency_snapshots.push_back(std::move(dependency_snapshot.snapshot));
+            }
+        }
 
-    const auto current_include_search_roots = msvc::include_search_roots(
-        request.options,
-        toolchain_.environment,
-        request.working_directory);
+        result.validation = CompileCacheValidator::validate(
+            request.unit,
+            toolchain_.identity,
+            request.options,
+            cached_entry,
+            source_snapshot.snapshot,
+            output_snapshots,
+            dependency_snapshots);
 
-    // Cache migration is owned by BuildSignature's compile domain. The v5
-    // domain invalidates pre-closure entries exactly once, including recipes
-    // with zero include roots and zero directory freshness evidence. Do not
-    // infer cache generation from whether those evidence vectors are empty.
+        const auto current_include_search_roots = msvc::include_search_roots(
+            request.options,
+            toolchain_.environment,
+            request.working_directory);
 
-    // CompilerOptions already identify typed/native /I ordering, but vcvars
-    // INCLUDE is ambient toolchain environment rather than argv. Compare the
-    // exact ordered roots persisted by cache v4 so root replacement/removal is
-    // freshness even when all previously resolved headers still exist.
-    if (cached_entry
-        && !same_ordered_paths(
-            cached_entry->include_search_roots,
-            current_include_search_roots)) {
-        add_reason_once(result.validation.reasons, BuildReason::dependency_changed);
-    }
+        // Cache migration is owned by BuildSignature's compile domain. The v5
+        // domain invalidates pre-closure entries exactly once, including recipes
+        // with zero include roots and zero directory freshness evidence. Do not
+        // infer cache generation from whether those evidence vectors are empty.
 
-    if (request.force_rebuild) {
-        add_reason_once(result.validation.reasons, BuildReason::explicit_rebuild);
-    }
+        // CompilerOptions already identify typed/native /I ordering, but vcvars
+        // INCLUDE is ambient toolchain environment rather than argv. Compare the
+        // exact ordered roots persisted by cache v4 so root replacement/removal is
+        // freshness even when all previously resolved headers still exist.
+        if (cached_entry
+            && !same_ordered_paths(
+                cached_entry->include_search_roots,
+                current_include_search_roots)) {
+            add_reason_once(result.validation.reasons, BuildReason::dependency_changed);
+        }
 
-    // The validator is authoritative for incremental freshness. Once it says
-    // this compile is reusable there is no action for the generic planner to
-    // derive, so return directly on the hot no-op path. Cold/miss paths still
-    // flow through BuildPlanner and retain all existing structural validation.
-    if (result.validation.reusable()) {
-        return result;
+        // The validator is authoritative for incremental freshness. Once it says
+        // this compile is reusable there is no action for the generic planner to
+        // derive, so return directly on the hot no-op path. Cold/miss paths still
+        // flow through BuildPlanner and retain all existing structural validation.
+        if (result.validation.reusable()) {
+            return result;
+        }
     }
 
     const std::array<CompilePlanItem, 1> items{

--- a/cpp/src/orchestration/incremental/MsvcIncrementalStaticTargetCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalStaticTargetCoordinator.cpp
@@ -47,7 +47,8 @@ using Clock = std::chrono::steady_clock;
 
 [[nodiscard]] IncrementalCompileRequest compile_request_for(
     const TargetSourceRequest& source,
-    const CompilerOptions& options) {
+    const CompilerOptions& options,
+    const bool force_rebuild) {
     TranslationUnit unit;
     unit.source = source.source;
     unit.kind = TranslationUnitKind::source;
@@ -58,6 +59,7 @@ using Clock = std::chrono::steady_clock;
         .cache_file = source.artifacts.compile_cache,
         .source_dependencies_file = source.artifacts.dependencies,
         .working_directory = source.source.parent_path(),
+        .force_rebuild = force_rebuild,
     };
 }
 
@@ -130,7 +132,10 @@ MsvcIncrementalStaticTargetCoordinator::run(const IncrementalStaticTargetRequest
     const auto scheduled = BoundedWorkScheduler::run(
         request.sources.size(), request.max_parallel_compiles,
         [&](const std::size_t index) {
-            auto compile_request = compile_request_for(request.sources[index], request.compiler_options);
+            auto compile_request = compile_request_for(
+                request.sources[index],
+                request.compiler_options,
+                request.force_downstream_rebuild);
             attempts[index].emplace(compile_coordinator_.run(compile_request));
             return attempts[index]->has_value();
         });

--- a/cpp/src/orchestration/incremental/MsvcIncrementalTargetCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalTargetCoordinator.cpp
@@ -57,7 +57,8 @@ using Clock = std::chrono::steady_clock;
 
 [[nodiscard]] IncrementalCompileRequest compile_request_for(
     const TargetSourceRequest& source,
-    const CompilerOptions& options) {
+    const CompilerOptions& options,
+    const bool force_rebuild) {
     TranslationUnit unit;
     unit.source = source.source;
     unit.kind = TranslationUnitKind::source;
@@ -72,6 +73,7 @@ using Clock = std::chrono::steady_clock;
         .cache_file = source.artifacts.compile_cache,
         .source_dependencies_file = source.artifacts.dependencies,
         .working_directory = source.source.parent_path(),
+        .force_rebuild = force_rebuild,
     };
 }
 
@@ -150,7 +152,10 @@ MsvcIncrementalTargetCoordinator::run(const IncrementalTargetRequest& request) c
         request.max_parallel_compiles,
         [&](const std::size_t index) {
             const auto& source = request.sources[index];
-            auto compile_request = compile_request_for(source, request.compiler_options);
+            auto compile_request = compile_request_for(
+                source,
+                request.compiler_options,
+                request.force_downstream_rebuild);
             attempts[index].emplace(compile_coordinator_.run(compile_request));
             return attempts[index]->has_value();
         });

--- a/cpp/tests/e2e/mqb_pch_e2e_tests.cpp
+++ b/cpp/tests/e2e/mqb_pch_e2e_tests.cpp
@@ -66,6 +66,18 @@ run_process(
         || result.stderr_text.find(text) != std::string::npos;
 }
 
+[[nodiscard]] std::size_t occurrence_count(
+    const std::string_view text,
+    const std::string_view needle) {
+    std::size_t count = 0;
+    for (std::size_t position = 0;
+         (position = text.find(needle, position)) != std::string_view::npos;
+         position += needle.size()) {
+        ++count;
+    }
+    return count;
+}
+
 struct TempTree {
     fs::path root;
     ~TempTree() {
@@ -183,6 +195,29 @@ int main(const int argc, char* argv[]) {
                "PCH rebuild should invalidate all ordinary PCH consumers");
         expect(contains(*header_changed, "[link] pch_app.exe"),
                "PCH creator rebuild should force downstream relink");
+
+        const auto creator_position = header_changed->stdout_text.find("[pch]");
+        const auto main_position = header_changed->stdout_text.find("[compile] main.cpp");
+        const auto worker_position = header_changed->stdout_text.find("[compile] worker.cpp");
+        const auto link_position = header_changed->stdout_text.find("[link] pch_app.exe");
+        expect(creator_position < main_position && creator_position < worker_position,
+               "PCH creator must finish before either consumer compile is reported");
+        expect(main_position < link_position && worker_position < link_position,
+               "every PCH consumer must finish before the target link is reported");
+        expect(occurrence_count(header_changed->stdout_text, "[link] pch_app.exe") == 1,
+               "PCH header change should link exactly once");
+    }
+
+    auto post_header_warm = run_process(runner, mqb_executable, tree.root, build_args());
+    expect(post_header_warm.has_value(), "post-header warm PCH build should launch");
+    if (post_header_warm) {
+        if (post_header_warm->exit_code != 0) dump_failure(*post_header_warm);
+        expect(post_header_warm->exit_code == 0, "post-header warm PCH build should succeed");
+        expect(contains(*post_header_warm, "[up-to-date] pch")
+                   && contains(*post_header_warm, "[up-to-date] main.cpp")
+                   && contains(*post_header_warm, "[up-to-date] worker.cpp")
+                   && contains(*post_header_warm, "[up-to-date] pch_app.exe"),
+               "PCH header rebuild should reseal creator, consumers, and link cache for the next no-op");
     }
 
     std::error_code remove_error;
@@ -561,6 +596,79 @@ int main(const int argc, char* argv[]) {
         expect(static_build->exit_code == 0, "ordinary C++ static target should support first-class PCH");
         expect(fs::is_regular_file(tree.root / ".mqb/bin/pch_static.lib"),
                "static PCH build should produce archive containing the synthetic creator object");
+    }
+
+    rewrite_after_tick(
+        pch_header,
+        "#pragma once\n"
+        "struct PchValue { int value; };\n"
+        "inline constexpr int pch_bias = 12;\n");
+    auto static_header_changed = run_process(
+        runner,
+        mqb_executable,
+        tree.root,
+        {"build", "static_source.cpp", "--env", "vs", "--no-discover", "--debug",
+         "--type", "static", "--pch", "include/pch.hpp", "-o", "pch_static"});
+    expect(static_header_changed.has_value(), "static PCH header rebuild should launch");
+    if (static_header_changed) {
+        if (static_header_changed->exit_code != 0) dump_failure(*static_header_changed);
+        expect(static_header_changed->exit_code == 0, "static PCH header rebuild should succeed");
+        expect(contains(*static_header_changed, "[pch]")
+                   && contains(*static_header_changed, "[compile] static_source.cpp")
+                   && contains(*static_header_changed, "[archive] pch_static.lib"),
+               "static PCH rebuild should compile its consumer and archive exactly once");
+        expect(occurrence_count(static_header_changed->stdout_text, "[archive] pch_static.lib") == 1,
+               "static PCH header rebuild should archive exactly once");
+    }
+
+    write_text(
+        tree.root / "pch_dll.cpp",
+        "extern \"C\" __declspec(dllexport) int pch_dll_value() { return pch_bias; }\n");
+    const std::vector<std::string> dll_build_args{
+        "build", "pch_dll.cpp", "--env", "vs", "--no-discover", "--debug",
+        "--type", "dll", "--pch", "include/pch.hpp", "-o", "pch_dll",
+    };
+    auto dll_build = run_process(runner, mqb_executable, tree.root, dll_build_args);
+    expect(dll_build.has_value(), "DLL PCH build should launch");
+    if (dll_build) {
+        if (dll_build->exit_code != 0) dump_failure(*dll_build);
+        expect(dll_build->exit_code == 0, "ordinary C++ DLL target should support first-class PCH");
+        expect(fs::is_regular_file(tree.root / ".mqb/bin/pch_dll.dll"),
+               "DLL PCH build should produce the requested DLL");
+    }
+
+    rewrite_after_tick(
+        pch_header,
+        "#pragma once\n"
+        "struct PchValue { int value; };\n"
+        "inline constexpr int pch_bias = 13;\n");
+    auto dll_header_changed = run_process(runner, mqb_executable, tree.root, dll_build_args);
+    expect(dll_header_changed.has_value(), "DLL PCH header rebuild should launch");
+    if (dll_header_changed) {
+        if (dll_header_changed->exit_code != 0) dump_failure(*dll_header_changed);
+        expect(dll_header_changed->exit_code == 0, "DLL PCH header rebuild should succeed");
+        expect(contains(*dll_header_changed, "[pch]")
+                   && contains(*dll_header_changed, "[compile] pch_dll.cpp")
+                   && contains(*dll_header_changed, "[link] pch_dll.dll"),
+               "DLL PCH rebuild should compile its consumer and link exactly once");
+        const auto creator_position = dll_header_changed->stdout_text.find("[pch]");
+        const auto consumer_position = dll_header_changed->stdout_text.find("[compile] pch_dll.cpp");
+        const auto link_position = dll_header_changed->stdout_text.find("[link] pch_dll.dll");
+        expect(creator_position < consumer_position && consumer_position < link_position,
+               "DLL PCH creator, consumer, and link should retain the required order");
+        expect(occurrence_count(dll_header_changed->stdout_text, "[link] pch_dll.dll") == 1,
+               "DLL PCH header rebuild should link exactly once");
+    }
+
+    auto dll_warm = run_process(runner, mqb_executable, tree.root, dll_build_args);
+    expect(dll_warm.has_value(), "post-header warm DLL PCH build should launch");
+    if (dll_warm) {
+        if (dll_warm->exit_code != 0) dump_failure(*dll_warm);
+        expect(dll_warm->exit_code == 0, "post-header warm DLL PCH build should succeed");
+        expect(contains(*dll_warm, "[up-to-date] pch")
+                   && contains(*dll_warm, "[up-to-date] pch_dll.cpp")
+                   && contains(*dll_warm, "[up-to-date] pch_dll.dll"),
+               "DLL PCH rebuild should reseal creator, consumer, and link cache for the next no-op");
     }
 
     if (failures != 0) {

--- a/cpp/tests/orchestration/incremental/incremental_compile_coordinator_tests.cpp
+++ b/cpp/tests/orchestration/incremental/incremental_compile_coordinator_tests.cpp
@@ -221,6 +221,7 @@ int main() {
 
     auto forced_request = request;
     forced_request.force_rebuild = true;
+    write_text(cache_file, "not an MQB cache file");
     const auto forced = coordinator.run(forced_request);
     expect(forced.has_value(), "explicit rebuild request should compile successfully");
     if (forced) {
@@ -232,6 +233,10 @@ int main() {
                "explicit rebuild should be visible as explicit_rebuild");
         expect(!has_reason(forced->validation, mqb::BuildReason::compiler_options_changed),
                "explicit rebuild must not masquerade as a compile-signature change");
+        expect(!has_reason(forced->validation, mqb::BuildReason::missing_cache_entry),
+               "authoritative explicit rebuild should not inspect stale cache metadata");
+        expect(forced->warnings.empty(),
+               "authoritative explicit rebuild should bypass stale cache load warnings");
     }
     expect(runner.calls == 2,
            "explicit rebuild should invoke the compiler exactly once");

--- a/cpp/tests/orchestration/incremental/incremental_target_coordinator_tests.cpp
+++ b/cpp/tests/orchestration/incremental/incremental_target_coordinator_tests.cpp
@@ -331,6 +331,46 @@ int main() {
     expect(runner.link_calls() == 1,
            "warm target should not invoke the linker runner");
 
+    auto forced_request = request;
+    forced_request.force_downstream_rebuild = true;
+    const auto forced = target_coordinator.run(forced_request);
+    expect(forced.has_value(), "upstream rebuild should force the complete target successfully");
+    if (forced) {
+        expect(forced->any_compiled,
+               "upstream rebuild should force every target consumer to compile");
+        expect(forced->link.linked,
+               "upstream rebuild should link exactly once after forced consumers finish");
+        expect(std::all_of(
+                   forced->compiles.begin(),
+                   forced->compiles.end(),
+                   [](const mqb::orchestration::TargetCompileResult& compile) {
+                       return std::find(
+                                  compile.result.validation.reasons.begin(),
+                                  compile.result.validation.reasons.end(),
+                                  mqb::BuildReason::explicit_rebuild)
+                           != compile.result.validation.reasons.end();
+                   }),
+               "upstream rebuild should retain explicit evidence on every forced consumer");
+    }
+    expect(runner.compile_calls() == 8,
+           "upstream rebuild should compile all four consumers exactly once more");
+    expect(runner.link_calls() == 2,
+           "upstream rebuild should add exactly one link invocation");
+
+    const auto warm_after_force = target_coordinator.run(request);
+    expect(warm_after_force.has_value(),
+           "ordinary warm target after upstream forcing should succeed");
+    if (warm_after_force) {
+        expect(!warm_after_force->any_compiled,
+               "upstream forcing must not poison the next warm compile check");
+        expect(!warm_after_force->link.linked,
+               "upstream forcing must not poison the next warm link check");
+    }
+    expect(runner.compile_calls() == 8,
+           "post-force warm target should not launch more compiler processes");
+    expect(runner.link_calls() == 2,
+           "post-force warm target should not launch another linker process");
+
     {
         auto invalid = request;
         invalid.max_parallel_compiles = 0;

--- a/docs/20260826-220833-header-rebuild-paths/benchmark-after.json
+++ b/docs/20260826-220833-header-rebuild-paths/benchmark-after.json
@@ -1,0 +1,1969 @@
+{
+  "schema_version": 1,
+  "generated_utc": "2026-08-26T14:23:31.3026542Z",
+  "methodology": {
+    "translation_units": 100,
+    "iterations": 5,
+    "jobs": 32,
+    "target_architecture": "x64",
+    "build_configuration": "release",
+    "cpp_standard_flag": "/std:c++23preview",
+    "same_source_tree_per_iteration": true,
+    "alternating_execution_order": true,
+    "cmake_generator": "Ninja",
+    "cmake_configure_excluded_from_build_timings": true,
+    "ninja_invoked_directly": true,
+    "pch_uses_native_build_system_mechanism": true,
+    "note": "This is machine-specific reproducible evidence, not a universal performance claim."
+  },
+  "environment": {
+    "os_version": "Microsoft Windows NT 10.0.22631.0",
+    "powershell": "7.6.0",
+    "processor_identifier": "Intel64 Family 6 Model 183 Stepping 1, GenuineIntel",
+    "logical_processors": 32,
+    "physical_memory_bytes": 16894455808,
+    "msvc_environment_isolated": true,
+    "vsdevcmd_imported": true,
+    "visual_studio_installation": "C:\\Program Files\\Microsoft Visual Studio\\18\\Community",
+    "cl_path_verified": "C:\\Program Files\\Microsoft Visual Studio\\18\\Community\\VC\\Tools\\MSVC\\14.51.36231\\bin\\HostX64\\x64\\cl.exe",
+    "link_path_verified": "C:\\Program Files\\Microsoft Visual Studio\\18\\Community\\VC\\Tools\\MSVC\\14.51.36231\\bin\\HostX64\\x64\\link.exe",
+    "vctools_version": "14.51.36231",
+    "windows_sdk_version": "10.0.26100.0\\"
+  },
+  "tools": {
+    "mqb": {
+      "path": "X:\\native-dev\\release\\mqb.exe",
+      "sha256": "600617da46959f69365334dd5bf1947ec66aecddb917b862e23a9960b8b177d3",
+      "file_version": "",
+      "product_version": ""
+    },
+    "cmake": {
+      "identity": {
+        "path": "C:\\Program Files\\CMake\\bin\\cmake.exe",
+        "sha256": "bce3d4c9e2bb3eab0c90eae3fe7ea9626d9dc35263194adc9132cf5349d628a3",
+        "file_version": "4.1.2",
+        "product_version": "4.1.2"
+      },
+      "version": "cmake version 4.1.2"
+    },
+    "ninja": {
+      "identity": {
+        "path": "C:\\Users\\Iviesever\\AppData\\Local\\Microsoft\\WinGet\\Packages\\Ninja-build.Ninja_Microsoft.Winget.Source_8wekyb3d8bbwe\\ninja.exe",
+        "sha256": "2df494116decdae84d74c02373119176bbfc4797a6f49a6c709d85d961d6a0d8",
+        "file_version": "",
+        "product_version": ""
+      },
+      "version": "1.13.1"
+    },
+    "cl": {
+      "identity": {
+        "path": "C:\\Program Files\\Microsoft Visual Studio\\18\\Community\\VC\\Tools\\MSVC\\14.51.36231\\bin\\HostX64\\x64\\cl.exe",
+        "sha256": "dc8426b8760d92cf757df3d10b9f0244a95b454ff43194a58161568a0ec70d53",
+        "file_version": "19.51.36248.0",
+        "product_version": "14.51.36248.0"
+      },
+      "version": "用法: cl [ 选项... ] 文件名... [ /link 链接选项... ]"
+    }
+  },
+  "cmake_configure_samples": [
+    {
+      "iteration": 1,
+      "fixture": "ordinary",
+      "elapsed_ms": 1346.177
+    },
+    {
+      "iteration": 1,
+      "fixture": "pch",
+      "elapsed_ms": 797.026
+    },
+    {
+      "iteration": 2,
+      "fixture": "ordinary",
+      "elapsed_ms": 789.071
+    },
+    {
+      "iteration": 2,
+      "fixture": "pch",
+      "elapsed_ms": 803.081
+    },
+    {
+      "iteration": 3,
+      "fixture": "ordinary",
+      "elapsed_ms": 820.822
+    },
+    {
+      "iteration": 3,
+      "fixture": "pch",
+      "elapsed_ms": 706.124
+    },
+    {
+      "iteration": 4,
+      "fixture": "ordinary",
+      "elapsed_ms": 797.753
+    },
+    {
+      "iteration": 4,
+      "fixture": "pch",
+      "elapsed_ms": 854.279
+    },
+    {
+      "iteration": 5,
+      "fixture": "ordinary",
+      "elapsed_ms": 756.948
+    },
+    {
+      "iteration": 5,
+      "fixture": "pch",
+      "elapsed_ms": 815.475
+    }
+  ],
+  "cmake_configure_summary": [
+    {
+      "fixture": "ordinary",
+      "samples": 5,
+      "median_ms": 797.753
+    },
+    {
+      "fixture": "pch",
+      "samples": 5,
+      "median_ms": 803.081
+    }
+  ],
+  "samples": [
+    {
+      "iteration": 1,
+      "scenario": "ordinary-cold",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 750.34,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 1,
+      "scenario": "ordinary-cold",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 663.003,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.545,
+          "compile": 522.469,
+          "link": 45.138,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 655.096
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 101
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 1,
+      "scenario": "ordinary-no-op",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 26.853,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.532,
+          "compile": 8.449,
+          "link": 2.785,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 20.57
+        },
+        "cache": {
+          "compile": {
+            "hits": 101,
+            "misses": 0
+          },
+          "link": {
+            "hits": 1,
+            "misses": 0
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 1,
+      "scenario": "ordinary-no-op",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 21.805,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 1,
+      "scenario": "ordinary-single-tu",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 124.075,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 1,
+      "scenario": "ordinary-single-tu",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 103.148,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.57,
+          "compile": 43.836,
+          "link": 41.931,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 95.103
+        },
+        "cache": {
+          "compile": {
+            "hits": 100,
+            "misses": 1
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 1,
+      "scenario": "ordinary-public-header",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 472.578,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.672,
+          "compile": 414.853,
+          "link": 40.421,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 464.837
+        },
+        "cache": {
+          "compile": {
+            "hits": 1,
+            "misses": 100
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 1,
+      "scenario": "ordinary-public-header",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 717.461,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 1,
+      "scenario": "pch-cold",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 883.763,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 1,
+      "scenario": "pch-cold",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 955.218,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.517,
+          "compile": 817.147,
+          "link": 40.121,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 944.261
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 102
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 1,
+      "scenario": "pch-no-op",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 33.513,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.48,
+          "compile": 12.898,
+          "link": 2.87,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 25.57
+        },
+        "cache": {
+          "compile": {
+            "hits": 102,
+            "misses": 0
+          },
+          "link": {
+            "hits": 1,
+            "misses": 0
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 1,
+      "scenario": "pch-no-op",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 23.133,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 1,
+      "scenario": "pch-single-tu",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 119.875,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 1,
+      "scenario": "pch-single-tu",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 101.847,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.521,
+          "compile": 45.067,
+          "link": 37.964,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 93.996
+        },
+        "cache": {
+          "compile": {
+            "hits": 101,
+            "misses": 1
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 1,
+      "scenario": "pch-header",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 954.957,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.537,
+          "compile": 882.25,
+          "link": 54.409,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 946.454
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 102
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 1,
+      "scenario": "pch-header",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 898.831,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 2,
+      "scenario": "ordinary-cold",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 665.782,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.579,
+          "compile": 525.755,
+          "link": 41.864,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 656.947
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 101
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 2,
+      "scenario": "ordinary-cold",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 714.569,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 2,
+      "scenario": "ordinary-no-op",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 20.005,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 2,
+      "scenario": "ordinary-no-op",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 29.895,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.576,
+          "compile": 10.1,
+          "link": 2.914,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 22.629
+        },
+        "cache": {
+          "compile": {
+            "hits": 101,
+            "misses": 0
+          },
+          "link": {
+            "hits": 1,
+            "misses": 0
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 2,
+      "scenario": "ordinary-single-tu",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 93.43,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.541,
+          "compile": 42.537,
+          "link": 33.766,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 85.785
+        },
+        "cache": {
+          "compile": {
+            "hits": 100,
+            "misses": 1
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 2,
+      "scenario": "ordinary-single-tu",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 126.3,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 2,
+      "scenario": "ordinary-public-header",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 689.622,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 2,
+      "scenario": "ordinary-public-header",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 516.697,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.556,
+          "compile": 450.877,
+          "link": 46.637,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 507.623
+        },
+        "cache": {
+          "compile": {
+            "hits": 1,
+            "misses": 100
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 2,
+      "scenario": "pch-cold",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 976.249,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.568,
+          "compile": 833.519,
+          "link": 46.461,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 968.072
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 102
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 2,
+      "scenario": "pch-cold",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 895.614,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 2,
+      "scenario": "pch-no-op",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 23.55,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 2,
+      "scenario": "pch-no-op",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 31.795,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.498,
+          "compile": 12.862,
+          "link": 2.891,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 25.3
+        },
+        "cache": {
+          "compile": {
+            "hits": 102,
+            "misses": 0
+          },
+          "link": {
+            "hits": 1,
+            "misses": 0
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 2,
+      "scenario": "pch-single-tu",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 99.798,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.503,
+          "compile": 45.221,
+          "link": 37.828,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 92.43
+        },
+        "cache": {
+          "compile": {
+            "hits": 101,
+            "misses": 1
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 2,
+      "scenario": "pch-single-tu",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 117.14,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 2,
+      "scenario": "pch-header",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 867.323,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 2,
+      "scenario": "pch-header",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 872.046,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.633,
+          "compile": 814.696,
+          "link": 40.304,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 864.798
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 102
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 3,
+      "scenario": "ordinary-cold",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 686.356,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 3,
+      "scenario": "ordinary-cold",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 678.432,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.559,
+          "compile": 541.014,
+          "link": 39.453,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 669.77
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 101
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 3,
+      "scenario": "ordinary-no-op",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 27.042,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.548,
+          "compile": 8.184,
+          "link": 2.879,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 20.904
+        },
+        "cache": {
+          "compile": {
+            "hits": 101,
+            "misses": 0
+          },
+          "link": {
+            "hits": 1,
+            "misses": 0
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 3,
+      "scenario": "ordinary-no-op",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 24.079,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 3,
+      "scenario": "ordinary-single-tu",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 119.996,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 3,
+      "scenario": "ordinary-single-tu",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 97.293,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.617,
+          "compile": 41.079,
+          "link": 39.452,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 90.694
+        },
+        "cache": {
+          "compile": {
+            "hits": 100,
+            "misses": 1
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 3,
+      "scenario": "ordinary-public-header",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 454.001,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.602,
+          "compile": 396.68,
+          "link": 39.996,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 446.394
+        },
+        "cache": {
+          "compile": {
+            "hits": 1,
+            "misses": 100
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 3,
+      "scenario": "ordinary-public-header",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 697.129,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 3,
+      "scenario": "pch-cold",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 891.406,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 3,
+      "scenario": "pch-cold",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 974.771,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.527,
+          "compile": 838.919,
+          "link": 43.877,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 967.436
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 102
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 3,
+      "scenario": "pch-no-op",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 33.859,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.491,
+          "compile": 14.167,
+          "link": 2.699,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 26.435
+        },
+        "cache": {
+          "compile": {
+            "hits": 102,
+            "misses": 0
+          },
+          "link": {
+            "hits": 1,
+            "misses": 0
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 3,
+      "scenario": "pch-no-op",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 25.846,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 3,
+      "scenario": "pch-single-tu",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 120.269,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 3,
+      "scenario": "pch-single-tu",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 104.799,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.507,
+          "compile": 43.455,
+          "link": 43.929,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 96.898
+        },
+        "cache": {
+          "compile": {
+            "hits": 101,
+            "misses": 1
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 3,
+      "scenario": "pch-header",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 783.394,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.52,
+          "compile": 724.628,
+          "link": 42.961,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 777.317
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 102
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 3,
+      "scenario": "pch-header",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 933.524,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 4,
+      "scenario": "ordinary-cold",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 672.608,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.599,
+          "compile": 532.015,
+          "link": 43.473,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 663.729
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 101
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 4,
+      "scenario": "ordinary-cold",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 732.599,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 4,
+      "scenario": "ordinary-no-op",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 19.348,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 4,
+      "scenario": "ordinary-no-op",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 28.74,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.535,
+          "compile": 9.797,
+          "link": 2.785,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 21.986
+        },
+        "cache": {
+          "compile": {
+            "hits": 101,
+            "misses": 0
+          },
+          "link": {
+            "hits": 1,
+            "misses": 0
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 4,
+      "scenario": "ordinary-single-tu",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 97.468,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.568,
+          "compile": 45.976,
+          "link": 36.239,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 91.703
+        },
+        "cache": {
+          "compile": {
+            "hits": 100,
+            "misses": 1
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 4,
+      "scenario": "ordinary-single-tu",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 124.54,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 4,
+      "scenario": "ordinary-public-header",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 702.649,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 4,
+      "scenario": "ordinary-public-header",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 523.317,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.579,
+          "compile": 466.003,
+          "link": 40.781,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 516.171
+        },
+        "cache": {
+          "compile": {
+            "hits": 1,
+            "misses": 100
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 4,
+      "scenario": "pch-cold",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 991.124,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.502,
+          "compile": 850.648,
+          "link": 42.764,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 983.73
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 102
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 4,
+      "scenario": "pch-cold",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 858.949,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 4,
+      "scenario": "pch-no-op",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 18.559,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 4,
+      "scenario": "pch-no-op",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 32.08,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.506,
+          "compile": 13.441,
+          "link": 3.105,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 25.68
+        },
+        "cache": {
+          "compile": {
+            "hits": 102,
+            "misses": 0
+          },
+          "link": {
+            "hits": 1,
+            "misses": 0
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 4,
+      "scenario": "pch-single-tu",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 97.1,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.507,
+          "compile": 45.144,
+          "link": 35.762,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 90.126
+        },
+        "cache": {
+          "compile": {
+            "hits": 101,
+            "misses": 1
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 4,
+      "scenario": "pch-single-tu",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 115.439,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 4,
+      "scenario": "pch-header",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 891.521,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 4,
+      "scenario": "pch-header",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 875.383,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.482,
+          "compile": 812.467,
+          "link": 47.913,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 869.725
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 102
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 5,
+      "scenario": "ordinary-cold",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 732.354,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 5,
+      "scenario": "ordinary-cold",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 747.791,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.568,
+          "compile": 589.65,
+          "link": 46.725,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 739.263
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 101
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 5,
+      "scenario": "ordinary-no-op",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 30.846,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.585,
+          "compile": 9.191,
+          "link": 3.467,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 23.91
+        },
+        "cache": {
+          "compile": {
+            "hits": 101,
+            "misses": 0
+          },
+          "link": {
+            "hits": 1,
+            "misses": 0
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 5,
+      "scenario": "ordinary-no-op",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 34.096,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 5,
+      "scenario": "ordinary-single-tu",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 151.207,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 5,
+      "scenario": "ordinary-single-tu",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 132.198,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.55,
+          "compile": 71.708,
+          "link": 42.645,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 124.131
+        },
+        "cache": {
+          "compile": {
+            "hits": 100,
+            "misses": 1
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 5,
+      "scenario": "ordinary-public-header",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 526.737,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.558,
+          "compile": 462.166,
+          "link": 47.697,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 519.713
+        },
+        "cache": {
+          "compile": {
+            "hits": 1,
+            "misses": 100
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 5,
+      "scenario": "ordinary-public-header",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 689.15,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 5,
+      "scenario": "pch-cold",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 863.24,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 5,
+      "scenario": "pch-cold",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 976.612,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.686,
+          "compile": 843.748,
+          "link": 40.793,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 968.904
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 102
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 5,
+      "scenario": "pch-no-op",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 32.382,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.498,
+          "compile": 12.475,
+          "link": 2.853,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 24.446
+        },
+        "cache": {
+          "compile": {
+            "hits": 102,
+            "misses": 0
+          },
+          "link": {
+            "hits": 1,
+            "misses": 0
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 5,
+      "scenario": "pch-no-op",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 18.402,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 5,
+      "scenario": "pch-single-tu",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 119.719,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 5,
+      "scenario": "pch-single-tu",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 104.522,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.502,
+          "compile": 44.546,
+          "link": 42.256,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 96.026
+        },
+        "cache": {
+          "compile": {
+            "hits": 101,
+            "misses": 1
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 5,
+      "scenario": "pch-header",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 907.24,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.562,
+          "compile": 847.65,
+          "link": 43.395,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 900.721
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 102
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 5,
+      "scenario": "pch-header",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 895.905,
+      "mqb_timing": null
+    }
+  ],
+  "comparison": [
+    {
+      "scenario": "ordinary-cold",
+      "samples_per_system": 5,
+      "mqb_median_ms": 672.608,
+      "cmake_ninja_median_ms": 732.354,
+      "mqb_delta_ms_vs_cmake_ninja": -59.746,
+      "mqb_delta_pct_vs_cmake_ninja": -8.16,
+      "cmake_ninja_over_mqb_ratio": 1.089
+    },
+    {
+      "scenario": "ordinary-no-op",
+      "samples_per_system": 5,
+      "mqb_median_ms": 28.74,
+      "cmake_ninja_median_ms": 21.805,
+      "mqb_delta_ms_vs_cmake_ninja": 6.935,
+      "mqb_delta_pct_vs_cmake_ninja": 31.8,
+      "cmake_ninja_over_mqb_ratio": 0.759
+    },
+    {
+      "scenario": "ordinary-single-tu",
+      "samples_per_system": 5,
+      "mqb_median_ms": 97.468,
+      "cmake_ninja_median_ms": 124.54,
+      "mqb_delta_ms_vs_cmake_ninja": -27.072,
+      "mqb_delta_pct_vs_cmake_ninja": -21.74,
+      "cmake_ninja_over_mqb_ratio": 1.278
+    },
+    {
+      "scenario": "ordinary-public-header",
+      "samples_per_system": 5,
+      "mqb_median_ms": 516.697,
+      "cmake_ninja_median_ms": 697.129,
+      "mqb_delta_ms_vs_cmake_ninja": -180.432,
+      "mqb_delta_pct_vs_cmake_ninja": -25.88,
+      "cmake_ninja_over_mqb_ratio": 1.349
+    },
+    {
+      "scenario": "pch-cold",
+      "samples_per_system": 5,
+      "mqb_median_ms": 976.249,
+      "cmake_ninja_median_ms": 883.763,
+      "mqb_delta_ms_vs_cmake_ninja": 92.486,
+      "mqb_delta_pct_vs_cmake_ninja": 10.47,
+      "cmake_ninja_over_mqb_ratio": 0.905
+    },
+    {
+      "scenario": "pch-no-op",
+      "samples_per_system": 5,
+      "mqb_median_ms": 32.382,
+      "cmake_ninja_median_ms": 23.133,
+      "mqb_delta_ms_vs_cmake_ninja": 9.249,
+      "mqb_delta_pct_vs_cmake_ninja": 39.98,
+      "cmake_ninja_over_mqb_ratio": 0.714
+    },
+    {
+      "scenario": "pch-single-tu",
+      "samples_per_system": 5,
+      "mqb_median_ms": 101.847,
+      "cmake_ninja_median_ms": 119.719,
+      "mqb_delta_ms_vs_cmake_ninja": -17.872,
+      "mqb_delta_pct_vs_cmake_ninja": -14.93,
+      "cmake_ninja_over_mqb_ratio": 1.175
+    },
+    {
+      "scenario": "pch-header",
+      "samples_per_system": 5,
+      "mqb_median_ms": 875.383,
+      "cmake_ninja_median_ms": 895.905,
+      "mqb_delta_ms_vs_cmake_ninja": -20.522,
+      "mqb_delta_pct_vs_cmake_ninja": -2.29,
+      "cmake_ninja_over_mqb_ratio": 1.023
+    }
+  ],
+  "retained_worktree": null
+}

--- a/docs/20260826-220833-header-rebuild-paths/benchmark-before.json
+++ b/docs/20260826-220833-header-rebuild-paths/benchmark-before.json
@@ -1,0 +1,1969 @@
+{
+  "schema_version": 1,
+  "generated_utc": "2026-08-26T14:11:26.7693392Z",
+  "methodology": {
+    "translation_units": 100,
+    "iterations": 5,
+    "jobs": 32,
+    "target_architecture": "x64",
+    "build_configuration": "release",
+    "cpp_standard_flag": "/std:c++23preview",
+    "same_source_tree_per_iteration": true,
+    "alternating_execution_order": true,
+    "cmake_generator": "Ninja",
+    "cmake_configure_excluded_from_build_timings": true,
+    "ninja_invoked_directly": true,
+    "pch_uses_native_build_system_mechanism": true,
+    "note": "This is machine-specific reproducible evidence, not a universal performance claim."
+  },
+  "environment": {
+    "os_version": "Microsoft Windows NT 10.0.22631.0",
+    "powershell": "7.6.0",
+    "processor_identifier": "Intel64 Family 6 Model 183 Stepping 1, GenuineIntel",
+    "logical_processors": 32,
+    "physical_memory_bytes": 16894455808,
+    "msvc_environment_isolated": true,
+    "vsdevcmd_imported": true,
+    "visual_studio_installation": "C:\\Program Files\\Microsoft Visual Studio\\18\\Community",
+    "cl_path_verified": "C:\\Program Files\\Microsoft Visual Studio\\18\\Community\\VC\\Tools\\MSVC\\14.51.36231\\bin\\HostX64\\x64\\cl.exe",
+    "link_path_verified": "C:\\Program Files\\Microsoft Visual Studio\\18\\Community\\VC\\Tools\\MSVC\\14.51.36231\\bin\\HostX64\\x64\\link.exe",
+    "vctools_version": "14.51.36231",
+    "windows_sdk_version": "10.0.26100.0\\"
+  },
+  "tools": {
+    "mqb": {
+      "path": "X:\\native-dev\\release\\mqb.exe",
+      "sha256": "01a8fa8367c4e0144605eec7ea0cfbdcea1b4fc42d54a422302011be85ac1349",
+      "file_version": "",
+      "product_version": ""
+    },
+    "cmake": {
+      "identity": {
+        "path": "C:\\Program Files\\CMake\\bin\\cmake.exe",
+        "sha256": "bce3d4c9e2bb3eab0c90eae3fe7ea9626d9dc35263194adc9132cf5349d628a3",
+        "file_version": "4.1.2",
+        "product_version": "4.1.2"
+      },
+      "version": "cmake version 4.1.2"
+    },
+    "ninja": {
+      "identity": {
+        "path": "C:\\Users\\Iviesever\\AppData\\Local\\Microsoft\\WinGet\\Packages\\Ninja-build.Ninja_Microsoft.Winget.Source_8wekyb3d8bbwe\\ninja.exe",
+        "sha256": "2df494116decdae84d74c02373119176bbfc4797a6f49a6c709d85d961d6a0d8",
+        "file_version": "",
+        "product_version": ""
+      },
+      "version": "1.13.1"
+    },
+    "cl": {
+      "identity": {
+        "path": "C:\\Program Files\\Microsoft Visual Studio\\18\\Community\\VC\\Tools\\MSVC\\14.51.36231\\bin\\HostX64\\x64\\cl.exe",
+        "sha256": "dc8426b8760d92cf757df3d10b9f0244a95b454ff43194a58161568a0ec70d53",
+        "file_version": "19.51.36248.0",
+        "product_version": "14.51.36248.0"
+      },
+      "version": "用法: cl [ 选项... ] 文件名... [ /link 链接选项... ]"
+    }
+  },
+  "cmake_configure_samples": [
+    {
+      "iteration": 1,
+      "fixture": "ordinary",
+      "elapsed_ms": 1339.789
+    },
+    {
+      "iteration": 1,
+      "fixture": "pch",
+      "elapsed_ms": 710.232
+    },
+    {
+      "iteration": 2,
+      "fixture": "ordinary",
+      "elapsed_ms": 714.107
+    },
+    {
+      "iteration": 2,
+      "fixture": "pch",
+      "elapsed_ms": 676.417
+    },
+    {
+      "iteration": 3,
+      "fixture": "ordinary",
+      "elapsed_ms": 869.377
+    },
+    {
+      "iteration": 3,
+      "fixture": "pch",
+      "elapsed_ms": 847.808
+    },
+    {
+      "iteration": 4,
+      "fixture": "ordinary",
+      "elapsed_ms": 836.647
+    },
+    {
+      "iteration": 4,
+      "fixture": "pch",
+      "elapsed_ms": 873.624
+    },
+    {
+      "iteration": 5,
+      "fixture": "ordinary",
+      "elapsed_ms": 753.618
+    },
+    {
+      "iteration": 5,
+      "fixture": "pch",
+      "elapsed_ms": 904.65
+    }
+  ],
+  "cmake_configure_summary": [
+    {
+      "fixture": "ordinary",
+      "samples": 5,
+      "median_ms": 836.647
+    },
+    {
+      "fixture": "pch",
+      "samples": 5,
+      "median_ms": 847.808
+    }
+  ],
+  "samples": [
+    {
+      "iteration": 1,
+      "scenario": "ordinary-cold",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 759.199,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 1,
+      "scenario": "ordinary-cold",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 691.63,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.555,
+          "compile": 549.678,
+          "link": 43.633,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 683.235
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 101
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 1,
+      "scenario": "ordinary-no-op",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 31.795,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.554,
+          "compile": 11.79,
+          "link": 3.109,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 25.078
+        },
+        "cache": {
+          "compile": {
+            "hits": 101,
+            "misses": 0
+          },
+          "link": {
+            "hits": 1,
+            "misses": 0
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 1,
+      "scenario": "ordinary-no-op",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 28.144,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 1,
+      "scenario": "ordinary-single-tu",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 117.887,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 1,
+      "scenario": "ordinary-single-tu",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 105.109,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.557,
+          "compile": 46.01,
+          "link": 40.155,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 96.459
+        },
+        "cache": {
+          "compile": {
+            "hits": 100,
+            "misses": 1
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 1,
+      "scenario": "ordinary-public-header",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 572.155,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.608,
+          "compile": 504.86,
+          "link": 46.958,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 562.5
+        },
+        "cache": {
+          "compile": {
+            "hits": 1,
+            "misses": 100
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 1,
+      "scenario": "ordinary-public-header",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 684.738,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 1,
+      "scenario": "pch-cold",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 914.49,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 1,
+      "scenario": "pch-cold",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 938.123,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.535,
+          "compile": 804.758,
+          "link": 38.782,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 928.335
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 102
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 1,
+      "scenario": "pch-no-op",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 34.381,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.477,
+          "compile": 15.586,
+          "link": 2.917,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 27.967
+        },
+        "cache": {
+          "compile": {
+            "hits": 102,
+            "misses": 0
+          },
+          "link": {
+            "hits": 1,
+            "misses": 0
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 1,
+      "scenario": "pch-no-op",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 23.017,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 1,
+      "scenario": "pch-single-tu",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 116.414,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 1,
+      "scenario": "pch-single-tu",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 113.569,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.594,
+          "compile": 46.147,
+          "link": 48.007,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 104.666
+        },
+        "cache": {
+          "compile": {
+            "hits": 101,
+            "misses": 1
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 1,
+      "scenario": "pch-header",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 941.264,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.519,
+          "compile": 876.652,
+          "link": 47.225,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 934.548
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 102
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 1,
+      "scenario": "pch-header",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 867.437,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 2,
+      "scenario": "ordinary-cold",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 683.146,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.729,
+          "compile": 534.72,
+          "link": 44.714,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 673.988
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 101
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 2,
+      "scenario": "ordinary-cold",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 681.486,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 2,
+      "scenario": "ordinary-no-op",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 28.199,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 2,
+      "scenario": "ordinary-no-op",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 28.866,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.537,
+          "compile": 10.303,
+          "link": 2.671,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 22.116
+        },
+        "cache": {
+          "compile": {
+            "hits": 101,
+            "misses": 0
+          },
+          "link": {
+            "hits": 1,
+            "misses": 0
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 2,
+      "scenario": "ordinary-single-tu",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 91.312,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.586,
+          "compile": 41.849,
+          "link": 33.301,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 84.454
+        },
+        "cache": {
+          "compile": {
+            "hits": 100,
+            "misses": 1
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 2,
+      "scenario": "ordinary-single-tu",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 107.357,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 2,
+      "scenario": "ordinary-public-header",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 635.911,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 2,
+      "scenario": "ordinary-public-header",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 526.988,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.545,
+          "compile": 474.42,
+          "link": 36.271,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 520.188
+        },
+        "cache": {
+          "compile": {
+            "hits": 1,
+            "misses": 100
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 2,
+      "scenario": "pch-cold",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 933.154,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.527,
+          "compile": 801.147,
+          "link": 41.169,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 926.76
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 102
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 2,
+      "scenario": "pch-cold",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 839.516,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 2,
+      "scenario": "pch-no-op",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 20.912,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 2,
+      "scenario": "pch-no-op",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 30.844,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.486,
+          "compile": 11.867,
+          "link": 2.698,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 23.882
+        },
+        "cache": {
+          "compile": {
+            "hits": 102,
+            "misses": 0
+          },
+          "link": {
+            "hits": 1,
+            "misses": 0
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 2,
+      "scenario": "pch-single-tu",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 90.695,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.489,
+          "compile": 39.171,
+          "link": 34.897,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 83.235
+        },
+        "cache": {
+          "compile": {
+            "hits": 101,
+            "misses": 1
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 2,
+      "scenario": "pch-single-tu",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 106.076,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 2,
+      "scenario": "pch-header",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 825.737,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 2,
+      "scenario": "pch-header",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 874.438,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.524,
+          "compile": 810.551,
+          "link": 45.822,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 866.587
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 102
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 3,
+      "scenario": "ordinary-cold",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 823.882,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 3,
+      "scenario": "ordinary-cold",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 714.001,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.596,
+          "compile": 564.349,
+          "link": 42.757,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 705.453
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 101
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 3,
+      "scenario": "ordinary-no-op",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 28.472,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.666,
+          "compile": 7.832,
+          "link": 2.838,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 21.032
+        },
+        "cache": {
+          "compile": {
+            "hits": 101,
+            "misses": 0
+          },
+          "link": {
+            "hits": 1,
+            "misses": 0
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 3,
+      "scenario": "ordinary-no-op",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 42.89,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 3,
+      "scenario": "ordinary-single-tu",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 122.817,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 3,
+      "scenario": "ordinary-single-tu",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 104.395,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.543,
+          "compile": 43.483,
+          "link": 43.243,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 96.33
+        },
+        "cache": {
+          "compile": {
+            "hits": 100,
+            "misses": 1
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 3,
+      "scenario": "ordinary-public-header",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 577.764,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.596,
+          "compile": 495.297,
+          "link": 62.508,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 568.77
+        },
+        "cache": {
+          "compile": {
+            "hits": 1,
+            "misses": 100
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 3,
+      "scenario": "ordinary-public-header",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 843.635,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 3,
+      "scenario": "pch-cold",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 959.016,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 3,
+      "scenario": "pch-cold",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 989.937,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.529,
+          "compile": 850.376,
+          "link": 39.011,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 978.827
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 102
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 3,
+      "scenario": "pch-no-op",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 32.092,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.5,
+          "compile": 11.71,
+          "link": 2.907,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 24.519
+        },
+        "cache": {
+          "compile": {
+            "hits": 102,
+            "misses": 0
+          },
+          "link": {
+            "hits": 1,
+            "misses": 0
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 3,
+      "scenario": "pch-no-op",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 38.37,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 3,
+      "scenario": "pch-single-tu",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 117.738,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 3,
+      "scenario": "pch-single-tu",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 98.466,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.535,
+          "compile": 42.31,
+          "link": 39.494,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 92.097
+        },
+        "cache": {
+          "compile": {
+            "hits": 101,
+            "misses": 1
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 3,
+      "scenario": "pch-header",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 937.686,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.553,
+          "compile": 869.945,
+          "link": 50.193,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 929.649
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 102
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 3,
+      "scenario": "pch-header",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 865.562,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 4,
+      "scenario": "ordinary-cold",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 658.759,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.603,
+          "compile": 519.962,
+          "link": 43.365,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 650.96
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 101
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 4,
+      "scenario": "ordinary-cold",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 772.674,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 4,
+      "scenario": "ordinary-no-op",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 28.493,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 4,
+      "scenario": "ordinary-no-op",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 33.959,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.596,
+          "compile": 10.778,
+          "link": 3.268,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 24.918
+        },
+        "cache": {
+          "compile": {
+            "hits": 101,
+            "misses": 0
+          },
+          "link": {
+            "hits": 1,
+            "misses": 0
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 4,
+      "scenario": "ordinary-single-tu",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 111.89,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.55,
+          "compile": 48.144,
+          "link": 44.894,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 102.89
+        },
+        "cache": {
+          "compile": {
+            "hits": 100,
+            "misses": 1
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 4,
+      "scenario": "ordinary-single-tu",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 136.238,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 4,
+      "scenario": "ordinary-public-header",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 927.851,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 4,
+      "scenario": "ordinary-public-header",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 560.496,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.572,
+          "compile": 497.126,
+          "link": 40.971,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 548.583
+        },
+        "cache": {
+          "compile": {
+            "hits": 1,
+            "misses": 100
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 4,
+      "scenario": "pch-cold",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 1006.566,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.509,
+          "compile": 866.382,
+          "link": 41.693,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 997.671
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 102
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 4,
+      "scenario": "pch-cold",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 980.929,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 4,
+      "scenario": "pch-no-op",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 34.123,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 4,
+      "scenario": "pch-no-op",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 33.417,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.505,
+          "compile": 13.127,
+          "link": 2.886,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 25.749
+        },
+        "cache": {
+          "compile": {
+            "hits": 102,
+            "misses": 0
+          },
+          "link": {
+            "hits": 1,
+            "misses": 0
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 4,
+      "scenario": "pch-single-tu",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 102.423,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.485,
+          "compile": 47.293,
+          "link": 37.893,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 95.061
+        },
+        "cache": {
+          "compile": {
+            "hits": 101,
+            "misses": 1
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 4,
+      "scenario": "pch-single-tu",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 140.792,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 4,
+      "scenario": "pch-header",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 865.807,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 4,
+      "scenario": "pch-header",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 874.505,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.51,
+          "compile": 815.975,
+          "link": 40.303,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 866.01
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 102
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 5,
+      "scenario": "ordinary-cold",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 766.374,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 5,
+      "scenario": "ordinary-cold",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 678.254,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.587,
+          "compile": 537.899,
+          "link": 40.292,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 669.126
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 101
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 5,
+      "scenario": "ordinary-no-op",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 40.168,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.711,
+          "compile": 8.028,
+          "link": 3.854,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 28.946
+        },
+        "cache": {
+          "compile": {
+            "hits": 101,
+            "misses": 0
+          },
+          "link": {
+            "hits": 1,
+            "misses": 0
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 5,
+      "scenario": "ordinary-no-op",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 23.006,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 5,
+      "scenario": "ordinary-single-tu",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 119.82,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 5,
+      "scenario": "ordinary-single-tu",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 96.584,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.563,
+          "compile": 43.699,
+          "link": 35.299,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 89.011
+        },
+        "cache": {
+          "compile": {
+            "hits": 100,
+            "misses": 1
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 5,
+      "scenario": "ordinary-public-header",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 496.691,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.568,
+          "compile": 431.7,
+          "link": 47.017,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 488.479
+        },
+        "cache": {
+          "compile": {
+            "hits": 1,
+            "misses": 100
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 5,
+      "scenario": "ordinary-public-header",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 755.961,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 5,
+      "scenario": "pch-cold",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 1042.966,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 5,
+      "scenario": "pch-cold",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 1155.567,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.534,
+          "compile": 989.9,
+          "link": 63.382,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 1146.052
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 102
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 5,
+      "scenario": "pch-no-op",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 38.36,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.539,
+          "compile": 14.533,
+          "link": 3.317,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 28.705
+        },
+        "cache": {
+          "compile": {
+            "hits": 102,
+            "misses": 0
+          },
+          "link": {
+            "hits": 1,
+            "misses": 0
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 5,
+      "scenario": "pch-no-op",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 44.761,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 5,
+      "scenario": "pch-single-tu",
+      "system": "cmake+ninja",
+      "execution_order": 1,
+      "elapsed_ms": 131.574,
+      "mqb_timing": null
+    },
+    {
+      "iteration": 5,
+      "scenario": "pch-single-tu",
+      "system": "mqb",
+      "execution_order": 2,
+      "elapsed_ms": 100.333,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.478,
+          "compile": 43.852,
+          "link": 39.733,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 92.888
+        },
+        "cache": {
+          "compile": {
+            "hits": 101,
+            "misses": 1
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 5,
+      "scenario": "pch-header",
+      "system": "mqb",
+      "execution_order": 1,
+      "elapsed_ms": 859.886,
+      "mqb_timing": {
+        "type": "mqb.timings",
+        "schema_version": 1,
+        "unit": "ms",
+        "phases": {
+          "discovery": 0.0,
+          "dependency_scan": 0.0,
+          "compile_queue": 0.551,
+          "compile": 795.485,
+          "link": 46.358,
+          "archive": 0.0,
+          "run_startup": 0.0,
+          "total": 851.618
+        },
+        "cache": {
+          "compile": {
+            "hits": 0,
+            "misses": 102
+          },
+          "link": {
+            "hits": 0,
+            "misses": 1
+          },
+          "archive": {
+            "hits": 0,
+            "misses": 0
+          }
+        }
+      }
+    },
+    {
+      "iteration": 5,
+      "scenario": "pch-header",
+      "system": "cmake+ninja",
+      "execution_order": 2,
+      "elapsed_ms": 1045.899,
+      "mqb_timing": null
+    }
+  ],
+  "comparison": [
+    {
+      "scenario": "ordinary-cold",
+      "samples_per_system": 5,
+      "mqb_median_ms": 683.146,
+      "cmake_ninja_median_ms": 766.374,
+      "mqb_delta_ms_vs_cmake_ninja": -83.228,
+      "mqb_delta_pct_vs_cmake_ninja": -10.86,
+      "cmake_ninja_over_mqb_ratio": 1.122
+    },
+    {
+      "scenario": "ordinary-no-op",
+      "samples_per_system": 5,
+      "mqb_median_ms": 31.795,
+      "cmake_ninja_median_ms": 28.199,
+      "mqb_delta_ms_vs_cmake_ninja": 3.596,
+      "mqb_delta_pct_vs_cmake_ninja": 12.75,
+      "cmake_ninja_over_mqb_ratio": 0.887
+    },
+    {
+      "scenario": "ordinary-single-tu",
+      "samples_per_system": 5,
+      "mqb_median_ms": 104.395,
+      "cmake_ninja_median_ms": 119.82,
+      "mqb_delta_ms_vs_cmake_ninja": -15.425,
+      "mqb_delta_pct_vs_cmake_ninja": -12.87,
+      "cmake_ninja_over_mqb_ratio": 1.148
+    },
+    {
+      "scenario": "ordinary-public-header",
+      "samples_per_system": 5,
+      "mqb_median_ms": 560.496,
+      "cmake_ninja_median_ms": 755.961,
+      "mqb_delta_ms_vs_cmake_ninja": -195.465,
+      "mqb_delta_pct_vs_cmake_ninja": -25.86,
+      "cmake_ninja_over_mqb_ratio": 1.349
+    },
+    {
+      "scenario": "pch-cold",
+      "samples_per_system": 5,
+      "mqb_median_ms": 989.937,
+      "cmake_ninja_median_ms": 959.016,
+      "mqb_delta_ms_vs_cmake_ninja": 30.921,
+      "mqb_delta_pct_vs_cmake_ninja": 3.22,
+      "cmake_ninja_over_mqb_ratio": 0.969
+    },
+    {
+      "scenario": "pch-no-op",
+      "samples_per_system": 5,
+      "mqb_median_ms": 33.417,
+      "cmake_ninja_median_ms": 34.123,
+      "mqb_delta_ms_vs_cmake_ninja": -0.706,
+      "mqb_delta_pct_vs_cmake_ninja": -2.07,
+      "cmake_ninja_over_mqb_ratio": 1.021
+    },
+    {
+      "scenario": "pch-single-tu",
+      "samples_per_system": 5,
+      "mqb_median_ms": 100.333,
+      "cmake_ninja_median_ms": 117.738,
+      "mqb_delta_ms_vs_cmake_ninja": -17.405,
+      "mqb_delta_pct_vs_cmake_ninja": -14.78,
+      "cmake_ninja_over_mqb_ratio": 1.173
+    },
+    {
+      "scenario": "pch-header",
+      "samples_per_system": 5,
+      "mqb_median_ms": 874.505,
+      "cmake_ninja_median_ms": 865.807,
+      "mqb_delta_ms_vs_cmake_ninja": 8.698,
+      "mqb_delta_pct_vs_cmake_ninja": 1.0,
+      "cmake_ninja_over_mqb_ratio": 0.99
+    }
+  ],
+  "retained_worktree": null
+}

--- a/docs/20260826-220833-header-rebuild-paths/implementation_plan.md
+++ b/docs/20260826-220833-header-rebuild-paths/implementation_plan.md
@@ -1,0 +1,62 @@
+# Implementation plan - Header rebuild paths
+
+## Decision
+
+Reuse the existing PCH downstream force signal. When the first-class PCH creator actually recompiles successfully, `Application` passes that fact through `force_downstream_rebuild` into the ordinary/static target request. The target coordinator marks each consumer compile request as forced. The compile coordinator recognizes this authoritative upstream invalidation before loading or validating the old cache and executes the normal compiler/cache-write path with `explicit_rebuild` evidence.
+
+This preserves the required barrier:
+
+`PCH creator compile -> verify owned .pch -> parallel consumer compiles -> link/archive`
+
+## Alternatives considered
+
+1. **Recommended: PCH downstream forced-rebuild fast path.** Smallest semantic surface and directly supported by creator success evidence. It eliminates work that cannot change the decision.
+2. **Invocation-scoped shared file-snapshot memoization.** Could help ordinary and PCH dependency validation, but adds synchronization and risks hiding filesystem changes that occur during an invocation.
+3. **Batch inverse-dependency planning.** Could classify shared-header invalidation once for the whole graph, but requires a substantially larger planner/cache refactor and is not justified while compiler time dominates.
+
+## Change set
+
+### Incremental compile coordinator
+
+- Treat `IncrementalCompileRequest::force_rebuild` as an authoritative build decision.
+- Produce deterministic `explicit_rebuild` validation and the standard one-action compile plan without loading/snapshotting stale cache state.
+- Continue through the existing `MsvcCompileExecutor`, dependency reader, and `CompileCacheFile::save` path so outputs and new cache evidence remain identical to an ordinary rebuild.
+
+### Target coordinators and application wiring
+
+- Reuse the existing target-level `force_downstream_rebuild` bit instead of widening the request API.
+- Propagate it to every consumer `IncrementalCompileRequest` as `force_rebuild`.
+- Set the signal only when the PCH creator reports `compiled=true`; the same signal continues to force the required link/archive.
+- Apply the same contract to executable/DLL and static-library targets.
+
+### Deterministic tests
+
+- Extend incremental compile tests with a corrupt/unreadable old cache fixture proving forced rebuild succeeds, records `explicit_rebuild`, launches once, and replaces the cache.
+- Extend target/static-target tests to prove target-level forcing reaches every source and produces exactly one link/archive.
+- Extend PCH E2E coverage to prove header mutation rebuilds creator before every consumer, recompiles all consumers, links once, and returns to a no-op on the next invocation.
+- Retain ordinary public-header transition checks in the benchmark harness.
+
+## Red-green sequence
+
+1. Add the compile-coordinator forced-fast-path test and observe it fail because the current code emits `cache_load_failed` and performs ordinary validation.
+2. Add target propagation assertions and observe consumers are not explicitly forced.
+3. Implement the minimum fast path and propagation.
+4. Run the same focused tests until green, then refactor only duplicated planning/execution code if needed.
+
+## Benchmark evidence
+
+1. Build the exact pre-change Release candidate from `origin/main`.
+2. Run `benchmark_build_systems.ps1` with 100 translation units, 5 iterations, and 32 jobs; retain the JSON as `benchmark-before.json`.
+3. Build the final Release candidate and repeat with identical policy; retain `benchmark-after.json`.
+4. Compare raw samples, tool hashes, environment metadata, cache transitions, and ordinary/PCH header medians and MQB phase timings.
+5. Report any improvement honestly and identify the remaining compiler-dominated portion.
+
+## Verification gates
+
+- Focused incremental compile/target/static/PCH tests.
+- Debug and Release MQB self-builds.
+- Complete native Debug and Release shards.
+- Exact MSVC parameter and semantic variant inventories.
+- Release self-host and runtime-only package validation.
+- C++ responsibility layout and bilingual documentation parity.
+- `git diff --check` and final scope audit.

--- a/docs/20260826-220833-header-rebuild-paths/issue.md
+++ b/docs/20260826-220833-header-rebuild-paths/issue.md
@@ -1,0 +1,47 @@
+# Optimize public-header and PCH-header rebuild paths
+
+## Original intent
+
+Complete GitHub Issue #130: reduce MQB-owned work when an ordinary public header or the configured PCH header changes, while preserving exact dependency invalidation, PCH ownership, creator-before-consumer ordering, and the existing no-op/single-TU contracts.
+
+## Current gap
+
+The fresh 100-TU x 5 baseline from the exact current `main` tree shows that required compiler work dominates both header-rebuild scenarios:
+
+- `ordinary-public-header`: MQB median 560.50 ms versus direct Ninja 755.96 ms; 100 misses, 1 hit, and 1 link.
+- `pch-header`: MQB median 874.50 ms versus direct Ninja 865.81 ms; 102 misses and 1 link.
+
+The corrected baseline already places the ordinary public-header path ahead of direct Ninja, while the PCH-header path is effectively tied within normal workstation variance. This issue is not permission to skip required compilation. The evidence-selected redundant work is narrower: after the PCH creator successfully recompiles, every PCH consumer is guaranteed to require recompilation, but each consumer still loads its old compile cache and snapshots its source, outputs, and complete dependency set before discovering that the newly written `.pch` is newer.
+
+## Contract
+
+### Objective
+
+Add an explicit forced-consumer rebuild path for a successfully rebuilt first-class PCH so downstream consumer compilation can begin without redundant cache/freshness probing.
+
+### Acceptance
+
+1. A rebuilt PCH creator forces every consumer to compile and the target to link exactly once.
+2. The creator finishes successfully and its owned `.pch` exists before any consumer starts.
+3. Forced consumers retain deterministic `explicit_rebuild` evidence and write normal fresh compile caches.
+4. A warm unchanged PCH build keeps the ordinary cache-validation path and remains a no-op.
+5. Ordinary public-header invalidation still recompiles every dependent ordinary TU and links once.
+6. Missing outputs, stale headers, corrupt caches, ordinary/PCH single-TU, and no-op contracts remain unchanged.
+7. Corrected 100-TU x 5 before/after reports retain raw samples, phase timings, exact cache transitions, and tool/environment identity.
+8. Debug/Release builds, complete native shards, self-host/package, layout, and bilingual documentation gates pass.
+
+### Non-goals
+
+- Skipping required compiler or linker work.
+- Reusing a stale PCH or consumer object.
+- Adding a wall-clock CI threshold.
+- Introducing an invocation-global filesystem snapshot cache whose freshness semantics span unrelated targets.
+- Replacing the incremental coordinator with a new inverse-dependency graph.
+- Addressing the separate Windows Unicode `argv` defect observed in a Chinese repository path.
+
+## Constraints
+
+- Use MQB as the only build/test execution authority.
+- Keep the product diff focused on the existing incremental compile/target/PCH pipeline.
+- Prove the behavior with deterministic tests before relying on benchmark evidence.
+- Treat machine-local timing as evidence, not a universal performance claim.

--- a/docs/20260826-220833-header-rebuild-paths/walkthrough.md
+++ b/docs/20260826-220833-header-rebuild-paths/walkthrough.md
@@ -1,0 +1,123 @@
+# Issue #130 walkthrough
+
+## Outcome
+
+MQB now treats a successfully rebuilt first-class PCH as an authoritative invalidation decision for every executable/DLL/static consumer. Consumers skip stale cache loading and filesystem snapshots, compile through the existing executor, write normal fresh cache evidence, and then link or archive once.
+
+The ordinary public-header path was deliberately left on exact per-TU dependency validation. The fresh baseline already placed it ahead of direct Ninja, and introducing invocation-global snapshot memoization would widen the freshness risk for an unproven gain.
+
+## Deterministic behavior
+
+- `IncrementalCompileRequest::force_rebuild` produces only `explicit_rebuild` decision evidence before compilation and does not inspect a deliberately corrupt old cache.
+- `force_downstream_rebuild` reaches all target and static-target consumer compile requests.
+- A PCH creator is compiled and its owned `.pch` is verified before consumer scheduling begins.
+- Every PCH consumer compiles, then exactly one link/archive occurs.
+- The next unchanged build is a complete creator/consumer/link no-op.
+- Executable, DLL, and static-library PCH compositions are each exercised directly.
+- Ordinary corrupt-cache, missing-output, public-header, no-op, and single-TU behavior remains on the existing validator path.
+
+## TDD evidence
+
+Before the product change, the new compile-coordinator test failed with:
+
+```text
+FAIL: authoritative explicit rebuild should not inspect stale cache metadata
+FAIL: authoritative explicit rebuild should bypass stale cache load warnings
+2 test(s) failed
+```
+
+The target propagation test also failed before the product change with:
+
+```text
+FAIL: upstream rebuild should force every target consumer to compile
+FAIL: upstream rebuild should retain explicit evidence on every forced consumer
+FAIL: upstream rebuild should compile all four consumers exactly once more
+FAIL: post-force warm target should not launch more compiler processes
+4 test(s) failed
+```
+
+After the minimum implementation, focused Release runs reported:
+
+```text
+mqb_orchestration_incremental_tests passed
+MQB-native shard 63/64: 1/1 selected tests passed.
+
+mqb_incremental_target_coordinator_tests passed
+MQB-native shard 15/64: 2/2 selected tests passed.
+
+mqb_pch_e2e_tests passed
+MQB-native shard 3/64: 1/1 selected tests passed.
+```
+
+## 100-TU x 5 evidence
+
+Both retained JSON reports use 100 translation units, 5 iterations, 32 workers, Release, x64, the same isolated MSVC environment, CMake 4.1.2, Ninja 1.13.1, and MSVC 19.51.36248. They contain all 80 raw samples, execution order, MQB phase timings, exact cache counters, executable paths, and SHA-256 identities.
+
+| Scenario | Before MQB | After MQB | After Ninja | After MQB delta vs Ninja |
+|---|---:|---:|---:|---:|
+| ordinary cold | 683.15 ms | 672.61 ms | 732.35 ms | -8.16% |
+| ordinary no-op | 31.80 ms | 28.74 ms | 21.80 ms | +31.80% |
+| ordinary single TU | 104.39 ms | 97.47 ms | 124.54 ms | -21.74% |
+| ordinary public header | 560.50 ms | 516.70 ms | 697.13 ms | -25.88% |
+| PCH cold | 989.94 ms | 976.25 ms | 883.76 ms | +10.47% |
+| PCH no-op | 33.42 ms | 32.38 ms | 23.13 ms | +39.98% |
+| PCH single TU | 100.33 ms | 101.85 ms | 119.72 ms | -14.93% |
+| PCH header | 874.50 ms | 875.38 ms | 895.90 ms | -2.29% |
+
+The representative median PCH compile phase changed from 815.975 ms to 812.467 ms, while end-to-end wall-clock changed by +0.88 ms (+0.10%). This is not a measurable wall-clock speedup. Required parallel MSVC compilation dominates the rebuild, and the removed MQB bookkeeping is smaller than ordinary workstation variance. The change is retained because it removes semantically redundant work with deterministic coverage and no widened freshness surface.
+
+Raw evidence:
+
+- [`benchmark-before.json`](benchmark-before.json)
+- [`benchmark-after.json`](benchmark-after.json)
+
+## Full verification
+
+```text
+C++ responsibility layout contract passed.
+Bilingual documentation parity check passed for 17 maintained pairs.
+Final Closure cross-stage state/path/environment gate passed.
+```
+
+```text
+MSVC /external:env ownership boundary and explicit /external:I replacement checks passed.
+MSVC /fsanitize=kernel-address WDK/driver ownership boundary check passed.
+Real MSVC AddressSanitizer runtime, VCAsan freshness/opt-out, non-incremental LINK, and mqb run checks passed.
+Real MSVC LibFuzzer default-runtime, CRT selection, suppression, and warm-cache checks passed.
+Real MSVC classic OpenMP runtime freshness, NODEFAULTLIB, Modules, and LLVM ownership checks passed.
+Real MSVC transitive .drectve default-library freshness, search reroute, and LTCG checks passed.
+Include search resolution freshness checks passed.
+__has_include absent-to-present freshness check passed.
+Real MSVC linker side-output/repro isolation plus raw WHOLEARCHIVE freshness checks passed.
+```
+
+```text
+Exact MSVC parameter inventory: compiler=309, linker=114, librarian=21, total=444
+MSVC semantic variant inventory: 44 concrete high-risk variants
+```
+
+Both configurations built the 73-TU MQB product and the 72-TU shared native-test library. All deterministic native tests passed in both configurations:
+
+```text
+Debug:   subshards 0/8 through 7/8, 77/77 tests passed
+Release: subshards 0/8 through 7/8, 77/77 tests passed
+```
+
+Self-host and package closure:
+
+```text
+Stage 1 SHA256: 463a9d01ad72a5ab2d04e6b03f5f7e4c2bd93c5358faa1904903bd9abeb30de5
+Stage 2 SHA256: f3f1f5ae72bb1f52c5cdc2d367802b353f8120dcd9104b2347034f60b7caa619
+MQB-native self-host closure passed: Stage 0 -> Stage 1 -> Stage 2 used MQB for every build generation.
+native installer install / reinstall / uninstall / PATH ownership validation passed
+Exact runtime-only package validation passed.
+Package SHA256: 67d76eb93b066efd5c358d92b9087ca566f10f85374154df7d1f44750ee1dd92
+```
+
+## Scope audit
+
+- No cache schema or public request API changed.
+- No compiler/linker flags changed.
+- No invalidation was skipped.
+- No wall-clock CI threshold was introduced.
+- The unrelated Windows Unicode `argv` defect for a Chinese repository path remains outside Issue #130.

--- a/docs/BUILD_SYSTEM_BENCHMARK.md
+++ b/docs/BUILD_SYSTEM_BENCHMARK.md
@@ -99,6 +99,21 @@ The selected product change removes redundant `vcvarsall.bat` environment captur
 
 The complete raw reports, including all 80 samples per report, MQB phase timings, tool hashes, and exact cache counters, are retained as [`benchmark-before.json`](20260826-195200-cold-build-overhead/benchmark-before.json) and [`benchmark-after.json`](20260826-195200-cold-build-overhead/benchmark-after.json).
 
+## Issue #130 measured evidence
+
+Issue #130 repeated the same 100-TU, 5-iteration, 32-worker contract for ordinary public-header and configured PCH-header rebuilds. The before/after reports have identical Windows, PowerShell, CPU, Visual Studio, MSVC 19.51.36248, Windows SDK, CMake 4.1.2, Ninja 1.13.1, and harness policy metadata; only the expected MQB candidate hash differs.
+
+| Scenario | Before MQB median | After MQB median | After Ninja median | After MQB delta vs Ninja |
+|---|---:|---:|---:|---:|
+| `ordinary-public-header` | 560.50 ms | 516.70 ms | 697.13 ms | -25.88% |
+| `pch-header` | 874.50 ms | 875.38 ms | 895.90 ms | -2.29% |
+
+The selected product change is semantic and narrow: once the owned PCH creator has successfully rebuilt and the `.pch` exists, every consumer compile is already mandatory. MQB now propagates that authoritative decision to every consumer and skips loading and snapshotting stale consumer cache state, while retaining the normal compiler, dependency-reader, cache-write, and single-link path. Deterministic tests prove creator-before-consumer ordering, all-consumer invalidation, exactly one link/archive, and a following no-op.
+
+The representative median PCH compile phase moved from 815.975 ms to 812.467 ms, but PCH wall-clock moved by only +0.88 ms (+0.10%). That is not a measurable end-to-end speedup on this run and must not be presented as one: required parallel MSVC compilation dominates the scenario and normal workstation variance is larger than the removed MQB bookkeeping. The ordinary public-header path remained correct and materially faster than direct Ninja in the after report. No-op and single-TU samples also retained their exact cache-transition contracts; their small timing movements are treated as measurement variance rather than product claims.
+
+The complete 80-sample reports, raw execution order, MQB phase timings, tool hashes, environment identity, and exact cache counters are retained as [`benchmark-before.json`](20260826-220833-header-rebuild-paths/benchmark-before.json) and [`benchmark-after.json`](20260826-220833-header-rebuild-paths/benchmark-after.json).
+
 ## CI contract
 
 `.github/workflows/build-system-evidence.yml` runs a small correctness-sized fixture on relevant pull requests. It builds the current MQB product from the repository, runs one comparison iteration with a small TU count, and uploads the JSON report.

--- a/docs/BUILD_SYSTEM_BENCHMARK_ZH.md
+++ b/docs/BUILD_SYSTEM_BENCHMARK_ZH.md
@@ -99,6 +99,21 @@ Issue #129 按本契约完成了同机 100 TU、5 iterations、32 workers 的 be
 
 完整 raw report 保留为 [`benchmark-before.json`](20260826-195200-cold-build-overhead/benchmark-before.json) 与 [`benchmark-after.json`](20260826-195200-cold-build-overhead/benchmark-after.json)，其中包含每份报告的全部 80 个样本、MQB phase timings、tool hashes 与 exact cache counters。
 
+## Issue #130 实测证据
+
+Issue #130 继续使用同一套 100 TU、5 iterations、32 workers 契约，测量普通公共头文件与配置 PCH 头文件的重建路径。Before/after 报告中的 Windows、PowerShell、CPU、Visual Studio、MSVC 19.51.36248、Windows SDK、CMake 4.1.2、Ninja 1.13.1 以及 harness policy 元数据完全一致；只有包含优化代码的 MQB candidate hash 按预期不同。
+
+| 场景 | Before MQB median | After MQB median | After Ninja median | After MQB 相对 Ninja 差值 |
+|---|---:|---:|---:|---:|
+| `ordinary-public-header` | 560.50 ms | 516.70 ms | 697.13 ms | -25.88% |
+| `pch-header` | 874.50 ms | 875.38 ms | 895.90 ms | -2.29% |
+
+本次产品改动刻意保持很小的语义范围：MQB 自有的 PCH creator 成功重建且 `.pch` 已存在后，每个 consumer 都已经必然需要编译。MQB 现在把这个确定的决定传播给所有 consumer，跳过读取和快照陈旧 consumer cache 状态；编译器、依赖读取器、cache 写入与单次链接路径保持不变。确定性测试证明 creator 先于 consumer、所有 consumer 均失效、只发生一次 link/archive，并且下一轮恢复 no-op。
+
+代表性 median PCH compile phase 从 815.975 ms 变为 812.467 ms，但 PCH wall-clock 只变化了 +0.88 ms（+0.10%）。本轮数据不构成可测量的端到端提速，也不应被表述成提速：该场景由必需的并行 MSVC 编译主导，普通工作站波动大于删除掉的 MQB bookkeeping。普通公共头文件路径保持正确，并在 after 报告中继续明显快于 direct Ninja。No-op 与 single-TU 样本也保持精确的 cache-transition 契约；其小幅时间变化只按测量波动处理，不作为产品结论。
+
+完整的 80-sample 报告、raw execution order、MQB phase timings、tool hashes、environment identity 与 exact cache counters 保留为 [`benchmark-before.json`](20260826-220833-header-rebuild-paths/benchmark-before.json) 与 [`benchmark-after.json`](20260826-220833-header-rebuild-paths/benchmark-after.json)。
+
 ## CI 契约
 
 `.github/workflows/build-system-evidence.yml` 会在相关 pull request 上运行一个小规模 correctness fixture。它从当前仓库源码构建 MQB，使用较小 TU 数执行一次对比，并上传 JSON 报告。


### PR DESCRIPTION
## Summary

- treat PCH-triggered consumer rebuilds as authoritative and skip stale cache/filesystem validation
- propagate the existing downstream force signal through executable/DLL/static target coordinators without changing the public request API or cache schema
- add deterministic EXE/DLL/static PCH ordering, exact link/archive, cache reseal, and no-op coverage
- retain corrected 100-TU x 5 before/after reports and bilingual methodology

## Measured evidence

| Scenario | Before MQB | After MQB | After Ninja | After MQB vs Ninja |
|---|---:|---:|---:|---:|
| ordinary public header | 560.50 ms | 516.70 ms | 697.13 ms | -25.88% |
| PCH header | 874.50 ms | 875.38 ms | 895.90 ms | -2.29% |

The representative PCH compile phase moved from 815.975 ms to 812.467 ms, but wall-clock changed by +0.88 ms (+0.10%). This is explicitly documented as no measurable end-to-end speedup: required MSVC compilation dominates and workstation variance is larger than the removed bookkeeping.

## Verification

- Debug and Release MQB builds
- Debug native tests: 77/77 across 8 subshards
- Release native tests: 77/77 across 8 subshards
- focused compile/target/PCH RED-GREEN coverage
- exact 444-entry MSVC parameter inventory and 44 semantic variants
- ASan, LibFuzzer, OpenMP, freshness, side-output, environment-ownership gates
- Stage 0 -> Stage 1 -> Stage 2 self-host closure
- exact runtime-only package and installer lifecycle
- C++ layout, bilingual docs, and Final Closure cross-stage gates
- independent review; DLL coverage follow-up resolved, no remaining findings

Evidence: `docs/20260826-220833-header-rebuild-paths/`

Closes #130