### PR TITLE
refactor: add side-effect-free PCH inspection

### DIFF
--- a/.github/workflows/pch-inspection-evidence.yml
+++ b/.github/workflows/pch-inspection-evidence.yml
@@ -1,0 +1,52 @@
+name: PCH Inspection Evidence
+
+on:
+  pull_request:
+    paths:
+      - 'cpp/include/mqb/orchestration/MsvcIncrementalPchCoordinator.hpp'
+      - 'cpp/src/orchestration/incremental/MsvcIncrementalPchCoordinator.cpp'
+      - 'cpp/include/mqb/orchestration/MsvcIncrementalCompileCoordinator.hpp'
+      - 'cpp/src/orchestration/incremental/MsvcIncrementalCompileCoordinator.cpp'
+      - 'cpp/src/core/**'
+      - 'cpp/src/msvc/**'
+      - 'cpp/mqb.json'
+      - 'tests/native/pch_inspection_contract.cpp'
+      - 'tests/native/verify_pch_inspection.ps1'
+      - 'tests/native/assert_cpp_layout.ps1'
+      - '.github/workflows/pch-inspection-evidence.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pch-inspection-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify-pch-inspection:
+    name: Verify side-effect-free PCH inspection
+    runs-on: windows-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Acquire pinned MQB seed
+        id: seed
+        shell: pwsh
+        run: |
+          $seed = & (Join-Path $PWD 'tests/native/acquire_seed.ps1') `
+            -RepoRoot $PWD `
+            -OutputRoot (Join-Path $PWD 'native-seed')
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          "path=$seed" >> $env:GITHUB_OUTPUT
+
+      - name: Verify PCH inspection contract
+        shell: pwsh
+        run: |
+          & (Join-Path $PWD 'tests/native/verify_pch_inspection.ps1') `
+            -BuilderMqbPath '${{ steps.seed.outputs.path }}' `
+            -RepoRoot $PWD
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/cpp/include/mqb/orchestration/MsvcIncrementalPchCoordinator.hpp
+++ b/cpp/include/mqb/orchestration/MsvcIncrementalPchCoordinator.hpp
@@ -31,6 +31,17 @@ struct IncrementalPchRequest {
     std::filesystem::path working_directory;
 };
 
+struct IncrementalPchInspection {
+    // Exact typed compile request projected by the PCH coordinator. Future
+    // introspection consumers can feed this directly into build_recipe()
+    // without reproducing /Yc, /Fp, /FI, artifact, or working-directory policy.
+    IncrementalCompileRequest compile_request;
+    IncrementalCompileInspection compile;
+    // The synthetic creator is MQB-owned writable state. Inspection reports
+    // whether execution would have to materialize/repair it, but never writes it.
+    bool creator_source_materialization_required{false};
+};
+
 struct IncrementalPchResult {
     IncrementalCompileResult compile;
 };
@@ -40,6 +51,12 @@ public:
     explicit MsvcIncrementalPchCoordinator(
         MsvcIncrementalCompileCoordinator& compile_coordinator)
         : compile_coordinator_(compile_coordinator) {}
+
+    // Validate the PCH request, project its exact typed creator compile request,
+    // and inspect incremental freshness without creating directories, writing the
+    // synthetic creator source, touching cache/output state, or launching cl.exe.
+    [[nodiscard]] std::expected<IncrementalPchInspection, IncrementalPchError>
+    inspect(const IncrementalPchRequest& request) const;
 
     [[nodiscard]] std::expected<IncrementalPchResult, IncrementalPchError>
     run(const IncrementalPchRequest& request) const;

--- a/cpp/include/mqb/orchestration/MsvcIncrementalPchCoordinator.hpp
+++ b/cpp/include/mqb/orchestration/MsvcIncrementalPchCoordinator.hpp
@@ -35,7 +35,7 @@ struct IncrementalPchInspection {
     // Exact typed execution request projected by the PCH coordinator. Future
     // introspection consumers can feed this directly into build_recipe()
     // without reproducing /Yc, /Fp, /FI, artifact, or working-directory policy.
-    msvc::CompileExecutionRequest recipe_request;
+    msvc::CompileExecutionRequest compile_request;
     IncrementalCompileInspection compile;
     // The synthetic creator is MQB-owned writable state. Inspection reports
     // whether execution would have to materialize/repair it, but never writes it.

--- a/cpp/include/mqb/orchestration/MsvcIncrementalPchCoordinator.hpp
+++ b/cpp/include/mqb/orchestration/MsvcIncrementalPchCoordinator.hpp
@@ -32,10 +32,10 @@ struct IncrementalPchRequest {
 };
 
 struct IncrementalPchInspection {
-    // Exact typed compile request projected by the PCH coordinator. Future
+    // Exact typed execution request projected by the PCH coordinator. Future
     // introspection consumers can feed this directly into build_recipe()
     // without reproducing /Yc, /Fp, /FI, artifact, or working-directory policy.
-    IncrementalCompileRequest compile_request;
+    msvc::CompileExecutionRequest recipe_request;
     IncrementalCompileInspection compile;
     // The synthetic creator is MQB-owned writable state. Inspection reports
     // whether execution would have to materialize/repair it, but never writes it.
@@ -52,7 +52,7 @@ public:
         MsvcIncrementalCompileCoordinator& compile_coordinator)
         : compile_coordinator_(compile_coordinator) {}
 
-    // Validate the PCH request, project its exact typed creator compile request,
+    // Validate the PCH request, project its exact typed creator recipe request,
     // and inspect incremental freshness without creating directories, writing the
     // synthetic creator source, touching cache/output state, or launching cl.exe.
     [[nodiscard]] std::expected<IncrementalPchInspection, IncrementalPchError>

--- a/cpp/src/orchestration/incremental/MsvcIncrementalPchCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalPchCoordinator.cpp
@@ -24,6 +24,7 @@ constexpr std::string_view creator_source_text =
 
 struct PchInspectionState {
     IncrementalPchInspection inspection;
+    IncrementalCompileRequest compile_request;
     // If a stale-but-timestamp-reusable creator source must be repaired, force
     // the execution recheck to compile even if the filesystem timestamp happens
     // to retain coarse equality after materialization. Public diagnostics still
@@ -168,6 +169,16 @@ make_compile_request(const IncrementalPchRequest& request) {
     };
 }
 
+[[nodiscard]] msvc::CompileExecutionRequest recipe_request_for(
+    const IncrementalCompileRequest& request) {
+    return msvc::CompileExecutionRequest{
+        .unit = request.unit,
+        .options = request.options,
+        .source_dependencies_file = request.source_dependencies_file,
+        .working_directory = request.working_directory,
+    };
+}
+
 [[nodiscard]] std::expected<PchInspectionState, IncrementalPchError>
 inspect_pch(
     const IncrementalPchRequest& request,
@@ -188,7 +199,8 @@ inspect_pch(
             compile.error()));
     }
 
