### PR TITLE
feat: add deterministic compilation database export

### DIFF
--- a/.github/workflows/compdb-evidence.yml
+++ b/.github/workflows/compdb-evidence.yml
@@ -1,0 +1,69 @@
+name: Compilation Database Evidence
+
+on:
+  pull_request:
+    paths:
+      - 'cpp/mqb.json'
+      - 'cpp/src/app/main.cpp'
+      - 'cpp/src/app/targets/CompdbCommand.cpp'
+      - 'cpp/src/app/targets/CompdbCommand.hpp'
+      - 'cpp/include/mqb/msvc/MsvcCompileExecutor.hpp'
+      - 'cpp/include/mqb/msvc/MsvcCompiler.hpp'
+      - 'cpp/src/msvc/compiler/**'
+      - 'tests/native/verify_compdb.ps1'
+      - '.github/workflows/compdb-evidence.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: compdb-evidence-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify-compdb:
+    name: Verify compile_commands.json contract
+    runs-on: windows-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Acquire pinned MQB seed
+        id: seed
+        shell: pwsh
+        run: |
+          $seed = & (Join-Path $PWD 'tests/native/acquire_seed.ps1') `
+            -RepoRoot $PWD `
+            -OutputRoot (Join-Path $PWD 'native-seed')
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          "path=$seed" >> $env:GITHUB_OUTPUT
+
+      - name: Build current Release MQB
+        id: current
+        shell: pwsh
+        run: |
+          $version = (Get-Content -LiteralPath 'VERSION' -Raw).Trim()
+          $output = Join-Path $PWD 'native-out/compdb-candidate/mqb.exe'
+          $mqb = & (Join-Path $PWD 'tests/native/build_mqb.ps1') `
+            -BuilderMqbPath '${{ steps.seed.outputs.path }}' `
+            -RepoRoot $PWD `
+            -Version "$version-compdb" `
+            -Configuration Release `
+            -Clean `
+            -OutputPath $output
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          if (-not (Test-Path -LiteralPath $mqb -PathType Leaf)) {
+            throw "Release MQB build output missing: $mqb"
+          }
+          "path=$mqb" >> $env:GITHUB_OUTPUT
+
+      - name: Verify compilation database contract
+        shell: pwsh
+        run: |
+          & (Join-Path $PWD 'tests/native/verify_compdb.ps1') `
+            -MqbPath '${{ steps.current.outputs.path }}' `
+            -RepoRoot $PWD
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/.github/workflows/compdb-evidence.yml
+++ b/.github/workflows/compdb-evidence.yml
@@ -10,6 +10,7 @@ on:
       - 'cpp/include/mqb/msvc/MsvcCompileExecutor.hpp'
       - 'cpp/include/mqb/msvc/MsvcCompiler.hpp'
       - 'cpp/src/msvc/compiler/**'
+      - 'tests/native/assert_cpp_layout.ps1'
       - 'tests/native/verify_compdb.ps1'
       - '.github/workflows/compdb-evidence.yml'
   workflow_dispatch:

--- a/cpp/mqb.json
+++ b/cpp/mqb.json
@@ -31,6 +31,7 @@
       "src/app/diagnostics/Diagnostics.cpp",
       "src/app/diagnostics/PerformanceTimings.cpp",
       "src/app/cli/Invocation.cpp",
+      "src/app/targets/CompdbCommand.cpp",
       "src/app/targets/ModuleCliTarget.cpp",
       "src/app/project/ProjectSetup.cpp",
       "src/app/targets/StaticCliTarget.cpp",

--- a/cpp/src/app/main.cpp
+++ b/cpp/src/app/main.cpp
@@ -3,12 +3,18 @@
 #include <vector>
 
 #include "Application.hpp"
