### PR TITLE
refactor: add side-effect-free module scan inspection

### DIFF
--- a/.github/workflows/module-scan-inspection-evidence.yml
+++ b/.github/workflows/module-scan-inspection-evidence.yml
@@ -1,0 +1,54 @@
+name: Module Scan Inspection Evidence
+
+on:
+  pull_request:
+    paths:
+      - 'cpp/mqb.json'
+      - 'cpp/include/mqb/msvc/MsvcModuleDependencyScanner.hpp'
+      - 'cpp/include/mqb/orchestration/MsvcIncrementalModuleScanCoordinator.hpp'
+      - 'cpp/src/msvc/modules/MsvcModuleDependencyScanner.cpp'
+      - 'cpp/src/orchestration/modules/ModuleTargetScanner.cpp'
+      - 'cpp/src/orchestration/modules/ModuleTargetScanner.hpp'
+      - 'cpp/src/orchestration/modules/MsvcIncrementalModuleScanCoordinator.cpp'
+      - 'cpp/src/core/**'
+      - 'cpp/tests/msvc/modules/module_dependency_scanner_tests.cpp'
+      - 'tests/native/module_scan_inspection_contract.cpp'
+      - 'tests/native/verify_module_scan_inspection.ps1'
+      - 'tests/native/assert_cpp_layout.ps1'
+      - '.github/workflows/module-scan-inspection-evidence.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: module-scan-inspection-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify-module-scan-inspection:
+    name: Verify side-effect-free module scan inspection
+    runs-on: windows-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Acquire pinned MQB seed
+        id: seed
+        shell: pwsh
+        run: |
+          $seed = & (Join-Path $PWD 'tests/native/acquire_seed.ps1') `
+            -RepoRoot $PWD `
+            -OutputRoot (Join-Path $PWD 'native-seed')
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          "path=$seed" >> $env:GITHUB_OUTPUT
+
+      - name: Verify module scan inspection contract
+        shell: pwsh
+        run: |
+          & (Join-Path $PWD 'tests/native/verify_module_scan_inspection.ps1') `
+            -BuilderMqbPath '${{ steps.seed.outputs.path }}' `
+            -RepoRoot $PWD
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/cpp/include/mqb/msvc/MsvcModuleDependencyScanner.hpp
+++ b/cpp/include/mqb/msvc/MsvcModuleDependencyScanner.hpp
@@ -22,6 +22,15 @@ struct ModuleScanInvocation {
     std::optional<std::filesystem::path> working_directory;
 };
 
