### PR TITLE
refactor: add side-effect-free module target inspection

### DIFF
--- a/.github/workflows/module-target-inspection-evidence.yml
+++ b/.github/workflows/module-target-inspection-evidence.yml
@@ -1,0 +1,67 @@
+name: Module Target Inspection Evidence
+
+on:
+  pull_request:
+    paths:
+      - 'cpp/include/mqb/orchestration/MsvcModuleTargetCoordinator.hpp'
+      - 'cpp/include/mqb/orchestration/MsvcModuleCompileCoordinator.hpp'
+      - 'cpp/include/mqb/orchestration/MsvcIncrementalModuleScanCoordinator.hpp'
+      - 'cpp/include/mqb/orchestration/MsvcIncrementalLinkCoordinator.hpp'
+      - 'cpp/src/orchestration/modules/ModuleTargetArtifactRegistry.cpp'
+      - 'cpp/src/orchestration/modules/ModuleTargetArtifactRegistry.hpp'
+      - 'cpp/src/orchestration/modules/ModuleTargetScanner.cpp'
+      - 'cpp/src/orchestration/modules/ModuleTargetScanner.hpp'
+      - 'cpp/src/orchestration/modules/ModuleTargetPreparation.cpp'
+      - 'cpp/src/orchestration/modules/ModuleTargetPreparation.hpp'
+      - 'cpp/src/orchestration/modules/ModuleTargetLinkRequestFactory.cpp'
+      - 'cpp/src/orchestration/modules/ModuleTargetLinkRequestFactory.hpp'
+      - 'cpp/src/orchestration/modules/StandardLibraryModuleProvider.cpp'
+      - 'cpp/src/orchestration/modules/StandardLibraryModuleProvider.hpp'
+      - 'cpp/src/orchestration/modules/MsvcModuleTargetCoordinator.cpp'
+      - 'cpp/src/orchestration/modules/MsvcModuleCompileCoordinator.cpp'
+      - 'cpp/src/orchestration/modules/MsvcIncrementalModuleScanCoordinator.cpp'
+      - 'cpp/src/orchestration/incremental/MsvcIncrementalLinkCoordinator.cpp'
+      - 'cpp/src/core/**'
+      - 'cpp/src/modules/**'
+      - 'cpp/src/msvc/**'
+      - 'cpp/mqb.json'
+      - 'tests/native/module_target_inspection_contract.cpp'
+      - 'tests/native/verify_module_target_inspection.ps1'
+      - 'tests/native/assert_cpp_layout.ps1'
+      - '.github/workflows/module-target-inspection-evidence.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: module-target-inspection-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify-module-target-inspection:
+    name: Verify side-effect-free module target inspection
+    runs-on: windows-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Acquire pinned MQB seed
+        id: seed
+        shell: pwsh
+        run: |
+          $seed = & (Join-Path $PWD 'tests/native/acquire_seed.ps1') `
+            -RepoRoot $PWD `
+            -OutputRoot (Join-Path $PWD 'native-seed')
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          "path=$seed" >> $env:GITHUB_OUTPUT
+
+      - name: Verify module target inspection contract
+        shell: pwsh
+        run: |
+          & (Join-Path $PWD 'tests/native/verify_module_target_inspection.ps1') `
+            -BuilderMqbPath '${{ steps.seed.outputs.path }}' `
+            -RepoRoot $PWD
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/cpp/include/mqb/orchestration/MsvcModuleTargetCoordinator.hpp
+++ b/cpp/include/mqb/orchestration/MsvcModuleTargetCoordinator.hpp
@@ -13,6 +13,7 @@
 #include "mqb/modules/ModuleDependencyGraph.hpp"
 #include "mqb/msvc/MsvcModuleDependencyScanner.hpp"
 #include "mqb/orchestration/MsvcIncrementalLinkCoordinator.hpp"
+#include "mqb/orchestration/MsvcIncrementalModuleScanCoordinator.hpp"
 #include "mqb/orchestration/MsvcModuleCompileCoordinator.hpp"
 #include "mqb/orchestration/ParallelismPolicy.hpp"
 #include "mqb/orchestration/TargetTimings.hpp"
