### PR TITLE
perf: avoid repeated physical artifact containment probes

### DIFF
--- a/cpp/src/core/planning/ProjectArtifactLayout.cpp
+++ b/cpp/src/core/planning/ProjectArtifactLayout.cpp
@@ -109,13 +109,19 @@ namespace fs = std::filesystem;
     const fs::path& source) {
     const fs::path normalized_source = normalize_existing_identity(source);
 
-    if (auto relative = physical_relative(project_root, normalized_source)) {
-        return *relative;
-    }
-
-    fs::path relative = normalized_source.lexically_relative(project_root);
+    // Existing project roots and sources have already passed through
+    // weakly_canonical(), so the overwhelmingly common in-project case has a
+    // direct lexical relationship. Resolve it without repeating exists() and
+    // equivalent() probes for every translation unit. Keep the physical walk as
+    // a correctness fallback for an alias the platform canonicalizer did not
+    // collapse to the project-root spelling.
+    const fs::path relative = normalized_source.lexically_relative(project_root);
     if (safe_relative(relative)) {
         return identity_path(relative);
+    }
+
+    if (auto physical = physical_relative(project_root, normalized_source)) {
+        return *physical;
     }
 
     const fs::path identity = identity_path(normalized_source);


### PR DESCRIPTION
## Stack

This is a focused follow-up to #149 and is intentionally based on `perf/linear-target-path-validation`. Review this PR as the one-commit delta from that branch; merge #149 first, then retarget this PR to `main` before merging it.

## Summary

- try the already-canonical source/project lexical relationship before physical containment probing in `ProjectArtifactLayout`
- keep the existing `exists()` + parent-by-parent `equivalent()` walk unchanged as a correctness fallback
- preserve external-source hashing, Windows path identity, artifact names, cache locations, and all public APIs

## Why

`ProjectArtifactLayout::create()` canonicalizes the project root and `source_key()` canonicalizes every existing source before containment is determined. The old order nevertheless performed two additional existence probes and one or more filesystem-equivalence probes per translation unit before attempting the lexical relative path that succeeds for ordinary canonical in-project sources.

For a 129-TU target this means hundreds of avoidable filesystem queries before toolchain discovery or target compile-queue validation. The new order performs the syscall-free lexical test first. Physical aliases that are not collapsed by `weakly_canonical()` still reach the exact previous fallback.

## Correctness boundaries

- no cache format or build signature change
- no source identity weakening: relative keys still pass through the central Windows `path_identity_key()` authority
- no change for external sources
- no removal of physical-alias handling
- existing Unicode/case-alias artifact-layout coverage remains applicable

## Performance evidence

Both measurements compare the exact same base and candidate on one Windows runner, with five iterations per binary and base executed before candidate.

Base: `c36149c37def49bca2765d0f67da5bf7638bd7ad` (#149 head)  
Candidate: `eeb3f9c52607599c4891eebd8a1426f8b7c570cf`

### Initial exact-head run

Run: https://github.com/Iviesever/msvc-quick-build/actions/runs/33843743189

| Scenario | Base total ms | Candidate total ms | Total Δ |
|---|---:|---:|---:|
| `target-scale-cold` | 4250.392 | 4146.318 | -2.45% |
| `target-scale-no-op` | 46.870 | 38.534 | **-17.79%** |
| `target-scale-single-tu` | 139.824 | 136.850 | -2.13% |
| `no-op` | 4.652 | 4.598 | -1.16% |
| `single-tu` | 99.118 | 93.323 | -5.85% |

### Independent ready-for-review rerun

Run: https://github.com/Iviesever/msvc-quick-build/actions/runs/33845132736

| Scenario | Base total ms | Candidate total ms | Total Δ |
|---|---:|---:|---:|
| `target-scale-cold` | 4803.597 | 4213.419 | **-12.29%** |
| `target-scale-no-op` | 41.562 | 33.782 | **-18.72%** |
| `target-scale-single-tu` | 195.908 | 151.842 | **-22.49%** |
| `no-op` | 4.606 | 4.403 | -4.41% |
| `single-tu` | 112.561 | 106.395 | -5.48% |

The current timing schema does not assign artifact allocation/preflight its own phase. As a diagnostic cross-check, subtracting all named phase samples (`discovery`, `dependency_scan`, `compile_queue`, `compile`, `link`, `archive`, `run_startup`) from total time gives the following median uninstrumented front-half residual:

| Scenario | Initial residual Δ | Independent rerun residual Δ |
|---|---:|---:|
| `target-scale-no-op` | **-31.75%** (26.504 → 18.090 ms) | **-32.77%** (22.966 → 15.439 ms) |
| `target-scale-single-tu` | **-32.93%** (26.973 → 18.092 ms) | **-33.11%** (22.846 → 15.281 ms) |
| `target-scale-cold` | -2.76% (1597.422 → 1553.356 ms) | -3.68% (1585.014 → 1526.628 ms) |

This residual is not claimed as a standalone timing phase; it also contains other uninstrumented front-half work. In this one-production-file delta, however, two independent runs reproduce an approximately one-third reduction in both warm 129-TU residuals, which is consistent with removing the repeated filesystem containment probes.

The changed code executes before `compile_queue`, so queue deltas are not claimed as an effect. The retained artifacts include every positive and negative delta, all raw samples, all phase values, and the exact cache hit/miss records. In the independent rerun every reported total median improved except `discovery-header` (+1.29%), an unrelated ~1.8 ms hosted-runner variation.

## Validation

Exact candidate head `eeb3f9c52607599c4891eebd8a1426f8b7c570cf` passed:

- `Performance Evidence` twice, including the ready-for-review rerun
- `Native C++`: Debug build, all four Debug test shards, and aggregate gate
- `Native Release`: Stage 0 build, all four Release test shards, Stage 0 → Stage 1 → Stage 2 self-host closure, runtime-only package manifest/checksum/version validation, and installer lifecycle
- `Build Plan Evidence`, `Final Closure Cross-Stage`, `Incremental Inspection Evidence`, `PCH Inspection Evidence`, `Module Scan Inspection Evidence`, `Module Compile Inspection Evidence`, `Module Target Inspection Evidence`, and `Documentation`

The release publication job was skipped by design because this is a pull request, not a push to `main`. No review comments or unresolved review threads are present.

## Scope

One production file and one source-key decision-order change. No merge, tag, release, `/MP`, compiler recipe, linker recipe, archive recipe, cache format, or public API change.