+// Pure, inspectable representation of the exact cl.exe /scanDependencies
+// contract. Construction does not prepare output directories, remove stale
+// metadata, write cache state, or launch a process.
+struct MsvcModuleScanRecipe {
+    ToolchainIdentity toolchain;
+    ModuleScanInvocation invocation;
+    process::ProcessSpec process;
+};
+
 struct ModuleScanResult {
     process::ProcessResult process;
     modules::P1689Document dependencies;
@@ -56,6 +65,14 @@ public:
 
     [[nodiscard]] static std::expected<std::vector<std::string>, ModuleScanError>
     build_arguments(const ModuleScanInvocation& invocation);
+
+    [[nodiscard]] static std::expected<MsvcModuleScanRecipe, ModuleScanError>
+    build_recipe(
+        const MsvcToolchain& toolchain,
+        const ModuleScanInvocation& invocation);
+
+    [[nodiscard]] std::expected<ModuleScanResult, ModuleScanError>
+    execute_recipe(const MsvcModuleScanRecipe& recipe) const;
 
     [[nodiscard]] std::expected<ModuleScanResult, ModuleScanError>
     scan(const ModuleScanInvocation& invocation) const;

--- a/cpp/include/mqb/orchestration/MsvcIncrementalModuleScanCoordinator.hpp
+++ b/cpp/include/mqb/orchestration/MsvcIncrementalModuleScanCoordinator.hpp
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <expected>
+#include <filesystem>
+#include <optional>
+#include <string_view>
+#include <vector>
+
+#include "mqb/core/CompilerOptions.hpp"
+#include "mqb/core/TranslationUnit.hpp"
+#include "mqb/modules/P1689.hpp"
+#include "mqb/msvc/MsvcModuleDependencyScanner.hpp"
+
+namespace mqb::orchestration {
+
+struct IncrementalModuleScanRequest {
+    std::filesystem::path source;
+    std::filesystem::path module_dependencies_file;
+    std::filesystem::path compile_cache_file;
+    CompilerOptions options;
+    TranslationUnitKind kind{TranslationUnitKind::source};
+    std::optional<std::filesystem::path> working_directory;
+};
+
+enum class ModuleScanReason {
+    missing_cache_entry,
+    missing_scan_evidence,
+    include_search_roots_changed,
+    scan_signature_changed,
+    source_changed,
+    output_changed,
+    dependency_changed,
+    dependency_metadata_invalid,
+};
+
+[[nodiscard]] std::string_view to_string(ModuleScanReason reason) noexcept;
+
+struct IncrementalModuleScanInspection {
+    // The recipe is always available, including on reusable warm paths. This
+    // lets introspection show the exact cl.exe scan contract without launching
+    // it while keeping one source of truth for real execution.
+    msvc::MsvcModuleScanRecipe recipe;
+    std::vector<ModuleScanReason> reasons;
+    std::optional<modules::P1689Document> dependencies;
+
+    [[nodiscard]] bool reusable() const noexcept {
+        return reasons.empty() && dependencies.has_value();
+    }
+
+    [[nodiscard]] bool scan_required() const noexcept {
+        return !reusable();
+    }
+};
+
+struct IncrementalModuleScanResult {
+    IncrementalModuleScanInspection inspection;
+    msvc::ModuleScanResult result;
+    bool scanned{false};
+};
+
+class MsvcIncrementalModuleScanCoordinator {
+public:
+    explicit MsvcIncrementalModuleScanCoordinator(
+        msvc::MsvcModuleDependencyScanner& scanner)
+        : scanner_(scanner) {}
+
+    // Inspect compile-cache scan evidence and parse reusable P1689 metadata
+    // without creating directories, rewriting metadata, or launching cl.exe.
+    [[nodiscard]] std::expected<IncrementalModuleScanInspection, msvc::ModuleScanError>
+    inspect(const IncrementalModuleScanRequest& request) const;
+
+    // Execute the exact recipe from inspect() only when evidence is not
+    // reusable. Scan evidence remains sealed by the subsequent successful
+    // compile, preserving the existing scan/compile freshness contract.
+    [[nodiscard]] std::expected<IncrementalModuleScanResult, msvc::ModuleScanError>
+    run(const IncrementalModuleScanRequest& request) const;
+
+private:
+    msvc::MsvcModuleDependencyScanner& scanner_;
+};
+
+} // namespace mqb::orchestration

--- a/cpp/mqb.json
+++ b/cpp/mqb.json
@@ -95,6 +95,7 @@
       "src/orchestration/modules/ModuleTargetLinkRequestFactory.cpp",
       "src/orchestration/modules/ModuleTargetPreparation.cpp",
       "src/orchestration/modules/ModuleTargetScanner.cpp",
+      "src/orchestration/modules/MsvcIncrementalModuleScanCoordinator.cpp",
       "src/orchestration/modules/MsvcModuleCompileCoordinator.cpp",
       "src/orchestration/modules/MsvcModuleTargetCoordinator.cpp",
       "src/orchestration/modules/StandardLibraryModuleProvider.cpp",

--- a/cpp/src/msvc/modules/MsvcModuleDependencyScanner.cpp
+++ b/cpp/src/msvc/modules/MsvcModuleDependencyScanner.cpp
@@ -7,6 +7,7 @@
 #include <utility>
 
 #include "mqb/core/TranslationUnitClassifier.hpp"
+#include "mqb/platform/windows/PathIdentity.hpp"
 
 namespace mqb::msvc {
 namespace {
@@ -70,6 +71,32 @@ void suppress_ambient_compiler_options(
     // variables entirely so scan and compile share the same launch contract.
     environment.push_back(process::EnvironmentVariable{"CL", {}, true});
     environment.push_back(process::EnvironmentVariable{"_CL_", {}, true});
+}
+
+[[nodiscard]] bool same_toolchain_identity(
+    const ToolchainIdentity& left,
+    const ToolchainIdentity& right) {
+    return mqb::platform::windows::path_identity_key(left.compiler)
+            == mqb::platform::windows::path_identity_key(right.compiler)
+        && left.version == right.version
+        && left.binary_stamp == right.binary_stamp;
+}
+
+[[nodiscard]] process::ProcessSpec make_scan_process_spec(
+    const MsvcToolchain& toolchain,
+    std::vector<std::string> arguments,
+    const std::optional<fs::path>& working_directory) {
+    process::ProcessSpec spec{
+        .executable = toolchain.identity.compiler,
+        .arguments = std::move(arguments),
+        .working_directory = working_directory,
+        .environment = toolchain.environment,
+        .inherit_environment = true,
+        .capture_stdout = true,
+        .capture_stderr = true,
+    };
+    suppress_ambient_compiler_options(spec.environment);
+    return spec;
 }
 
 [[nodiscard]] std::expected<void, ModuleScanError> prepare_output(
@@ -195,29 +222,38 @@ MsvcModuleDependencyScanner::build_arguments(const ModuleScanInvocation& invocat
     return arguments;
 }
 
-std::expected<ModuleScanResult, ModuleScanError>
-MsvcModuleDependencyScanner::scan(const ModuleScanInvocation& invocation) const {
+std::expected<MsvcModuleScanRecipe, ModuleScanError>
+MsvcModuleDependencyScanner::build_recipe(
+    const MsvcToolchain& toolchain,
+    const ModuleScanInvocation& invocation) {
     auto arguments = build_arguments(invocation);
-    if (!arguments) {
-        return std::unexpected(arguments.error());
+    if (!arguments) return std::unexpected(arguments.error());
+
+    return MsvcModuleScanRecipe{
+        .toolchain = toolchain.identity,
+        .invocation = invocation,
+        .process = make_scan_process_spec(
+            toolchain,
+            std::move(*arguments),
+            invocation.working_directory),
+    };
+}
+
+std::expected<ModuleScanResult, ModuleScanError>
+MsvcModuleDependencyScanner::execute_recipe(
+    const MsvcModuleScanRecipe& recipe) const {
+    if (!same_toolchain_identity(recipe.toolchain, toolchain_.identity)) {
+        return std::unexpected(failure(
+            ModuleScanErrorCode::invalid_request,
+            "MSVC module scan recipe was built for a different compiler toolchain"));
     }
 
-    auto prepared = prepare_output(invocation.output_file);
+    auto prepared = prepare_output(recipe.invocation.output_file);
     if (!prepared) {
         return std::unexpected(prepared.error());
     }
 
-    process::ProcessSpec spec;
-    spec.executable = toolchain_.identity.compiler;
-    spec.arguments = std::move(*arguments);
-    spec.working_directory = invocation.working_directory;
-    spec.environment = toolchain_.environment;
-    suppress_ambient_compiler_options(spec.environment);
-    spec.inherit_environment = true;
-    spec.capture_stdout = true;
-    spec.capture_stderr = true;
-
-    auto result = runner_.run(spec);
+    auto result = runner_.run(recipe.process);
     if (!result) {
         ModuleScanError error = failure(
             ModuleScanErrorCode::process_failed,
@@ -235,7 +271,9 @@ MsvcModuleDependencyScanner::scan(const ModuleScanInvocation& invocation) const 
     }
 
     std::error_code exists_error;
-    const bool exists = fs::is_regular_file(invocation.output_file, exists_error);
+    const bool exists = fs::is_regular_file(
+        recipe.invocation.output_file,
+        exists_error);
     if (exists_error || !exists) {
         ModuleScanError error = failure(
             ModuleScanErrorCode::output_missing,
@@ -244,7 +282,7 @@ MsvcModuleDependencyScanner::scan(const ModuleScanInvocation& invocation) const 
         return std::unexpected(std::move(error));
     }
 
-    auto text = read_text_file(invocation.output_file);
+    auto text = read_text_file(recipe.invocation.output_file);
     if (!text) {
         auto error = text.error();
         error.process_result = std::move(*result);
@@ -265,6 +303,13 @@ MsvcModuleDependencyScanner::scan(const ModuleScanInvocation& invocation) const 
         .process = std::move(*result),
         .dependencies = std::move(*dependencies),
     };
+}
+
+std::expected<ModuleScanResult, ModuleScanError>
+MsvcModuleDependencyScanner::scan(const ModuleScanInvocation& invocation) const {
+    auto recipe = build_recipe(toolchain_, invocation);
+    if (!recipe) return std::unexpected(recipe.error());
+    return execute_recipe(*recipe);
 }
 
 } // namespace mqb::msvc

--- a/cpp/src/orchestration/modules/ModuleTargetScanner.cpp
+++ b/cpp/src/orchestration/modules/ModuleTargetScanner.cpp
@@ -2,21 +2,13 @@
 
 #include <expected>
 #include <filesystem>
-#include <fstream>
-#include <iterator>
 #include <optional>
-#include <span>
 #include <string>
 #include <utility>
 #include <vector>
 
-#include "mqb/core/BuildSignature.hpp"
-#include "mqb/core/CompileCache.hpp"
-#include "mqb/core/CompileCacheFile.hpp"
-#include "mqb/core/FileSnapshot.hpp"
-#include "mqb/modules/P1689.hpp"
-#include "mqb/msvc/MsvcIncludeSearchFreshness.hpp"
 #include "mqb/orchestration/BoundedWorkScheduler.hpp"
+#include "mqb/orchestration/MsvcIncrementalModuleScanCoordinator.hpp"
 
 namespace mqb::orchestration::detail {
 namespace {
@@ -42,126 +34,6 @@ namespace fs = std::filesystem;
     return std::nullopt;
 }
 
-[[nodiscard]] std::optional<FileSnapshot> snapshot_regular_file(const fs::path& path) {
-    if (path.empty()) return std::nullopt;
-    std::error_code error_code;
-    const auto status = fs::status(path, error_code);
-    if (error_code || !fs::is_regular_file(status)) return std::nullopt;
-    const auto modified = fs::last_write_time(path, error_code);
-    if (error_code) return std::nullopt;
-    return FileSnapshot{
-        .path = path,
-        .exists = true,
-        .modified = modified,
-    };
-}
-
-[[nodiscard]] std::optional<FileSnapshot> snapshot_file_or_directory(const fs::path& path) {
-    if (path.empty()) return std::nullopt;
-    // Module-scan evidence admits both file and directory dependencies. Its
-    // identity is existence + mtime, so last_write_time() alone provides the
-    // required warm-path probe and avoids a redundant preceding status().
-    std::error_code error_code;
-    const auto modified = fs::last_write_time(path, error_code);
-    if (error_code) return std::nullopt;
-    return FileSnapshot{
-        .path = path,
-        .exists = true,
-        .modified = modified,
-    };
-}
-
-[[nodiscard]] bool same_path(const fs::path& left, const fs::path& right) {
-    if (left == right || left.lexically_normal() == right.lexically_normal()) {
-        return true;
-    }
-    std::error_code error_code;
-    return fs::equivalent(left, right, error_code) && !error_code;
-}
-
-[[nodiscard]] bool same_ordered_paths(
-    const std::span<const fs::path> left,
-    const std::span<const fs::path> right) {
-    if (left.size() != right.size()) return false;
-    for (std::size_t index = 0; index < left.size(); ++index) {
-        if (!same_path(left[index], right[index])) return false;
-    }
-    return true;
-}
-
-[[nodiscard]] std::optional<std::string> read_text_file(const fs::path& path) {
-    std::ifstream stream{path, std::ios::binary};
-    if (!stream) return std::nullopt;
-    std::string text{
-        std::istreambuf_iterator<char>{stream},
-        std::istreambuf_iterator<char>{}};
-    if (stream.bad()) return std::nullopt;
-    return text;
-}
-
-[[nodiscard]] std::optional<msvc::ModuleScanResult> try_reuse_scan(
-    const ModuleCompileSourceRequest& source,
-    const CompilerOptions& options,
-    const std::optional<fs::path>& working_directory,
-    msvc::MsvcModuleDependencyScanner& scanner) {
-    auto loaded = CompileCacheFile::load(source.artifacts.compile_cache);
-    if (!loaded || !*loaded || !(**loaded).module_scan) {
-        return std::nullopt;
-    }
-    const auto& entry = **loaded;
-    const auto& evidence = *entry.module_scan;
-
-    // Module-scan migration is encoded in BuildSignature's v2 scan domain.
-    // Old evidence fails signature validation exactly once; valid new evidence
-    // may legitimately have zero include roots and zero directory snapshots.
-    const auto current_roots = msvc::include_search_roots(
-        options,
-        scanner.toolchain().environment,
-        working_directory);
-    if (!same_ordered_paths(entry.include_search_roots, current_roots)) {
-        return std::nullopt;
-    }
-
-    const BuildSignature signature = BuildSignature::for_module_scan(
-        source.source,
-        source.kind,
-        scanner.toolchain().identity,
-        options);
-    auto source_snapshot = snapshot_regular_file(source.source);
-    auto output_snapshot = snapshot_regular_file(source.artifacts.module_dependencies);
-    if (!source_snapshot || !output_snapshot) {
-        return std::nullopt;
-    }
-
-    std::vector<FileSnapshot> dependency_snapshots;
-    dependency_snapshots.reserve(evidence.dependencies.size());
-    for (const auto& dependency : evidence.dependencies) {
-        auto snapshot = snapshot_file_or_directory(dependency.path);
-        if (!snapshot) return std::nullopt;
-        dependency_snapshots.push_back(std::move(*snapshot));
-    }
-
-    if (!ModuleScanEvidenceValidator::reusable(
-            evidence,
-            signature,
-            *source_snapshot,
-            *output_snapshot,
-            dependency_snapshots)) {
-        return std::nullopt;
-    }
-
-    auto text = read_text_file(source.artifacts.module_dependencies);
-    if (!text) return std::nullopt;
-    auto dependencies = modules::P1689Parser::parse(*text);
-    if (!dependencies) return std::nullopt;
-
-    return msvc::ModuleScanResult{
-        .process = process::ProcessResult{},
-        .dependencies = std::move(*dependencies),
-        .reused = true,
-    };
-}
-
 } // namespace
 
 std::expected<msvc::ModuleScanResult, msvc::ModuleScanError>
@@ -170,24 +42,19 @@ scan_module_source(
     const CompilerOptions& options,
     const fs::path& working_directory,
     msvc::MsvcModuleDependencyScanner& scanner) {
-    const auto effective_working_directory = working_directory_for(
-        working_directory,
-        source.source);
-    if (auto reused = try_reuse_scan(
-            source,
-            options,
-            effective_working_directory,
-            scanner)) {
-        return std::move(*reused);
-    }
-
-    return scanner.scan(msvc::ModuleScanInvocation{
+    MsvcIncrementalModuleScanCoordinator coordinator{scanner};
+    auto scanned = coordinator.run(IncrementalModuleScanRequest{
         .source = source.source,
-        .output_file = source.artifacts.module_dependencies,
+        .module_dependencies_file = source.artifacts.module_dependencies,
+        .compile_cache_file = source.artifacts.compile_cache,
         .options = options,
         .kind = source.kind,
-        .working_directory = effective_working_directory,
+        .working_directory = working_directory_for(
+            working_directory,
+            source.source),
     });
+    if (!scanned) return std::unexpected(scanned.error());
+    return std::move(scanned->result);
 }
 
 std::expected<ModuleTargetScanBatch, IncrementalModuleTargetError>

--- a/cpp/src/orchestration/modules/MsvcIncrementalModuleScanCoordinator.cpp
+++ b/cpp/src/orchestration/modules/MsvcIncrementalModuleScanCoordinator.cpp
@@ -1,0 +1,272 @@
+#include "mqb/orchestration/MsvcIncrementalModuleScanCoordinator.hpp"
+
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <optional>
+#include <span>
+#include <string>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+#include "mqb/core/BuildSignature.hpp"
+#include "mqb/core/CompileCache.hpp"
+#include "mqb/core/CompileCacheFile.hpp"
+#include "mqb/core/FileSnapshot.hpp"
+#include "mqb/msvc/MsvcIncludeSearchFreshness.hpp"
+#include "mqb/platform/windows/PathIdentity.hpp"
+
+namespace mqb::orchestration {
+namespace {
+
+namespace fs = std::filesystem;
+
+void add_reason(
+    std::vector<ModuleScanReason>& reasons,
+    const ModuleScanReason reason) {
+    if (std::find(reasons.begin(), reasons.end(), reason) == reasons.end()) {
+        reasons.push_back(reason);
+    }
+}
+
+[[nodiscard]] bool same_path(
+    const fs::path& left,
+    const fs::path& right) {
+    if (mqb::platform::windows::path_identity_key(left)
+        == mqb::platform::windows::path_identity_key(right)) {
+        return true;
+    }
+
+    // Existing scan evidence may have been recorded through a junction or
+    // symlink spelling. Physical equivalence is only a compatibility fallback;
+    // all normal cache identity remains owned by PathIdentity.
+    std::error_code error_code;
+    return fs::equivalent(left, right, error_code) && !error_code;
+}
+
+[[nodiscard]] bool same_ordered_paths(
+    const std::span<const fs::path> left,
+    const std::span<const fs::path> right) {
+    if (left.size() != right.size()) return false;
+    for (std::size_t index = 0; index < left.size(); ++index) {
+        if (!same_path(left[index], right[index])) return false;
+    }
+    return true;
+}
+
+[[nodiscard]] bool same_snapshot(
+    const FileSnapshot& left,
+    const FileSnapshot& right) {
+    return same_path(left.path, right.path)
+        && left.exists == right.exists
+        && (!left.exists || left.modified == right.modified);
+}
+
+[[nodiscard]] std::optional<FileSnapshot> snapshot_regular_file(
+    const fs::path& path) {
+    if (path.empty()) return std::nullopt;
+    std::error_code error_code;
+    const auto status = fs::status(path, error_code);
+    if (error_code || !fs::is_regular_file(status)) return std::nullopt;
+    const auto modified = fs::last_write_time(path, error_code);
+    if (error_code) return std::nullopt;
+    return FileSnapshot{
+        .path = path,
+        .exists = true,
+        .modified = modified,
+    };
+}
+
+[[nodiscard]] std::optional<FileSnapshot> snapshot_file_or_directory(
+    const fs::path& path) {
+    if (path.empty()) return std::nullopt;
+    std::error_code error_code;
+    const auto modified = fs::last_write_time(path, error_code);
+    if (error_code) return std::nullopt;
+    return FileSnapshot{
+        .path = path,
+        .exists = true,
+        .modified = modified,
+    };
+}
+
+[[nodiscard]] std::optional<std::string> read_text_file(const fs::path& path) {
+    std::ifstream stream{path, std::ios::binary};
+    if (!stream) return std::nullopt;
+    std::string text{
+        std::istreambuf_iterator<char>{stream},
+        std::istreambuf_iterator<char>{}};
+    if (stream.bad()) return std::nullopt;
+    return text;
+}
+
+} // namespace
+
+std::string_view to_string(const ModuleScanReason reason) noexcept {
+    switch (reason) {
+    case ModuleScanReason::missing_cache_entry:
+        return "missing cache entry";
+    case ModuleScanReason::missing_scan_evidence:
+        return "missing module scan evidence";
+    case ModuleScanReason::include_search_roots_changed:
+        return "include search roots changed";
+    case ModuleScanReason::scan_signature_changed:
+        return "module scan recipe changed";
+    case ModuleScanReason::source_changed:
+        return "module scan source changed";
+    case ModuleScanReason::output_changed:
+        return "module dependency output changed";
+    case ModuleScanReason::dependency_changed:
+        return "module scan dependency changed";
+    case ModuleScanReason::dependency_metadata_invalid:
+        return "module dependency metadata invalid";
+    }
+    return "unknown module scan reason";
+}
+
+std::expected<IncrementalModuleScanInspection, msvc::ModuleScanError>
+MsvcIncrementalModuleScanCoordinator::inspect(
+    const IncrementalModuleScanRequest& request) const {
+    const msvc::ModuleScanInvocation invocation{
+        .source = request.source,
+        .output_file = request.module_dependencies_file,
+        .options = request.options,
+        .kind = request.kind,
+        .working_directory = request.working_directory,
+    };
+    auto recipe = msvc::MsvcModuleDependencyScanner::build_recipe(
+        scanner_.toolchain(),
+        invocation);
+    if (!recipe) return std::unexpected(recipe.error());
+
+    IncrementalModuleScanInspection inspection{
+        .recipe = std::move(*recipe),
+    };
+
+    auto loaded = CompileCacheFile::load(request.compile_cache_file);
+    if (!loaded || !*loaded) {
+        add_reason(inspection.reasons, ModuleScanReason::missing_cache_entry);
+        return inspection;
+    }
+
+    const CompileCacheEntry& entry = **loaded;
+    if (!entry.module_scan) {
+        add_reason(inspection.reasons, ModuleScanReason::missing_scan_evidence);
+        return inspection;
+    }
+    const ModuleScanEvidence& evidence = *entry.module_scan;
+
+    const auto current_roots = msvc::include_search_roots(
+        request.options,
+        scanner_.toolchain().environment,
+        request.working_directory);
+    if (!same_ordered_paths(entry.include_search_roots, current_roots)) {
+        add_reason(
+            inspection.reasons,
+            ModuleScanReason::include_search_roots_changed);
+    }
+
+    const BuildSignature current_signature = BuildSignature::for_module_scan(
+        request.source,
+        request.kind,
+        scanner_.toolchain().identity,
+        request.options);
+    if (evidence.signature != current_signature) {
+        add_reason(inspection.reasons, ModuleScanReason::scan_signature_changed);
+    }
+
+    const auto source_snapshot = snapshot_regular_file(request.source);
+    if (!source_snapshot || !same_snapshot(evidence.source, *source_snapshot)) {
+        add_reason(inspection.reasons, ModuleScanReason::source_changed);
+    }
+
+    const auto output_snapshot = snapshot_regular_file(
+        request.module_dependencies_file);
+    if (!output_snapshot || !same_snapshot(evidence.output, *output_snapshot)) {
+        add_reason(inspection.reasons, ModuleScanReason::output_changed);
+    }
+
+    std::vector<FileSnapshot> dependency_snapshots;
+    dependency_snapshots.reserve(evidence.dependencies.size());
+    bool dependency_snapshots_complete = true;
+    for (const auto& dependency : evidence.dependencies) {
+        auto snapshot = snapshot_file_or_directory(dependency.path);
+        if (!snapshot) {
+            dependency_snapshots_complete = false;
+            add_reason(inspection.reasons, ModuleScanReason::dependency_changed);
+            continue;
+        }
+        if (!same_snapshot(dependency, *snapshot)) {
+            add_reason(inspection.reasons, ModuleScanReason::dependency_changed);
+        }
+        dependency_snapshots.push_back(std::move(*snapshot));
+    }
+
+    if (inspection.reasons.empty()
+        && source_snapshot
+        && output_snapshot
+        && dependency_snapshots_complete
+        && !ModuleScanEvidenceValidator::reusable(
+            evidence,
+            current_signature,
+            *source_snapshot,
+            *output_snapshot,
+            dependency_snapshots)) {
+        // Preserve fail-closed behavior if the core validator gains an
+        // additional invariant that this diagnostic projection does not yet
+        // classify explicitly.
+        add_reason(inspection.reasons, ModuleScanReason::dependency_changed);
+    }
+
+    if (!inspection.reasons.empty()) {
+        return inspection;
+    }
+
+    auto text = read_text_file(request.module_dependencies_file);
+    if (!text) {
+        add_reason(
+            inspection.reasons,
+            ModuleScanReason::dependency_metadata_invalid);
+        return inspection;
+    }
+    auto dependencies = modules::P1689Parser::parse(*text);
+    if (!dependencies) {
+        add_reason(
+            inspection.reasons,
+            ModuleScanReason::dependency_metadata_invalid);
+        return inspection;
+    }
+    inspection.dependencies = std::move(*dependencies);
+    return inspection;
+}
+
+std::expected<IncrementalModuleScanResult, msvc::ModuleScanError>
+MsvcIncrementalModuleScanCoordinator::run(
+    const IncrementalModuleScanRequest& request) const {
+    auto inspection = inspect(request);
+    if (!inspection) return std::unexpected(inspection.error());
+
+    if (inspection->reusable()) {
+        return IncrementalModuleScanResult{
+            .inspection = std::move(*inspection),
+            .result = msvc::ModuleScanResult{
+                .process = process::ProcessResult{},
+                .dependencies = *inspection->dependencies,
+                .reused = true,
+            },
+            .scanned = false,
+        };
+    }
+
+    auto scanned = scanner_.execute_recipe(inspection->recipe);
+    if (!scanned) return std::unexpected(scanned.error());
+    return IncrementalModuleScanResult{
+        .inspection = std::move(*inspection),
+        .result = std::move(*scanned),
+        .scanned = true,
+    };
+}
+
+} // namespace mqb::orchestration

--- a/cpp/src/orchestration/modules/MsvcIncrementalModuleScanCoordinator.cpp
+++ b/cpp/src/orchestration/modules/MsvcIncrementalModuleScanCoordinator.cpp
@@ -249,11 +249,12 @@ MsvcIncrementalModuleScanCoordinator::run(
     if (!inspection) return std::unexpected(inspection.error());
 
     if (inspection->reusable()) {
+        auto dependencies = *inspection->dependencies;
         return IncrementalModuleScanResult{
             .inspection = std::move(*inspection),
             .result = msvc::ModuleScanResult{
                 .process = process::ProcessResult{},
-                .dependencies = *inspection->dependencies,
+                .dependencies = std::move(dependencies),
                 .reused = true,
             },
             .scanned = false,

--- a/cpp/tests/msvc/modules/module_dependency_scanner_tests.cpp
+++ b/cpp/tests/msvc/modules/module_dependency_scanner_tests.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <chrono>
+#include <expected>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
@@ -26,6 +27,32 @@ void expect(const bool condition, const std::string_view message) {
     const std::vector<std::string>& arguments,
     const std::string_view value) {
     return std::find(arguments.begin(), arguments.end(), value) != arguments.end();
+}
+
+[[nodiscard]] bool same_environment(
+    const std::vector<mqb::process::EnvironmentVariable>& left,
+    const std::vector<mqb::process::EnvironmentVariable>& right) {
+    if (left.size() != right.size()) return false;
+    for (std::size_t index = 0; index < left.size(); ++index) {
+        if (left[index].name != right[index].name
+            || left[index].value != right[index].value
+            || left[index].remove != right[index].remove) {
+            return false;
+        }
+    }
+    return true;
+}
+
+[[nodiscard]] bool same_process_spec(
+    const mqb::process::ProcessSpec& left,
+    const mqb::process::ProcessSpec& right) {
+    return left.executable == right.executable
+        && left.arguments == right.arguments
+        && left.working_directory == right.working_directory
+        && same_environment(left.environment, right.environment)
+        && left.inherit_environment == right.inherit_environment
+        && left.capture_stdout == right.capture_stdout
+        && left.capture_stderr == right.capture_stderr;
 }
 
 [[nodiscard]] fs::path make_temp_root() {
@@ -159,6 +186,10 @@ int main() {
 
     MsvcToolchain toolchain;
     toolchain.identity.compiler = "fake-cl.exe";
+    toolchain.identity.version = "19.50.test";
+    toolchain.identity.binary_stamp = "fake-compiler-stamp";
+    toolchain.environment.push_back(
+        mqb::process::EnvironmentVariable{"PATH", "fake-toolchain-path", false});
     FakeRunner runner;
     MsvcModuleDependencyScanner scanner{toolchain, runner};
 
@@ -167,6 +198,38 @@ int main() {
     invocation.output_file = output;
     invocation.kind = TranslationUnitKind::module_interface;
     invocation.working_directory = root;
+
+    auto recipe = MsvcModuleDependencyScanner::build_recipe(toolchain, invocation);
+    expect(recipe.has_value(), "pure module scan recipe construction should succeed");
+    expect(runner.calls == 0, "pure module scan recipe construction must not launch cl.exe");
+    expect(!fs::exists(output.parent_path()),
+           "pure module scan recipe construction must not prepare output directories");
+    if (recipe) {
+        expect(recipe->toolchain.compiler == toolchain.identity.compiler
+                   && recipe->toolchain.version == toolchain.identity.version
+                   && recipe->toolchain.binary_stamp == toolchain.identity.binary_stamp,
+               "module scan recipe should bind the selected compiler identity");
+        expect(recipe->process.executable == toolchain.identity.compiler,
+               "module scan recipe should expose the selected cl.exe");
+        expect(recipe->process.working_directory == root,
+               "module scan recipe should preserve the requested working directory");
+        expect(contains(recipe->process.arguments, "/scanDependencies"),
+               "module scan recipe should expose /scanDependencies");
+        expect(std::any_of(
+                   recipe->process.environment.begin(),
+                   recipe->process.environment.end(),
+                   [](const auto& variable) {
+                       return variable.name == "CL" && variable.remove;
+                   }),
+               "module scan recipe should suppress ambient CL");
+        expect(std::any_of(
+                   recipe->process.environment.begin(),
+                   recipe->process.environment.end(),
+                   [](const auto& variable) {
+                       return variable.name == "_CL_" && variable.remove;
+                   }),
+               "module scan recipe should suppress ambient _CL_");
+    }
 
     {
         fs::create_directories(output.parent_path());
@@ -189,6 +252,22 @@ int main() {
                "scanner should launch the discovered compiler");
         expect(runner.last_spec.working_directory == root,
                "scanner should preserve the requested working directory");
+        if (recipe) {
+            expect(same_process_spec(recipe->process, runner.last_spec),
+                   "pure module scan recipe must exactly match production scan ProcessSpec");
+        }
+    }
+
+    if (recipe) {
+        auto different_toolchain = toolchain;
+        different_toolchain.identity.binary_stamp = "different-compiler-stamp";
+        MsvcModuleDependencyScanner different_scanner{different_toolchain, runner};
+        const int calls_before = runner.calls;
+        auto rejected = different_scanner.execute_recipe(*recipe);
+        expect(!rejected && rejected.error().code == ModuleScanErrorCode::invalid_request,
+               "scan recipe execution should reject a different compiler identity");
+        expect(runner.calls == calls_before,
+               "toolchain-mismatched scan recipe must fail before process launch");
     }
 
     {

--- a/tests/native/assert_cpp_layout.ps1
+++ b/tests/native/assert_cpp_layout.ps1
@@ -265,6 +265,7 @@ $orchestrationLeafFiles = [ordered]@{
         'ModuleTargetLinkRequestFactory.cpp', 'ModuleTargetLinkRequestFactory.hpp',
         'ModuleTargetPreparation.cpp', 'ModuleTargetPreparation.hpp',
         'ModuleTargetScanner.cpp', 'ModuleTargetScanner.hpp',
+        'MsvcIncrementalModuleScanCoordinator.cpp',
         'MsvcModuleCompileCoordinator.cpp', 'MsvcModuleTargetCoordinator.cpp',
         'StandardLibraryModuleProvider.cpp', 'StandardLibraryModuleProvider.hpp'
     )

--- a/tests/native/module_scan_inspection_contract.cpp
+++ b/tests/native/module_scan_inspection_contract.cpp
@@ -1,0 +1,367 @@
+#include <algorithm>
+#include <chrono>
+#include <expected>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "mqb/core/Artifact.hpp"
+#include "mqb/core/BuildSignature.hpp"
+#include "mqb/core/CompileCache.hpp"
+#include "mqb/core/CompileCacheFile.hpp"
+#include "mqb/core/CompilerOptions.hpp"
+#include "mqb/core/FileSnapshot.hpp"
+#include "mqb/core/TranslationUnit.hpp"
+#include "mqb/msvc/MsvcIncludeSearchFreshness.hpp"
+#include "mqb/msvc/MsvcModuleDependencyScanner.hpp"
+#include "mqb/msvc/MsvcToolchainLocator.hpp"
+#include "mqb/orchestration/MsvcIncrementalModuleScanCoordinator.hpp"
+#include "mqb/process/Process.hpp"
+
+namespace {
+
+namespace fs = std::filesystem;
+int failures = 0;
+
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+class TemporaryDirectory {
+public:
+    TemporaryDirectory() {
+        const auto tick = std::chrono::steady_clock::now().time_since_epoch().count();
+        root_ = fs::temp_directory_path()
+            / ("mqb-module-scan-inspection-" + std::to_string(tick));
+        fs::create_directories(root_);
+    }
+
+    ~TemporaryDirectory() {
+        std::error_code ignored;
+        fs::remove_all(root_, ignored);
+    }
+
+    [[nodiscard]] const fs::path& root() const noexcept { return root_; }
+
+private:
+    fs::path root_;
+};
+
+void write_text(const fs::path& path, const std::string_view text) {
+    if (!path.parent_path().empty()) {
+        fs::create_directories(path.parent_path());
+    }
+    std::ofstream stream{path, std::ios::binary | std::ios::trunc};
+    stream.write(text.data(), static_cast<std::streamsize>(text.size()));
+}
+
+[[nodiscard]] std::string read_text(const fs::path& path) {
+    std::ifstream stream{path, std::ios::binary};
+    return std::string{
+        std::istreambuf_iterator<char>{stream},
+        std::istreambuf_iterator<char>{}};
+}
+
+[[nodiscard]] std::string path_to_utf8(const fs::path& path) {
+    const auto bytes = path.lexically_normal().generic_u8string();
+    return std::string{
+        reinterpret_cast<const char*>(bytes.data()),
+        bytes.size()};
+}
+
+[[nodiscard]] std::string json_escape(const std::string_view value) {
+    std::string result;
+    for (const char character : value) {
+        switch (character) {
+        case '\\': result += "\\\\"; break;
+        case '"': result += "\\\""; break;
+        case '\n': result += "\\n"; break;
+        case '\r': result += "\\r"; break;
+        case '\t': result += "\\t"; break;
+        default: result.push_back(character); break;
+        }
+    }
+    return result;
+}
+
+[[nodiscard]] bool same_environment(
+    const std::vector<mqb::process::EnvironmentVariable>& left,
+    const std::vector<mqb::process::EnvironmentVariable>& right) {
+    if (left.size() != right.size()) return false;
+    for (std::size_t index = 0; index < left.size(); ++index) {
+        if (left[index].name != right[index].name
+            || left[index].value != right[index].value
+            || left[index].remove != right[index].remove) {
+            return false;
+        }
+    }
+    return true;
+}
+
+[[nodiscard]] bool same_process_spec(
+    const mqb::process::ProcessSpec& left,
+    const mqb::process::ProcessSpec& right) {
+    return left.executable == right.executable
+        && left.arguments == right.arguments
+        && left.working_directory == right.working_directory
+        && same_environment(left.environment, right.environment)
+        && left.inherit_environment == right.inherit_environment
+        && left.capture_stdout == right.capture_stdout
+        && left.capture_stderr == right.capture_stderr;
+}
+
+[[nodiscard]] bool has_reason(
+    const mqb::orchestration::IncrementalModuleScanInspection& inspection,
+    const mqb::orchestration::ModuleScanReason reason) {
+    return std::find(
+        inspection.reasons.begin(),
+        inspection.reasons.end(),
+        reason) != inspection.reasons.end();
+}
+
+[[nodiscard]] mqb::FileSnapshot snapshot(const fs::path& path) {
+    std::error_code error_code;
+    const auto modified = fs::last_write_time(path, error_code);
+    expect(!error_code, "snapshot timestamp should be readable");
+    return mqb::FileSnapshot{
+        .path = path,
+        .exists = !error_code,
+        .modified = modified,
+    };
+}
+
+class ScanRunner final : public mqb::process::ProcessRunner {
+public:
+    int calls{};
+    std::optional<mqb::process::ProcessSpec> last_spec;
+
+    std::expected<mqb::process::ProcessResult, mqb::process::ProcessError>
+    run(const mqb::process::ProcessSpec& spec) override {
+        ++calls;
+        last_spec = spec;
+
+        fs::path output;
+        for (std::size_t index = 0; index + 1 < spec.arguments.size(); ++index) {
+            if (spec.arguments[index] == "/scanDependencies") {
+                output = fs::path{spec.arguments[index + 1]};
+                break;
+            }
+        }
+        if (output.empty()) {
+            return mqb::process::ProcessResult{
+                .exit_code = 2,
+                .stderr_text = "missing /scanDependencies output",
+            };
+        }
+
+        const std::string primary = json_escape(path_to_utf8(output.parent_path() / "demo.obj"));
+        write_text(output,
+            "{\n"
+            "  \"version\": 1,\n"
+            "  \"revision\": 0,\n"
+            "  \"rules\": [ {\n"
+            "    \"primary-output\": \"" + primary + "\",\n"
+            "    \"provides\": [ { \"logical-name\": \"demo\" } ]\n"
+            "  } ]\n"
+            "}\n");
+        return mqb::process::ProcessResult{
+            .exit_code = 0,
+            .stdout_text = "module scan complete",
+        };
+    }
+};
+
+} // namespace
+
+int main() {
+    TemporaryDirectory fixture;
+    const fs::path source = fixture.root() / "input" / "demo.ixx";
+    const fs::path output = fixture.root() / "state" / "demo.p1689.json";
+    const fs::path cache = fixture.root() / "cache" / "demo.mqbcache";
+    write_text(source, "export module demo;\nexport int value() { return 7; }\n");
+
+    mqb::msvc::MsvcToolchain toolchain;
+    toolchain.identity.compiler = fixture.root() / "toolchain" / "cl.exe";
+    toolchain.identity.version = "19.51.module-inspection";
+    toolchain.identity.binary_stamp = "fake-module-scanner-stamp";
+    toolchain.environment.push_back(
+        mqb::process::EnvironmentVariable{"PATH", "fake-toolchain-path", false});
+
+    mqb::CompilerOptions options;
+    options.configuration = mqb::BuildConfiguration::debug;
+    options.architecture = mqb::Architecture::x64;
+    options.standard = mqb::CppStandard::cpp23;
+    options.defines = {"FEATURE=1"};
+
+    const mqb::orchestration::IncrementalModuleScanRequest request{
+        .source = source,
+        .module_dependencies_file = output,
+        .compile_cache_file = cache,
+        .options = options,
+        .kind = mqb::TranslationUnitKind::module_interface,
+        .working_directory = fixture.root(),
+    };
+
+    ScanRunner runner;
+    mqb::msvc::MsvcModuleDependencyScanner scanner{toolchain, runner};
+    mqb::orchestration::MsvcIncrementalModuleScanCoordinator coordinator{scanner};
+
+    const auto cold = coordinator.inspect(request);
+    expect(cold.has_value(), "cold module scan inspection should succeed");
+    if (cold) {
+        expect(cold->scan_required(), "cold module scan inspection should require a scan");
+        expect(has_reason(
+                   *cold,
+                   mqb::orchestration::ModuleScanReason::missing_cache_entry),
+               "cold module scan inspection should report missing cache evidence");
+        expect(!cold->dependencies.has_value(),
+               "cold module scan inspection must not invent a P1689 graph");
+        expect(cold->recipe.process.executable == toolchain.identity.compiler,
+               "cold inspection should expose the exact selected cl.exe");
+        expect(cold->recipe.process.working_directory == fixture.root(),
+               "cold inspection should preserve the scan working directory");
+        expect(std::find(
+                   cold->recipe.process.arguments.begin(),
+                   cold->recipe.process.arguments.end(),
+                   "/scanDependencies") != cold->recipe.process.arguments.end(),
+               "cold inspection should expose /scanDependencies argv");
+    }
+    expect(runner.calls == 0, "cold module scan inspection must not launch cl.exe");
+    expect(!fs::exists(output) && !fs::exists(cache),
+           "cold module scan inspection must not create output or cache state");
+    expect(!fs::exists(output.parent_path()),
+           "cold module scan inspection must not prepare output directories");
+
+    auto cold_run = coordinator.run(request);
+    expect(cold_run.has_value() && cold_run->scanned,
+           "cold module scan run should execute the inspected scan recipe");
+    expect(runner.calls == 1, "cold module scan run should launch cl.exe exactly once");
+    expect(fs::is_regular_file(output),
+           "cold module scan run should produce P1689 metadata");
+    expect(!fs::exists(cache),
+           "module scan alone must not seal compile-cache evidence before compilation");
+    if (cold_run) {
+        expect(cold_run->result.dependencies.rules.size() == 1,
+               "cold module scan run should parse one P1689 rule");
+        expect(cold_run->result.dependencies.rules.front().provided_modules.size() == 1
+                   && cold_run->result.dependencies.rules.front()
+                       .provided_modules.front().logical_name == "demo",
+               "cold module scan run should expose the provided module identity");
+        expect(runner.last_spec.has_value()
+                   && same_process_spec(
+                       cold_run->inspection.recipe.process,
+                       *runner.last_spec),
+               "incremental scan run must execute the exact inspected ProcessSpec");
+    }
+
+    mqb::TranslationUnit unit;
+    unit.source = source;
+    unit.kind = mqb::TranslationUnitKind::module_interface;
+    unit.outputs = {
+        mqb::Artifact{fixture.root() / "objects" / "demo.obj", mqb::ArtifactKind::object},
+        mqb::Artifact{fixture.root() / "ifc" / "demo.ifc", mqb::ArtifactKind::module_interface},
+    };
+    const auto include_roots = mqb::msvc::include_search_roots(
+        options,
+        toolchain.environment,
+        request.working_directory);
+    mqb::CompileCacheEntry entry{
+        .source = source,
+        .kind = unit.kind,
+        .toolchain = toolchain.identity,
+        .signature = mqb::BuildSignature::for_compile(
+            unit,
+            toolchain.identity,
+            options),
+        .outputs = unit.outputs,
+        .include_search_roots = include_roots,
+        .module_scan = mqb::ModuleScanEvidence{
+            .signature = mqb::BuildSignature::for_module_scan(
+                source,
+                unit.kind,
+                toolchain.identity,
+                options),
+            .source = snapshot(source),
+            .output = snapshot(output),
+            .dependencies = {},
+        },
+    };
+    const auto saved = mqb::CompileCacheFile::save(cache, entry);
+    expect(saved.has_value(), "test should be able to seal module scan evidence");
+
+    const std::string output_before = read_text(output);
+    const std::string cache_before = read_text(cache);
+    const auto warm = coordinator.inspect(request);
+    expect(warm.has_value() && warm->reusable(),
+           "warm module scan inspection should reuse sealed P1689 evidence");
+    if (warm) {
+        expect(warm->reasons.empty(),
+               "warm module scan inspection should expose no rebuild reasons");
+        expect(warm->dependencies.has_value()
+                   && warm->dependencies->rules.size() == 1,
+               "warm module scan inspection should parse reusable P1689 metadata");
+    }
+    expect(runner.calls == 1, "warm module scan inspection must not launch cl.exe");
+    expect(read_text(output) == output_before && read_text(cache) == cache_before,
+           "warm module scan inspection must not mutate output or cache state");
+
+    const auto warm_run = coordinator.run(request);
+    expect(warm_run.has_value() && !warm_run->scanned && warm_run->result.reused,
+           "warm module scan run should return reusable evidence without execution");
+    expect(runner.calls == 1, "warm module scan run must not launch cl.exe");
+
+    const auto output_time = fs::last_write_time(output);
+    write_text(output, "{ malformed P1689 metadata");
+    fs::last_write_time(output, output_time);
+    const auto corrupt = coordinator.inspect(request);
+    expect(corrupt.has_value() && corrupt->scan_required(),
+           "corrupted P1689 content should require a fresh scan");
+    if (corrupt) {
+        expect(has_reason(
+                   *corrupt,
+                   mqb::orchestration::ModuleScanReason::dependency_metadata_invalid),
+               "timestamp-preserving P1689 corruption should expose a metadata reason");
+    }
+    expect(runner.calls == 1,
+           "corrupted metadata inspection must not repair or execute the scan");
+    expect(read_text(cache) == cache_before,
+           "corrupted metadata inspection must not rewrite sealed cache state");
+
+    write_text(output, output_before);
+    fs::last_write_time(output, output_time);
+    const auto source_time = fs::last_write_time(source);
+    write_text(source, "export module demo;\nexport int value() { return 8; }\n");
+    fs::last_write_time(source, source_time + std::chrono::seconds{1});
+    const auto stale_source = coordinator.inspect(request);
+    expect(stale_source.has_value() && stale_source->scan_required(),
+           "source mutation should invalidate module scan evidence");
+    if (stale_source) {
+        expect(has_reason(
+                   *stale_source,
+                   mqb::orchestration::ModuleScanReason::source_changed),
+               "source mutation should expose a source_changed scan reason");
+    }
+    expect(runner.calls == 1,
+           "stale source inspection must not launch cl.exe");
+
+    auto rescanned = coordinator.run(request);
+    expect(rescanned.has_value() && rescanned->scanned,
+           "stale source module scan run should execute a fresh recipe");
+    expect(runner.calls == 2,
+           "stale source module scan run should launch cl.exe exactly once more");
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+    std::cout << "mqb_module_scan_inspection_contract passed\n";
+    return 0;
+}

--- a/tests/native/verify_module_scan_inspection.ps1
+++ b/tests/native/verify_module_scan_inspection.ps1
@@ -1,0 +1,91 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$BuilderMqbPath,
+    [Parameter(Mandatory = $true)][string]$RepoRoot
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+$RepoRoot = [System.IO.Path]::GetFullPath($RepoRoot)
+$BuilderMqbPath = [System.IO.Path]::GetFullPath($BuilderMqbPath)
+if (-not (Test-Path -LiteralPath $BuilderMqbPath -PathType Leaf)) {
+    throw "Builder MQB not found: $BuilderMqbPath"
+}
+
+$cppRoot = Join-Path $RepoRoot 'cpp'
+$configPath = Join-Path $cppRoot 'mqb.json'
+$contractSource = Join-Path $RepoRoot 'tests/native/module_scan_inspection_contract.cpp'
+foreach ($path in @($configPath, $contractSource)) {
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+        throw "Module scan inspection evidence input missing: $path"
+    }
+}
+
+& (Join-Path $RepoRoot 'tests/native/assert_cpp_layout.ps1') -CppRoot $cppRoot
+
+$config = Get-Content -LiteralPath $configPath -Raw | ConvertFrom-Json
+$productionSources = @($config.discovery.extra_sources | ForEach-Object {
+    'cpp/' + ([string]$_).Replace('\', '/')
+})
+if ($productionSources.Count -eq 0) {
+    throw 'cpp/mqb.json has no production sources for module scan inspection evidence.'
+}
+
+$arguments = [System.Collections.ArrayList]::new()
+[void]$arguments.Add('tests/native/module_scan_inspection_contract.cpp')
+foreach ($source in $productionSources) {
+    [void]$arguments.Add($source)
+}
+[void]$arguments.Add('--no-discover')
+[void]$arguments.Add('--env')
+[void]$arguments.Add('vs')
+[void]$arguments.Add('--debug')
+[void]$arguments.Add('--std')
+[void]$arguments.Add([string]$config.build.standard)
+[void]$arguments.Add('--runtime')
+[void]$arguments.Add('MTd')
+foreach ($include in @($config.build.include_dirs)) {
+    [void]$arguments.Add('-I')
+    [void]$arguments.Add('cpp/' + ([string]$include).Replace('\', '/'))
+}
+foreach ($compilerArg in @($config.build.compiler_args)) {
+    [void]$arguments.Add('--compiler-arg')
+    [void]$arguments.Add([string]$compilerArg)
+}
+[void]$arguments.Add('--lib')
+[void]$arguments.Add('shell32.lib')
+[void]$arguments.Add('-o')
+[void]$arguments.Add('module_scan_inspection_contract')
+
+$stateRoot = Join-Path $RepoRoot '.mqb'
+if (Test-Path -LiteralPath $stateRoot) {
+    Remove-Item -LiteralPath $stateRoot -Recurse -Force
+}
+
+Push-Location $RepoRoot
+try {
+    $buildOutput = @(& $BuilderMqbPath @arguments 2>&1)
+    $buildExit = $LASTEXITCODE
+    foreach ($line in $buildOutput) { Write-Host $line }
+    if ($buildExit -ne 0) {
+        throw "Failed to build module scan inspection contract (exit $buildExit)."
+    }
+
+    $contractExe = Join-Path $RepoRoot '.mqb/bin/module_scan_inspection_contract.exe'
+    if (-not (Test-Path -LiteralPath $contractExe -PathType Leaf)) {
+        throw "Module scan inspection contract executable missing: $contractExe"
+    }
+
+    $testOutput = @(& $contractExe 2>&1)
+    $testExit = $LASTEXITCODE
+    foreach ($line in $testOutput) { Write-Host $line }
+    if ($testExit -ne 0) {
+        throw "Module scan inspection contract failed (exit $testExit)."
+    }
+}
+finally {
+    Pop-Location
+}
+
+Write-Host 'Module scan inspection evidence passed.'


### PR DESCRIPTION
## Goal

Establish the first graph-aware introspection foundation for C++ Modules/Header Units without pretending that a cold project already has a trustworthy dependency graph.

## Product / architecture change

Add a first-class, pure `MsvcModuleScanRecipe` for the exact MSVC `/scanDependencies` process contract and a typed `MsvcIncrementalModuleScanCoordinator` that inspects persisted scan evidence without writing files or launching `cl.exe`.

The inspection reports why a fresh P1689 scan is required, including missing cache/evidence, scan recipe changes, include-search root changes, source/output/dependency freshness changes, and timestamp-preserving malformed metadata. When sealed evidence is reusable, it parses and returns the existing P1689 document without process execution.

## Execution parity

`MsvcModuleDependencyScanner::scan()` now builds and executes the same first-class recipe exposed to introspection. The recipe includes:

- selected compiler identity;
- exact ordered scan argv;
- working directory;
- vcvars/toolchain environment;
- ambient `CL` / `_CL_` suppression;
- stdout/stderr capture policy.

Recipe construction has no filesystem/process side effects. Execution owns output-directory preparation and stale metadata removal exactly as before. Recipe execution also rejects a compiler-identity mismatch before process launch.

## Existing module build integration

The production module target scanner no longer maintains a private second implementation of scan-cache reuse. Cold scans and warm P1689 reuse now both flow through `MsvcIncrementalModuleScanCoordinator::run()`.

Successful scan execution still does **not** seal cache evidence by itself. The existing successful compile path remains the authority that seals scan evidence after proving the scan topology and completed compile are mutually fresh.

## Cold graph honesty boundary

This PR does not add user-facing Modules support to `mqb plan` yet. On a cold or stale module project, a complete graph cannot be known without executing `/scanDependencies`; future plan output must therefore report pending scan steps rather than invent providers, compile waves, or link decisions. On a warm project, this authority makes reusable P1689 available without execution.

## Focused evidence

The dedicated Windows/MSVC contract proves:

- cold inspection before the scan output directory exists;
- exact scan recipe construction with zero writes/process launches;
- cold run executing the exact inspected `ProcessSpec`;
- no premature compile-cache sealing after scan alone;
- manually sealed warm P1689 reuse with zero mutation/process execution;
- timestamp-preserving malformed P1689 detection;
- source freshness invalidation and subsequent rescan;
- scanner recipe/production execution parity and toolchain mismatch rejection.

The existing `mqb compdb`, ordinary/PCH/static `mqb plan`, PCH inspection, incremental inspection, module target, Header Unit, Debug and Release test surfaces remain green.

## Non-goals

- no user-facing module `mqb plan` output yet;
- no module compile-wave inspection yet;
- no Header Unit or standard-library module behavior change;
- no config/cache schema or version change;
- no release publication.

## Exact validated head

`b7980dec5b132627e28b1dde659ea412dcf58c2d`

Base remains `main @ 48085173a47e0333f08fd75a37fa7a50048ba6b9`. The branch is 12 commits ahead and 0 behind, with changes limited to 11 files.

## Validation

All required validation is green on the exact head above:

- Module Scan Inspection Evidence: **success**;
- Compilation Database Evidence: **success**;
- Build Plan Evidence: **success**;
- PCH Inspection Evidence: **success**;
- Incremental Inspection Evidence: **success**;
- Documentation: **success**;
- Final Closure Cross-Stage: **success**;
- Native C++ candidate self-build/preflight: **success**;
- environment isolation, ASan, LibFuzzer, OpenMP, default-library freshness, include-search freshness, `__has_include`, linker side-output repair: **success**;
- exact MSVC parameter inventory and semantic variant inventory: **success**;
- Native Debug tests: **4/4 shards success**;
- Native C++ gate: **success**;
- Native Release Stage 0/shared product build: **success**;
- Native Release tests: **4/4 shards success**;
- Release self-host: **success**;
- runtime-only package staging/validation/upload: **success**;
- Performance Evidence: intentionally skipped because this is not a performance PR;
- release publication: intentionally skipped for a pull request.

One first-attempt Incremental Inspection job was interrupted before tests by an anonymous GitHub Release API HTTP 403 rate limit while acquiring the historical seed. The failed jobs were rerun; seed acquisition and the full inspection contract then completed successfully. No product test failed.

No inline review threads or submitted blocking reviews are present. `main` did not move during validation.

This PR is ready for merge review and remains unmerged pending explicit authorization.