@@ -36,6 +37,35 @@ struct IncrementalModuleTargetRequest {
 struct ModuleTargetScanResult {
     std::filesystem::path source;
     msvc::ModuleScanResult result;
+};
+
+struct ModuleTargetScanInspection {
+    std::filesystem::path source;
+    IncrementalModuleScanInspection result;
+    // Requested project sources are reported first in request order. Any
+    // selected VC Tools std/std.compat provider is appended and marked here so
+    // user-facing introspection can distinguish project and toolchain ownership.
+    bool toolchain_owned{false};
+};
+
+struct IncrementalModuleTargetInspection {
+    std::vector<ModuleTargetScanInspection> scans;
+    // These stages remain absent whenever any required P1689 scan is stale or
+    // missing. A dependency graph cannot be inferred honestly until every
+    // required scan document is reusable.
+    std::optional<modules::ModuleDependencyPlan> plan;
+    std::optional<ModuleCompileWaveRequest> compile_request;
+    std::optional<ModuleCompileWaveInspection> compiles;
+    std::optional<IncrementalLinkRequest> link_request;
+    std::optional<IncrementalLinkInspection> link;
+
+    [[nodiscard]] bool graph_ready() const noexcept {
+        return plan.has_value();
+    }
+
+    [[nodiscard]] bool scan_required() const noexcept {
+        return !graph_ready();
+    }
 };
 
 enum class IncrementalModuleTargetErrorCode {
@@ -90,6 +120,13 @@ public:
         : scanner_(scanner),
           compile_coordinator_(compile_coordinator),
           link_coordinator_(link_coordinator) {}
+
+    // Inspect the complete module target without launching cl.exe/link.exe or
+    // mutating scan, compile, link, or output state. Cold/stale scan evidence
+    // yields scan recipes only; warm trustworthy P1689 continues through graph,
+    // compile-wave, and final-link inspection.
+    [[nodiscard]] std::expected<IncrementalModuleTargetInspection, IncrementalModuleTargetError>
+    inspect(const IncrementalModuleTargetRequest& request) const;
 
     [[nodiscard]] std::expected<IncrementalModuleTargetResult, IncrementalModuleTargetError>
     run(const IncrementalModuleTargetRequest& request) const;

--- a/cpp/src/orchestration/modules/ModuleTargetPreparation.cpp
+++ b/cpp/src/orchestration/modules/ModuleTargetPreparation.cpp
@@ -43,12 +43,8 @@ using Clock = std::chrono::steady_clock;
     return std::nullopt;
 }
 
-} // namespace
-
-std::expected<ModuleTargetPreparation, IncrementalModuleTargetError>
-prepare_module_target(
-    const IncrementalModuleTargetRequest& request,
-    msvc::MsvcModuleDependencyScanner& scanner) {
+[[nodiscard]] std::expected<void, IncrementalModuleTargetError>
+validate_request(const IncrementalModuleTargetRequest& request) {
     if (request.sources.empty()) {
         return std::unexpected(failure(
             IncrementalModuleTargetErrorCode::no_sources,
@@ -59,9 +55,11 @@ prepare_module_target(
             IncrementalModuleTargetErrorCode::invalid_parallelism,
             "module target scan and compile parallelism must be automatic or a positive fixed worker count"));
     }
+    return {};
+}
 
-    const auto preparation_started = Clock::now();
-
+[[nodiscard]] std::expected<ModuleTargetArtifactRegistry, IncrementalModuleTargetError>
+register_requested_artifacts(const IncrementalModuleTargetRequest& request) {
     ModuleTargetArtifactRegistry artifacts{request.sources.size()};
     for (const auto& source : request.sources) {
         if (auto registered = artifacts.add_requested_source(source); !registered) {
@@ -71,30 +69,15 @@ prepare_module_target(
     if (auto registered = artifacts.add_target(request.target); !registered) {
         return std::unexpected(std::move(registered.error()));
     }
+    return artifacts;
+}
 
-    const auto scan_started = Clock::now();
-    auto scanned = scan_requested_module_sources(request, scanner);
-    if (!scanned) {
-        return std::unexpected(std::move(scanned.error()));
-    }
-
-    ModuleTargetPreparation prepared;
-    prepared.scans = std::move(scanned->scans);
-    std::vector<modules::ScannedModuleUnit> scanned_units = std::move(scanned->units);
-    std::vector<ModuleCompileSourceRequest> compile_sources = request.sources;
-    compile_sources.reserve(request.sources.size() + 2u);
-
-    if (auto injected = inject_standard_library_module_providers(
-            request,
-            scanner,
-            artifacts,
-            scanned_units,
-            compile_sources); !injected) {
-        return std::unexpected(std::move(injected.error()));
-    }
-    prepared.timings.dependency_scan = std::chrono::duration_cast<std::chrono::nanoseconds>(
-        Clock::now() - scan_started);
-
+[[nodiscard]] std::expected<ModuleTargetPreparation, IncrementalModuleTargetError>
+finish_preparation(
+    const IncrementalModuleTargetRequest& request,
+    ModuleTargetArtifactRegistry& artifacts,
+    std::vector<modules::ScannedModuleUnit> scanned_units,
+    std::vector<ModuleCompileSourceRequest> compile_sources) {
     auto plan = modules::ModuleDependencyGraphBuilder::build(
         scanned_units,
         request.compiler_options.external_module_providers);
@@ -105,7 +88,9 @@ prepare_module_target(
         error.graph_error = plan.error();
         return std::unexpected(std::move(error));
     }
-    prepared.plan = *plan;
+
+    ModuleTargetPreparation prepared;
+    prepared.plan = std::move(*plan);
 
     std::vector<ModuleCompileHeaderUnitRequest> header_units;
     header_units.reserve(prepared.plan.header_units.size());
@@ -157,10 +142,106 @@ prepare_module_target(
         .working_directory = request.working_directory,
         .max_parallel_compiles = request.max_parallel_compiles,
     };
+    return prepared;
+}
 
+} // namespace
+
+std::expected<ModuleTargetPreparationInspection, IncrementalModuleTargetError>
+inspect_module_target_preparation(
+    const IncrementalModuleTargetRequest& request,
+    msvc::MsvcModuleDependencyScanner& scanner) {
+    if (auto validated = validate_request(request); !validated) {
+        return std::unexpected(std::move(validated.error()));
+    }
+
+    auto artifacts = register_requested_artifacts(request);
+    if (!artifacts) return std::unexpected(std::move(artifacts.error()));
+
+    auto inspected = inspect_requested_module_sources(request, scanner);
+    if (!inspected) return std::unexpected(std::move(inspected.error()));
+
+    ModuleTargetPreparationInspection result;
+    result.scans = std::move(inspected->scans);
+    if (!inspected->complete) {
+        return result;
+    }
+
+    std::vector<modules::ScannedModuleUnit> scanned_units =
+        std::move(inspected->units);
+    std::vector<ModuleCompileSourceRequest> compile_sources = request.sources;
+    compile_sources.reserve(request.sources.size() + 2u);
+
+    auto standard_modules_complete = inspect_standard_library_module_providers(
+        request,
+        scanner,
+        *artifacts,
+        scanned_units,
+        compile_sources,
+        result.scans);
+    if (!standard_modules_complete) {
+        return std::unexpected(std::move(standard_modules_complete.error()));
+    }
+    if (!*standard_modules_complete) {
+        return result;
+    }
+
+    auto prepared = finish_preparation(
+        request,
+        *artifacts,
+        std::move(scanned_units),
+        std::move(compile_sources));
+    if (!prepared) return std::unexpected(std::move(prepared.error()));
+    result.prepared = std::move(*prepared);
+    return result;
+}
+
+std::expected<ModuleTargetPreparation, IncrementalModuleTargetError>
+prepare_module_target(
+    const IncrementalModuleTargetRequest& request,
+    msvc::MsvcModuleDependencyScanner& scanner) {
+    if (auto validated = validate_request(request); !validated) {
+        return std::unexpected(std::move(validated.error()));
+    }
+
+    const auto preparation_started = Clock::now();
+
+    auto artifacts = register_requested_artifacts(request);
+    if (!artifacts) return std::unexpected(std::move(artifacts.error()));
+
+    const auto scan_started = Clock::now();
+    auto scanned = scan_requested_module_sources(request, scanner);
+    if (!scanned) return std::unexpected(std::move(scanned.error()));
+
+    std::vector<ModuleTargetScanResult> scans = std::move(scanned->scans);
+    std::vector<modules::ScannedModuleUnit> scanned_units =
+        std::move(scanned->units);
+    std::vector<ModuleCompileSourceRequest> compile_sources = request.sources;
+    compile_sources.reserve(request.sources.size() + 2u);
+
+    if (auto injected = inject_standard_library_module_providers(
+            request,
+            scanner,
+            *artifacts,
+            scanned_units,
+            compile_sources); !injected) {
+        return std::unexpected(std::move(injected.error()));
+    }
+    const auto dependency_scan = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        Clock::now() - scan_started);
+
+    auto prepared = finish_preparation(
+        request,
+        *artifacts,
+        std::move(scanned_units),
+        std::move(compile_sources));
+    if (!prepared) return std::unexpected(std::move(prepared.error()));
+
+    prepared->scans = std::move(scans);
+    prepared->timings.dependency_scan = dependency_scan;
     const auto preparation_total = std::chrono::duration_cast<std::chrono::nanoseconds>(
         Clock::now() - preparation_started);
-    prepared.timings.compile_queue = preparation_total - prepared.timings.dependency_scan;
+    prepared->timings.compile_queue = preparation_total - dependency_scan;
     return prepared;
 }
 

--- a/cpp/src/orchestration/modules/ModuleTargetPreparation.hpp
+++ b/cpp/src/orchestration/modules/ModuleTargetPreparation.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <expected>
+#include <optional>
 #include <vector>
 
 #include "mqb/orchestration/MsvcModuleTargetCoordinator.hpp"
@@ -13,6 +14,18 @@ struct ModuleTargetPreparation {
     ModuleCompileWaveRequest compile_request;
     TargetTimings timings;
 };
+
+struct ModuleTargetPreparationInspection {
+    std::vector<ModuleTargetScanInspection> scans;
+    // Absent when at least one requested or toolchain-owned provider scan must
+    // execute before a trustworthy graph can be constructed.
+    std::optional<ModuleTargetPreparation> prepared;
+};
+
+[[nodiscard]] std::expected<ModuleTargetPreparationInspection, IncrementalModuleTargetError>
+inspect_module_target_preparation(
+    const IncrementalModuleTargetRequest& request,
+    msvc::MsvcModuleDependencyScanner& scanner);
 
 [[nodiscard]] std::expected<ModuleTargetPreparation, IncrementalModuleTargetError>
 prepare_module_target(

--- a/cpp/src/orchestration/modules/ModuleTargetScanner.cpp
+++ b/cpp/src/orchestration/modules/ModuleTargetScanner.cpp
@@ -34,16 +34,11 @@ namespace fs = std::filesystem;
     return std::nullopt;
 }
 
-} // namespace
-
-std::expected<msvc::ModuleScanResult, msvc::ModuleScanError>
-scan_module_source(
+[[nodiscard]] IncrementalModuleScanRequest make_scan_request(
     const ModuleCompileSourceRequest& source,
     const CompilerOptions& options,
-    const fs::path& working_directory,
-    msvc::MsvcModuleDependencyScanner& scanner) {
-    MsvcIncrementalModuleScanCoordinator coordinator{scanner};
-    auto scanned = coordinator.run(IncrementalModuleScanRequest{
+    const fs::path& working_directory) {
+    return IncrementalModuleScanRequest{
         .source = source.source,
         .module_dependencies_file = source.artifacts.module_dependencies,
         .compile_cache_file = source.artifacts.compile_cache,
@@ -52,9 +47,133 @@ scan_module_source(
         .working_directory = working_directory_for(
             working_directory,
             source.source),
-    });
+    };
+}
+
+[[nodiscard]] IncrementalModuleTargetError scan_failure(
+    const fs::path& source,
+    msvc::ModuleScanError error) {
+    IncrementalModuleTargetError result = failure(
+        IncrementalModuleTargetErrorCode::scan_failed,
+        "module dependency scan inspection failed",
+        source);
+    result.scan_error = std::move(error);
+    return result;
+}
+
+[[nodiscard]] std::expected<modules::ScannedModuleUnit, IncrementalModuleTargetError>
+scanned_unit_from(
+    const fs::path& source,
+    const modules::P1689Document& dependencies,
+    const bool toolchain_owned = false) {
+    if (dependencies.rules.size() != 1) {
+        return std::unexpected(failure(
+            IncrementalModuleTargetErrorCode::invalid_scan_result,
+            "one-source module scan must produce exactly one P1689 rule",
+            source));
+    }
+    return modules::ScannedModuleUnit{
+        .source = source,
+        .rule = dependencies.rules.front(),
+        .toolchain_owned = toolchain_owned,
+    };
+}
+
+} // namespace
+
+std::expected<IncrementalModuleScanInspection, msvc::ModuleScanError>
+inspect_module_source(
+    const ModuleCompileSourceRequest& source,
+    const CompilerOptions& options,
+    const fs::path& working_directory,
+    msvc::MsvcModuleDependencyScanner& scanner) {
+    MsvcIncrementalModuleScanCoordinator coordinator{scanner};
+    return coordinator.inspect(make_scan_request(
+        source,
+        options,
+        working_directory));
+}
+
+std::expected<msvc::ModuleScanResult, msvc::ModuleScanError>
+scan_module_source(
+    const ModuleCompileSourceRequest& source,
+    const CompilerOptions& options,
+    const fs::path& working_directory,
+    msvc::MsvcModuleDependencyScanner& scanner) {
+    MsvcIncrementalModuleScanCoordinator coordinator{scanner};
+    auto scanned = coordinator.run(make_scan_request(
+        source,
+        options,
+        working_directory));
     if (!scanned) return std::unexpected(scanned.error());
     return std::move(scanned->result);
+}
+
+std::expected<ModuleTargetScanInspectionBatch, IncrementalModuleTargetError>
+inspect_requested_module_sources(
+    const IncrementalModuleTargetRequest& request,
+    msvc::MsvcModuleDependencyScanner& scanner) {
+    using InspectionAttempt = std::expected<
+        IncrementalModuleScanInspection,
+        msvc::ModuleScanError>;
+    std::vector<std::optional<InspectionAttempt>> attempts(request.sources.size());
+
+    const auto scheduled = BoundedWorkScheduler::run(
+        request.sources.size(),
+        request.max_parallel_scans,
+        ParallelismWorkload::dependency_scan,
+        [&](const std::size_t index) {
+            attempts[index].emplace(inspect_module_source(
+                request.sources[index],
+                request.compiler_options,
+                request.working_directory,
+                scanner));
+            return attempts[index]->has_value();
+        });
+    if (!scheduled) {
+        return std::unexpected(failure(
+            IncrementalModuleTargetErrorCode::scheduling_failed,
+            "module scan inspection scheduler failed: " + scheduled.error().message));
+    }
+
+    for (std::size_t index = 0; index < attempts.size(); ++index) {
+        if (attempts[index] && !attempts[index]->has_value()) {
+            return std::unexpected(scan_failure(
+                request.sources[index].source,
+                attempts[index]->error()));
+        }
+    }
+
+    ModuleTargetScanInspectionBatch batch;
+    batch.scans.reserve(request.sources.size());
+    batch.units.reserve(request.sources.size() + 2u);
+
+    for (std::size_t index = 0; index < request.sources.size(); ++index) {
+        if (!attempts[index]) {
+            return std::unexpected(failure(
+                IncrementalModuleTargetErrorCode::scheduling_failed,
+                "module scan inspection scheduler stopped without a recorded failure",
+                request.sources[index].source));
+        }
+
+        auto inspection = std::move(attempts[index]->value());
+        if (inspection.reusable()) {
+            auto unit = scanned_unit_from(
+                request.sources[index].source,
+                *inspection.dependencies);
+            if (!unit) return std::unexpected(std::move(unit.error()));
+            batch.units.push_back(std::move(*unit));
+        } else {
+            batch.complete = false;
+        }
+        batch.scans.push_back(ModuleTargetScanInspection{
+            .source = request.sources[index].source,
+            .result = std::move(inspection),
+            .toolchain_owned = false,
+        });
+    }
+
+    return batch;
 }
 
 std::expected<ModuleTargetScanBatch, IncrementalModuleTargetError>
@@ -105,16 +224,11 @@ scan_requested_module_sources(
                 request.sources[index].source));
         }
         auto scan = std::move(attempts[index]->value());
-        if (scan.dependencies.rules.size() != 1) {
-            return std::unexpected(failure(
-                IncrementalModuleTargetErrorCode::invalid_scan_result,
-                "one-source module scan must produce exactly one P1689 rule",
-                request.sources[index].source));
-        }
-        batch.units.push_back(modules::ScannedModuleUnit{
-            .source = request.sources[index].source,
-            .rule = scan.dependencies.rules.front(),
-        });
+        auto unit = scanned_unit_from(
+            request.sources[index].source,
+            scan.dependencies);
+        if (!unit) return std::unexpected(std::move(unit.error()));
+        batch.units.push_back(std::move(*unit));
         batch.scans.push_back(ModuleTargetScanResult{
             .source = request.sources[index].source,
             .result = std::move(scan),

--- a/cpp/src/orchestration/modules/ModuleTargetScanner.hpp
+++ b/cpp/src/orchestration/modules/ModuleTargetScanner.hpp
@@ -13,11 +13,31 @@ struct ModuleTargetScanBatch {
     std::vector<modules::ScannedModuleUnit> units;
 };
 
+struct ModuleTargetScanInspectionBatch {
+    std::vector<ModuleTargetScanInspection> scans;
+    // Reusable source scans are projected into units. Callers must not build a
+    // graph unless complete is true because pending scans can change topology.
+    std::vector<modules::ScannedModuleUnit> units;
+    bool complete{true};
+};
+
+[[nodiscard]] std::expected<IncrementalModuleScanInspection, msvc::ModuleScanError>
+inspect_module_source(
+    const ModuleCompileSourceRequest& source,
+    const CompilerOptions& options,
+    const std::filesystem::path& working_directory,
+    msvc::MsvcModuleDependencyScanner& scanner);
+
 [[nodiscard]] std::expected<msvc::ModuleScanResult, msvc::ModuleScanError>
 scan_module_source(
     const ModuleCompileSourceRequest& source,
     const CompilerOptions& options,
     const std::filesystem::path& working_directory,
+    msvc::MsvcModuleDependencyScanner& scanner);
+
+[[nodiscard]] std::expected<ModuleTargetScanInspectionBatch, IncrementalModuleTargetError>
+inspect_requested_module_sources(
+    const IncrementalModuleTargetRequest& request,
     msvc::MsvcModuleDependencyScanner& scanner);
 
 [[nodiscard]] std::expected<ModuleTargetScanBatch, IncrementalModuleTargetError>

--- a/cpp/src/orchestration/modules/MsvcModuleTargetCoordinator.cpp
+++ b/cpp/src/orchestration/modules/MsvcModuleTargetCoordinator.cpp
@@ -24,7 +24,75 @@ using Clock = std::chrono::steady_clock;
     };
 }
 
+[[nodiscard]] IncrementalModuleTargetError compile_failure(
+    std::string message,
+    ModuleCompileError error) {
+    IncrementalModuleTargetError result = failure(
+        IncrementalModuleTargetErrorCode::compile_failed,
+        std::move(message),
+        error.source);
+    result.compile_error = std::move(error);
+    return result;
+}
+
+[[nodiscard]] IncrementalModuleTargetError link_failure(
+    std::string message,
+    IncrementalLinkError error) {
+    IncrementalModuleTargetError result = failure(
+        IncrementalModuleTargetErrorCode::link_failed,
+        std::move(message));
+    result.link_error = std::move(error);
+    return result;
+}
+
 } // namespace
