### PR TITLE
perf: canonicalize artifact paths without a separate existence probe

### DIFF
--- a/cpp/src/core/planning/ProjectArtifactLayout.cpp
+++ b/cpp/src/core/planning/ProjectArtifactLayout.cpp
@@ -37,12 +37,13 @@ namespace fs = std::filesystem;
 [[nodiscard]] fs::path normalize_existing_identity(const fs::path& path) {
     fs::path normalized = path.lexically_normal();
     std::error_code error_code;
-    if (!fs::exists(normalized, error_code) || error_code) {
-        return normalized;
-    }
 
-    error_code.clear();
-    fs::path canonical = fs::weakly_canonical(normalized, error_code);
+    // For a fully existing path, weakly_canonical() is equivalent to
+    // canonical(). Calling canonical() directly avoids the separate exists()
+    // probe that every project root and translation unit previously paid. A
+    // missing, inaccessible, or otherwise unresolvable path still fails closed
+    // to the exact normalized spelling used by the previous implementation.
+    fs::path canonical = fs::canonical(normalized, error_code);
     if (error_code || canonical.empty()) {
         return normalized;
     }
@@ -110,7 +111,7 @@ namespace fs = std::filesystem;
     const fs::path normalized_source = normalize_existing_identity(source);
 
     // Existing project roots and sources have already passed through
-    // weakly_canonical(), so the overwhelmingly common in-project case has a
+    // canonicalization, so the overwhelmingly common in-project case has a
     // direct lexical relationship. Resolve it without repeating exists() and
     // equivalent() probes for every translation unit. Keep the physical walk as
     // a correctness fallback for an alias the platform canonicalizer did not


### PR DESCRIPTION
## Summary

- replace `exists() + weakly_canonical()` with one error-code `canonical()` call in `ProjectArtifactLayout` path normalization
- preserve the exact normalized-spelling fallback for missing, inaccessible, and otherwise unresolvable paths
- retain existing Windows path identity, physical-alias behavior, external-source hashing, artifact names, cache locations, and public APIs

## Why

`ProjectArtifactLayout::create()` normalizes the project root once, and `for_source()` normalizes every translation unit before allocating object/dependency/module/cache artifacts. For a fully existing path, `weakly_canonical()` has the same result as `canonical()`, but the previous implementation first paid a separate `exists()` query and then canonicalized the same path.

The 129-TU performance fixture therefore performs at least 130 avoidable existence probes before compile-queue validation: one for the project root and one for every source. Calling the error-code overload of `canonical()` directly removes that separate filesystem query. If canonicalization fails, the implementation still returns the original `lexically_normal()` spelling, matching the previous fail-closed result for missing or inaccessible paths.

## Correctness boundaries

- existing paths still resolve physical aliases through standard-library canonicalization
- non-existing synthetic paths still retain their normalized lexical spelling
- the physical-containment fallback remains unchanged
- no cache format or build-signature change
- no CLI, configuration, artifact-layout, or public-API change

The existing artifact-layout tests cover synthetic non-existing paths, project/external separation, same-basename collision avoidance, target layouts, and Unicode/ASCII case aliases on Windows.

## Performance evidence

Both runs compare the same immutable base and candidate on one Windows runner per run, with five iterations per binary and the exact base executed before the candidate.

Base: `5476fa45044986c8668edc8ceacf245cf5e218ff`  
Candidate: `b71a75012b94d08b985406ab45d7ca198010c159`

### Initial exact-head run

Run: https://github.com/Iviesever/msvc-quick-build/actions/runs/33852577386

| Scenario | Base total ms | Candidate total ms | Total Δ |
|---|---:|---:|---:|
| `target-scale-cold` | 4394.513 | 4113.189 | **-6.40%** |
| `target-scale-no-op` | 38.711 | 36.066 | **-6.83%** |
| `target-scale-single-tu` | 175.231 | 156.846 | **-10.49%** |
| `no-op` | 4.642 | 4.610 | -0.69% |
| `single-tu` | 125.559 | 113.122 | -9.91% |

### Independent ready-for-review rerun

Run: https://github.com/Iviesever/msvc-quick-build/actions/runs/33853562941

| Scenario | Base total ms | Candidate total ms | Total Δ |
|---|---:|---:|---:|
| `target-scale-cold` | 3863.450 | 3973.448 | +2.85% |
| `target-scale-no-op` | 32.703 | 31.292 | **-4.31%** |
| `target-scale-single-tu` | 124.238 | 134.399 | +8.18% |
| `no-op` | 4.195 | 4.352 | +3.74% |
| `single-tu` | 93.318 | 96.974 | +3.92% |

Cache behavior remained exact in every sample of both runs:

- `target-scale-cold`: 0 compile hits / 129 misses; 0 link hits / 1 miss
- `target-scale-no-op`: 129 compile hits / 0 misses; 1 link hit / 0 misses
- `target-scale-single-tu`: 128 compile hits / 1 miss; 0 link hits / 1 miss

Artifact allocation/preflight does not yet have a dedicated timing phase. As a diagnostic cross-check, subtracting all named phase samples (`discovery`, `dependency_scan`, `compile_queue`, `compile`, `link`, `archive`, `run_startup`) from each total and then taking the median gives:

| Scenario | Initial residual Δ | Independent residual Δ |
|---|---:|---:|
| `target-scale-cold` | -0.85% (1531.736 → 1518.753 ms) | -0.01% (1488.736 → 1488.618 ms) |
| `target-scale-no-op` | **-13.44%** (18.073 → 15.644 ms) | **-11.59%** (14.871 → 13.148 ms) |
| `target-scale-single-tu` | **-13.48%** (17.810 → 15.409 ms) | **-12.46%** (14.994 → 13.126 ms) |

The residual is not claimed as a standalone MQB phase; it also contains other uninstrumented front-half work. The important repeatable result is that both independent runs reduce the warm 129-TU front-half residual by about 12–13%, while the clean no-op end-to-end scenario improves by 6.83% and 4.31%.

The inconsistent cold and single-TU totals are retained rather than hidden. In the independent run, `target-scale-single-tu` compile time was effectively flat while link time increased by about 9.6 ms; the changed normalization code runs before both and its per-sample residual still fell by 12.46%. Likewise, cold totals are dominated by compiler/process variance: the two runs reverse direction while the modified front-half residual is flat or lower. Other initially positive medians also reversed or shrank on rerun (`link-only` +6.92% → -1.75%, `discovery-no-op` +1.85% → -1.48%, `discovery-header` +5.14% → +1.81%), supporting hosted-runner/order noise rather than a systematic behavior regression.

The retained comparison artifacts include all raw samples, named phases, and cache records for both runs.

## Validation

Exact candidate head `b71a75012b94d08b985406ab45d7ca198010c159` passed:

- two independent `Performance Evidence` runs
- full `Native C++`: Debug product build, all four Debug test shards, and aggregate gate
- full `Native Release`: Stage 0 build, all four Release test shards, Stage 0 → Stage 1 → Stage 2 self-host closure, runtime-only package manifest/checksum/version validation, and installer lifecycle
- `Build Plan Evidence`, `Final Closure Cross-Stage`, `Incremental Inspection Evidence`, `PCH Inspection Evidence`, `Module Scan Inspection Evidence`, `Module Compile Inspection Evidence`, `Module Target Inspection Evidence`, and `Documentation`

The release publication job was skipped by design because this is a pull request, not a push to `main`.

## Scope

One production file and one focused syscall-elimination change. No `/MP`, compiler/linker/librarian recipe change, cache schema change, tag, release, or merge.