### PR TITLE
perf: make target path validation linear

### DIFF
--- a/.github/workflows/performance-evidence.yml
+++ b/.github/workflows/performance-evidence.yml
@@ -111,12 +111,23 @@ jobs:
           $lines.Add('')
           $lines.Add('Negative deltas mean the candidate is faster. These values are review evidence, not correctness thresholds.')
           $lines.Add('')
+          $lines.Add('### Wall-clock and discovery phases')
+          $lines.Add('')
           $lines.Add('| Scenario | Base total ms | Candidate total ms | Total Δ% | Base discovery ms | Candidate discovery ms | Discovery Δ% |')
           $lines.Add('|---|---:|---:|---:|---:|---:|---:|')
           foreach ($row in @($report.comparison)) {
             $totalDelta = if ($null -eq $row.total_delta_pct) { 'n/a' } else { [string]$row.total_delta_pct }
             $discoveryDelta = if ($null -eq $row.discovery_delta_pct) { 'n/a' } else { [string]$row.discovery_delta_pct }
             $lines.Add("| $($row.scenario) | $($row.baseline_total_ms) | $($row.candidate_total_ms) | $totalDelta | $($row.baseline_discovery_ms) | $($row.candidate_discovery_ms) | $discoveryDelta |")
+          }
+          $lines.Add('')
+          $lines.Add('### Compile queue phase')
+          $lines.Add('')
+          $lines.Add('| Scenario | Base queue ms | Candidate queue ms | Queue Δ% |')
+          $lines.Add('|---|---:|---:|---:|')
+          foreach ($row in @($report.comparison)) {
+            $queueDelta = if ($null -eq $row.compile_queue_delta_pct) { 'n/a' } else { [string]$row.compile_queue_delta_pct }
+            $lines.Add("| $($row.scenario) | $($row.baseline_compile_queue_ms) | $($row.candidate_compile_queue_ms) | $queueDelta |")
           }
           $lines | Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Encoding utf8
 

--- a/cpp/src/orchestration/incremental/MsvcIncrementalStaticTargetCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalStaticTargetCoordinator.cpp
@@ -1,31 +1,25 @@
 #include "mqb/orchestration/MsvcIncrementalStaticTargetCoordinator.hpp"
 
-#include <algorithm>
-#include <cctype>
 #include <chrono>
 #include <expected>
 #include <filesystem>
 #include <optional>
 #include <string>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
 #include "mqb/core/Artifact.hpp"
 #include "mqb/core/TranslationUnit.hpp"
 #include "mqb/orchestration/BoundedWorkScheduler.hpp"