+#include "CompdbCommand.hpp"
 
 int main(const int argc, char* argv[]) {
     std::vector<std::string_view> arguments;
     arguments.reserve(argc > 1 ? static_cast<std::size_t>(argc - 1) : 0u);
     for (int index = 1; index < argc; ++index) {
         arguments.emplace_back(argv[index]);
+    }
+
+    if (!arguments.empty() && arguments.front() == "compdb") {
+        return mqb::app::run_compdb_command(
+            std::span<const std::string_view>{arguments}.subspan(1));
     }
 
     mqb::app::Application application;

--- a/cpp/src/app/targets/CompdbCommand.cpp
+++ b/cpp/src/app/targets/CompdbCommand.cpp
@@ -1,0 +1,544 @@
+#include "CompdbCommand.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <expected>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "Cli.hpp"
+#include "Diagnostics.hpp"
+#include "Invocation.hpp"
+#include "ProjectSetup.hpp"
+#include "mqb/core/Artifact.hpp"
+#include "mqb/core/ProjectArtifactLayout.hpp"
+#include "mqb/core/TranslationUnitClassifier.hpp"
+#include "mqb/discovery/SourceDiscovery.hpp"
+#include "mqb/msvc/MsvcCompileExecutor.hpp"
+#include "mqb/msvc/MsvcParameterCapabilities.hpp"
+#include "mqb/msvc/MsvcParameterEngine.hpp"
+#include "mqb/msvc/MsvcToolchainLocator.hpp"
+#include "mqb/orchestration/MsvcIncrementalTargetCoordinator.hpp"
+#include "mqb/platform/windows/PathIdentity.hpp"
+#include "mqb/platform/windows/WindowsProcessRunner.hpp"
+
+namespace mqb::app {
+namespace {
+
+namespace fs = std::filesystem;
+
+struct ParsedCompdbOptions {
+    mqb::cli::Options build;
+    std::optional<fs::path> output;
+};
+
+struct CompilationDatabaseEntry {
+    fs::path directory;
+    fs::path file;
+    fs::path output;
+    std::vector<std::string> arguments;
+};
+
+[[nodiscard]] std::string path_to_utf8(const fs::path& path) {
+    const auto bytes = path.lexically_normal().generic_u8string();
+    return std::string{
+        reinterpret_cast<const char*>(bytes.data()),
+        bytes.size()};
+}
+
+[[nodiscard]] std::string json_escape(const std::string_view value) {
+    std::ostringstream escaped;
+    escaped << std::hex << std::uppercase;
+    for (const unsigned char ch : value) {
+        switch (ch) {
+        case '"': escaped << "\\\""; break;
+        case '\\': escaped << "\\\\"; break;
+        case '\b': escaped << "\\b"; break;
+        case '\f': escaped << "\\f"; break;
+        case '\n': escaped << "\\n"; break;
+        case '\r': escaped << "\\r"; break;
+        case '\t': escaped << "\\t"; break;
+        default:
+            if (ch < 0x20u) {
+                escaped << "\\u00"
+                        << std::setw(2) << std::setfill('0')
+                        << static_cast<unsigned int>(ch);
+            } else {
+                escaped << static_cast<char>(ch);
+            }
+            break;
+        }
+    }
+    return escaped.str();
+}
+
+[[nodiscard]] fs::path absolute_from(
+    const fs::path& base,
+    const fs::path& path) {
+    return path.is_absolute()
+        ? path.lexically_normal()
+        : (base / path).lexically_normal();
+}
+
+[[nodiscard]] bool inside_project(
+    const fs::path& project_root,
+    const fs::path& path) {
+    return mqb::platform::windows::path_identity_contains(project_root, path);
+}
+
+void add_portable_root_if_missing(
+    std::vector<fs::path>& roots,
+    const fs::path& candidate) {
+    if (candidate.empty()) return;
+    const fs::path normalized = candidate.lexically_normal();
+    const std::string candidate_key = mqb::platform::windows::path_identity_key(normalized);
+    const bool present = std::any_of(
+        roots.begin(),
+        roots.end(),
+        [&](const fs::path& root) {
+            return mqb::platform::windows::path_identity_key(root) == candidate_key;
+        });
+    if (!present) roots.push_back(normalized);
+}
+
+[[nodiscard]] bool validate_compiler_capabilities(
+    const std::vector<std::string>& arguments,
+    const std::string_view vc_tools_version) {
+    for (const auto& argument : arguments) {
+        const auto capability = mqb::msvc::MsvcParameterCapabilities::inspect(
+            mqb::msvc::ParameterTool::compiler,
+            argument,
+            vc_tools_version);
+        if (capability.lifecycle == mqb::msvc::ParameterLifecycle::active) continue;
+
+        std::string message = "MSVC compiler option '" + argument + "' is ";
+        message += mqb::msvc::to_string(capability.lifecycle);
+        message += " for toolset ";
+        message += vc_tools_version;
+        if (!capability.guidance.empty()) {
+            message += ": ";
+            message += capability.guidance;
+        }
+        if (capability.lifecycle == mqb::msvc::ParameterLifecycle::deprecated) {
+            diagnostics::print_warning(message);
+            continue;
+        }
+        diagnostics::print_error(message);
+        return false;
+    }
+    return true;
+}
+
+[[nodiscard]] std::expected<ParsedCompdbOptions, std::string>
+parse_compdb_arguments(const std::span<const std::string_view> arguments) {
+    std::vector<std::string_view> forwarded;
+    forwarded.reserve(arguments.size() + 1u);
+    forwarded.emplace_back("build");
+
+    std::optional<fs::path> output;
+    bool native_tail = false;
+    for (std::size_t index = 0; index < arguments.size(); ++index) {
+        const std::string_view argument = arguments[index];
+        if (!native_tail && (argument == "/link" || argument == "-link"
+                || argument == "/lib" || argument == "/LIB")) {
+            native_tail = true;
+            forwarded.push_back(argument);
+            continue;
+        }
+        if (!native_tail && (argument == "-o" || argument == "--output")) {
+            if (output) {
+                return std::unexpected("mqb compdb --output may be specified only once");
+            }
+            if (index + 1 >= arguments.size() || arguments[index + 1].empty()) {
+                return std::unexpected("mqb compdb --output requires a path");
+            }
+            output = fs::u8path(arguments[++index]);
+            continue;
+        }
+        if (!native_tail && argument.starts_with("--output=")) {
+            if (output) {
+                return std::unexpected("mqb compdb --output may be specified only once");
+            }
+            const std::string_view value = argument.substr(std::string_view{"--output="}.size());
+            if (value.empty()) {
+                return std::unexpected("mqb compdb --output requires a path");
+            }
+            output = fs::u8path(value);
+            continue;
+        }
+        forwarded.push_back(argument);
+    }
+
+    auto parsed = mqb::cli::parse_arguments(forwarded);
+    if (!parsed) return std::unexpected(parsed.error().message);
+    return ParsedCompdbOptions{
+        .build = std::move(*parsed),
+        .output = std::move(output),
+    };
+}
+
+[[nodiscard]] std::string render_compilation_database(
+    const std::vector<CompilationDatabaseEntry>& entries) {
+    std::ostringstream output;
+    output << "[\n";
+    for (std::size_t index = 0; index < entries.size(); ++index) {
+        const auto& entry = entries[index];
+        output << "  {\n"
+               << "    \"directory\": \"" << json_escape(path_to_utf8(entry.directory)) << "\",\n"
+               << "    \"file\": \"" << json_escape(path_to_utf8(entry.file)) << "\",\n"
+               << "    \"arguments\": [";
+        for (std::size_t argument_index = 0;
+             argument_index < entry.arguments.size();
+             ++argument_index) {
+            if (argument_index != 0) output << ", ";
+            output << "\"" << json_escape(entry.arguments[argument_index]) << "\"";
+        }
+        output << "],\n"
+               << "    \"output\": \"" << json_escape(path_to_utf8(entry.output)) << "\"\n"
+               << "  }";
+        if (index + 1 != entries.size()) output << ',';
+        output << '\n';
+    }
+    output << "]\n";
+    return output.str();
+}
+
+[[nodiscard]] std::expected<void, std::string>
+write_database_file(
+    const fs::path& output,
+    const std::string_view content) {
+    std::error_code error_code;
+    const fs::path parent = output.parent_path();
+    if (!parent.empty()) {
+        fs::create_directories(parent, error_code);
+        if (error_code) {
+            return std::unexpected("failed to create compilation database output directory");
+        }
+    }
+
+    fs::path temporary = output;
+    temporary += ".tmp-";
+    temporary += std::to_string(
+        std::chrono::steady_clock::now().time_since_epoch().count());
+
+    {
+        std::ofstream stream{temporary, std::ios::binary | std::ios::trunc};
+        if (!stream) {
+            return std::unexpected("failed to create temporary compilation database file");
+        }
+        stream.write(content.data(), static_cast<std::streamsize>(content.size()));
+        stream.flush();
+        if (!stream) {
+            std::error_code ignored;
+            fs::remove(temporary, ignored);
+            return std::unexpected("failed to write compilation database file");
+        }
+    }
+
+    fs::rename(temporary, output, error_code);
+    if (error_code) {
+        error_code.clear();
+        fs::remove(output, error_code);
+        if (error_code) {
+            std::error_code ignored;
+            fs::remove(temporary, ignored);
+            return std::unexpected("failed to replace existing compilation database");
+        }
+        fs::rename(temporary, output, error_code);
+    }
+    if (error_code) {
+        std::error_code ignored;
+        fs::remove(temporary, ignored);
+        return std::unexpected("failed to publish compilation database");
+    }
+    return {};
+}
+
+} // namespace
+
+int run_compdb_command(const std::span<const std::string_view> arguments) {
+    auto parsed = parse_compdb_arguments(arguments);
+    if (!parsed) {
+        diagnostics::print_error(parsed.error());
+        return 2;
+    }
+    auto options = std::move(parsed->build);
+    if (options.show_help) {
+        std::cout << compdb_usage();
+        return 0;
+    }
+
+    auto invocation = resolve_invocation(options);
+    if (!invocation) {
+        diagnostics::print_error(invocation.error());
+        return 2;
+    }
+
+    auto project = prepare_project(options, invocation->directory);
+    if (!project) {
+        if (project.error().config_error) {
+            diagnostics::print_config_error(*project.error().config_error);
+        } else {
+            diagnostics::print_error(project.error().message);
+        }
+        return 2;
+    }
+
+    auto& project_config = project->config;
+    auto& effective = project->effective;
+    const fs::path& project_root = project->project_root;
+
+    if (invocation->requested_sources.empty()) {
+        auto entry = resolve_default_entry(
+            project_root,
+            project_config ? project_config->build.entry : std::nullopt);
+        if (!entry) {
+            diagnostics::print_error(entry.error());
+            return 2;
+        }
+        invocation->requested_sources.push_back(std::move(*entry));
+    }
+
+    const auto& requested_sources = invocation->requested_sources;
+    std::vector<fs::path> sources = requested_sources;
+    bool discovery_requires_module_pipeline = false;
+    if (options.discover_sources
+        && requested_sources.size() == 1
+        && !mqb::cli::is_module_interface_source(requested_sources.front())) {
+        auto forced_includes = mqb::msvc::MsvcParameterEngine::forced_includes(
+            options.compiler_arguments);
+        if (!forced_includes) {
+            diagnostics::print_error(forced_includes.error().message);
+            return 2;
+        }
+        if (effective.precompiled_header) {
+            forced_includes->push_back(effective.precompiled_header->lexically_normal());
+        }
+
+        const fs::path& entry = requested_sources.front();
+        const bool project_scoped = inside_project(project_root, entry);
+        const fs::path discovery_root = project_scoped
+            ? project_root
+            : entry.parent_path();
+        mqb::discovery::Request discovery_request{
+            .project_root = discovery_root,
+            .entry = entry,
+            .include_directories = options.discovery_include_directories,
+            .forced_includes = std::move(*forced_includes),
+        };
+        if (project_scoped) {
+            discovery_request.excluded_directories = effective.discovery_exclude_directories;
+            discovery_request.extra_sources = effective.discovery_extra_sources;
+            discovery_request.excluded_sources = effective.discovery_exclude_sources;
+        }
+        auto discovered = mqb::discovery::SourceDiscovery::discover(discovery_request);
+        if (!discovered) {
+            diagnostics::print_error("source discovery failed: " + discovered.error().message);
+            return 2;
+        }
+        for (const auto& warning : discovered->warnings) {
+            diagnostics::print_warning("source discovery: " + warning.message);
+        }
+        discovery_requires_module_pipeline = discovered->requires_module_pipeline;
+        sources = std::move(discovered->sources);
+    }
+    options.build.sources = sources;
+
+    auto layout = mqb::ProjectArtifactLayout::create(project_root);
+    if (!layout) {
+        diagnostics::print_error(layout.error().message);
+        return 2;
+    }
+
+    std::vector<mqb::orchestration::TargetSourceRequest> target_sources;
+    target_sources.reserve(sources.size());
+    for (const auto& source : sources) {
+        auto artifacts = layout->for_source(source);
+        if (!artifacts) {
+            diagnostics::print_error(artifacts.error().message);
+            return 2;
+        }
+        target_sources.push_back(mqb::orchestration::TargetSourceRequest{
+            .source = source,
+            .artifacts = std::move(*artifacts),
+        });
+    }
+
+    add_portable_root_if_missing(options.portable_roots, project_root / "portable_msvc");
+    for (const auto& source : sources) {
+        add_portable_root_if_missing(options.portable_roots, source.parent_path() / "portable_msvc");
+    }
+
+    mqb::platform::windows::WindowsProcessRunner runner;
+    mqb::msvc::MsvcToolchainLocator locator{runner};
+    mqb::msvc::DiscoveryOptions toolchain_discovery;
+    toolchain_discovery.target_architecture = options.build.architecture;
+    toolchain_discovery.host_architecture = mqb::Architecture::x64;
+    toolchain_discovery.preference = options.toolchain_preference;
+    toolchain_discovery.portable_roots = options.portable_roots;
+    std::string toolchain_cache_name = "vs-";
+    toolchain_cache_name += mqb::to_string(options.build.architecture);
+    toolchain_cache_name += ".cache";
+    toolchain_discovery.cache_file = layout->artifact_root()
+        / "cache"
+        / "toolchain"
+        / toolchain_cache_name;
+
+    auto toolchain = locator.discover(toolchain_discovery);
+    if (!toolchain) {
+        diagnostics::print_error(toolchain.error().message);
+        return 3;
+    }
+    if (!validate_compiler_capabilities(
+            options.compiler_arguments,
+            toolchain->identity.version)) {
+        return 2;
+    }
+
+    mqb::CompilerOptions compiler_options;
+    compiler_options.configuration = options.build.configuration;
+    compiler_options.architecture = options.build.architecture;
+    compiler_options.standard = options.build.standard;
+    compiler_options.runtime_library = options.runtime_override;
+    compiler_options.link_time_code_generation = effective.link_time_code_generation;
+    compiler_options.defines = std::move(options.defines);
+    compiler_options.include_directories = std::move(options.include_directories);
+    compiler_options.additional_arguments = std::move(options.compiler_arguments);
+    compiler_options.external_module_providers = options.external_module_providers;
+
+    const bool module_target = !compiler_options.external_module_providers.empty()
+        || discovery_requires_module_pipeline
+        || std::any_of(
+            target_sources.begin(),
+            target_sources.end(),
+            [](const mqb::orchestration::TargetSourceRequest& source) {
+                return mqb::cli::is_module_interface_source(source.source);
+            });
+    if (module_target) {
+        diagnostics::print_error(
+            "mqb compdb currently supports ordinary C/C++ targets only; "
+            "Modules/Header Units require P1689 graph materialization and are intentionally fail-closed");
+        return 2;
+    }
+
+    const std::string target_name = options.build.output_name.value_or(
+        requested_sources.front().stem().string());
+    if (effective.precompiled_header) {
+        const auto c_source = std::find_if(
+            target_sources.begin(),
+            target_sources.end(),
+            [](const mqb::orchestration::TargetSourceRequest& source) {
+                return mqb::is_c_translation_unit_path(source.source);
+            });
+        if (c_source != target_sources.end()) {
+            diagnostics::print_error(
+                "first-class PCH currently requires an ordinary C++ source set");
+            return 2;
+        }
+        auto pch = layout->for_precompiled_header(
+            target_name,
+            options.build.configuration,
+            options.build.architecture);
+        if (!pch) {
+            diagnostics::print_error(pch.error().message);
+            return 2;
+        }
+        compiler_options.precompiled_header = mqb::PrecompiledHeaderBinding{
+            .header = effective.precompiled_header->lexically_normal(),
+            .artifact = pch->precompiled_header.lexically_normal(),
+            .role = mqb::PrecompiledHeaderRole::use,
+        };
+    }
+
+    mqb::msvc::MsvcCompileExecutor executor{*toolchain, runner};
+    std::vector<CompilationDatabaseEntry> entries;
+    entries.reserve(target_sources.size());
+    for (const auto& source : target_sources) {
+        const auto kind = mqb::classify_translation_unit_path(source.source);
+        if (!kind || *kind != mqb::TranslationUnitKind::source) {
+            diagnostics::print_error(
+                "mqb compdb encountered a non-ordinary translation unit after ordinary-target validation");
+            return 2;
+        }
+
+        mqb::TranslationUnit unit;
+        unit.source = source.source;
+        unit.kind = *kind;
+        unit.outputs = {
+            mqb::Artifact{source.artifacts.object, mqb::ArtifactKind::object},
+        };
+        const mqb::msvc::CompileExecutionRequest request{
+            .unit = std::move(unit),
+            .options = compiler_options,
+            .source_dependencies_file = source.artifacts.dependencies,
+            .working_directory = project_root,
+        };
+        auto recipe = executor.build_recipe(request);
+        if (!recipe) {
+            diagnostics::print_error(
+                "failed to model compile recipe: " + recipe.error().message);
+            return 2;
+        }
+
+        CompilationDatabaseEntry entry;
+        entry.directory = absolute_from(invocation->directory, project_root);
+        entry.file = absolute_from(invocation->directory, source.source);
+        entry.output = absolute_from(project_root, source.artifacts.object);
+        entry.arguments.reserve(recipe->process.arguments.size() + 1u);
+        entry.arguments.push_back(path_to_utf8(recipe->process.executable));
+        entry.arguments.insert(
+            entry.arguments.end(),
+            recipe->process.arguments.begin(),
+            recipe->process.arguments.end());
+        entries.push_back(std::move(entry));
+    }
+
+    std::sort(
+        entries.begin(),
+        entries.end(),
+        [](const CompilationDatabaseEntry& left, const CompilationDatabaseEntry& right) {
+            return mqb::platform::windows::path_identity_key(left.file)
+                < mqb::platform::windows::path_identity_key(right.file);
+        });
+
+    const fs::path output = parsed->output
+        ? absolute_from(invocation->directory, *parsed->output)
+        : (project_root / "compile_commands.json").lexically_normal();
+    const std::string content = render_compilation_database(entries);
+    auto written = write_database_file(output, content);
+    if (!written) {
+        diagnostics::print_error(written.error());
+        return 2;
+    }
+
+    std::cout << "[compdb] " << entries.size() << " translation units\n"
+              << "output: " << path_to_utf8(output) << '\n';
+    return 0;
+}
+
+std::string_view compdb_usage() noexcept {
+    return R"(Usage:
+  mqb compdb [entry.cpp] [options] [MSVC-compiler-options]
+  mqb compdb [source...] [options] [MSVC-compiler-options]
+
+Generate a deterministic compile_commands.json from MQB's exact MSVC compile recipes.
+The command performs project/config resolution, source discovery, artifact layout and toolchain
+discovery, but does not compile, link, archive, or run the target.
+
+Options are the same compile-side options accepted by `mqb build`.
+For this command only:
+  -o, --output <path>      Compilation database path (default: <project>/compile_commands.json)
+
+The first release supports ordinary C/C++ targets, including MQB-owned PCH consumer recipes.
+Targets requiring the Modules/Header Units P1689 pipeline fail closed until graph-aware compdb
+materialization is added in a follow-up iteration.
+)";
+}
+
+} // namespace mqb::app