-    state.inspection.compile_request = *compile_request;
+    state.compile_request = *compile_request;
+    state.inspection.recipe_request = recipe_request_for(*compile_request);
     state.inspection.compile = std::move(*compile);
 
     // Compile freshness normally observes the creator source by path + timestamp.
@@ -257,7 +269,7 @@ MsvcIncrementalPchCoordinator::run(const IncrementalPchRequest& request) const {
     auto creator = write_creator_if_needed(request.artifacts.source);
     if (!creator) return std::unexpected(creator.error());
 
-    IncrementalCompileRequest compile_request = inspected->inspection.compile_request;
+    IncrementalCompileRequest compile_request = inspected->compile_request;
     if (inspected->force_compile_after_materialization) {
         compile_request.force_rebuild = true;
     }

--- a/cpp/src/orchestration/incremental/MsvcIncrementalPchCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalPchCoordinator.cpp
@@ -200,7 +200,7 @@ inspect_pch(
     }
 
     state.compile_request = *compile_request;
-    state.inspection.recipe_request = recipe_request_for(*compile_request);
+    state.inspection.compile_request = recipe_request_for(*compile_request);
     state.inspection.compile = std::move(*compile);
 
     // Compile freshness normally observes the creator source by path + timestamp.

--- a/cpp/src/orchestration/incremental/MsvcIncrementalPchCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalPchCoordinator.cpp
@@ -1,5 +1,6 @@
 #include "mqb/orchestration/MsvcIncrementalPchCoordinator.hpp"
 
+#include <algorithm>
 #include <expected>
 #include <filesystem>
 #include <fstream>
@@ -8,8 +9,10 @@
 #include <string_view>
 #include <system_error>
 #include <utility>
+#include <vector>
 
 #include "mqb/core/Artifact.hpp"
+#include "mqb/core/BuildTypes.hpp"
 #include "mqb/core/TranslationUnit.hpp"
 
 namespace mqb::orchestration {
@@ -18,6 +21,15 @@ namespace {
 namespace fs = std::filesystem;
 constexpr std::string_view creator_source_text =
     "// MQB synthetic precompiled-header creator. Header injection is owned by /FI.\n";
+
+struct PchInspectionState {
+    IncrementalPchInspection inspection;
+    // If a stale-but-timestamp-reusable creator source must be repaired, force
+    // the execution recheck to compile even if the filesystem timestamp happens
+    // to retain coarse equality after materialization. Public diagnostics still
+    // report the semantic source_changed reason modeled by inspection.
+    bool force_compile_after_materialization{false};
+};
 
 [[nodiscard]] IncrementalPchError failure(
     const IncrementalPchErrorCode code,
@@ -28,9 +40,34 @@ constexpr std::string_view creator_source_text =
     };
 }
 
+[[nodiscard]] IncrementalPchError compile_failure(
+    std::string message,
+    IncrementalCompileError compile_error) {
+    IncrementalPchError error = failure(
+        IncrementalPchErrorCode::compile_failed,
+        std::move(message));
+    error.compile_error = std::move(compile_error);
+    return error;
+}
+
 [[nodiscard]] bool regular_file(const fs::path& path) {
     std::error_code error_code;
     return fs::is_regular_file(path, error_code) && !error_code;
+}
+
+[[nodiscard]] bool creator_source_is_current(const fs::path& source) {
+    if (!regular_file(source)) {
+        return false;
+    }
+
+    std::ifstream input{source, std::ios::binary};
+    if (!input) {
+        return false;
+    }
+    const std::string existing{
+        std::istreambuf_iterator<char>{input},
+        std::istreambuf_iterator<char>{}};
+    return existing == creator_source_text;
 }
 
 [[nodiscard]] std::expected<void, IncrementalPchError> ensure_parent(
@@ -51,16 +88,8 @@ constexpr std::string_view creator_source_text =
     auto parent = ensure_parent(source);
     if (!parent) return std::unexpected(parent.error());
 
-    if (regular_file(source)) {
-        std::ifstream input{source, std::ios::binary};
-        if (input) {
-            const std::string existing{
-                std::istreambuf_iterator<char>{input},
-                std::istreambuf_iterator<char>{}};
-            if (existing == creator_source_text) {
-                return {};
-            }
-        }
+    if (creator_source_is_current(source)) {
+        return {};
     }
 
     std::ofstream output{source, std::ios::binary | std::ios::trunc};
@@ -79,10 +108,16 @@ constexpr std::string_view creator_source_text =
     return {};
 }
 
-} // namespace
+void add_reason_once(
+    std::vector<BuildReason>& reasons,
+    const BuildReason reason) {
+    if (std::find(reasons.begin(), reasons.end(), reason) == reasons.end()) {
+        reasons.push_back(reason);
+    }
+}
 
-std::expected<IncrementalPchResult, IncrementalPchError>
-MsvcIncrementalPchCoordinator::run(const IncrementalPchRequest& request) const {
+[[nodiscard]] std::expected<IncrementalCompileRequest, IncrementalPchError>
+make_compile_request(const IncrementalPchRequest& request) {
     if (request.header.empty()) {
         return std::unexpected(failure(
             IncrementalPchErrorCode::invalid_request,
@@ -102,17 +137,6 @@ MsvcIncrementalPchCoordinator::run(const IncrementalPchRequest& request) const {
             IncrementalPchErrorCode::invalid_request,
             "PCH artifact layout contains an empty path"));
     }
-
-    for (const fs::path* artifact : {
-             &request.artifacts.object,
-             &request.artifacts.dependencies,
-             &request.artifacts.precompiled_header,
-             &request.artifacts.compile_cache}) {
-        auto parent = ensure_parent(*artifact);
-        if (!parent) return std::unexpected(parent.error());
-    }
-    auto creator = write_creator_if_needed(request.artifacts.source);
-    if (!creator) return std::unexpected(creator.error());
 
     CompilerOptions creator_options = request.compiler_options;
     creator_options.precompiled_header = PrecompiledHeaderBinding{
@@ -135,22 +159,129 @@ MsvcIncrementalPchCoordinator::run(const IncrementalPchRequest& request) const {
         },
     };
 
-    IncrementalCompileRequest compile_request{
+    return IncrementalCompileRequest{
         .unit = std::move(unit),
         .options = std::move(creator_options),
         .cache_file = request.artifacts.compile_cache,
         .source_dependencies_file = request.artifacts.dependencies,
         .working_directory = request.working_directory,
     };
+}
+
+[[nodiscard]] std::expected<PchInspectionState, IncrementalPchError>
+inspect_pch(
+    const IncrementalPchRequest& request,
+    MsvcIncrementalCompileCoordinator& compile_coordinator) {
+    auto compile_request = make_compile_request(request);
+    if (!compile_request) {
+        return std::unexpected(compile_request.error());
+    }
+
+    PchInspectionState state;
+    state.inspection.creator_source_materialization_required =
+        !creator_source_is_current(request.artifacts.source);
+
+    auto compile = compile_coordinator.inspect(*compile_request);
+    if (!compile) {
+        return std::unexpected(compile_failure(
+            "failed to inspect precompiled-header creator compilation",
+            compile.error()));
+    }
+
+    state.inspection.compile_request = *compile_request;
+    state.inspection.compile = std::move(*compile);
+
+    // Compile freshness normally observes the creator source by path + timestamp.
+    // That is sufficient for a missing creator, but an MQB-owned creator with
+    // stale/corrupt content could retain an old timestamp and otherwise look
+    // reusable. Model the repair as source_changed without writing the file.
+    if (state.inspection.creator_source_materialization_required
+        && state.inspection.compile.validation.reusable()) {
+        auto forced_request = *compile_request;
+        forced_request.force_rebuild = true;
+        auto forced = compile_coordinator.inspect(forced_request);
+        if (!forced) {
+            return std::unexpected(compile_failure(
+                "failed to plan precompiled-header creator repair",
+                forced.error()));
+        }
+        state.inspection.compile.plan = std::move(forced->plan);
+        add_reason_once(
+            state.inspection.compile.validation.reasons,
+            BuildReason::source_changed);
+        state.force_compile_after_materialization = true;
+    }
+
+    return state;
+}
+
+[[nodiscard]] IncrementalCompileResult result_from_inspection(
+    const IncrementalCompileInspection& inspection) {
+    IncrementalCompileResult result;
+    result.validation = inspection.validation;
+    result.plan = inspection.plan;
+    result.warnings = inspection.warnings;
+    return result;
+}
+
+} // namespace
+
+std::expected<IncrementalPchInspection, IncrementalPchError>
+MsvcIncrementalPchCoordinator::inspect(const IncrementalPchRequest& request) const {
+    auto inspected = inspect_pch(request, compile_coordinator_);
+    if (!inspected) return std::unexpected(inspected.error());
+    return std::move(inspected->inspection);
+}
+
+std::expected<IncrementalPchResult, IncrementalPchError>
+MsvcIncrementalPchCoordinator::run(const IncrementalPchRequest& request) const {
+    auto inspected = inspect_pch(request, compile_coordinator_);
+    if (!inspected) return std::unexpected(inspected.error());
+
+    // A warm PCH hit is now truly read-only at this layer: do not recreate
+    // directories or reopen the MQB-owned synthetic source for writing.
+    if (inspected->inspection.compile.plan.empty()) {
+        return IncrementalPchResult{
+            .compile = result_from_inspection(inspected->inspection.compile),
+        };
+    }
+
+    for (const fs::path* artifact : {
+             &request.artifacts.object,
+             &request.artifacts.dependencies,
+             &request.artifacts.precompiled_header,
+             &request.artifacts.compile_cache}) {
+        auto parent = ensure_parent(*artifact);
+        if (!parent) return std::unexpected(parent.error());
+    }
+    auto creator = write_creator_if_needed(request.artifacts.source);
+    if (!creator) return std::unexpected(creator.error());
+
+    IncrementalCompileRequest compile_request = inspected->inspection.compile_request;
+    if (inspected->force_compile_after_materialization) {
+        compile_request.force_rebuild = true;
+    }
 
     auto compiled = compile_coordinator_.run(compile_request);
     if (!compiled) {
-        IncrementalPchError error = failure(
-            IncrementalPchErrorCode::compile_failed,
-            "precompiled-header creator compilation failed");
-        error.compile_error = compiled.error();
-        return std::unexpected(std::move(error));
+        return std::unexpected(compile_failure(
+            "precompiled-header creator compilation failed",
+            compiled.error()));
     }
+
+    if (inspected->force_compile_after_materialization) {
+        // The force flag is an internal race/timestamp safety mechanism. Preserve
+        // the semantic inspection decision for diagnostics and future plan parity.
+        auto execution_warnings = std::move(compiled->warnings);
+        compiled->validation = inspected->inspection.compile.validation;
+        compiled->plan = inspected->inspection.compile.plan;
+        compiled->warnings = inspected->inspection.compile.warnings;
+        compiled->warnings.insert(
+            compiled->warnings.end(),
+            std::make_move_iterator(execution_warnings.begin()),
+            std::make_move_iterator(execution_warnings.end()));
+    }
+
     if (!regular_file(request.artifacts.precompiled_header)) {
         return std::unexpected(failure(
             IncrementalPchErrorCode::compile_failed,

--- a/tests/native/pch_inspection_contract.cpp
+++ b/tests/native/pch_inspection_contract.cpp
@@ -1,0 +1,379 @@
+#include <algorithm>
+#include <chrono>
+#include <expected>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <variant>
+
+#include "mqb/core/BuildAction.hpp"
+#include "mqb/core/BuildTypes.hpp"
+#include "mqb/core/CompilerOptions.hpp"
+#include "mqb/core/ProjectArtifactLayout.hpp"
+#include "mqb/msvc/MsvcCompileExecutor.hpp"
+#include "mqb/msvc/MsvcToolchainLocator.hpp"
+#include "mqb/orchestration/MsvcIncrementalCompileCoordinator.hpp"
+#include "mqb/orchestration/MsvcIncrementalPchCoordinator.hpp"
+#include "mqb/process/Process.hpp"
+
+namespace {
+
+namespace fs = std::filesystem;
+int failures = 0;
+
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+class TemporaryDirectory {
+public:
+    TemporaryDirectory() {
+        const auto tick = std::chrono::steady_clock::now().time_since_epoch().count();
+        path_ = fs::temp_directory_path()
+            / ("mqb-pch-inspection-test-" + std::to_string(tick));
+        fs::create_directories(path_);
+    }
+
+    ~TemporaryDirectory() {
+        std::error_code ignored;
+        fs::remove_all(path_, ignored);
+    }
+
+    [[nodiscard]] const fs::path& path() const noexcept { return path_; }
+
+private:
+    fs::path path_;
+};
+
+void write_text(const fs::path& path, const std::string_view text) {
+    if (!path.parent_path().empty()) {
+        fs::create_directories(path.parent_path());
+    }
+    std::ofstream file{path, std::ios::binary | std::ios::trunc};
+    file.write(text.data(), static_cast<std::streamsize>(text.size()));
+}
+
+[[nodiscard]] std::string read_text(const fs::path& path) {
+    std::ifstream file{path, std::ios::binary};
+    return std::string{
+        std::istreambuf_iterator<char>{file},
+        std::istreambuf_iterator<char>{}};
+}
+
+[[nodiscard]] std::string path_to_utf8(const fs::path& path) {
+    const auto bytes = path.lexically_normal().generic_u8string();
+    return std::string{
+        reinterpret_cast<const char*>(bytes.data()),
+        bytes.size()};
+}
+
+[[nodiscard]] std::string json_escape(const std::string_view value) {
+    std::string result;
+    for (const char ch : value) {
+        switch (ch) {
+        case '\\': result += "\\\\"; break;
+        case '"': result += "\\\""; break;
+        case '\n': result += "\\n"; break;
+        case '\r': result += "\\r"; break;
+        case '\t': result += "\\t"; break;
+        default: result.push_back(ch); break;
+        }
+    }
+    return result;
+}
+
+[[nodiscard]] bool has_reason(
+    const mqb::CompileCacheValidation& validation,
+    const mqb::BuildReason reason) {
+    return std::find(validation.reasons.begin(), validation.reasons.end(), reason)
+        != validation.reasons.end();
+}
+
+class PchCompilerRunner final : public mqb::process::ProcessRunner {
+public:
+    fs::path source;
+    fs::path header;
+    fs::path object;
+    fs::path dependencies;
+    fs::path pch;
+    int calls{};
+
+    std::expected<mqb::process::ProcessResult, mqb::process::ProcessError>
+    run(const mqb::process::ProcessSpec& spec) override {
+        ++calls;
+        last_spec = spec;
+
+        write_text(object, "PCH creator object");
+        write_text(pch, "PCH artifact");
+        const std::string json =
+            "{\"Data\":{\"Source\":\""
+            + json_escape(path_to_utf8(source))
+            + "\",\"Includes\":[\""
+            + json_escape(path_to_utf8(header))
+            + "\"]}}";
+        write_text(dependencies, json);
+
+        return mqb::process::ProcessResult{
+            .exit_code = 0,
+            .stdout_text = "PCH compile success",
+        };
+    }
+
+    mqb::process::ProcessSpec last_spec;
+};
+
+} // namespace
+
+int main() {
+    TemporaryDirectory fixture;
+
+    const fs::path fake_compiler = fixture.path() / "toolchain" / "cl.exe";
+    write_text(fake_compiler, "compiler identity");
+
+    const mqb::msvc::MsvcToolchain toolchain{
+        .identity = mqb::ToolchainIdentity{
+            .compiler = fake_compiler,
+            .version = "19.51.pch-inspect",
+            .binary_stamp = "compiler-stamp",
+        },
+        .linker = fixture.path() / "toolchain" / "link.exe",
+        .librarian = fixture.path() / "toolchain" / "lib.exe",
+        .vc_tools_root = fixture.path() / "toolchain",
+        .source = mqb::msvc::ToolchainSource::visual_studio,
+    };
+
+    const fs::path header = fixture.path() / "input" / "include" / "pch.hpp";
+    write_text(header, "#pragma once\ninline constexpr int pch_value = 42;\n");
+
+    const fs::path state_root = fixture.path() / "owned-state" / "pch";
+    const mqb::PrecompiledHeaderArtifacts artifacts{
+        .source = state_root / "creator.cpp",
+        .object = state_root / "creator.obj",
+        .dependencies = state_root / "creator.deps.json",
+        .precompiled_header = state_root / "project.pch",
+        .compile_cache = state_root / "creator.cache",
+    };
+
+    mqb::CompilerOptions options;
+    options.configuration = mqb::BuildConfiguration::debug;
+    options.architecture = mqb::Architecture::x64;
+    options.standard = mqb::CppStandard::cpp23;
+
+    PchCompilerRunner runner;
+    runner.source = artifacts.source;
+    runner.header = header;
+    runner.object = artifacts.object;
+    runner.dependencies = artifacts.dependencies;
+    runner.pch = artifacts.precompiled_header;
+
+    mqb::msvc::MsvcCompileExecutor executor{toolchain, runner};
+    mqb::orchestration::MsvcIncrementalCompileCoordinator compile_coordinator{
+        toolchain,
+        executor};
+    mqb::orchestration::MsvcIncrementalPchCoordinator pch_coordinator{
+        compile_coordinator};
+
+    const mqb::orchestration::IncrementalPchRequest request{
+        .header = header,
+        .artifacts = artifacts,
+        .compiler_options = options,
+        .working_directory = fixture.path(),
+    };
+
+    const auto cold_inspection = pch_coordinator.inspect(request);
+    expect(cold_inspection.has_value(), "cold PCH inspection should succeed");
+    if (cold_inspection) {
+        expect(cold_inspection->creator_source_materialization_required,
+               "cold PCH inspection should report missing synthetic creator materialization");
+        expect(cold_inspection->compile.plan.actions.size() == 1
+                   && std::holds_alternative<mqb::CompileAction>(
+                       cold_inspection->compile.plan.actions.front()),
+               "cold PCH inspection should expose one creator CompileAction");
+        expect(has_reason(
+                   cold_inspection->compile.validation,
+                   mqb::BuildReason::missing_cache_entry),
+               "cold PCH inspection should report missing creator cache");
+        expect(has_reason(
+                   cold_inspection->compile.validation,
+                   mqb::BuildReason::missing_output),
+               "cold PCH inspection should report missing creator outputs");
+        expect(cold_inspection->compile_request.unit.source == artifacts.source,
+               "PCH inspection should expose the exact synthetic creator source path");
+        expect(cold_inspection->compile_request.source_dependencies_file == artifacts.dependencies,
+               "PCH inspection should expose the exact sourceDependencies path");
+        expect(cold_inspection->compile_request.options.precompiled_header.has_value(),
+               "PCH inspection should project a typed PCH creator binding");
+        if (cold_inspection->compile_request.options.precompiled_header) {
+            const auto& binding = *cold_inspection->compile_request.options.precompiled_header;
+            expect(binding.role == mqb::PrecompiledHeaderRole::create,
+                   "PCH inspection binding should use create role");
+            expect(binding.header == header.lexically_normal(),
+                   "PCH inspection binding should retain the configured header");
+            expect(binding.artifact == artifacts.precompiled_header.lexically_normal(),
+                   "PCH inspection binding should retain the owned .pch artifact");
+        }
+
+        const auto recipe = executor.build_recipe(cold_inspection->compile_request);
+        expect(recipe.has_value(),
+               "PCH inspection compile request should produce an exact recipe before creator materialization");
+        expect(!fs::exists(state_root),
+               "PCH recipe modeling after inspection must still leave owned state absent");
+    }
+    expect(runner.calls == 0,
+           "cold PCH inspection must not launch cl.exe");
+    expect(!fs::exists(state_root),
+           "cold PCH inspection must not create PCH directories or synthetic source state");
+
+    const auto cold_run = pch_coordinator.run(request);
+    expect(cold_run.has_value() && cold_run->compile.compiled,
+           "cold PCH run should materialize the creator and compile");
+    if (cold_inspection && cold_run) {
+        expect(cold_run->compile.validation.reasons
+                   == cold_inspection->compile.validation.reasons,
+               "cold PCH run and inspection should expose identical rebuild reasons");
+        expect(cold_run->compile.plan.actions.size()
+                   == cold_inspection->compile.plan.actions.size(),
+               "cold PCH run and inspection should expose identical plan cardinality");
+    }
+    expect(runner.calls == 1,
+           "cold PCH run should launch cl.exe exactly once");
+    expect(fs::is_regular_file(artifacts.source)
+               && fs::is_regular_file(artifacts.object)
+               && fs::is_regular_file(artifacts.dependencies)
+               && fs::is_regular_file(artifacts.precompiled_header)
+               && fs::is_regular_file(artifacts.compile_cache),
+           "cold PCH run should materialize creator, outputs, dependency metadata, and cache");
+    expect(read_text(artifacts.source).find("MQB synthetic precompiled-header creator")
+               != std::string::npos,
+           "cold PCH run should materialize the canonical MQB creator source");
+
+    const std::string warm_source_before = read_text(artifacts.source);
+    const std::string warm_object_before = read_text(artifacts.object);
+    const std::string warm_pch_before = read_text(artifacts.precompiled_header);
+    const std::string warm_cache_before = read_text(artifacts.compile_cache);
+    const auto warm_inspection = pch_coordinator.inspect(request);
+    expect(warm_inspection.has_value(), "warm PCH inspection should succeed");
+    if (warm_inspection) {
+        expect(!warm_inspection->creator_source_materialization_required,
+               "warm PCH inspection should recognize the canonical creator source");
+        expect(warm_inspection->compile.validation.reusable(),
+               "warm PCH inspection should report reusable compile state");
+        expect(warm_inspection->compile.plan.empty(),
+               "warm PCH inspection should expose an empty compile plan");
+    }
+    expect(runner.calls == 1,
+           "warm PCH inspection must not launch cl.exe");
+    expect(read_text(artifacts.source) == warm_source_before
+               && read_text(artifacts.object) == warm_object_before
+               && read_text(artifacts.precompiled_header) == warm_pch_before
+               && read_text(artifacts.compile_cache) == warm_cache_before,
+           "warm PCH inspection must not mutate creator, outputs, or cache");
+
+    const auto warm_run = pch_coordinator.run(request);
+    expect(warm_run.has_value() && !warm_run->compile.compiled,
+           "warm PCH run should remain a no-op");
+    expect(runner.calls == 1,
+           "warm PCH run should not launch cl.exe");
+    expect(read_text(artifacts.source) == warm_source_before,
+           "warm PCH run should not rewrite the canonical creator source");
+
+    std::this_thread::sleep_for(std::chrono::milliseconds{40});
+    write_text(header, "#pragma once\ninline constexpr int pch_value = 43;\n");
+    const auto header_inspection = pch_coordinator.inspect(request);
+    expect(header_inspection.has_value(), "header-changed PCH inspection should succeed");
+    if (header_inspection) {
+        expect(!header_inspection->creator_source_materialization_required,
+               "header change should not require creator-source repair");
+        expect(has_reason(
+                   header_inspection->compile.validation,
+                   mqb::BuildReason::dependency_changed),
+               "PCH header change should surface dependency_changed");
+        expect(header_inspection->compile.plan.actions.size() == 1,
+               "PCH header change should plan one creator compile");
+    }
+    expect(runner.calls == 1,
+           "header-change inspection must not launch cl.exe");
+
+    const auto header_run = pch_coordinator.run(request);
+    expect(header_run.has_value() && header_run->compile.compiled,
+           "PCH header change should execute creator compilation");
+    if (header_inspection && header_run) {
+        expect(header_run->compile.validation.reasons
+                   == header_inspection->compile.validation.reasons,
+               "PCH header-change run and inspection should expose identical reasons");
+    }
+    expect(runner.calls == 2,
+           "PCH header change should launch cl.exe exactly once more");
+
+    const auto creator_timestamp = fs::last_write_time(artifacts.source);
+    const std::string cache_before_corruption = read_text(artifacts.compile_cache);
+    const std::string pch_before_corruption = read_text(artifacts.precompiled_header);
+    write_text(artifacts.source, "// tampered MQB-owned creator\nint injected = 1;\n");
+    std::error_code timestamp_error;
+    fs::last_write_time(artifacts.source, creator_timestamp, timestamp_error);
+    expect(!timestamp_error,
+           "test should restore the creator timestamp to simulate stale content hidden from mtime freshness");
+
+    const auto corrupt_inspection = pch_coordinator.inspect(request);
+    expect(corrupt_inspection.has_value(), "corrupt creator PCH inspection should succeed");
+    if (corrupt_inspection) {
+        expect(corrupt_inspection->creator_source_materialization_required,
+               "corrupt creator content should require materialization repair");
+        expect(has_reason(
+                   corrupt_inspection->compile.validation,
+                   mqb::BuildReason::source_changed),
+               "corrupt creator content should surface semantic source_changed");
+        expect(corrupt_inspection->compile.plan.actions.size() == 1,
+               "corrupt creator content should plan one creator compile even with an old timestamp");
+    }
+    expect(runner.calls == 2,
+           "corrupt creator inspection must not launch cl.exe");
+    expect(read_text(artifacts.source).find("tampered") != std::string::npos,
+           "corrupt creator inspection must not repair the file while observing it");
+    expect(read_text(artifacts.compile_cache) == cache_before_corruption
+               && read_text(artifacts.precompiled_header) == pch_before_corruption,
+           "corrupt creator inspection must not mutate cache or .pch output");
+
+    const auto repaired = pch_coordinator.run(request);
+    expect(repaired.has_value() && repaired->compile.compiled,
+           "corrupt creator run should repair and recompile the PCH");
+    if (repaired) {
+        expect(has_reason(
+                   repaired->compile.validation,
+                   mqb::BuildReason::source_changed),
+               "creator repair execution should preserve semantic source_changed diagnostics");
+    }
+    expect(runner.calls == 3,
+           "creator repair should launch cl.exe exactly once");
+    expect(read_text(artifacts.source).find("tampered") == std::string::npos
+               && read_text(artifacts.source).find("MQB synthetic precompiled-header creator")
+                   != std::string::npos,
+           "creator repair should restore canonical MQB-owned source content");
+
+    const auto final_warm = pch_coordinator.inspect(request);
+    expect(final_warm.has_value(), "post-repair warm PCH inspection should succeed");
+    if (final_warm) {
+        expect(!final_warm->creator_source_materialization_required,
+               "post-repair creator should be canonical");
+        expect(final_warm->compile.validation.reusable()
+                   && final_warm->compile.plan.empty(),
+               "post-repair PCH state should immediately return to reusable no-op");
+    }
+    expect(runner.calls == 3,
+           "post-repair inspection must remain execution-free");
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+
+    std::cout << "mqb_pch_inspection_contract passed\n";
+    return 0;
+}

--- a/tests/native/verify_pch_inspection.ps1
+++ b/tests/native/verify_pch_inspection.ps1
@@ -1,0 +1,91 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$BuilderMqbPath,
+    [Parameter(Mandatory = $true)][string]$RepoRoot
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+$RepoRoot = [System.IO.Path]::GetFullPath($RepoRoot)
+$BuilderMqbPath = [System.IO.Path]::GetFullPath($BuilderMqbPath)
+if (-not (Test-Path -LiteralPath $BuilderMqbPath -PathType Leaf)) {
+    throw "Builder MQB not found: $BuilderMqbPath"
+}
+
+$cppRoot = Join-Path $RepoRoot 'cpp'
+$configPath = Join-Path $cppRoot 'mqb.json'
+$contractSource = Join-Path $RepoRoot 'tests/native/pch_inspection_contract.cpp'
+foreach ($path in @($configPath, $contractSource)) {
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+        throw "PCH inspection evidence input missing: $path"
+    }
+}
+
+& (Join-Path $RepoRoot 'tests/native/assert_cpp_layout.ps1') -CppRoot $cppRoot
+
+$config = Get-Content -LiteralPath $configPath -Raw | ConvertFrom-Json
+$productionSources = @($config.discovery.extra_sources | ForEach-Object {
+    'cpp/' + ([string]$_).Replace('\', '/')
+})
+if ($productionSources.Count -eq 0) {
+    throw 'cpp/mqb.json has no production sources for PCH inspection evidence.'
+}
+
+$arguments = [System.Collections.ArrayList]::new()
+[void]$arguments.Add('tests/native/pch_inspection_contract.cpp')
+foreach ($source in $productionSources) {
+    [void]$arguments.Add($source)
+}
+[void]$arguments.Add('--no-discover')
+[void]$arguments.Add('--env')
+[void]$arguments.Add('vs')
+[void]$arguments.Add('--debug')
+[void]$arguments.Add('--std')
+[void]$arguments.Add([string]$config.build.standard)
+[void]$arguments.Add('--runtime')
+[void]$arguments.Add('MTd')
+foreach ($include in @($config.build.include_dirs)) {
+    [void]$arguments.Add('-I')
+    [void]$arguments.Add('cpp/' + ([string]$include).Replace('\', '/'))
+}
+foreach ($compilerArg in @($config.build.compiler_args)) {
+    [void]$arguments.Add('--compiler-arg')
+    [void]$arguments.Add([string]$compilerArg)
+}
+[void]$arguments.Add('--lib')
+[void]$arguments.Add('shell32.lib')
+[void]$arguments.Add('-o')
+[void]$arguments.Add('pch_inspection_contract')
+
+$stateRoot = Join-Path $RepoRoot '.mqb'
+if (Test-Path -LiteralPath $stateRoot) {
+    Remove-Item -LiteralPath $stateRoot -Recurse -Force
+}
+
+Push-Location $RepoRoot
+try {
+    $buildOutput = @(& $BuilderMqbPath @arguments 2>&1)
+    $buildExit = $LASTEXITCODE
+    foreach ($line in $buildOutput) { Write-Host $line }
+    if ($buildExit -ne 0) {
+        throw "Failed to build PCH inspection contract (exit $buildExit)."
+    }
+
+    $contractExe = Join-Path $RepoRoot '.mqb/bin/pch_inspection_contract.exe'
+    if (-not (Test-Path -LiteralPath $contractExe -PathType Leaf)) {
+        throw "PCH inspection contract executable missing: $contractExe"
+    }
+
+    $testOutput = @(& $contractExe 2>&1)
+    $testExit = $LASTEXITCODE
+    foreach ($line in $testOutput) { Write-Host $line }
+    if ($testExit -ne 0) {
+        throw "PCH inspection contract failed (exit $testExit)."
+    }
+}
+finally {
+    Pop-Location
+}
+
+Write-Host 'PCH inspection evidence passed.'


### PR DESCRIPTION
## Goal

Extend the v5.4 build-introspection authority to first-class PCH creation without adding `mqb plan` yet.

## Product / architecture change

Add `MsvcIncrementalPchCoordinator::inspect()` as a zero-write, zero-execution PCH planning surface.

The inspection:

- validates the configured PCH header and artifact layout;
- internally projects the same `IncrementalCompileRequest` used for cache/freshness planning and real PCH execution;
- publicly exposes the exact `msvc::CompileExecutionRequest` needed by `MsvcCompileExecutor::build_recipe()`;
- delegates cache/freshness/build-plan decisions to `MsvcIncrementalCompileCoordinator::inspect()`;
- exposes whether MQB's synthetic creator source needs materialization/repair;
- never creates PCH directories, writes the synthetic creator, touches cache/output state, or launches `cl.exe`.

The public compile request can be fed directly into `build_recipe()` so a future `mqb plan` consumer gets the exact `/Yc`, `/Fp`, `/FI`, artifact, working-directory, and MSVC argv authority used by real execution without reproducing PCH policy.

## Synthetic creator correctness

The MQB-owned creator source has canonical deterministic content. Path/timestamp freshness alone is insufficient if that internal file is corrupted while its timestamp is old enough to look reusable.

PCH inspection therefore reads the creator content without modifying it. If content repair is required while ordinary compile inspection would otherwise be reusable, it:

- semantically reports `source_changed`;
- derives the actual `CompileAction` through the existing compile coordinator planner;
- does not write the creator during inspection;
- guarantees the following real run executes the repair even if filesystem timestamp resolution would otherwise hide the rewrite.

`run()` shares the same PCH inspection helper. A warm/no-op PCH run now returns directly without directory creation or creator-source write attempts.

## Focused evidence

The dedicated Windows/MSVC contract proves:

1. cold PCH inspection before the synthetic creator directory exists;
2. exact typed PCH creator recipe construction before materialization;
3. no directory/source/cache/output/process side effects during inspection;
4. cold inspection/run reason and plan parity;
5. warm reusable inspection and warm no-op run;
6. PCH-header dependency invalidation;
7. creator-source corruption whose timestamp is deliberately restored to an old value, proving content-aware repair planning;
8. repair execution and immediate return to reusable warm state.

## Non-goals

- no `mqb plan` command yet;
- no PCH + Modules/Header Units support change;
- no config/schema/cache/signature/version change;
- no new production translation unit;
- no ordinary compile/link/archive behavior change.

## Exact validated head

`1faae0b1cfe0cd8269a6ece22927f62b4617bd68`

Base remains `main @ 7fb23d2c43655a586a31796ac29f2440cebc2f29`; the branch is 9 commits ahead and 0 behind, with changes limited to 5 files (2 PCH production files + 3 focused evidence files).

## Validation

All required validation is green on the exact head above:

- PCH Inspection Evidence: **success**;
- Documentation: **success**;
- Final Closure Cross-Stage: **success**;
- Native C++ candidate self-build/preflight: **success**;
- environment isolation, ASan, LibFuzzer, OpenMP, default-library freshness, include-search freshness, `__has_include`, linker side-output repair: **success**;
- exact MSVC parameter inventory and semantic variant inventory: **success**;
- Native Debug tests: **4/4 shards success**;
- Native C++ gate: **success**;
- Native Release Stage 0/shared product build: **success**;
- Native Release tests: **4/4 shards success**;
- Release self-host: **success**;
- runtime-only package staging/validation/upload: **success**;
- Performance Evidence: intentionally skipped because this is not a performance PR;
- release publication: intentionally skipped for a pull request.

No inline review threads are open. `main` did not move during validation.

This PR remains Draft and unmerged pending explicit merge authorization.