+
+std::expected<IncrementalModuleTargetInspection, IncrementalModuleTargetError>
+MsvcModuleTargetCoordinator::inspect(
+    const IncrementalModuleTargetRequest& request) const {
+    auto preparation = detail::inspect_module_target_preparation(
+        request,
+        scanner_);
+    if (!preparation) {
+        return std::unexpected(std::move(preparation.error()));
+    }
+
+    IncrementalModuleTargetInspection result;
+    result.scans = std::move(preparation->scans);
+    if (!preparation->prepared) {
+        // At least one required P1689 document is stale or missing. The scan
+        // recipes above are the complete honest plan at this point; provider
+        // graph, compile waves, and link decisions depend on their output.
+        return result;
+    }
+
+    detail::ModuleTargetPreparation prepared =
+        std::move(*preparation->prepared);
+    auto compiled = compile_coordinator_.inspect(prepared.compile_request);
+    if (!compiled) {
+        return std::unexpected(compile_failure(
+            "module target compile-wave inspection failed",
+            std::move(compiled.error())));
+    }
+
+    IncrementalLinkRequest link_request = detail::make_module_target_link_request(
+        request,
+        prepared.compile_request,
+        compiled->any_planned);
+    auto linked = link_coordinator_.inspect(link_request);
+    if (!linked) {
+        return std::unexpected(link_failure(
+            "module target link inspection failed",
+            std::move(linked.error())));
+    }
+
+    result.plan = std::move(prepared.plan);
+    result.compile_request = std::move(prepared.compile_request);
+    result.compiles = std::move(*compiled);
+    result.link_request = std::move(link_request);
+    result.link = std::move(*linked);
+    return result;
+}
 
 std::expected<IncrementalModuleTargetResult, IncrementalModuleTargetError>
 MsvcModuleTargetCoordinator::run(const IncrementalModuleTargetRequest& request) const {
@@ -43,12 +111,9 @@ MsvcModuleTargetCoordinator::run(const IncrementalModuleTargetRequest& request) 
     result.timings.compile = std::chrono::duration_cast<std::chrono::nanoseconds>(
         Clock::now() - compile_started);
     if (!compiled) {
-        IncrementalModuleTargetError error = failure(
-            IncrementalModuleTargetErrorCode::compile_failed,
+        return std::unexpected(compile_failure(
             "module target compile waves failed",
-            compiled.error().source);
-        error.compile_error = compiled.error();
-        return std::unexpected(std::move(error));
+            std::move(compiled.error())));
     }
     result.compiles = std::move(*compiled);
 
@@ -60,11 +125,9 @@ MsvcModuleTargetCoordinator::run(const IncrementalModuleTargetRequest& request) 
     result.timings.link = std::chrono::duration_cast<std::chrono::nanoseconds>(
         Clock::now() - link_started);
     if (!linked) {
-        IncrementalModuleTargetError error = failure(
-            IncrementalModuleTargetErrorCode::link_failed,
-            "module target link failed");
-        error.link_error = linked.error();
-        return std::unexpected(std::move(error));
+        return std::unexpected(link_failure(
+            "module target link failed",
+            std::move(linked.error())));
     }
     result.link = std::move(*linked);
     return result;

--- a/cpp/src/orchestration/modules/StandardLibraryModuleProvider.cpp
+++ b/cpp/src/orchestration/modules/StandardLibraryModuleProvider.cpp
@@ -1,6 +1,7 @@
 #include "StandardLibraryModuleProvider.hpp"
 
 #include <algorithm>
+#include <expected>
 #include <filesystem>
 #include <optional>
 #include <string>
@@ -55,12 +56,12 @@ struct PendingStandardLibraryRequirement {
 [[nodiscard]] std::optional<PendingStandardLibraryRequirement>
 next_standard_library_requirement(
     const std::vector<modules::ScannedModuleUnit>& units,
-    const std::unordered_set<std::string>& injected) {
+    const std::unordered_set<std::string>& visited) {
     for (const auto& unit : units) {
         for (const auto& requirement : unit.rule.required_modules) {
             if (!named_requirement(requirement)
                 || !standard_library_module_name(requirement.logical_name)
-                || injected.contains(requirement.logical_name)) {
+                || visited.contains(requirement.logical_name)) {
                 continue;
             }
             return PendingStandardLibraryRequirement{
@@ -90,7 +91,159 @@ next_standard_library_requirement(
     return fs::is_regular_file(path, error_code) && !error_code;
 }
 
+[[nodiscard]] std::expected<ModuleCompileSourceRequest, IncrementalModuleTargetError>
+resolve_standard_library_provider(
+    const IncrementalModuleTargetRequest& request,
+    msvc::MsvcModuleDependencyScanner& scanner,
+    ModuleTargetArtifactRegistry& artifacts,
+    const PendingStandardLibraryRequirement& pending) {
+    if (request.compiler_options.standard != CppStandard::latest) {
+        return std::unexpected(failure(
+            IncrementalModuleTargetErrorCode::standard_library_module_standard_unsupported,
+            "MSVC standard-library module '" + pending.logical_name
+                + "' requires --std latest",
+            pending.consumer));
+    }
+    if (!request.artifact_layout) {
+        return std::unexpected(failure(
+            IncrementalModuleTargetErrorCode::artifact_layout_missing,
+            "standard-library module provider requires an artifact layout",
+            pending.consumer));
+    }
+
+    auto source = standard_library_module_source(
+        scanner.toolchain(),
+        pending.logical_name);
+    if (!source || source->empty() || !regular_file(*source)) {
+        return std::unexpected(failure(
+            IncrementalModuleTargetErrorCode::standard_library_module_unavailable,
+            "selected MSVC toolchain " + scanner.toolchain().identity.version
+                + " does not provide standard-library module source '"
+                + pending.logical_name + "'",
+            pending.consumer));
+    }
+
+    if (auto registered = artifacts.add_standard_library_source_identity(*source);
+        !registered) {
+        return std::unexpected(std::move(registered.error()));
+    }
+
+    auto source_artifacts = request.artifact_layout->for_source(*source);
+    if (!source_artifacts) {
+        IncrementalModuleTargetError error = failure(
+            IncrementalModuleTargetErrorCode::artifact_layout_failed,
+            "failed to assign artifacts to standard-library module provider",
+            *source);
+        error.artifact_layout_error = source_artifacts.error();
+        return std::unexpected(std::move(error));
+    }
+
+    if (auto registered = artifacts.add_standard_library_artifacts(
+            *source,
+            *source_artifacts); !registered) {
+        return std::unexpected(std::move(registered.error()));
+    }
+
+    return ModuleCompileSourceRequest{
+        .source = *source,
+        .artifacts = std::move(*source_artifacts),
+        .kind = TranslationUnitKind::module_interface,
+    };
+}
+
+[[nodiscard]] std::expected<modules::P1689Rule, IncrementalModuleTargetError>
+validated_standard_library_rule(
+    const fs::path& source,
+    const std::string_view logical_name,
+    const modules::P1689Document& dependencies) {
+    if (dependencies.rules.size() != 1
+        || !provides_named_interface(
+            dependencies.rules.front(),
+            logical_name)) {
+        return std::unexpected(failure(
+            IncrementalModuleTargetErrorCode::invalid_scan_result,
+            "selected MSVC standard-library module source did not provide expected interface '"
+                + std::string{logical_name} + "'",
+            source));
+    }
+    return dependencies.rules.front();
+}
+
+void append_reusable_standard_library_provider(
+    const ModuleCompileSourceRequest& provider,
+    modules::P1689Rule rule,
+    std::vector<modules::ScannedModuleUnit>& scanned_units,
+    std::vector<ModuleCompileSourceRequest>& compile_sources) {
+    scanned_units.push_back(modules::ScannedModuleUnit{
+        .source = provider.source,
+        .rule = std::move(rule),
+        .toolchain_owned = true,
+    });
+    compile_sources.push_back(provider);
+}
+
 } // namespace
+
+std::expected<bool, IncrementalModuleTargetError>
+inspect_standard_library_module_providers(
+    const IncrementalModuleTargetRequest& request,
+    msvc::MsvcModuleDependencyScanner& scanner,
+    ModuleTargetArtifactRegistry& artifacts,
+    std::vector<modules::ScannedModuleUnit>& scanned_units,
+    std::vector<ModuleCompileSourceRequest>& compile_sources,
+    std::vector<ModuleTargetScanInspection>& scan_inspections) {
+    std::unordered_set<std::string> inspected_standard_modules;
+    bool complete = true;
+
+    while (auto pending = next_standard_library_requirement(
+               scanned_units,
+               inspected_standard_modules)) {
+        auto provider = resolve_standard_library_provider(
+            request,
+            scanner,
+            artifacts,
+            *pending);
+        if (!provider) return std::unexpected(std::move(provider.error()));
+
+        auto inspection = inspect_module_source(
+            *provider,
+            request.compiler_options,
+            request.working_directory,
+            scanner);
+        if (!inspection) {
+            IncrementalModuleTargetError error = failure(
+                IncrementalModuleTargetErrorCode::scan_failed,
+                "standard-library module dependency scan inspection failed",
+                provider->source);
+            error.scan_error = inspection.error();
+            return std::unexpected(std::move(error));
+        }
+
+        inspected_standard_modules.emplace(pending->logical_name);
+        if (inspection->reusable()) {
+            auto rule = validated_standard_library_rule(
+                provider->source,
+                pending->logical_name,
+                *inspection->dependencies);
+            if (!rule) return std::unexpected(std::move(rule.error()));
+            append_reusable_standard_library_provider(
+                *provider,
+                std::move(*rule),
+                scanned_units,
+                compile_sources);
+        } else {
+            complete = false;
+        }
+
+        scan_inspections.push_back(ModuleTargetScanInspection{
+            .source = provider->source,
+            .result = std::move(*inspection),
+            .toolchain_owned = true,
+        });
+    }
+
+    return complete;
+}
 
 std::expected<void, IncrementalModuleTargetError>
 inject_standard_library_module_providers(
@@ -103,60 +256,15 @@ inject_standard_library_module_providers(
     while (auto pending = next_standard_library_requirement(
                scanned_units,
                injected_standard_modules)) {
-        if (request.compiler_options.standard != CppStandard::latest) {
-            return std::unexpected(failure(
-                IncrementalModuleTargetErrorCode::standard_library_module_standard_unsupported,
-                "MSVC standard-library module '" + pending->logical_name
-                    + "' requires --std latest",
-                pending->consumer));
-        }
-        if (!request.artifact_layout) {
-            return std::unexpected(failure(
-                IncrementalModuleTargetErrorCode::artifact_layout_missing,
-                "standard-library module provider requires an artifact layout",
-                pending->consumer));
-        }
+        auto provider = resolve_standard_library_provider(
+            request,
+            scanner,
+            artifacts,
+            *pending);
+        if (!provider) return std::unexpected(std::move(provider.error()));
 
-        auto source = standard_library_module_source(
-            scanner.toolchain(),
-            pending->logical_name);
-        if (!source || source->empty() || !regular_file(*source)) {
-            return std::unexpected(failure(
-                IncrementalModuleTargetErrorCode::standard_library_module_unavailable,
-                "selected MSVC toolchain " + scanner.toolchain().identity.version
-                    + " does not provide standard-library module source '"
-                    + pending->logical_name + "'",
-                pending->consumer));
-        }
-
-        if (auto registered = artifacts.add_standard_library_source_identity(*source);
-            !registered) {
-            return std::unexpected(std::move(registered.error()));
-        }
-
-        auto source_artifacts = request.artifact_layout->for_source(*source);
-        if (!source_artifacts) {
-            IncrementalModuleTargetError error = failure(
-                IncrementalModuleTargetErrorCode::artifact_layout_failed,
-                "failed to assign artifacts to standard-library module provider",
-                *source);
-            error.artifact_layout_error = source_artifacts.error();
-            return std::unexpected(std::move(error));
-        }
-
-        if (auto registered = artifacts.add_standard_library_artifacts(
-                *source,
-                *source_artifacts); !registered) {
-            return std::unexpected(std::move(registered.error()));
-        }
-
-        ModuleCompileSourceRequest provider{
-            .source = *source,
-            .artifacts = *source_artifacts,
-            .kind = TranslationUnitKind::module_interface,
-        };
         auto scan = scan_module_source(
-            provider,
+            *provider,
             request.compiler_options,
             request.working_directory,
             scanner);
@@ -164,27 +272,21 @@ inject_standard_library_module_providers(
             IncrementalModuleTargetError error = failure(
                 IncrementalModuleTargetErrorCode::scan_failed,
                 "standard-library module dependency scan failed",
-                *source);
+                provider->source);
             error.scan_error = scan.error();
             return std::unexpected(std::move(error));
         }
-        if (scan->dependencies.rules.size() != 1
-            || !provides_named_interface(
-                scan->dependencies.rules.front(),
-                pending->logical_name)) {
-            return std::unexpected(failure(
-                IncrementalModuleTargetErrorCode::invalid_scan_result,
-                "selected MSVC standard-library module source did not provide expected interface '"
-                    + pending->logical_name + "'",
-                *source));
-        }
 
-        scanned_units.push_back(modules::ScannedModuleUnit{
-            .source = *source,
-            .rule = scan->dependencies.rules.front(),
-            .toolchain_owned = true,
-        });
-        compile_sources.push_back(std::move(provider));
+        auto rule = validated_standard_library_rule(
+            provider->source,
+            pending->logical_name,
+            scan->dependencies);
+        if (!rule) return std::unexpected(std::move(rule.error()));
+        append_reusable_standard_library_provider(
+            *provider,
+            std::move(*rule),
+            scanned_units,
+            compile_sources);
         injected_standard_modules.emplace(std::move(pending->logical_name));
     }
 

--- a/cpp/src/orchestration/modules/StandardLibraryModuleProvider.hpp
+++ b/cpp/src/orchestration/modules/StandardLibraryModuleProvider.hpp
@@ -8,6 +8,18 @@
 
 namespace mqb::orchestration::detail {
 
+// Inspect every currently knowable toolchain-owned std/std.compat provider.
+// Returns false when at least one provider scan must execute before the fixed
+// point and final module graph can be known.
+[[nodiscard]] std::expected<bool, IncrementalModuleTargetError>
+inspect_standard_library_module_providers(
+    const IncrementalModuleTargetRequest& request,
+    msvc::MsvcModuleDependencyScanner& scanner,
+    ModuleTargetArtifactRegistry& artifacts,
+    std::vector<modules::ScannedModuleUnit>& scanned_units,
+    std::vector<ModuleCompileSourceRequest>& compile_sources,
+    std::vector<ModuleTargetScanInspection>& scan_inspections);
+
 [[nodiscard]] std::expected<void, IncrementalModuleTargetError>
 inject_standard_library_module_providers(
     const IncrementalModuleTargetRequest& request,

--- a/tests/native/module_target_inspection_contract.cpp
+++ b/tests/native/module_target_inspection_contract.cpp
@@ -1,0 +1,663 @@
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <expected>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "mqb/core/BuildTypes.hpp"
+#include "mqb/core/ProjectArtifactLayout.hpp"
+#include "mqb/msvc/MsvcCompileExecutor.hpp"
+#include "mqb/msvc/MsvcLinker.hpp"
+#include "mqb/msvc/MsvcModuleDependencyScanner.hpp"
+#include "mqb/orchestration/MsvcIncrementalCompileCoordinator.hpp"
+#include "mqb/orchestration/MsvcIncrementalLinkCoordinator.hpp"
+#include "mqb/orchestration/MsvcModuleCompileCoordinator.hpp"
+#include "mqb/orchestration/MsvcModuleTargetCoordinator.hpp"
+#include "mqb/process/Process.hpp"
+
+namespace {
+
+namespace fs = std::filesystem;
+int failures = 0;
+
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) {
+        ++failures;
+        std::cerr << "FAIL: " << message << '\n';
+    }
+}
+
+class TemporaryDirectory {
+public:
+    TemporaryDirectory() {
+        const auto tick = std::chrono::steady_clock::now().time_since_epoch().count();
+        path_ = fs::temp_directory_path()
+            / ("mqb-module-target-inspection-" + std::to_string(tick));
+        fs::create_directories(path_);
+    }
+
+    ~TemporaryDirectory() {
+        std::error_code ignored;
+        fs::remove_all(path_, ignored);
+    }
+
+    [[nodiscard]] const fs::path& path() const noexcept { return path_; }
+
+private:
+    fs::path path_;
+};
+
+void write_text(const fs::path& path, const std::string_view text) {
+    if (!path.parent_path().empty()) {
+        fs::create_directories(path.parent_path());
+    }
+    std::ofstream stream{path, std::ios::binary | std::ios::trunc};
+    stream.write(text.data(), static_cast<std::streamsize>(text.size()));
+}
+
+[[nodiscard]] std::string read_text(const fs::path& path) {
+    std::ifstream stream{path, std::ios::binary};
+    return std::string{
+        std::istreambuf_iterator<char>{stream},
+        std::istreambuf_iterator<char>{}};
+}
+
+[[nodiscard]] std::string path_to_utf8(const fs::path& path) {
+    const auto bytes = path.lexically_normal().generic_u8string();
+    return std::string{
+        reinterpret_cast<const char*>(bytes.data()),
+        bytes.size()};
+}
+
+[[nodiscard]] std::string json_escape(const std::string_view value) {
+    std::string escaped;
+    for (const char character : value) {
+        switch (character) {
+        case '\\': escaped += "\\\\"; break;
+        case '"': escaped += "\\\""; break;
+        case '\n': escaped += "\\n"; break;
+        case '\r': escaped += "\\r"; break;
+        case '\t': escaped += "\\t"; break;
+        default: escaped.push_back(character); break;
+        }
+    }
+    return escaped;
+}
+
+class ToolchainLikeRunner final : public mqb::process::ProcessRunner {
+public:
+    fs::path linker;
+    std::atomic<int> scan_calls{0};
+    std::atomic<int> compile_calls{0};
+    std::atomic<int> link_calls{0};
+
+    std::expected<mqb::process::ProcessResult, mqb::process::ProcessError>
+    run(const mqb::process::ProcessSpec& spec) override {
+        if (spec.executable == linker) return run_link(spec);
+        if (std::find(
+                spec.arguments.begin(),
+                spec.arguments.end(),
+                "/scanDependencies") != spec.arguments.end()) {
+            return run_scan(spec);
+        }
+        return run_compile(spec);
+    }
+
+private:
+    [[nodiscard]] static std::string scan_rule_for(const fs::path& source) {
+        const std::string filename = source.filename().string();
+        if (filename == "math.ixx") {
+            return R"json({"provides":[{"logical-name":"math","is-interface":true}]})json";
+        }
+        if (filename == "std.ixx") {
+            return R"json({"provides":[{"logical-name":"std","is-interface":true}]})json";
+        }
+        if (filename == "std_main.cpp") {
+            return R"json({"requires":[{"logical-name":"std"}]})json";
+        }
+        return R"json({"requires":[{"logical-name":"math"}]})json";
+    }
+
+    std::expected<mqb::process::ProcessResult, mqb::process::ProcessError>
+    run_scan(const mqb::process::ProcessSpec& spec) {
+        ++scan_calls;
+        fs::path output;
+        for (std::size_t index = 0; index + 1 < spec.arguments.size(); ++index) {
+            if (spec.arguments[index] == "/scanDependencies") {
+                output = fs::path{spec.arguments[index + 1]};
+                break;
+            }
+        }
+        const fs::path source = spec.arguments.empty()
+            ? fs::path{}
+            : fs::path{spec.arguments.back()};
+        if (output.empty() || source.empty()) {
+            return mqb::process::ProcessResult{
+                .exit_code = 2,
+                .stderr_text = "invalid synthetic scan request",
+            };
+        }
+        write_text(
+            output,
+            "{\"version\":1,\"revision\":0,\"rules\":["
+                + scan_rule_for(source) + "]}");
+        return mqb::process::ProcessResult{.exit_code = 0};
+    }
+
+    std::expected<mqb::process::ProcessResult, mqb::process::ProcessError>
+    run_compile(const mqb::process::ProcessSpec& spec) {
+        ++compile_calls;
+        fs::path source;
+        fs::path object;
+        fs::path dependencies;
+        fs::path interface_file;
+        for (std::size_t index = 0; index < spec.arguments.size(); ++index) {
+            const auto& argument = spec.arguments[index];
+            if (argument.starts_with("/Fo")) {
+                object = fs::path{argument.substr(3)};
+            } else if (argument == "/sourceDependencies"
+                       && index + 1 < spec.arguments.size()) {
+                dependencies = fs::path{spec.arguments[++index]};
+            } else if (argument == "/ifcOutput"
+                       && index + 1 < spec.arguments.size()) {
+                interface_file = fs::path{spec.arguments[++index]};
+            }
+        }
+        if (!spec.arguments.empty()) source = fs::path{spec.arguments.back()};
+        if (source.empty() || object.empty() || dependencies.empty()) {
+            return mqb::process::ProcessResult{
+                .exit_code = 2,
+                .stderr_text = "invalid synthetic compile request",
+            };
+        }
+
+        write_text(object, "fake object");
+        if (!interface_file.empty()) write_text(interface_file, "fake ifc");
+        write_text(
+            dependencies,
+            "{\"Data\":{\"Source\":\""
+                + json_escape(path_to_utf8(source))
+                + "\",\"Includes\":[]}}");
+        return mqb::process::ProcessResult{.exit_code = 0};
+    }
+
+    std::expected<mqb::process::ProcessResult, mqb::process::ProcessError>
+    run_link(const mqb::process::ProcessSpec& spec) {
+        ++link_calls;
+        fs::path output;
+        for (const auto& argument : spec.arguments) {
+            constexpr std::string_view prefix = "/OUT:";
+            if (argument.starts_with(prefix)) {
+                output = fs::path{argument.substr(prefix.size())};
+                break;
+            }
+        }
+        if (output.empty()) {
+            return mqb::process::ProcessResult{
+                .exit_code = 2,
+                .stderr_text = "invalid synthetic link request",
+            };
+        }
+        write_text(output, "fake executable");
+        return mqb::process::ProcessResult{.exit_code = 0};
+    }
+};
+
+[[nodiscard]] bool has_argument(
+    const mqb::process::ProcessSpec& process,
+    const std::string_view expected) {
+    return std::find(
+        process.arguments.begin(),
+        process.arguments.end(),
+        expected) != process.arguments.end();
+}
+
+[[nodiscard]] bool has_pair(
+    const mqb::process::ProcessSpec& process,
+    const std::string_view flag,
+    const std::string_view value) {
+    for (std::size_t index = 0; index + 1 < process.arguments.size(); ++index) {
+        if (process.arguments[index] == flag
+            && process.arguments[index + 1] == value) {
+            return true;
+        }
+    }
+    return false;
+}
+
+[[nodiscard]] bool has_reason(
+    const mqb::orchestration::IncrementalCompileInspection& inspection,
+    const mqb::BuildReason reason) {
+    return std::find(
+        inspection.validation.reasons.begin(),
+        inspection.validation.reasons.end(),
+        reason) != inspection.validation.reasons.end();
+}
+
+[[nodiscard]] const mqb::orchestration::ModuleTargetScanInspection* find_scan(
+    const mqb::orchestration::IncrementalModuleTargetInspection& inspection,
+    const fs::path& source) {
+    const auto found = std::find_if(
+        inspection.scans.begin(),
+        inspection.scans.end(),
+        [&](const mqb::orchestration::ModuleTargetScanInspection& item) {
+            return item.source.lexically_normal() == source.lexically_normal();
+        });
+    return found == inspection.scans.end() ? nullptr : &*found;
+}
+
+[[nodiscard]] const mqb::orchestration::ModuleCompileInspection* find_compile(
+    const mqb::orchestration::ModuleCompileWaveInspection& inspection,
+    const fs::path& source) {
+    const auto found = std::find_if(
+        inspection.compiles.begin(),
+        inspection.compiles.end(),
+        [&](const mqb::orchestration::ModuleCompileInspection& item) {
+            return item.source.lexically_normal() == source.lexically_normal();
+        });
+    return found == inspection.compiles.end() ? nullptr : &*found;
+}
+
+[[nodiscard]] mqb::msvc::CompileExecutionRequest execution_request_for(
+    const mqb::orchestration::IncrementalCompileRequest& request) {
+    return mqb::msvc::CompileExecutionRequest{
+        .unit = request.unit,
+        .options = request.options,
+        .source_dependencies_file = request.source_dependencies_file,
+        .working_directory = request.working_directory,
+    };
+}
+
+void print_target_error(
+    const mqb::orchestration::IncrementalModuleTargetError& error) {
+    std::cerr << "target error: " << error.message << '\n';
+    if (!error.source.empty()) {
+        std::cerr << "  source=" << path_to_utf8(error.source) << '\n';
+    }
+    if (error.scan_error) {
+        std::cerr << "  scan=" << error.scan_error->message << '\n';
+    }
+    if (error.graph_error) {
+        std::cerr << "  graph=" << error.graph_error->message << '\n';
+    }
+    if (error.compile_error) {
+        std::cerr << "  compile=" << error.compile_error->message << '\n';
+    }
+    if (error.link_error) {
+        std::cerr << "  link=" << error.link_error->message << '\n';
+    }
+}
+
+} // namespace
+
+int main() {
+    TemporaryDirectory fixture;
+    const fs::path root = fixture.path();
+    const fs::path toolchain_root = root / "toolchain";
+    const fs::path fake_compiler = toolchain_root / "cl.exe";
+    const fs::path fake_linker = toolchain_root / "link.exe";
+    const fs::path fake_librarian = toolchain_root / "lib.exe";
+    const fs::path std_source = toolchain_root / "modules" / "std.ixx";
+    write_text(fake_compiler, "fake compiler");
+    write_text(fake_linker, "fake linker");
+    write_text(fake_librarian, "fake librarian");
+    write_text(std_source, "export module std;\n");
+
+    mqb::msvc::MsvcToolchain toolchain{
+        .identity = {
+            .compiler = fake_compiler,
+            .version = "19.51.module-target-inspection",
+            .binary_stamp = "fake-compiler-stamp",
+        },
+        .linker = fake_linker,
+        .librarian = fake_librarian,
+        .vc_tools_root = toolchain_root,
+        .source = mqb::msvc::ToolchainSource::visual_studio,
+    };
+    toolchain.standard_library_modules.std = std_source;
+
+    ToolchainLikeRunner runner;
+    runner.linker = fake_linker;
+    mqb::msvc::MsvcModuleDependencyScanner scanner{toolchain, runner};
+    mqb::msvc::MsvcCompileExecutor executor{toolchain, runner};
+    mqb::orchestration::MsvcIncrementalCompileCoordinator incremental_compile{
+        toolchain,
+        executor};
+    mqb::orchestration::MsvcModuleCompileCoordinator module_compile{
+        incremental_compile};
+    mqb::msvc::MsvcLinker linker{toolchain, runner};
+    mqb::orchestration::MsvcIncrementalLinkCoordinator incremental_link{
+        toolchain,
+        linker};
+    mqb::orchestration::MsvcModuleTargetCoordinator target{
+        scanner,
+        module_compile,
+        incremental_link};
+
+    const fs::path project_root = root / "project";
+    const fs::path module_source = project_root / "modules" / "math.ixx";
+    const fs::path consumer_source = project_root / "src" / "main.cpp";
+    write_text(module_source, "export module math;\n");
+    write_text(consumer_source, "import math;\nint main(){return 0;}\n");
+
+    auto layout = mqb::ProjectArtifactLayout::create(project_root);
+    expect(layout.has_value(), "project artifact layout should be created");
+    if (!layout) return 1;
+    auto module_artifacts = layout->for_source(module_source);
+    auto consumer_artifacts = layout->for_source(consumer_source);
+    auto target_artifacts = layout->for_target("module-inspection");
+    expect(module_artifacts && consumer_artifacts && target_artifacts,
+           "module target artifacts should be assigned");
+    if (!module_artifacts || !consumer_artifacts || !target_artifacts) return 1;
+
+    mqb::orchestration::IncrementalModuleTargetRequest request;
+    request.sources = {
+        mqb::orchestration::ModuleCompileSourceRequest{
+            .source = consumer_source,
+            .artifacts = *consumer_artifacts,
+            .kind = mqb::TranslationUnitKind::source,
+        },
+        mqb::orchestration::ModuleCompileSourceRequest{
+            .source = module_source,
+            .artifacts = *module_artifacts,
+            .kind = mqb::TranslationUnitKind::module_interface,
+        },
+    };
+    request.target = *target_artifacts;
+    request.artifact_layout = *layout;
+    request.compiler_options.standard = mqb::CppStandard::latest;
+    request.link_options.architecture = mqb::Architecture::x64;
+    request.link_options.subsystem = mqb::LinkSubsystem::console;
+    request.working_directory = project_root;
+    request.max_parallel_scans = 2;
+    request.max_parallel_compiles = 2;
+
+    const auto cold = target.inspect(request);
+    expect(cold.has_value(), "cold module target inspection should succeed");
+    if (!cold) {
+        print_target_error(cold.error());
+        return 1;
+    }
+    expect(cold->scan_required() && !cold->graph_ready(),
+           "cold module target should stop before graph construction");
+    expect(cold->scans.size() == 2
+               && cold->scans[0].source == consumer_source
+               && cold->scans[1].source == module_source,
+           "cold scan inspection should preserve requested source order");
+    expect(!cold->plan && !cold->compiles && !cold->link,
+           "cold scan-only inspection must not invent graph/compile/link stages");
+    expect(runner.scan_calls.load() == 0
+               && runner.compile_calls.load() == 0
+               && runner.link_calls.load() == 0,
+           "cold module target inspection must not launch any process");
+    expect(!fs::exists(layout->artifact_root()),
+           "cold module target inspection must not create project .mqb state");
+    for (const auto& scan : cold->scans) {
+        expect(scan.result.scan_required(),
+               "every cold requested source should expose a pending scan");
+        expect(has_argument(scan.result.recipe.process, "/scanDependencies"),
+               "cold scan inspection should expose exact /scanDependencies argv");
+        expect(scan.result.recipe.process.executable == fake_compiler,
+               "cold scan recipe should bind the selected compiler");
+    }
+
+    const auto cold_run = target.run(request);
+    expect(cold_run.has_value(), "cold module target run should succeed");
+    if (!cold_run) {
+        print_target_error(cold_run.error());
+        return 1;
+    }
+    expect(runner.scan_calls.load() == 2
+               && runner.compile_calls.load() == 2
+               && runner.link_calls.load() == 1,
+           "cold run should execute two scans, two compiles, and one link");
+
+    const std::string consumer_scan_before = read_text(
+        consumer_artifacts->module_dependencies);
+    const std::string module_scan_before = read_text(
+        module_artifacts->module_dependencies);
+    const std::string consumer_cache_before = read_text(
+        consumer_artifacts->compile_cache);
+    const std::string module_cache_before = read_text(
+        module_artifacts->compile_cache);
+    const std::string link_cache_before = read_text(target_artifacts->link_cache);
+
+    const auto warm = target.inspect(request);
+    expect(warm.has_value(), "warm module target inspection should succeed");
+    if (!warm) {
+        print_target_error(warm.error());
+        return 1;
+    }
+    expect(warm->graph_ready() && !warm->scan_required(),
+           "warm reusable P1689 should unlock the full graph");
+    expect(warm->plan && warm->plan->compile_levels.size() == 2,
+           "warm module target should expose the provider/consumer levels");
+    expect(warm->compile_request && warm->compiles
+               && !warm->compiles->any_planned,
+           "unchanged warm compile wave should be fully reusable");
+    expect(warm->link_request && warm->link && warm->link->plan.empty(),
+           "unchanged warm target should expose an up-to-date link decision");
+    expect(runner.scan_calls.load() == 2
+               && runner.compile_calls.load() == 2
+               && runner.link_calls.load() == 1,
+           "warm full-target inspection must launch no process");
+    expect(read_text(consumer_artifacts->module_dependencies) == consumer_scan_before
+               && read_text(module_artifacts->module_dependencies) == module_scan_before
+               && read_text(consumer_artifacts->compile_cache) == consumer_cache_before
+               && read_text(module_artifacts->compile_cache) == module_cache_before
+               && read_text(target_artifacts->link_cache) == link_cache_before,
+           "warm full-target inspection must not mutate scan/compile/link state");
+
+    const auto* warm_consumer = find_compile(*warm->compiles, consumer_source);
+    expect(warm_consumer != nullptr,
+           "warm compile inspection should retain the consumer request");
+    if (warm_consumer) {
+        auto recipe = executor.build_recipe(execution_request_for(warm_consumer->request));
+        expect(recipe.has_value(),
+               "warm consumer inspection should model an exact compile recipe");
+        if (recipe) {
+            expect(has_pair(
+                       recipe->process,
+                       "/reference",
+                       "math=" + path_to_utf8(module_artifacts->module_interface)),
+                   "consumer recipe should expose /reference math=<IFC>");
+        }
+    }
+
+    std::error_code remove_error;
+    fs::remove(module_artifacts->module_interface, remove_error);
+    expect(!remove_error, "fixture should remove the provider IFC");
+    const auto repair = target.inspect(request);
+    expect(repair.has_value(), "missing provider IFC inspection should succeed");
+    if (!repair) {
+        print_target_error(repair.error());
+        return 1;
+    }
+    expect(repair->graph_ready() && repair->compiles && repair->link,
+           "reusable P1689 should still permit compile/link repair planning");
+    expect(repair->compiles->any_planned && !repair->link->plan.empty(),
+           "provider repair should plan compile work and a relink");
+    expect(repair->link_request && repair->link_request->force_relink,
+           "planned module work should force the exact final-link request");
+    const auto* repair_provider = find_compile(*repair->compiles, module_source);
+    const auto* repair_consumer = find_compile(*repair->compiles, consumer_source);
+    expect(repair_provider != nullptr && !repair_provider->result.plan.empty(),
+           "missing provider IFC should plan that provider");
+    expect(repair_consumer != nullptr && !repair_consumer->result.plan.empty(),
+           "missing provider IFC should plan its downstream consumer");
+    if (repair_consumer) {
+        expect(repair_consumer->request.force_rebuild
+                   && has_reason(
+                       repair_consumer->result,
+                       mqb::BuildReason::explicit_rebuild),
+               "provider repair should propagate as explicit_rebuild");
+    }
+    expect(runner.scan_calls.load() == 2
+               && runner.compile_calls.load() == 2
+               && runner.link_calls.load() == 1,
+           "provider repair inspection must launch no process");
+    expect(!fs::exists(module_artifacts->module_interface),
+           "inspection must not repair the missing IFC itself");
+
+    const auto consumer_scan_time = fs::last_write_time(
+        consumer_artifacts->module_dependencies);
+    write_text(
+        consumer_source,
+        "import math;\nint main(){return 1;} // topology may have changed\n");
+    fs::last_write_time(
+        consumer_source,
+        consumer_scan_time + std::chrono::seconds{2});
+    const auto stale_topology = target.inspect(request);
+    expect(stale_topology.has_value(),
+           "stale source topology inspection should succeed");
+    if (!stale_topology) {
+        print_target_error(stale_topology.error());
+        return 1;
+    }
+    const auto* stale_consumer_scan = find_scan(*stale_topology, consumer_source);
+    expect(stale_topology->scan_required() && !stale_topology->plan,
+           "stale requested scan must stop before graph construction");
+    expect(stale_consumer_scan != nullptr
+               && stale_consumer_scan->result.scan_required(),
+           "changed consumer should expose a pending scan");
+    expect(!stale_topology->compiles && !stale_topology->link,
+           "stale topology must not expose downstream compile/link guesses");
+    expect(runner.scan_calls.load() == 2
+               && runner.compile_calls.load() == 2
+               && runner.link_calls.load() == 1,
+           "stale topology inspection must not execute the pending scan");
+
+    // A second project exercises the toolchain-owned standard-module fixed
+    // point. Before its first scan, inspection cannot yet know that std is
+    // needed. After a successful build, both project and std scans are reusable
+    // and the full target becomes inspectable without execution.
+    const fs::path std_project_root = root / "std-project";
+    const fs::path std_consumer = std_project_root / "src" / "std_main.cpp";
+    write_text(std_consumer, "import std;\nint main(){return 0;}\n");
+    auto std_layout = mqb::ProjectArtifactLayout::create(std_project_root);
+    expect(std_layout.has_value(), "std project artifact layout should be created");
+    if (!std_layout) return 1;
+    auto std_consumer_artifacts = std_layout->for_source(std_consumer);
+    auto std_provider_artifacts = std_layout->for_source(std_source);
+    auto std_target_artifacts = std_layout->for_target("std-inspection");
+    expect(std_consumer_artifacts && std_provider_artifacts && std_target_artifacts,
+           "std project artifacts should be assigned");
+    if (!std_consumer_artifacts || !std_provider_artifacts || !std_target_artifacts) {
+        return 1;
+    }
+
+    mqb::orchestration::IncrementalModuleTargetRequest std_request;
+    std_request.sources = {
+        mqb::orchestration::ModuleCompileSourceRequest{
+            .source = std_consumer,
+            .artifacts = *std_consumer_artifacts,
+            .kind = mqb::TranslationUnitKind::source,
+        },
+    };
+    std_request.target = *std_target_artifacts;
+    std_request.artifact_layout = *std_layout;
+    std_request.compiler_options.standard = mqb::CppStandard::latest;
+    std_request.link_options.architecture = mqb::Architecture::x64;
+    std_request.link_options.subsystem = mqb::LinkSubsystem::console;
+    std_request.working_directory = std_project_root;
+    std_request.max_parallel_scans = 2;
+    std_request.max_parallel_compiles = 2;
+
+    const int scans_before_std = runner.scan_calls.load();
+    const int compiles_before_std = runner.compile_calls.load();
+    const int links_before_std = runner.link_calls.load();
+    const auto std_cold = target.inspect(std_request);
+    expect(std_cold.has_value() && std_cold->scan_required(),
+           "cold std consumer should expose only its currently knowable scan");
+    if (std_cold) {
+        expect(std_cold->scans.size() == 1
+                   && !std_cold->scans.front().toolchain_owned,
+               "std provider must not be guessed before consumer P1689 exists");
+    }
+    expect(runner.scan_calls.load() == scans_before_std
+               && runner.compile_calls.load() == compiles_before_std
+               && runner.link_calls.load() == links_before_std,
+           "cold std target inspection must not execute discovery");
+
+    const auto std_run = target.run(std_request);
+    expect(std_run.has_value(), "cold std module target should build successfully");
+    if (!std_run) {
+        print_target_error(std_run.error());
+        return 1;
+    }
+    expect(runner.scan_calls.load() == scans_before_std + 2
+               && runner.compile_calls.load() == compiles_before_std + 2
+               && runner.link_calls.load() == links_before_std + 1,
+           "std target should scan/compile consumer and toolchain provider exactly once");
+
+    const int scans_after_std_run = runner.scan_calls.load();
+    const int compiles_after_std_run = runner.compile_calls.load();
+    const int links_after_std_run = runner.link_calls.load();
+    const auto std_warm = target.inspect(std_request);
+    expect(std_warm.has_value() && std_warm->graph_ready(),
+           "warm std target should expose the full graph without execution");
+    if (!std_warm) {
+        print_target_error(std_warm.error());
+        return 1;
+    }
+    expect(std_warm->scans.size() == 2
+               && std_warm->scans[0].source == std_consumer
+               && !std_warm->scans[0].toolchain_owned
+               && std_warm->scans[1].source == std_source
+               && std_warm->scans[1].toolchain_owned,
+           "warm std inspection should append the selected toolchain-owned provider");
+    expect(std_warm->compile_request
+               && std_warm->compile_request->sources.size() == 2
+               && std_warm->compiles
+               && !std_warm->compiles->any_planned
+               && std_warm->link
+               && std_warm->link->plan.empty(),
+           "unchanged warm std target should be fully reusable");
+    expect(runner.scan_calls.load() == scans_after_std_run
+               && runner.compile_calls.load() == compiles_after_std_run
+               && runner.link_calls.load() == links_after_std_run,
+           "warm std target inspection must launch no process");
+
+    fs::remove(std_provider_artifacts->compile_cache, remove_error);
+    expect(!remove_error, "fixture should remove the std provider scan seal");
+    const auto std_provider_pending = target.inspect(std_request);
+    expect(std_provider_pending.has_value()
+               && std_provider_pending->scan_required()
+               && !std_provider_pending->plan,
+           "missing std provider scan seal should stop at graph-pending");
+    if (std_provider_pending) {
+        expect(std_provider_pending->scans.size() == 2,
+               "pending std provider inspection should retain both scan steps");
+        const auto* provider_scan = find_scan(*std_provider_pending, std_source);
+        expect(provider_scan != nullptr
+                   && provider_scan->toolchain_owned
+                   && provider_scan->result.scan_required()
+                   && has_argument(
+                       provider_scan->result.recipe.process,
+                       "/scanDependencies"),
+               "pending std provider should expose its exact toolchain-owned scan recipe");
+        expect(!std_provider_pending->compiles && !std_provider_pending->link,
+               "pending std topology must not invent compile/link decisions");
+    }
+    expect(!fs::exists(std_provider_artifacts->compile_cache),
+           "std provider inspection must not recreate the missing cache seal");
+    expect(runner.scan_calls.load() == scans_after_std_run
+               && runner.compile_calls.load() == compiles_after_std_run
+               && runner.link_calls.load() == links_after_std_run,
+           "pending std provider inspection must not execute any stage");
+
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed\n";
+        return 1;
+    }
+
+    std::cout << "mqb_module_target_inspection_contract passed\n";
+    return 0;
+}

--- a/tests/native/verify_module_target_inspection.ps1
+++ b/tests/native/verify_module_target_inspection.ps1
@@ -1,0 +1,91 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$BuilderMqbPath,
+    [Parameter(Mandatory = $true)][string]$RepoRoot
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+$RepoRoot = [System.IO.Path]::GetFullPath($RepoRoot)
+$BuilderMqbPath = [System.IO.Path]::GetFullPath($BuilderMqbPath)
+if (-not (Test-Path -LiteralPath $BuilderMqbPath -PathType Leaf)) {
+    throw "Builder MQB not found: $BuilderMqbPath"
+}
+
+$cppRoot = Join-Path $RepoRoot 'cpp'
+$configPath = Join-Path $cppRoot 'mqb.json'
+$contractSource = Join-Path $RepoRoot 'tests/native/module_target_inspection_contract.cpp'
+foreach ($path in @($configPath, $contractSource)) {
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+        throw "Module target inspection evidence input missing: $path"
+    }
+}
+
+& (Join-Path $RepoRoot 'tests/native/assert_cpp_layout.ps1') -CppRoot $cppRoot
+
+$config = Get-Content -LiteralPath $configPath -Raw | ConvertFrom-Json
+$productionSources = @($config.discovery.extra_sources | ForEach-Object {
+    'cpp/' + ([string]$_).Replace('\', '/')
+})
+if ($productionSources.Count -eq 0) {
+    throw 'cpp/mqb.json has no production sources for module target inspection evidence.'
+}
+
+$arguments = [System.Collections.ArrayList]::new()
+[void]$arguments.Add('tests/native/module_target_inspection_contract.cpp')
+foreach ($source in $productionSources) {
+    [void]$arguments.Add($source)
+}
+[void]$arguments.Add('--no-discover')
+[void]$arguments.Add('--env')
+[void]$arguments.Add('vs')
+[void]$arguments.Add('--debug')
+[void]$arguments.Add('--std')
+[void]$arguments.Add([string]$config.build.standard)
+[void]$arguments.Add('--runtime')
+[void]$arguments.Add('MTd')
+foreach ($include in @($config.build.include_dirs)) {
+    [void]$arguments.Add('-I')
+    [void]$arguments.Add('cpp/' + ([string]$include).Replace('\', '/'))
+}
+foreach ($compilerArg in @($config.build.compiler_args)) {
+    [void]$arguments.Add('--compiler-arg')
+    [void]$arguments.Add([string]$compilerArg)
+}
+[void]$arguments.Add('--lib')
+[void]$arguments.Add('shell32.lib')
+[void]$arguments.Add('-o')
+[void]$arguments.Add('module_target_inspection_contract')
+
+$stateRoot = Join-Path $RepoRoot '.mqb'
+if (Test-Path -LiteralPath $stateRoot) {
+    Remove-Item -LiteralPath $stateRoot -Recurse -Force
+}
+
+Push-Location $RepoRoot
+try {
+    $buildOutput = @(& $BuilderMqbPath @arguments 2>&1)
+    $buildExit = $LASTEXITCODE
+    foreach ($line in $buildOutput) { Write-Host $line }
+    if ($buildExit -ne 0) {
+        throw "Failed to build module target inspection contract (exit $buildExit)."
+    }
+
+    $contractExe = Join-Path $RepoRoot '.mqb/bin/module_target_inspection_contract.exe'
+    if (-not (Test-Path -LiteralPath $contractExe -PathType Leaf)) {
+        throw "Module target inspection contract executable missing: $contractExe"
+    }
+
+    $testOutput = @(& $contractExe 2>&1)
+    $testExit = $LASTEXITCODE
+    foreach ($line in $testOutput) { Write-Host $line }
+    if ($testExit -ne 0) {
+        throw "Module target inspection contract failed (exit $testExit)."
+    }
+}
+finally {
+    Pop-Location
+}
+
+Write-Host 'Module target inspection evidence passed.'


### PR DESCRIPTION
## Goal

Complete the graph-aware introspection foundation beneath a future module-aware `mqb plan` command by adding a side-effect-free `MsvcModuleTargetCoordinator::inspect()`.

## Behavior

The new target inspection follows the same module pipeline boundaries as real execution:

1. inspect every requested source's P1689 scan evidence;
2. stop with exact scan recipes when any requested scan is missing or stale;
3. when requested scans are reusable, inspect the demand-driven toolchain-owned `std` / `std.compat` provider fixed point;
4. stop before graph construction when any required standard-provider scan is pending;
5. only after all required P1689 is trustworthy, build the authoritative provider graph;
6. inspect named-module/Header Unit compile waves through the coordinator introduced in #144;
7. project planned compile work into the exact final link request and inspect the link decision.

Cold/stale topology never produces guessed compile levels or link actions. Warm state exposes the full graph, per-node compile requests/reasons, and final link request/decision without launching `cl.exe`/`link.exe` or mutating scan, compile, link, or output state.

## Shared authorities

- requested and toolchain-owned scans consume `MsvcIncrementalModuleScanCoordinator::inspect()`;
- standard-library provider discovery/artifact ownership shares the same resolver and validation used by real injection;
- graph construction uses `ModuleDependencyGraphBuilder`;
- Header Unit artifact assignment shares final preparation logic with real execution;
- compile-wave inspection uses `MsvcModuleCompileCoordinator::inspect()`;
- final link inspection uses `MsvcIncrementalLinkCoordinator::inspect()` and the existing module target link-request factory.

The real `run()` path still executes scans, compiles, and link with execution-time freshness checks. This PR does not make execution trust an earlier inspection snapshot.

## Focused evidence

The dedicated Windows/MSVC contract proves:

- cold requested-source inspection produces exact `/scanDependencies` recipes only;
- cold inspection creates no project `.mqb` tree and launches no process;
- a real cold build is followed by fully warm graph/compile/link inspection;
- warm scan, compile, and link state remains byte-identical after inspection;
- inspected consumers produce the exact `/reference math=<IFC>` recipe;
- a missing provider IFC plans the provider, downstream consumer, and final relink while scan evidence remains reusable;
- changed requested topology stops before graph, compile, and link decisions;
- cold `import std` does not guess a provider before consumer P1689 exists;
- warm `std` fixed-point inspection appends the selected toolchain-owned provider;
- a missing `std` scan seal exposes its exact pending scan recipe and stops before graph construction.

The contract is built with the repository's complete production source manifest and executed on Windows/MSVC.

## Non-goals

- no user-facing module `mqb plan` output yet;
- no `mqb compdb` Modules/Header Units support;
- no config/cache schema or version change;
- no release publication.

## Exact validated head

`4e9f7e26e47263e21c1269b1cce41da92196300a`

Base remains `main @ f9e0507051ade1531bc2c2b12ac137f661364ac8`. The branch is 11 commits ahead and 0 behind, with changes limited to 11 files (`+1395 / -132`). `main` did not move during validation.

## Validation

All required validation is green on the exact head above:

- Module Target Inspection Evidence: **success**;
- Module Scan Inspection Evidence: **success**;
- Documentation: **success**;
- Final Closure Cross-Stage: **success**;
- Native C++ candidate self-build/preflight: **success**;
- environment isolation, Kernel AddressSanitizer ownership, AddressSanitizer link policy, LibFuzzer, OpenMP, default-library freshness, include-search freshness, `__has_include`, and linker side-output repair: **success**;
- exact MSVC parameter inventory and semantic variant inventory: **success**;
- Native Debug tests: **4/4 shards success**;
- Native C++ gate: **success**;
- Native Release Stage 0/shared product build: **success**;
- Native Release tests: **4/4 shards success**;
- Release self-host: **success**;
- runtime-only package staging, exact package validation, installer lifecycle, and upload: **success**;
- Performance Evidence: intentionally skipped because this is not a performance PR;
- release publication: intentionally skipped for a pull request.

No inline review threads or submitted blocking reviews are present.

This PR is ready for merge review and remains unmerged pending explicit authorization.