--- a/cpp/src/app/targets/CompdbCommand.cpp
+++ b/cpp/src/app/targets/CompdbCommand.cpp
@@ -6,6 +6,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iomanip>
+#include <iostream>
 #include <optional>
 #include <sstream>
 #include <string>
@@ -50,6 +51,19 @@ struct CompilationDatabaseEntry {
     return std::string{
         reinterpret_cast<const char*>(bytes.data()),
         bytes.size()};
+}
+
+[[nodiscard]] fs::path path_from_utf8(const std::string_view value) {
+    std::u8string bytes;
+    bytes.assign(
+        reinterpret_cast<const char8_t*>(value.data()),
+        reinterpret_cast<const char8_t*>(value.data() + value.size()));
+    return fs::path{bytes};
+}
+
+[[nodiscard]] bool is_module_interface_source(const fs::path& path) {
+    const auto kind = mqb::classify_translation_unit_path(path);
+    return kind && *kind == mqb::TranslationUnitKind::module_interface;
 }
 
 [[nodiscard]] std::string json_escape(const std::string_view value) {
@@ -158,7 +172,7 @@ parse_compdb_arguments(const std::span<const std::string_view> arguments) {
             if (index + 1 >= arguments.size() || arguments[index + 1].empty()) {
                 return std::unexpected("mqb compdb --output requires a path");
             }
-            output = fs::u8path(arguments[++index]);
+            output = path_from_utf8(arguments[++index]);
             continue;
         }
         if (!native_tail && argument.starts_with("--output=")) {
@@ -169,7 +183,7 @@ parse_compdb_arguments(const std::span<const std::string_view> arguments) {
             if (value.empty()) {
                 return std::unexpected("mqb compdb --output requires a path");
             }
-            output = fs::u8path(value);
+            output = path_from_utf8(value);
             continue;
         }
         forwarded.push_back(argument);
@@ -310,7 +324,7 @@ int run_compdb_command(const std::span<const std::string_view> arguments) {
     bool discovery_requires_module_pipeline = false;
     if (options.discover_sources
         && requested_sources.size() == 1
-        && !mqb::cli::is_module_interface_source(requested_sources.front())) {
+        && !is_module_interface_source(requested_sources.front())) {
         auto forced_includes = mqb::msvc::MsvcParameterEngine::forced_includes(
             options.compiler_arguments);
         if (!forced_includes) {
@@ -418,7 +432,7 @@ int run_compdb_command(const std::span<const std::string_view> arguments) {
             target_sources.begin(),
             target_sources.end(),
             [](const mqb::orchestration::TargetSourceRequest& source) {
-                return mqb::cli::is_module_interface_source(source.source);
+                return is_module_interface_source(source.source);
             });
     if (module_target) {
         diagnostics::print_error(

--- a/cpp/src/app/targets/CompdbCommand.hpp
+++ b/cpp/src/app/targets/CompdbCommand.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <iostream>
 #include <span>
 #include <string_view>
 

--- a/cpp/src/app/targets/CompdbCommand.hpp
+++ b/cpp/src/app/targets/CompdbCommand.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <span>
+#include <string_view>
+
+namespace mqb::app {
+
+[[nodiscard]] int run_compdb_command(
+    std::span<const std::string_view> arguments);
+
+[[nodiscard]] std::string_view compdb_usage() noexcept;
+
+} // namespace mqb::app

--- a/cpp/src/app/targets/CompdbCommand.hpp
+++ b/cpp/src/app/targets/CompdbCommand.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <iostream>
 #include <span>
 #include <string_view>
 

--- a/tests/native/assert_cpp_layout.ps1
+++ b/tests/native/assert_cpp_layout.ps1
@@ -124,7 +124,11 @@ $appLeafFiles = [ordered]@{
     'cli' = @('Cli.cpp', 'Cli.hpp', 'Invocation.cpp', 'Invocation.hpp')
     'diagnostics' = @('Diagnostics.cpp', 'Diagnostics.hpp', 'PerformanceTimings.cpp', 'PerformanceTimings.hpp')
     'project' = @('ProjectSetup.cpp', 'ProjectSetup.hpp')
-    'targets' = @('ModuleCliTarget.cpp', 'ModuleCliTarget.hpp', 'StaticCliTarget.cpp', 'StaticCliTarget.hpp')
+    'targets' = @(
+        'CompdbCommand.cpp', 'CompdbCommand.hpp',
+        'ModuleCliTarget.cpp', 'ModuleCliTarget.hpp',
+        'StaticCliTarget.cpp', 'StaticCliTarget.hpp'
+    )
 }
 foreach ($leaf in $appLeafFiles.Keys) {
     $leafRoot = Join-Path $appRoot $leaf

--- a/tests/native/verify_compdb.ps1
+++ b/tests/native/verify_compdb.ps1
@@ -55,8 +55,11 @@ if (Test-Path -LiteralPath $root) {
 }
 New-Item -ItemType Directory -Path $root -Force | Out-Null
 
-# Ordinary C++: exact argv, Unicode-safe JSON, custom output, deterministic bytes,
-# and no compile/link/archive side effects.
+# Ordinary C++: exact argv, Unicode-safe project paths/JSON, custom output,
+# deterministic bytes, and no compile/link/archive side effects. Source argv
+# spellings stay ASCII here because MQB's legacy narrow main(int,char**) Unicode
+# command-line boundary is a separate pre-existing product issue; the Unicode
+# working/project path still exercises filesystem and JSON preservation here.
 $ordinary = Join-Path $root 'ordinary 项目'
 New-Item -ItemType Directory -Path (Join-Path $ordinary 'include') -Force | Out-Null
 New-Item -ItemType Directory -Path (Join-Path $ordinary 'src') -Force | Out-Null
@@ -64,7 +67,7 @@ Set-Content -LiteralPath (Join-Path $ordinary 'include/value.hpp') -Encoding utf
     '#pragma once',
     'int value();'
 )
-Set-Content -LiteralPath (Join-Path $ordinary 'src/主.cpp') -Encoding utf8 -Value @(
+Set-Content -LiteralPath (Join-Path $ordinary 'src/main.cpp') -Encoding utf8 -Value @(
     '#include "value.hpp"',
     'int main() { return value() == 7 ? 0 : 1; }'
 )
@@ -75,7 +78,7 @@ Set-Content -LiteralPath (Join-Path $ordinary 'src/value.cpp') -Encoding utf8 -V
 
 $ordinaryArgs = @(
     'compdb',
-    'src/主.cpp',
+    'src/main.cpp',
     'src/value.cpp',
     '--no-discover',
     '--std', '23',
@@ -93,11 +96,12 @@ Assert-True ($database.Count -eq 2) "expected 2 compilation database entries, go
 
 $files = @($database | ForEach-Object { [string]$_.file })
 Assert-True ($files[0] -lt $files[1]) 'compilation database entries are not deterministic path-sorted output'
-Assert-True (($files -join "`n") -match '主\.cpp') 'Unicode source path was not preserved in JSON'
+Assert-True (($files -join "`n") -match '编译 数据库') 'Unicode project path was not preserved in JSON'
 foreach ($entry in $database) {
     Assert-True ([System.IO.Path]::IsPathFullyQualified([string]$entry.directory)) 'directory must be absolute'
     Assert-True ([System.IO.Path]::IsPathFullyQualified([string]$entry.file)) 'file must be absolute'
     Assert-True ([System.IO.Path]::IsPathFullyQualified([string]$entry.output)) 'output must be absolute'
+    Assert-True (([string]$entry.directory) -match '编译 数据库') 'Unicode directory field was not preserved'
     $arguments = @($entry.arguments | ForEach-Object { [string]$_ })
     Assert-True ($arguments.Count -gt 1) 'arguments array must include compiler plus compiler argv'
     Assert-True ([System.IO.Path]::GetFileName($arguments[0]).Equals('cl.exe', [System.StringComparison]::OrdinalIgnoreCase)) 'arguments[0] must be cl.exe'

--- a/tests/native/verify_compdb.ps1
+++ b/tests/native/verify_compdb.ps1
@@ -24,8 +24,13 @@ function Invoke-MqbCaptured {
     Push-Location $WorkingDirectory
     try {
         $text = (& $MqbPath @Arguments 2>&1 | Out-String)
+        $exitCode = $LASTEXITCODE
+        # Some evidence cases intentionally exercise a non-zero MQB exit code.
+        # Preserve it in the returned record, but do not leak native-process
+        # status into the verifier's own final exit status.
+        $global:LASTEXITCODE = 0
         return [PSCustomObject]@{
-            ExitCode = $LASTEXITCODE
+            ExitCode = $exitCode
             Text = $text
         }
     }

--- a/tests/native/verify_compdb.ps1
+++ b/tests/native/verify_compdb.ps1
@@ -1,0 +1,168 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$MqbPath,
+    [Parameter(Mandatory = $true)][string]$RepoRoot
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+function Assert-True {
+    param(
+        [Parameter(Mandatory = $true)][bool]$Condition,
+        [Parameter(Mandatory = $true)][string]$Message
+    )
+    if (-not $Condition) { throw $Message }
+}
+
+function Invoke-MqbCaptured {
+    param(
+        [Parameter(Mandatory = $true)][string]$WorkingDirectory,
+        [Parameter(Mandatory = $true)][string[]]$Arguments
+    )
+
+    Push-Location $WorkingDirectory
+    try {
+        $text = (& $MqbPath @Arguments 2>&1 | Out-String)
+        return [PSCustomObject]@{
+            ExitCode = $LASTEXITCODE
+            Text = $text
+        }
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+function Assert-NoBuildArtifacts {
+    param([Parameter(Mandatory = $true)][string]$ProjectRoot)
+
+    foreach ($relative in @('.mqb/obj', '.mqb/deps', '.mqb/scan', '.mqb/ifc', '.mqb/bin', '.mqb/pch')) {
+        $path = Join-Path $ProjectRoot $relative
+        if (-not (Test-Path -LiteralPath $path)) { continue }
+        $files = @(Get-ChildItem -LiteralPath $path -Recurse -File -ErrorAction Stop)
+        Assert-True ($files.Count -eq 0) "mqb compdb produced build artifact(s) under $relative"
+    }
+}
+
+$MqbPath = [System.IO.Path]::GetFullPath($MqbPath)
+$RepoRoot = [System.IO.Path]::GetFullPath($RepoRoot)
+Assert-True (Test-Path -LiteralPath $MqbPath -PathType Leaf) "MQB executable not found: $MqbPath"
+
+$root = Join-Path $RepoRoot 'native-out/compdb-evidence/编译 数据库'
+if (Test-Path -LiteralPath $root) {
+    Remove-Item -LiteralPath $root -Recurse -Force
+}
+New-Item -ItemType Directory -Path $root -Force | Out-Null
+
+# Ordinary C++: exact argv, Unicode-safe JSON, custom output, deterministic bytes,
+# and no compile/link/archive side effects.
+$ordinary = Join-Path $root 'ordinary 项目'
+New-Item -ItemType Directory -Path (Join-Path $ordinary 'include') -Force | Out-Null
+New-Item -ItemType Directory -Path (Join-Path $ordinary 'src') -Force | Out-Null
+Set-Content -LiteralPath (Join-Path $ordinary 'include/value.hpp') -Encoding utf8 -Value @(
+    '#pragma once',
+    'int value();'
+)
+Set-Content -LiteralPath (Join-Path $ordinary 'src/主.cpp') -Encoding utf8 -Value @(
+    '#include "value.hpp"',
+    'int main() { return value() == 7 ? 0 : 1; }'
+)
+Set-Content -LiteralPath (Join-Path $ordinary 'src/value.cpp') -Encoding utf8 -Value @(
+    '#include "value.hpp"',
+    'int value() { return VALUE; }'
+)
+
+$ordinaryArgs = @(
+    'compdb',
+    'src/主.cpp',
+    'src/value.cpp',
+    '--no-discover',
+    '--std', '23',
+    '-I', 'include',
+    '-D', 'VALUE=7',
+    '--output', 'out/compile_commands.json'
+)
+$ordinaryRun = Invoke-MqbCaptured -WorkingDirectory $ordinary -Arguments $ordinaryArgs
+Assert-True ($ordinaryRun.ExitCode -eq 0) "ordinary compdb failed:`n$($ordinaryRun.Text)"
+
+$databasePath = Join-Path $ordinary 'out/compile_commands.json'
+Assert-True (Test-Path -LiteralPath $databasePath -PathType Leaf) 'compile_commands.json was not created'
+$database = @(Get-Content -LiteralPath $databasePath -Raw -Encoding utf8 | ConvertFrom-Json)
+Assert-True ($database.Count -eq 2) "expected 2 compilation database entries, got $($database.Count)"
+
+$files = @($database | ForEach-Object { [string]$_.file })
+Assert-True ($files[0] -lt $files[1]) 'compilation database entries are not deterministic path-sorted output'
+Assert-True (($files -join "`n") -match '主\.cpp') 'Unicode source path was not preserved in JSON'
+foreach ($entry in $database) {
+    Assert-True ([System.IO.Path]::IsPathFullyQualified([string]$entry.directory)) 'directory must be absolute'
+    Assert-True ([System.IO.Path]::IsPathFullyQualified([string]$entry.file)) 'file must be absolute'
+    Assert-True ([System.IO.Path]::IsPathFullyQualified([string]$entry.output)) 'output must be absolute'
+    $arguments = @($entry.arguments | ForEach-Object { [string]$_ })
+    Assert-True ($arguments.Count -gt 1) 'arguments array must include compiler plus compiler argv'
+    Assert-True ([System.IO.Path]::GetFileName($arguments[0]).Equals('cl.exe', [System.StringComparison]::OrdinalIgnoreCase)) 'arguments[0] must be cl.exe'
+    Assert-True (($arguments -join "`n") -match 'VALUE=7') 'typed define did not reach exact compiler argv'
+    Assert-True (($arguments -join "`n") -match 'include') 'include directory did not reach exact compiler argv'
+}
+Assert-NoBuildArtifacts -ProjectRoot $ordinary
+
+$firstHash = (Get-FileHash -LiteralPath $databasePath -Algorithm SHA256).Hash
+$ordinaryRun2 = Invoke-MqbCaptured -WorkingDirectory $ordinary -Arguments $ordinaryArgs
+Assert-True ($ordinaryRun2.ExitCode -eq 0) "second ordinary compdb failed:`n$($ordinaryRun2.Text)"
+$secondHash = (Get-FileHash -LiteralPath $databasePath -Algorithm SHA256).Hash
+Assert-True ($firstHash -eq $secondHash) 'identical compdb inputs did not produce byte-identical JSON'
+Assert-NoBuildArtifacts -ProjectRoot $ordinary
+
+# First-class PCH: compdb models consumer recipes without creating the synthetic
+# creator source, .pch, creator object, or any consumer object.
+$pch = Join-Path $root 'pch-project'
+New-Item -ItemType Directory -Path (Join-Path $pch 'include') -Force | Out-Null
+New-Item -ItemType Directory -Path (Join-Path $pch 'src') -Force | Out-Null
+Set-Content -LiteralPath (Join-Path $pch 'include/pch.hpp') -Encoding utf8 -Value '#pragma once'
+Set-Content -LiteralPath (Join-Path $pch 'src/main.cpp') -Encoding utf8 -Value 'int main() { return 0; }'
+Set-Content -LiteralPath (Join-Path $pch 'src/helper.cpp') -Encoding utf8 -Value 'int helper() { return 1; }'
+Set-Content -LiteralPath (Join-Path $pch 'mqb.json') -Encoding utf8 -Value @'
+{
+  "version": 1,
+  "build": {
+    "entry": "src/main.cpp",
+    "pch": "include/pch.hpp"
+  }
+}
+'@
+
+$pchRun = Invoke-MqbCaptured -WorkingDirectory $pch -Arguments @(
+    'compdb', 'src/main.cpp', 'src/helper.cpp', '--no-discover'
+)
+Assert-True ($pchRun.ExitCode -eq 0) "PCH compdb failed:`n$($pchRun.Text)"
+$pchDatabasePath = Join-Path $pch 'compile_commands.json'
+$pchDatabase = @(Get-Content -LiteralPath $pchDatabasePath -Raw -Encoding utf8 | ConvertFrom-Json)
+Assert-True ($pchDatabase.Count -eq 2) 'PCH compdb should expose both consumer translation units'
+foreach ($entry in $pchDatabase) {
+    $joined = (@($entry.arguments | ForEach-Object { [string]$_ }) -join "`n")
+    Assert-True ($joined -match '/Yu') 'PCH consumer recipe is missing /Yu'
+    Assert-True ($joined -match '/Fp') 'PCH consumer recipe is missing /Fp'
+    Assert-True ($joined -match '/FI') 'PCH consumer recipe is missing forced include policy'
+}
+Assert-NoBuildArtifacts -ProjectRoot $pch
+
+# Modules/Header Units intentionally fail closed in this first user-facing slice.
+$modules = Join-Path $root 'module-project'
+New-Item -ItemType Directory -Path $modules -Force | Out-Null
+Set-Content -LiteralPath (Join-Path $modules 'math.ixx') -Encoding utf8 -Value @(
+    'export module math;',
+    'export int answer() { return 42; }'
+)
+Set-Content -LiteralPath (Join-Path $modules 'main.cpp') -Encoding utf8 -Value @(
+    'import math;',
+    'int main() { return answer() == 42 ? 0 : 1; }'
+)
+$moduleRun = Invoke-MqbCaptured -WorkingDirectory $modules -Arguments @(
+    'compdb', 'main.cpp', 'math.ixx', '--no-discover', '--output', 'module.json'
+)
+Assert-True ($moduleRun.ExitCode -eq 2) "module compdb should fail closed with exit 2:`n$($moduleRun.Text)"
+Assert-True ($moduleRun.Text -match 'Modules/Header Units') 'module fail-closed diagnostic is missing the unsupported boundary'
+Assert-True (-not (Test-Path -LiteralPath (Join-Path $modules 'module.json'))) 'module fail-closed path must not publish partial JSON'
+Assert-NoBuildArtifacts -ProjectRoot $modules
+
+Write-Host 'mqb compdb evidence passed'


### PR DESCRIPTION
## Goal

Build the first user-facing v5.4 introspection feature on top of #134's first-class compile recipe authority: `mqb compdb`.

## Stacking

This PR is intentionally stacked on `refactor/first-class-compile-recipes` / PR #134. It does not target `main` directly and must not be merged before #134 is resolved.

## Product behavior

- add `mqb compdb [entry.cpp] [options]`;
- reuse the existing build-side parser by forwarding compile-side options through the normal `build` contract while reserving `-o/--output` for the compilation-database path in this command;
- reuse `prepare_project`, default-entry resolution, smart source discovery, project artifact layout, MSVC toolchain discovery, parameter lifecycle validation, and `MsvcCompileExecutor::build_recipe()`;
- emit standard `compile_commands.json` entries with `directory`, `file`, `arguments`, and `output`;
- include the compiler executable as argv[0] and preserve exact ordered MSVC argv from the first-class recipe;
- sort entries by Windows path identity for deterministic output;
- write through a temporary file and publish only after complete JSON rendering;
- ordinary C/C++ targets are supported, including first-class PCH consumer recipes without compiling the PCH;
- Modules/Header Units fail closed in this first slice because exact consumer argv requires P1689 graph materialization; graph-aware compdb support is a deliberate follow-up.

## Non-goals

- no compile/link/archive/run side effects;
- no cache-identity changes;
- no `mqb plan` yet;
- no config schema change;
- no version/release change;
- no module/header-unit compdb guessing.

## Validation

This PR remains draft while the exact branch is built and exercised on Windows/MSVC. Follow-up validation will include a real generated database, JSON parsing, argv/source/output checks, PCH modeling, and proof that no compile/link artifacts are produced by `mqb compdb` itself.