+#include "mqb/platform/windows/PathIdentity.hpp"
 
 namespace mqb::orchestration {
 namespace {
 
 namespace fs = std::filesystem;
 using Clock = std::chrono::steady_clock;
-
-[[nodiscard]] std::string windows_path_key(const fs::path& path) {
-    std::string value = path.lexically_normal().generic_string();
-    std::transform(value.begin(), value.end(), value.begin(),
-        [](const unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
-    return value;
-}
+using PathIdentitySet = std::unordered_set<std::string>;
 
 [[nodiscard]] IncrementalStaticTargetError failure(
     const IncrementalStaticTargetErrorCode code,
@@ -38,11 +32,11 @@ using Clock = std::chrono::steady_clock;
     };
 }
 
-[[nodiscard]] bool insert_unique(std::vector<std::string>& seen, const fs::path& path) {
-    const std::string key = windows_path_key(path);
-    if (std::find(seen.begin(), seen.end(), key) != seen.end()) return false;
-    seen.push_back(key);
-    return true;
+[[nodiscard]] bool insert_unique(
+    PathIdentitySet& seen,
+    const fs::path& path) {
+    return seen.emplace(
+        mqb::platform::windows::path_identity_key(path)).second;
 }
 
 [[nodiscard]] IncrementalCompileRequest compile_request_for(
@@ -81,11 +75,15 @@ MsvcIncrementalStaticTargetCoordinator::run(const IncrementalStaticTargetRequest
     TargetTimings timings;
     const auto queue_started = Clock::now();
 
-    std::vector<std::string> seen_sources;
-    std::vector<std::string> seen_objects;
-    std::vector<std::string> seen_dependencies;
-    std::vector<std::string> seen_caches;
+    PathIdentitySet seen_sources;
+    PathIdentitySet seen_objects;
+    PathIdentitySet seen_dependencies;
+    PathIdentitySet seen_caches;
+    seen_sources.reserve(request.sources.size());
     seen_objects.reserve(request.sources.size() + request.additional_objects.size());
+    seen_dependencies.reserve(request.sources.size());
+    seen_caches.reserve(request.sources.size());
+
     for (const auto& source : request.sources) {
         if (!insert_unique(seen_sources, source.source)) {
             return std::unexpected(failure(

--- a/cpp/src/orchestration/incremental/MsvcIncrementalTargetCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalTargetCoordinator.cpp
@@ -1,12 +1,11 @@
 #include "mqb/orchestration/MsvcIncrementalTargetCoordinator.hpp"
 
-#include <algorithm>
-#include <cctype>
 #include <chrono>
 #include <expected>
 #include <filesystem>
 #include <optional>
 #include <string>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -16,22 +15,14 @@
 #include "mqb/msvc/MsvcFuzzerPolicy.hpp"
 #include "mqb/msvc/MsvcOpenMpPolicy.hpp"
 #include "mqb/orchestration/BoundedWorkScheduler.hpp"
+#include "mqb/platform/windows/PathIdentity.hpp"
 
 namespace mqb::orchestration {
 namespace {
 
 namespace fs = std::filesystem;
 using Clock = std::chrono::steady_clock;
-
-[[nodiscard]] std::string windows_path_key(const fs::path& path) {
-    std::string value = path.lexically_normal().generic_string();
-    std::transform(
-        value.begin(),
-        value.end(),
-        value.begin(),
-        [](const unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
-    return value;
-}
+using PathIdentitySet = std::unordered_set<std::string>;
 
 [[nodiscard]] IncrementalTargetError failure(
     const IncrementalTargetErrorCode code,
@@ -45,14 +36,10 @@ using Clock = std::chrono::steady_clock;
 }
 
 [[nodiscard]] bool insert_unique(
-    std::vector<std::string>& seen,
+    PathIdentitySet& seen,
     const fs::path& path) {
-    const std::string key = windows_path_key(path);
-    if (std::find(seen.begin(), seen.end(), key) != seen.end()) {
-        return false;
-    }
-    seen.push_back(key);
-    return true;
+    return seen.emplace(
+        mqb::platform::windows::path_identity_key(path)).second;
 }
 
 [[nodiscard]] IncrementalCompileRequest compile_request_for(
@@ -95,10 +82,10 @@ MsvcIncrementalTargetCoordinator::run(const IncrementalTargetRequest& request) c
     TargetTimings timings;
     const auto queue_started = Clock::now();
 
-    std::vector<std::string> seen_sources;
-    std::vector<std::string> seen_objects;
-    std::vector<std::string> seen_dependencies;
-    std::vector<std::string> seen_compile_caches;
+    PathIdentitySet seen_sources;
+    PathIdentitySet seen_objects;
+    PathIdentitySet seen_dependencies;
+    PathIdentitySet seen_compile_caches;
     seen_sources.reserve(request.sources.size());
     seen_objects.reserve(request.sources.size() + request.additional_objects.size());
     seen_dependencies.reserve(request.sources.size());

--- a/tests/native/benchmark_mqb.ps1
+++ b/tests/native/benchmark_mqb.ps1
@@ -7,6 +7,7 @@ param(
 
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version 2.0
+$TargetScaleSourceCount = 256
 
 function Get-FullPath {
     param([Parameter(Mandatory = $true)][string]$Path)
@@ -71,6 +72,19 @@ function Invoke-TimedMqb {
     }
 }
 
+function Assert-CompileCacheCounts {
+    param(
+        [Parameter(Mandatory = $true)]$Sample,
+        [Parameter(Mandatory = $true)][int]$ExpectedHits,
+        [Parameter(Mandatory = $true)][int]$ExpectedMisses
+    )
+
+    if ([int]$Sample.compile_hits -ne $ExpectedHits
+        -or [int]$Sample.compile_misses -ne $ExpectedMisses) {
+        throw "Benchmark scenario '$($Sample.scenario)' produced compile cache $($Sample.compile_hits) hit(s) / $($Sample.compile_misses) miss(es); expected $ExpectedHits / $ExpectedMisses"
+    }
+}
+
 function Get-Median {
     param([Parameter(Mandatory = $true)][double[]]$Values)
 
@@ -117,6 +131,40 @@ int main() { return helper_value() == shared_value() + 2 ? 0 : 1; }
 
         $results.Add((Invoke-TimedMqb -Scenario 'build-run' -Iteration $iteration -WorkingDirectory $ordinaryRoot -Arguments ($ordinaryArgs + @('--run'))))
         $results.Add((Invoke-TimedMqb -Scenario 'link-only' -Iteration $iteration -WorkingDirectory $ordinaryRoot -Arguments ($ordinaryArgs + @('--linker-arg', '/MAP'))))
+
+        # Scale fixture for target setup/validation. All source and artifact
+        # identities are unique, so the compile_queue phase exposes how target
+        # registration grows without mixing in duplicate-error handling.
+        $targetScaleRoot = Join-Path $benchmarkRoot "target-scale-$iteration"
+        New-Item -ItemType Directory -Path $targetScaleRoot | Out-Null
+        Set-Content -LiteralPath (Join-Path $targetScaleRoot 'main.cpp') -Encoding utf8 -Value @'
+int main() { return 0; }
+'@
+        $targetScaleArgs = [System.Collections.Generic.List[string]]::new()
+        $targetScaleArgs.Add('main.cpp')
+        for ($sourceIndex = 0; $sourceIndex -lt $TargetScaleSourceCount; ++$sourceIndex) {
+            $sourceName = 'unit_{0:D3}.cpp' -f $sourceIndex
+            Set-Content -LiteralPath (Join-Path $targetScaleRoot $sourceName) -Encoding utf8 -Value "int target_scale_${sourceIndex}() { return $sourceIndex; }"
+            $targetScaleArgs.Add($sourceName)
+        }
+        $targetScaleArgs.Add('--output')
+        $targetScaleArgs.Add('target_scale_bench')
+        $targetScaleArguments = $targetScaleArgs.ToArray()
+        $targetScaleUnitCount = $TargetScaleSourceCount + 1
+
+        $targetScaleCold = Invoke-TimedMqb -Scenario 'target-scale-cold' -Iteration $iteration -WorkingDirectory $targetScaleRoot -Arguments $targetScaleArguments
+        Assert-CompileCacheCounts -Sample $targetScaleCold -ExpectedHits 0 -ExpectedMisses $targetScaleUnitCount
+        $results.Add($targetScaleCold)
+
+        $targetScaleNoOp = Invoke-TimedMqb -Scenario 'target-scale-no-op' -Iteration $iteration -WorkingDirectory $targetScaleRoot -Arguments $targetScaleArguments
+        Assert-CompileCacheCounts -Sample $targetScaleNoOp -ExpectedHits $targetScaleUnitCount -ExpectedMisses 0
+        $results.Add($targetScaleNoOp)
+
+        $lastScaleSource = 'unit_{0:D3}.cpp' -f ($TargetScaleSourceCount - 1)
+        Add-Content -LiteralPath (Join-Path $targetScaleRoot $lastScaleSource) -Encoding utf8 -Value "// target-scale mutation $iteration"
+        $targetScaleSingle = Invoke-TimedMqb -Scenario 'target-scale-single-tu' -Iteration $iteration -WorkingDirectory $targetScaleRoot -Arguments $targetScaleArguments
+        Assert-CompileCacheCounts -Sample $targetScaleSingle -ExpectedHits ($targetScaleUnitCount - 1) -ExpectedMisses 1
+        $results.Add($targetScaleSingle)
 
         # Dedicated smart-discovery fixture. Only the entry TU is passed to MQB;
         # helper.cpp must be found through the shared local header graph. The
@@ -172,11 +220,13 @@ $summary = @(
             $group = @($_.Group)
             $medianTotal = Get-Median -Values @($group.total_ms)
             $medianDiscovery = Get-Median -Values @($group.discovery_ms)
+            $medianCompileQueue = Get-Median -Values @($group.compile_queue_ms)
             [PSCustomObject]@{
                 scenario = $_.Name
                 samples = $group.Count
                 median_total_ms = [Math]::Round($medianTotal, 3)
                 median_discovery_ms = [Math]::Round($medianDiscovery, 3)
+                median_compile_queue_ms = [Math]::Round($medianCompileQueue, 3)
                 min_total_ms = [Math]::Round((($group.total_ms | Measure-Object -Minimum).Minimum), 3)
                 max_total_ms = [Math]::Round((($group.total_ms | Measure-Object -Maximum).Maximum), 3)
             }
@@ -197,6 +247,7 @@ if (-not [string]::IsNullOrWhiteSpace($OutputPath)) {
         generated_utc = [DateTime]::UtcNow.ToString('o')
         mqb = $MqbPath
         iterations = $Iterations
+        target_scale_source_count = $TargetScaleSourceCount
         samples = $ordered
         summary = $summary
     } | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $OutputPath -Encoding utf8

--- a/tests/native/benchmark_mqb.ps1
+++ b/tests/native/benchmark_mqb.ps1
@@ -7,7 +7,7 @@ param(
 
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version 2.0
-$TargetScaleSourceCount = 256
+$TargetScaleSourceCount = 128
 
 function Get-FullPath {
     param([Parameter(Mandatory = $true)][string]$Path)

--- a/tests/native/benchmark_mqb.ps1
+++ b/tests/native/benchmark_mqb.ps1
@@ -79,8 +79,9 @@ function Assert-CompileCacheCounts {
         [Parameter(Mandatory = $true)][int]$ExpectedMisses
     )
 
-    if ([int]$Sample.compile_hits -ne $ExpectedHits
-        -or [int]$Sample.compile_misses -ne $ExpectedMisses) {
+    $hitsMatch = [int]$Sample.compile_hits -eq $ExpectedHits
+    $missesMatch = [int]$Sample.compile_misses -eq $ExpectedMisses
+    if (-not ($hitsMatch -and $missesMatch)) {
         throw "Benchmark scenario '$($Sample.scenario)' produced compile cache $($Sample.compile_hits) hit(s) / $($Sample.compile_misses) miss(es); expected $ExpectedHits / $ExpectedMisses"
     }
 }

--- a/tests/native/compare_mqb_benchmarks.ps1
+++ b/tests/native/compare_mqb_benchmarks.ps1
@@ -16,6 +16,9 @@ $RequiredScenarios = @(
     'public-header',
     'build-run',
     'link-only',
+    'target-scale-cold',
+    'target-scale-no-op',
+    'target-scale-single-tu',
     'discovery-cold',
     'discovery-no-op',
     'discovery-header',
@@ -74,14 +77,23 @@ function Assert-BenchmarkContract {
             throw "$Label benchmark is missing required scenario '$scenario'"
         }
 
-        $summarySamples = [int]$summaryByScenario[$scenario].samples
+        $summaryRow = $summaryByScenario[$scenario]
+        $summarySamples = [int]$summaryRow.samples
         if ($summarySamples -ne $ExpectedIterations) {
             throw "$Label benchmark scenario '$scenario' summary has $summarySamples samples; expected $ExpectedIterations"
+        }
+        if ($null -eq $summaryRow.PSObject.Properties['median_compile_queue_ms']) {
+            throw "$Label benchmark scenario '$scenario' summary is missing median_compile_queue_ms"
         }
 
         $rawSamples = @($sampleRows | Where-Object { [string]$_.scenario -eq $scenario })
         if ($rawSamples.Count -ne $ExpectedIterations) {
             throw "$Label benchmark scenario '$scenario' has $($rawSamples.Count) raw samples; expected $ExpectedIterations"
+        }
+        foreach ($sample in $rawSamples) {
+            if ($null -eq $sample.PSObject.Properties['compile_queue_ms']) {
+                throw "$Label benchmark scenario '$scenario' contains a raw sample without compile_queue_ms"
+            }
         }
 
         $iterationsSeen = @($rawSamples | ForEach-Object { [int]$_.iteration } | Sort-Object -Unique)
@@ -152,8 +164,11 @@ try {
             $candidateTotal = [double]$candidateRow.median_total_ms
             $baselineDiscovery = [double]$baselineRow.median_discovery_ms
             $candidateDiscovery = [double]$candidateRow.median_discovery_ms
+            $baselineCompileQueue = [double]$baselineRow.median_compile_queue_ms
+            $candidateCompileQueue = [double]$candidateRow.median_compile_queue_ms
             $totalDeltaPct = Get-DeltaPercent -Baseline $baselineTotal -Candidate $candidateTotal
             $discoveryDeltaPct = Get-DeltaPercent -Baseline $baselineDiscovery -Candidate $candidateDiscovery
+            $compileQueueDeltaPct = Get-DeltaPercent -Baseline $baselineCompileQueue -Candidate $candidateCompileQueue
 
             [PSCustomObject]@{
                 scenario = $scenario
@@ -165,6 +180,10 @@ try {
                 candidate_discovery_ms = [Math]::Round($candidateDiscovery, 3)
                 discovery_delta_ms = [Math]::Round(($candidateDiscovery - $baselineDiscovery), 3)
                 discovery_delta_pct = if ($null -eq $discoveryDeltaPct) { $null } else { [Math]::Round($discoveryDeltaPct, 2) }
+                baseline_compile_queue_ms = [Math]::Round($baselineCompileQueue, 3)
+                candidate_compile_queue_ms = [Math]::Round($candidateCompileQueue, 3)
+                compile_queue_delta_ms = [Math]::Round(($candidateCompileQueue - $baselineCompileQueue), 3)
+                compile_queue_delta_pct = if ($null -eq $compileQueueDeltaPct) { $null } else { [Math]::Round($compileQueueDeltaPct, 2) }
             }
         }
     )


### PR DESCRIPTION
## Summary

- replace the executable-target source/object/dependency/cache registries from `std::vector<std::string> + std::find` to reserved `std::unordered_set<std::string>` membership
- apply the same linear-time registration path to static-library targets
- remove the local locale-sensitive ASCII lowering helper and route identity through the repository-wide Windows `path_identity_key()` authority
- add a 128-helper-TU (129 total TUs) benchmark fixture covering cold, no-op, and single-TU incremental builds
- assert the expected compile-cache hit/miss shape and publish median `compile_queue` timing in benchmark JSON and the Actions summary
- make the three scale scenarios part of the fail-closed benchmark evidence contract

## Why

Both ordinary executable/DLL targets and static-library targets performed four independent linear searches while registering every translation unit. For `N` source files this made pre-scheduling target validation O(N²), before compilation or cache validation started. The local path-key helper also diverged from MQB's Unicode-aware Windows path identity contract.

The new registries compute the same canonical identity once per inserted path and use average O(1) membership, making the registration stage O(N) while preserving all existing duplicate-source and artifact-collision failures.

## Performance evidence

Exact-head run: https://github.com/Iviesever/msvc-quick-build/actions/runs/33843559020

Base: `d041668de836b9eb9a36e2d6b96ff2114c5c358a`  
Candidate: `c36149c37def49bca2765d0f67da5bf7638bd7ad`  
Iterations: 5 per binary, same Windows runner, base first and candidate second.

| Scenario | Base total ms | Candidate total ms | Total Δ | Base queue ms | Candidate queue ms | Queue Δ |
|---|---:|---:|---:|---:|---:|---:|
| `target-scale-cold` | 5719.472 | 4329.619 | -24.30% | 1.251 | 0.997 | -20.30% |
| `target-scale-no-op` | 55.263 | 48.636 | -11.99% | 1.241 | 0.878 | -29.25% |
| `target-scale-single-tu` | 176.194 | 152.201 | -13.62% | 1.256 | 0.941 | -25.08% |

Cache-shape assertions remained exact:

- `target-scale-cold`: 0 hits / 129 compile misses
- `target-scale-no-op`: 129 hits / 0 compile misses
- `target-scale-single-tu`: 128 hits / 1 compile miss

All reported total medians in this exact-head run were flat or faster. The only positive queue deltas were `modules-cold` and `modules-no-op`, each exactly +0.001 ms (about +1% of a ~0.1 ms phase), which is immaterial hosted-runner noise and outside the changed ordinary/static target registries. The retained `benchmark-comparison.json` contains every raw sample and phase/cache record.

The fixture remains large enough for the old implementation to perform about 33,000 linear membership comparisons across its four registries, while staying below Windows process-command-line limits during the final link.

## Scope

No `/MP`, no compile/link/archive recipe changes, no cache-format change, and no merge performed. This PR changes only pre-scheduling path registration plus its performance evidence.