### PR TITLE
fix: preserve Unicode Windows command-line arguments

### DIFF
--- a/cpp/include/mqb/platform/windows/CommandLine.hpp
+++ b/cpp/include/mqb/platform/windows/CommandLine.hpp
@@ -1,10 +1,22 @@
 #pragma once
 
+#include <cstdint>
+#include <expected>
 #include <span>
 #include <string>
 #include <string_view>
 
 namespace mqb::platform::windows {
+
+struct CommandLineEncodingError {
+    std::uint32_t native_code{};
+    std::string message;
+};
+
+// Convert one Windows UTF-16 argv element into MQB's internal UTF-8 text
+// contract without depending on the active ANSI/OEM code page.
+[[nodiscard]] std::expected<std::string, CommandLineEncodingError>
+utf16_to_utf8(std::wstring_view value);
 
 // Encodes one argv element using the Microsoft C/C++ command-line parsing
 // rules. This is a platform boundary helper, not the process model itself.

--- a/cpp/src/app/Application.cpp
+++ b/cpp/src/app/Application.cpp
@@ -303,7 +303,7 @@ int Application::run(const std::span<const std::string_view> arguments) {
     }
 
     const std::string target_name = options.build.output_name.value_or(
-        requested_sources.front().stem().string());
+        diagnostics::path_text(requested_sources.front().stem()));
     auto target_artifacts = layout->for_target(target_name, options.build.target_kind);
     if (!target_artifacts) {
         diagnostics::print_error(target_artifacts.error().message);

--- a/cpp/src/app/cli/Cli.cpp
+++ b/cpp/src/app/cli/Cli.cpp
@@ -24,6 +24,14 @@ namespace {
     return Error{.message = std::move(message)};
 }
 
+[[nodiscard]] std::filesystem::path path_from_utf8(const std::string_view value) {
+    std::u8string bytes;
+    bytes.assign(
+        reinterpret_cast<const char8_t*>(value.data()),
+        reinterpret_cast<const char8_t*>(value.data() + value.size()));
+    return std::filesystem::path{bytes};
+}
+
 [[nodiscard]] bool is_legacy_option(const std::string_view argument) noexcept {
     return argument == "-config"
         || argument == "-std"
@@ -150,7 +158,7 @@ parse_external_module_provider(const std::string_view value) {
     }
     return ExternalModuleProvider{
         .logical_name = std::string{value.substr(0, separator)},
-        .interface_file = std::filesystem::u8path(value.substr(separator + 1)),
+        .interface_file = path_from_utf8(value.substr(separator + 1)),
     };
 }
 
@@ -357,7 +365,7 @@ parse_arguments(const std::span<const std::string_view> arguments) {
             if (!value) return std::unexpected(value.error());
             auto selected = select_pch(options, PrecompiledHeaderPolicy{
                 .enabled = true,
-                .header = std::filesystem::u8path(*value),
+                .header = path_from_utf8(*value),
             });
             if (!selected) return std::unexpected(selected.error());
             continue;
@@ -367,7 +375,7 @@ parse_arguments(const std::span<const std::string_view> arguments) {
             if (!value) return std::unexpected(value.error());
             auto selected = select_pch(options, PrecompiledHeaderPolicy{
                 .enabled = true,
-                .header = std::filesystem::u8path(*value),
+                .header = path_from_utf8(*value),
             });
             if (!selected) return std::unexpected(selected.error());
             continue;
@@ -574,19 +582,19 @@ parse_arguments(const std::span<const std::string_view> arguments) {
         if (argument == "--portable-root") {
             auto value = require_value(arguments, index, argument);
             if (!value) return std::unexpected(value.error());
-            options.portable_roots.emplace_back(std::string{*value});
+            options.portable_roots.push_back(path_from_utf8(*value));
             continue;
         }
         if (argument == "--lib-path") {
             auto value = require_value(arguments, index, argument);
             if (!value) return std::unexpected(value.error());
-            options.library_directories.emplace_back(std::string{*value});
+            options.library_directories.push_back(path_from_utf8(*value));
             continue;
         }
         if (argument.starts_with("--lib-path=")) {
             auto value = long_equals_value(argument, "--lib-path=");
             if (!value) return std::unexpected(value.error());
-            options.library_directories.emplace_back(std::string{*value});
+            options.library_directories.push_back(path_from_utf8(*value));
             continue;
         }
         if (argument == "--lib") {
@@ -610,7 +618,7 @@ parse_arguments(const std::span<const std::string_view> arguments) {
             auto value = attached_or_next(arguments, index, argument, "-I");
             if (!value) return std::unexpected(value.error());
             if (value->empty()) return std::unexpected(error("empty include directory"));
-            options.include_directories.emplace_back(std::string{*value});
+            options.include_directories.push_back(path_from_utf8(*value));
             continue;
         }
         if (argument == "-D" || argument.starts_with("-D")) {
@@ -624,7 +632,7 @@ parse_arguments(const std::span<const std::string_view> arguments) {
             auto value = attached_or_next(arguments, index, argument, "-L");
             if (!value) return std::unexpected(value.error());
             if (value->empty()) return std::unexpected(error("empty library directory"));
-            options.library_directories.emplace_back(std::string{*value});
+            options.library_directories.push_back(path_from_utf8(*value));
             continue;
         }
         if (argument == "-l" || argument.starts_with("-l")) {
@@ -652,7 +660,7 @@ parse_arguments(const std::span<const std::string_view> arguments) {
             return std::unexpected(error("unknown option '" + std::string{argument} + "'"));
         }
 
-        options.build.sources.emplace_back(std::string{argument});
+        options.build.sources.push_back(path_from_utf8(argument));
     }
 
     if (native_linker_tail && !native_linker_tail_has_argument) {

--- a/cpp/src/app/main.cpp
+++ b/cpp/src/app/main.cpp
@@ -1,15 +1,35 @@
+#include <iostream>
 #include <span>
+#include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include "Application.hpp"
 #include "CompdbCommand.hpp"
+#include "mqb/platform/windows/CommandLine.hpp"
 
-int main(const int argc, char* argv[]) {
-    std::vector<std::string_view> arguments;
-    arguments.reserve(argc > 1 ? static_cast<std::size_t>(argc - 1) : 0u);
+int wmain(const int argc, wchar_t* argv[]) {
+    std::vector<std::string> argument_storage;
+    argument_storage.reserve(argc > 1 ? static_cast<std::size_t>(argc - 1) : 0u);
     for (int index = 1; index < argc; ++index) {
-        arguments.emplace_back(argv[index]);
+        auto encoded = mqb::platform::windows::utf16_to_utf8(argv[index]);
+        if (!encoded) {
+            std::cerr << "error: failed to decode Windows command-line argument "
+                      << index << " as UTF-8: " << encoded.error().message;
+            if (encoded.error().native_code != 0) {
+                std::cerr << " (Win32 " << encoded.error().native_code << ')';
+            }
+            std::cerr << '\n';
+            return 2;
+        }
+        argument_storage.push_back(std::move(*encoded));
+    }
+
+    std::vector<std::string_view> arguments;
+    arguments.reserve(argument_storage.size());
+    for (const auto& argument : argument_storage) {
+        arguments.emplace_back(argument);
     }
 
     if (!arguments.empty() && arguments.front() == "compdb") {

--- a/cpp/src/app/targets/CompdbCommand.cpp
+++ b/cpp/src/app/targets/CompdbCommand.cpp
@@ -442,7 +442,7 @@ int run_compdb_command(const std::span<const std::string_view> arguments) {
     }
 
     const std::string target_name = options.build.output_name.value_or(
-        requested_sources.front().stem().string());
+        diagnostics::path_text(requested_sources.front().stem()));
     if (effective.precompiled_header) {
         const auto c_source = std::find_if(
             target_sources.begin(),

--- a/cpp/src/core/planning/ProjectArtifactLayout.cpp
+++ b/cpp/src/core/planning/ProjectArtifactLayout.cpp
@@ -15,6 +15,14 @@ namespace {
 
 namespace fs = std::filesystem;
 
+[[nodiscard]] fs::path path_from_utf8(const std::string_view value) {
+    std::u8string bytes;
+    bytes.assign(
+        reinterpret_cast<const char8_t*>(value.data()),
+        reinterpret_cast<const char8_t*>(value.data() + value.size()));
+    return fs::path{bytes};
+}
+
 [[nodiscard]] ArtifactLayoutError failure(
     const ArtifactLayoutErrorCode code,
     fs::path path,
@@ -43,11 +51,7 @@ namespace fs = std::filesystem;
 
 [[nodiscard]] fs::path identity_path(const fs::path& path) {
     const std::string key = platform::windows::path_identity_key(path);
-    std::u8string utf8;
-    utf8.assign(
-        reinterpret_cast<const char8_t*>(key.data()),
-        reinterpret_cast<const char8_t*>(key.data() + key.size()));
-    return fs::path{utf8};
+    return path_from_utf8(key);
 }
 
 [[nodiscard]] bool safe_relative(const fs::path& relative) {
@@ -122,7 +126,7 @@ namespace fs = std::filesystem;
 
 [[nodiscard]] bool valid_target_name(const std::string_view target_name) {
     if (target_name.empty()) return false;
-    const fs::path path{std::string{target_name}};
+    const fs::path path = path_from_utf8(target_name);
     return !path.has_root_path()
         && !path.has_parent_path()
         && path.filename() == path
@@ -212,14 +216,15 @@ ProjectArtifactLayout::for_precompiled_header(
     const std::string_view target_name,
     const BuildConfiguration configuration,
     const Architecture architecture) const {
+    const fs::path target_path = path_from_utf8(target_name);
     if (!valid_target_name(target_name)) {
         return std::unexpected(failure(
             ArtifactLayoutErrorCode::invalid_target_name,
-            fs::path{std::string{target_name}},
+            target_path,
             "target name must be one filename component"));
     }
 
-    const fs::path key = fs::path{std::string{target_name}}
+    const fs::path key = target_path
         / std::string{configuration_name(configuration)}
         / std::string{architecture_name(architecture)};
     const fs::path root = artifact_root_ / "pch" / key;
@@ -236,22 +241,23 @@ std::expected<TargetArtifacts, ArtifactLayoutError>
 ProjectArtifactLayout::for_target(
     const std::string_view target_name,
     const TargetKind target_kind) const {
+    const fs::path target_path = path_from_utf8(target_name);
     if (!valid_target_name(target_name)) {
         return std::unexpected(failure(
             ArtifactLayoutErrorCode::invalid_target_name,
-            fs::path{std::string{target_name}},
+            target_path,
             "target name must be one filename component"));
     }
 
-    fs::path executable = artifact_root_ / "bin" / std::string{target_name};
+    fs::path executable = artifact_root_ / "bin" / target_path;
     executable += target_suffix(target_kind);
 
     fs::path target_cache;
     if (target_kind == TargetKind::static_library) {
-        target_cache = artifact_root_ / "cache" / "archive" / std::string{target_name};
+        target_cache = artifact_root_ / "cache" / "archive" / target_path;
         target_cache += ".archivecache";
     } else {
-        target_cache = artifact_root_ / "cache" / "link" / std::string{target_name};
+        target_cache = artifact_root_ / "cache" / "link" / target_path;
         target_cache += ".linkcache";
     }
 

--- a/cpp/src/platform/windows/CommandLine.cpp
+++ b/cpp/src/platform/windows/CommandLine.cpp
@@ -1,9 +1,16 @@
 #include "mqb/platform/windows/CommandLine.hpp"
 
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+
 #include <cstddef>
+#include <limits>
 #include <span>
 #include <string>
 #include <string_view>
+#include <utility>
 
 namespace mqb::platform::windows {
 namespace {
@@ -21,7 +28,66 @@ namespace {
     return false;
 }
 
+[[nodiscard]] CommandLineEncodingError encoding_error(
+    const DWORD native_code,
+    std::string message) {
+    return CommandLineEncodingError{
+        .native_code = static_cast<std::uint32_t>(native_code),
+        .message = std::move(message),
+    };
+}
+
 } // namespace
+
+std::expected<std::string, CommandLineEncodingError>
+utf16_to_utf8(const std::wstring_view value) {
+    if (value.find(L'\0') != std::wstring_view::npos) {
+        return std::unexpected(encoding_error(
+            ERROR_INVALID_PARAMETER,
+            "Windows command-line argument contains an embedded NUL"));
+    }
+    if (value.empty()) {
+        return std::string{};
+    }
+    if (value.size() > static_cast<std::size_t>(std::numeric_limits<int>::max())) {
+        return std::unexpected(encoding_error(
+            ERROR_INSUFFICIENT_BUFFER,
+            "Windows command-line argument is too large to encode as UTF-8"));
+    }
+
+    const int source_length = static_cast<int>(value.size());
+    const int required = ::WideCharToMultiByte(
+        CP_UTF8,
+        WC_ERR_INVALID_CHARS,
+        value.data(),
+        source_length,
+        nullptr,
+        0,
+        nullptr,
+        nullptr);
+    if (required == 0) {
+        return std::unexpected(encoding_error(
+            ::GetLastError(),
+            "Windows command-line argument is not valid UTF-16"));
+    }
+
+    std::string result(static_cast<std::size_t>(required), '\0');
+    const int converted = ::WideCharToMultiByte(
+        CP_UTF8,
+        WC_ERR_INVALID_CHARS,
+        value.data(),
+        source_length,
+        result.data(),
+        required,
+        nullptr,
+        nullptr);
+    if (converted != required) {
+        return std::unexpected(encoding_error(
+            ::GetLastError(),
+            "failed to encode Windows command-line argument as UTF-8"));
+    }
+    return result;
+}
 
 std::wstring quote_command_line_argument(const std::wstring_view argument) {
     if (!needs_quotes(argument)) {

--- a/cpp/tests/platform/windows/windows_command_line_tests.cpp
+++ b/cpp/tests/platform/windows/windows_command_line_tests.cpp
@@ -92,6 +92,7 @@ int main() {
     using mqb::platform::windows::path_identity_contains;
     using mqb::platform::windows::path_identity_key;
     using mqb::platform::windows::quote_command_line_argument;
+    using mqb::platform::windows::utf16_to_utf8;
 
     expect(quote_command_line_argument(L"plain") == L"plain",
            "plain argument should not be quoted unnecessarily");
@@ -99,6 +100,24 @@ int main() {
            "empty argument must survive as an explicit argv element");
     expect(quote_command_line_argument(L"two words") == L"\"two words\"",
            "whitespace should force quoting");
+
+    const auto ascii_utf8 = utf16_to_utf8(L"plain");
+    expect(ascii_utf8.has_value() && *ascii_utf8 == "plain",
+           "UTF-16 ASCII argv should encode to identical UTF-8 text");
+    const auto unicode_utf8 = utf16_to_utf8(L"路径-日本語-测试-🙂");
+    expect(unicode_utf8.has_value() && *unicode_utf8 == "路径-日本語-测试-🙂",
+           "UTF-16 Unicode argv should preserve exact code points in UTF-8");
+    const auto empty_utf8 = utf16_to_utf8(L"");
+    expect(empty_utf8.has_value() && empty_utf8->empty(),
+           "empty UTF-16 argv should remain an explicit empty UTF-8 element");
+
+    const std::wstring embedded_nul{L'a', L'\0', L'b'};
+    expect(!utf16_to_utf8(embedded_nul).has_value(),
+           "embedded NUL must fail closed at the Windows argv encoding boundary");
+    const std::wstring unpaired_high_surrogate{
+        static_cast<wchar_t>(0xD800)};
+    expect(!utf16_to_utf8(unpaired_high_surrogate).has_value(),
+           "invalid UTF-16 surrogate input must fail closed instead of replacement encoding");
 
     expect_round_trip(
         L"C:\\Program Files\\MQB\\mqb.exe",

--- a/tests/native/verify_compdb.ps1
+++ b/tests/native/verify_compdb.ps1
@@ -60,11 +60,8 @@ if (Test-Path -LiteralPath $root) {
 }
 New-Item -ItemType Directory -Path $root -Force | Out-Null
 
-# Ordinary C++: exact argv, Unicode-safe project paths/JSON, custom output,
-# deterministic bytes, and no compile/link/archive side effects. Source argv
-# spellings stay ASCII here because MQB's legacy narrow main(int,char**) Unicode
-# command-line boundary is a separate pre-existing product issue; the Unicode
-# working/project path still exercises filesystem and JSON preservation here.
+# Ordinary C++: exact argv, Unicode-safe CLI/project paths/JSON, custom output,
+# deterministic bytes, and no compile/link/archive side effects.
 $ordinary = Join-Path $root 'ordinary 项目'
 New-Item -ItemType Directory -Path (Join-Path $ordinary 'include') -Force | Out-Null
 New-Item -ItemType Directory -Path (Join-Path $ordinary 'src') -Force | Out-Null
@@ -72,7 +69,7 @@ Set-Content -LiteralPath (Join-Path $ordinary 'include/value.hpp') -Encoding utf
     '#pragma once',
     'int value();'
 )
-Set-Content -LiteralPath (Join-Path $ordinary 'src/main.cpp') -Encoding utf8 -Value @(
+Set-Content -LiteralPath (Join-Path $ordinary 'src/主.cpp') -Encoding utf8 -Value @(
     '#include "value.hpp"',
     'int main() { return value() == 7 ? 0 : 1; }'
 )
@@ -83,7 +80,7 @@ Set-Content -LiteralPath (Join-Path $ordinary 'src/value.cpp') -Encoding utf8 -V
 
 $ordinaryArgs = @(
     'compdb',
-    'src/main.cpp',
+    'src/主.cpp',
     'src/value.cpp',
     '--no-discover',
     '--std', '23',
@@ -102,6 +99,7 @@ Assert-True ($database.Count -eq 2) "expected 2 compilation database entries, go
 $files = @($database | ForEach-Object { [string]$_.file })
 Assert-True ($files[0] -lt $files[1]) 'compilation database entries are not deterministic path-sorted output'
 Assert-True (($files -join "`n") -match '编译 数据库') 'Unicode project path was not preserved in JSON'
+Assert-True (($files -join "`n") -match '主\.cpp') 'Unicode source argv/path was not preserved in JSON'
 foreach ($entry in $database) {
     Assert-True ([System.IO.Path]::IsPathFullyQualified([string]$entry.directory)) 'directory must be absolute'
     Assert-True ([System.IO.Path]::IsPathFullyQualified([string]$entry.file)) 'file must be absolute'


### PR DESCRIPTION
## Goal

Close Issue #136 by fixing MQB's complete Windows Unicode CLI boundary so non-ASCII command-line text survives from the OS UTF-16 argv through MQB's UTF-8 CLI model into `std::filesystem::path` and back into UTF-8 product names without code-page loss.

## Stacking

This PR is intentionally stacked on `feat/compdb-introspection` / PR #135. It must not be merged before #135 is resolved. It remains Draft and does not modify `main` directly.

## Root cause

Real Windows CI exposed three distinct narrow-conversion boundaries:

1. **OS argv boundary** — the old `main(int, char**)` could receive `src/主.cpp` as `src/?.cpp` before MQB parsed it.
2. **UTF-8 -> filesystem boundary** — after moving to `wmain`, valid UTF-8 `CaféProject/main.cpp` was still passed to narrow `std::filesystem::path(std::string)` construction and became `CafÃ©Project/main.cpp`.
3. **filesystem -> product-name boundary** — once `src/主.cpp` reached `std::filesystem::path` correctly, the default target name still used `.stem().string()`, causing an ACP narrow conversion/exception for the stem `主`.

The final product contract is now explicit:

```text
Windows UTF-16 argv
  -> strict UTF-8 text
  -> UTF-8-aware filesystem paths
  -> UTF-8 product/target names
```

## Changes

- add strict `platform::windows::utf16_to_utf8()` in the existing Windows command-line authority;
- convert the executable entry point from narrow `main` to `wmain`;
- preserve every argv element in owned UTF-8 storage before exposing `std::string_view` to the existing CLI/application pipeline;
- fail closed on embedded NUL, invalid UTF-16 surrogate data, oversized input, or Win32 conversion failure;
- add one private UTF-8 path-construction authority in the CLI and use it for positional sources, `-I`, `-L`, `--lib-path`, `--portable-root`, typed PCH paths, and external IFC paths;
- remove the deprecated `std::filesystem::u8path` calls touched by this path;
- make `ProjectArtifactLayout` interpret UTF-8 target names as UTF-8 when validating and allocating executable/PCH/cache paths;
- derive default target names through the existing UTF-8 `diagnostics::path_text()` authority instead of `.stem().string()` in both ordinary Application and `mqb compdb`;
- add unit coverage for ASCII, multilingual Unicode, emoji/surrogate pairs, empty argv, embedded NUL, and invalid UTF-16;
- restore the compdb Windows evidence fixture to a real non-ASCII source filename `src/主.cpp` and require that exact filename in `compile_commands.json`;
- keep the existing Final Closure `CaféProject` Unicode/case-alias fixture unchanged so it independently proves ordinary `mqb build` path semantics.

## Non-goals

- no change to Windows path identity equivalence;
- no change to compiler/linker argv construction;
- no cache/signature changes;
- no config schema changes;
- no release/version changes.

## Exact validated head

`a3c1b9671c3f127d8c52a1d22812f2242a29b788`

## Validation

All required validation is green on the exact head above:

- Documentation: **success**;
- Final Closure Cross-Stage: **success** with the unchanged `CaféProject` fixture;
- Compilation Database Evidence: **success** with real `src/主.cpp`, deterministic JSON, exact compiler argv, PCH modeling, and no build side effects;
- Native C++ preflight: **success** including environment isolation, ASan, LibFuzzer, OpenMP, include-search freshness, `__has_include`, linker repair, exact parameter inventory, and semantic variant inventory;
- Native Debug tests: **4/4 shards success**;
- Native C++ gate: **success**;
- Native Release Stage 0 build: **success**;
- Native Release tests: **4/4 shards success**;
- Release self-host: **success**;
- runtime-only package staging/validation/upload: **success**;
- release publication: intentionally skipped for a pull request.

No PR is merged by this change.