### PR TITLE
perf: add attributable warm-path evidence

### DIFF
--- a/.github/workflows/performance-evidence.yml
+++ b/.github/workflows/performance-evidence.yml
@@ -14,16 +14,17 @@ jobs:
     name: Compare base and candidate
     if: github.event_name == 'workflow_dispatch' || (startsWith(github.event.pull_request.title, 'perf:') && (github.event.action != 'edited' || github.event.changes.title.from != null))
     runs-on: windows-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     permissions:
       contents: read
     env:
       GH_TOKEN: ${{ github.token }}
 
     steps:
-      - name: Checkout candidate
+      - name: Checkout exact candidate head
         uses: actions/checkout@v7
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           path: candidate
 
       - name: Checkout exact PR base
@@ -87,7 +88,16 @@ jobs:
             throw "Candidate Release MQB missing: $mqb"
           }
 
-      - name: Compare benchmark medians on the same runner
+      - name: Verify candidate performance instrumentation contract
+        shell: pwsh
+        run: |
+          $candidateRoot = Join-Path $env:GITHUB_WORKSPACE 'candidate'
+          $candidateMqb = Join-Path $env:GITHUB_WORKSPACE 'performance-out/candidate/mqb.exe'
+          & (Join-Path $candidateRoot 'tests/native/verify_performance_instrumentation.ps1') `
+            -MqbPath $candidateMqb
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Compare paired ABBA samples on the same runner
         shell: pwsh
         run: |
           $candidateRoot = Join-Path $env:GITHUB_WORKSPACE 'candidate'
@@ -97,37 +107,41 @@ jobs:
           & (Join-Path $candidateRoot 'tests/native/compare_mqb_benchmarks.ps1') `
             -BaselineMqbPath $baselineMqb `
             -CandidateMqbPath $candidateMqb `
-            -Iterations 5 `
+            -Iterations 4 `
             -OutputPath $comparison
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-      - name: Publish comparison summary
+      - name: Publish paired comparison summary
         shell: pwsh
         run: |
           $comparisonPath = Join-Path $env:GITHUB_WORKSPACE 'performance-out/benchmark-comparison.json'
           $report = Get-Content -LiteralPath $comparisonPath -Raw | ConvertFrom-Json
           $lines = [System.Collections.Generic.List[string]]::new()
-          $lines.Add('## MQB performance evidence')
+          $lines.Add('## MQB paired ABBA performance evidence')
           $lines.Add('')
-          $lines.Add('Negative deltas mean the candidate is faster. These values are review evidence, not correctness thresholds.')
+          $lines.Add("Execution order: $(@($report.execution_order) -join ' → ')")
+          $lines.Add('Negative deltas mean the candidate is faster. MAD and P95 are calculated from paired candidate-minus-baseline deltas; P95 uses nearest-rank.')
           $lines.Add('')
-          $lines.Add('### Wall-clock and discovery phases')
-          $lines.Add('')
-          $lines.Add('| Scenario | Base total ms | Candidate total ms | Total Δ% | Base discovery ms | Candidate discovery ms | Discovery Δ% |')
+          $lines.Add('| Scenario | Base median ms | Candidate median ms | Paired median Δms | Paired median Δ% | MAD Δms | P95 Δms |')
           $lines.Add('|---|---:|---:|---:|---:|---:|---:|')
           foreach ($row in @($report.comparison)) {
-            $totalDelta = if ($null -eq $row.total_delta_pct) { 'n/a' } else { [string]$row.total_delta_pct }
-            $discoveryDelta = if ($null -eq $row.discovery_delta_pct) { 'n/a' } else { [string]$row.discovery_delta_pct }
-            $lines.Add("| $($row.scenario) | $($row.baseline_total_ms) | $($row.candidate_total_ms) | $totalDelta | $($row.baseline_discovery_ms) | $($row.candidate_discovery_ms) | $discoveryDelta |")
+            $deltaPct = if ($null -eq $row.paired_median_total_delta_pct) { 'n/a' } else { [string]$row.paired_median_total_delta_pct }
+            $lines.Add("| $($row.scenario) | $($row.baseline_median_total_ms) | $($row.candidate_median_total_ms) | $($row.paired_median_total_delta_ms) | $deltaPct | $($row.paired_mad_total_delta_ms) | $($row.paired_p95_total_delta_ms) |")
           }
+
           $lines.Add('')
-          $lines.Add('### Compile queue phase')
+          $lines.Add('### Candidate warm-path attribution: 129-TU common-header no-op')
           $lines.Add('')
-          $lines.Add('| Scenario | Base queue ms | Candidate queue ms | Queue Δ% |')
-          $lines.Add('|---|---:|---:|---:|')
-          foreach ($row in @($report.comparison)) {
-            $queueDelta = if ($null -eq $row.compile_queue_delta_pct) { 'n/a' } else { [string]$row.compile_queue_delta_pct }
-            $lines.Add("| $($row.scenario) | $($row.baseline_compile_queue_ms) | $($row.candidate_compile_queue_ms) | $queueDelta |")
+          $lines.Add('| Pair | Orientation | Total ms | Compile inspect ms | Cache read ms | FS snapshot ms | Cache opens | Cache bytes | FS requests | Unique paths | Threads | cl/link/lib | Output lines/bytes |')
+          $lines.Add('|---:|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|---|')
+          $evidenceRows = @($report.paired_samples | Where-Object { $_.scenario -eq 'target-scale-common-header-no-op' } | Sort-Object pair)
+          foreach ($pair in $evidenceRows) {
+            $candidate = $pair.candidate
+            $work = $candidate.attribution.work
+            $counters = $candidate.counters
+            $processes = "$($counters.cl_processes_launched)/$($counters.link_processes_launched)/$($counters.lib_processes_launched)"
+            $output = "$($counters.output_lines_emitted)/$($counters.output_bytes_emitted)"
+            $lines.Add("| $($pair.pair) | $($pair.orientation) | $($candidate.total_ms) | $($work.compile_inspection) | $($work.compile_cache_read) | $($work.filesystem_snapshot) | $($counters.cache_files_opened) | $($counters.cache_bytes_read) | $($counters.filesystem_snapshot_requests) | $($counters.unique_filesystem_paths_probed) | $($counters.background_threads_created) | $processes | $output |")
           }
           $lines | Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Encoding utf8
 

--- a/cpp/include/mqb/core/PerformanceEvidence.hpp
+++ b/cpp/include/mqb/core/PerformanceEvidence.hpp
@@ -1,0 +1,538 @@
+#pragma once
+
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <mutex>
+#include <string>
+#include <unordered_set>
+
+#include "mqb/platform/windows/PathIdentity.hpp"
+
+namespace mqb::performance {
+
+using EvidenceClock = std::chrono::steady_clock;
+
+enum class WallKind : std::size_t {
+    project_setup,
+    artifact_layout,
+    toolchain_discovery,
+    target_validation,
+    reporting,
+    count,
+};
+
+enum class WorkKind : std::size_t {
+    compile_inspection,
+    compile_execution,
+    compile_cache_read,
+    compile_cache_write,
+    link_inspection,
+    link_execution,
+    link_resolution,
+    link_cache_read,
+    link_cache_write,
+    archive_inspection,
+    archive_execution,
+    archive_cache_read,
+    archive_cache_write,
+    discovery_cache_read,
+    discovery_cache_write,
+    toolchain_cache_read,
+    toolchain_cache_write,
+    module_scan_execution,
+    filesystem_snapshot_compile,
+    filesystem_snapshot_link,
+    filesystem_snapshot_archive,
+    filesystem_snapshot_discovery,
+    filesystem_snapshot_toolchain,
+    filesystem_snapshot_module_scan,
+    filesystem_snapshot_other,
+    count,
+};
+
+enum class CacheKind : std::size_t {
+    compile,
+    link,
+    archive,
+    discovery,
+    toolchain,
+    count,
+};
+
+enum class FilesystemKind : std::size_t {
+    compile,
+    link,
+    archive,
+    discovery,
+    toolchain,
+    module_scan,
+    other,
+    count,
+};
+
+enum class ProcessKind : std::size_t {
+    compiler,
+    linker,
+    librarian,
+    count,
+};
+
+inline constexpr std::size_t wall_kind_count = static_cast<std::size_t>(WallKind::count);
+inline constexpr std::size_t work_kind_count = static_cast<std::size_t>(WorkKind::count);
+inline constexpr std::size_t cache_kind_count = static_cast<std::size_t>(CacheKind::count);
+inline constexpr std::size_t filesystem_kind_count = static_cast<std::size_t>(FilesystemKind::count);
+inline constexpr std::size_t process_kind_count = static_cast<std::size_t>(ProcessKind::count);
+
+struct EvidenceSnapshot {
+    std::array<std::chrono::nanoseconds, wall_kind_count> wall{};
+    std::array<std::chrono::nanoseconds, work_kind_count> work{};
+    std::array<std::uint64_t, cache_kind_count> cache_files_opened{};
+    std::array<std::uint64_t, cache_kind_count> cache_bytes_read{};
+    std::array<std::uint64_t, cache_kind_count> cache_files_written{};
+    std::array<std::uint64_t, cache_kind_count> cache_bytes_written{};
+    std::array<std::uint64_t, filesystem_kind_count> filesystem_snapshot_requests{};
+    std::array<std::uint64_t, filesystem_kind_count> unique_filesystem_paths_probed{};
+    std::array<std::uint64_t, filesystem_kind_count> snapshot_evidence_reuses{};
+    std::array<std::uint64_t, process_kind_count> processes_launched{};
+    std::uint64_t unique_filesystem_paths_total{};
+    std::uint64_t background_threads_created{};
+    std::uint64_t output_lines_emitted{};
+    std::uint64_t output_bytes_emitted{};
+};
+
+class Collector {
+public:
+    Collector() noexcept {
+        clear(wall_);
+        clear(work_);
+        clear(cache_files_opened_);
+        clear(cache_bytes_read_);
+        clear(cache_files_written_);
+        clear(cache_bytes_written_);
+        clear(filesystem_snapshot_requests_);
+        clear(unique_filesystem_paths_by_kind_);
+        clear(snapshot_evidence_reuses_);
+        clear(processes_launched_);
+    }
+
+    Collector(const Collector&) = delete;
+    Collector& operator=(const Collector&) = delete;
+
+    void add_wall(const WallKind kind, const EvidenceClock::duration duration) noexcept {
+        add_duration(wall_[index(kind)], duration);
+    }
+
+    void add_work(const WorkKind kind, const EvidenceClock::duration duration) noexcept {
+        add_duration(work_[index(kind)], duration);
+    }
+
+    void record_cache_read(
+        const CacheKind kind,
+        const std::uint64_t bytes) noexcept {
+        cache_files_opened_[index(kind)].fetch_add(1, std::memory_order_relaxed);
+        cache_bytes_read_[index(kind)].fetch_add(bytes, std::memory_order_relaxed);
+    }
+
+    void record_cache_write(
+        const CacheKind kind,
+        const std::uint64_t bytes) noexcept {
+        cache_files_written_[index(kind)].fetch_add(1, std::memory_order_relaxed);
+        cache_bytes_written_[index(kind)].fetch_add(bytes, std::memory_order_relaxed);
+    }
+
+    void record_filesystem_probe(
+        const FilesystemKind kind,
+        const std::filesystem::path& path) noexcept {
+        filesystem_snapshot_requests_[index(kind)].fetch_add(1, std::memory_order_relaxed);
+        try {
+            const std::string key =
+                mqb::platform::windows::path_identity_key(path);
+            std::scoped_lock lock{path_mutex_};
+            if (unique_paths_.insert(key).second) {
+                unique_filesystem_paths_total_.fetch_add(1, std::memory_order_relaxed);
+            }
+            if (unique_paths_by_kind_[index(kind)].insert(key).second) {
+                unique_filesystem_paths_by_kind_[index(kind)].fetch_add(
+                    1,
+                    std::memory_order_relaxed);
+            }
+        } catch (...) {
+            // Observation must never change build behavior.
+        }
+    }
+
+    void record_snapshot_evidence_reuse(
+        const FilesystemKind kind,
+        const std::uint64_t count = 1) noexcept {
+        snapshot_evidence_reuses_[index(kind)].fetch_add(
+            count,
+            std::memory_order_relaxed);
+    }
+
+    void record_background_threads(const std::uint64_t count) noexcept {
+        background_threads_created_.fetch_add(count, std::memory_order_relaxed);
+    }
+
+    void record_process_launch(const ProcessKind kind) noexcept {
+        processes_launched_[index(kind)].fetch_add(1, std::memory_order_relaxed);
+    }
+
+    void record_output(
+        const std::uint64_t bytes,
+        const std::uint64_t lines) noexcept {
+        output_bytes_emitted_.fetch_add(bytes, std::memory_order_relaxed);
+        output_lines_emitted_.fetch_add(lines, std::memory_order_relaxed);
+    }
+
+    [[nodiscard]] EvidenceSnapshot snapshot() const noexcept {
+        EvidenceSnapshot result;
+        load(wall_, result.wall);
+        load(work_, result.work);
+        load(cache_files_opened_, result.cache_files_opened);
+        load(cache_bytes_read_, result.cache_bytes_read);
+        load(cache_files_written_, result.cache_files_written);
+        load(cache_bytes_written_, result.cache_bytes_written);
+        load(filesystem_snapshot_requests_, result.filesystem_snapshot_requests);
+        load(unique_filesystem_paths_by_kind_, result.unique_filesystem_paths_probed);
+        load(snapshot_evidence_reuses_, result.snapshot_evidence_reuses);
+        load(processes_launched_, result.processes_launched);
+        result.unique_filesystem_paths_total =
+            unique_filesystem_paths_total_.load(std::memory_order_relaxed);
+        result.background_threads_created =
+            background_threads_created_.load(std::memory_order_relaxed);
+        result.output_lines_emitted =
+            output_lines_emitted_.load(std::memory_order_relaxed);
+        result.output_bytes_emitted =
+            output_bytes_emitted_.load(std::memory_order_relaxed);
+        return result;
+    }
+
+private:
+    template <typename Enum>
+    [[nodiscard]] static constexpr std::size_t index(const Enum value) noexcept {
+        return static_cast<std::size_t>(value);
+    }
+
+    template <typename Integer, std::size_t Size>
+    static void clear(std::array<std::atomic<Integer>, Size>& values) noexcept {
+        for (auto& value : values) {
+            value.store(0, std::memory_order_relaxed);
+        }
+    }
+
+    template <std::size_t Size>
+    static void load(
+        const std::array<std::atomic<std::uint64_t>, Size>& source,
+        std::array<std::uint64_t, Size>& destination) noexcept {
+        for (std::size_t index = 0; index < Size; ++index) {
+            destination[index] = source[index].load(std::memory_order_relaxed);
+        }
+    }
+
+    template <std::size_t Size>
+    static void load(
+        const std::array<std::atomic<std::int64_t>, Size>& source,
+        std::array<std::chrono::nanoseconds, Size>& destination) noexcept {
+        for (std::size_t index = 0; index < Size; ++index) {
+            destination[index] = std::chrono::nanoseconds{
+                source[index].load(std::memory_order_relaxed)};
+        }
+    }
+
+    static void add_duration(
+        std::atomic<std::int64_t>& destination,
+        const EvidenceClock::duration duration) noexcept {
+        const auto nanoseconds = std::chrono::duration_cast<std::chrono::nanoseconds>(
+            duration);
+        destination.fetch_add(nanoseconds.count(), std::memory_order_relaxed);
+    }
+
+    std::array<std::atomic<std::int64_t>, wall_kind_count> wall_{};
+    std::array<std::atomic<std::int64_t>, work_kind_count> work_{};
+    std::array<std::atomic<std::uint64_t>, cache_kind_count> cache_files_opened_{};
+    std::array<std::atomic<std::uint64_t>, cache_kind_count> cache_bytes_read_{};
+    std::array<std::atomic<std::uint64_t>, cache_kind_count> cache_files_written_{};
+    std::array<std::atomic<std::uint64_t>, cache_kind_count> cache_bytes_written_{};
+    std::array<std::atomic<std::uint64_t>, filesystem_kind_count>
+        filesystem_snapshot_requests_{};
+    std::array<std::atomic<std::uint64_t>, filesystem_kind_count>
+        unique_filesystem_paths_by_kind_{};
+    std::array<std::atomic<std::uint64_t>, filesystem_kind_count>
+        snapshot_evidence_reuses_{};
+    std::array<std::atomic<std::uint64_t>, process_kind_count> processes_launched_{};
+    std::atomic<std::uint64_t> unique_filesystem_paths_total_{};
+    std::atomic<std::uint64_t> background_threads_created_{};
+    std::atomic<std::uint64_t> output_lines_emitted_{};
+    std::atomic<std::uint64_t> output_bytes_emitted_{};
+    mutable std::mutex path_mutex_;
+    std::unordered_set<std::string> unique_paths_;
+    std::array<std::unordered_set<std::string>, filesystem_kind_count>
+        unique_paths_by_kind_;
+};
+
+inline std::atomic<Collector*> active_collector{nullptr};
+inline thread_local FilesystemKind active_filesystem_kind = FilesystemKind::other;
+
+[[nodiscard]] inline Collector* current_collector() noexcept {
+    return active_collector.load(std::memory_order_acquire);
+}
+
+class Activation {
+public:
+    explicit Activation(Collector& collector) noexcept
+        : collector_(&collector),
+          previous_(active_collector.exchange(&collector, std::memory_order_acq_rel)) {}
+
+    ~Activation() noexcept {
+        Collector* expected = collector_;
+        (void)active_collector.compare_exchange_strong(
+            expected,
+            previous_,
+            std::memory_order_acq_rel,
+            std::memory_order_acquire);
+    }
+
+    Activation(const Activation&) = delete;
+    Activation& operator=(const Activation&) = delete;
+
+private:
+    Collector* collector_{};
+    Collector* previous_{};
+};
+
+class ScopedWall {
+public:
+    explicit ScopedWall(const WallKind kind) noexcept
+        : collector_(current_collector()),
+          kind_(kind),
+          started_(collector_ != nullptr ? EvidenceClock::now() : EvidenceClock::time_point{}) {}
+
+    ~ScopedWall() noexcept { finish(); }
+
+    ScopedWall(const ScopedWall&) = delete;
+    ScopedWall& operator=(const ScopedWall&) = delete;
+
+    void finish() noexcept {
+        if (!active_) return;
+        active_ = false;
+        if (collector_ != nullptr) {
+            collector_->add_wall(kind_, EvidenceClock::now() - started_);
+        }
+    }
+
+private:
+    Collector* collector_{};
+    WallKind kind_{};
+    EvidenceClock::time_point started_{};
+    bool active_{true};
+};
+
+class ScopedWork {
+public:
+    explicit ScopedWork(const WorkKind kind) noexcept
+        : collector_(current_collector()),
+          kind_(kind),
+          started_(collector_ != nullptr ? EvidenceClock::now() : EvidenceClock::time_point{}) {}
+
+    ~ScopedWork() noexcept { finish(); }
+
+    ScopedWork(const ScopedWork&) = delete;
+    ScopedWork& operator=(const ScopedWork&) = delete;
+
+    void finish() noexcept {
+        if (!active_) return;
+        active_ = false;
+        if (collector_ != nullptr) {
+            collector_->add_work(kind_, EvidenceClock::now() - started_);
+        }
+    }
+
+private:
+    Collector* collector_{};
+    WorkKind kind_{};
+    EvidenceClock::time_point started_{};
+    bool active_{true};
+};
+
+class ScopedFilesystemDomain {
+public:
+    explicit ScopedFilesystemDomain(const FilesystemKind kind) noexcept
+        : previous_(active_filesystem_kind),
+          active_(current_collector() != nullptr) {
+        if (active_) active_filesystem_kind = kind;
+    }
+
+    ~ScopedFilesystemDomain() noexcept {
+        if (active_) active_filesystem_kind = previous_;
+    }
+
+    ScopedFilesystemDomain(const ScopedFilesystemDomain&) = delete;
+    ScopedFilesystemDomain& operator=(const ScopedFilesystemDomain&) = delete;
+
+private:
+    FilesystemKind previous_{};
+    bool active_{false};
+};
+
+[[nodiscard]] inline WorkKind filesystem_work_kind(
+    const FilesystemKind kind) noexcept {
+    switch (kind) {
+    case FilesystemKind::compile: return WorkKind::filesystem_snapshot_compile;
+    case FilesystemKind::link: return WorkKind::filesystem_snapshot_link;
+    case FilesystemKind::archive: return WorkKind::filesystem_snapshot_archive;
+    case FilesystemKind::discovery: return WorkKind::filesystem_snapshot_discovery;
+    case FilesystemKind::toolchain: return WorkKind::filesystem_snapshot_toolchain;
+    case FilesystemKind::module_scan: return WorkKind::filesystem_snapshot_module_scan;
+    case FilesystemKind::other:
+    case FilesystemKind::count:
+        return WorkKind::filesystem_snapshot_other;
+    }
+    return WorkKind::filesystem_snapshot_other;
+}
+
+class ScopedFilesystemProbe {
+public:
+    explicit ScopedFilesystemProbe(
+        const std::filesystem::path& path,
+        const FilesystemKind kind = active_filesystem_kind) noexcept
+        : collector_(current_collector()),
+          kind_(kind) {
+        if (collector_ != nullptr) {
+            // Path identity and unique-path accounting are observer overhead, not
+            // filesystem metadata work. Start the work interval only after the
+            // deterministic request/uniqueness counters have been recorded.
+            collector_->record_filesystem_probe(kind_, path);
+            started_ = EvidenceClock::now();
+        }
+    }
+
+    ~ScopedFilesystemProbe() noexcept {
+        if (collector_ != nullptr) {
+            collector_->add_work(
+                filesystem_work_kind(kind_),
+                EvidenceClock::now() - started_);
+        }
+    }
+
+    ScopedFilesystemProbe(const ScopedFilesystemProbe&) = delete;
+    ScopedFilesystemProbe& operator=(const ScopedFilesystemProbe&) = delete;
+
+private:
+    Collector* collector_{};
+    FilesystemKind kind_{};
+    EvidenceClock::time_point started_{};
+};
+
+[[nodiscard]] inline WorkKind cache_read_work_kind(const CacheKind kind) noexcept {
+    switch (kind) {
+    case CacheKind::compile: return WorkKind::compile_cache_read;
+    case CacheKind::link: return WorkKind::link_cache_read;
+    case CacheKind::archive: return WorkKind::archive_cache_read;
+    case CacheKind::discovery: return WorkKind::discovery_cache_read;
+    case CacheKind::toolchain: return WorkKind::toolchain_cache_read;
+    case CacheKind::count: return WorkKind::compile_cache_read;
+    }
+    return WorkKind::compile_cache_read;
+}
+
+[[nodiscard]] inline WorkKind cache_write_work_kind(const CacheKind kind) noexcept {
+    switch (kind) {
+    case CacheKind::compile: return WorkKind::compile_cache_write;
+    case CacheKind::link: return WorkKind::link_cache_write;
+    case CacheKind::archive: return WorkKind::archive_cache_write;
+    case CacheKind::discovery: return WorkKind::discovery_cache_write;
+    case CacheKind::toolchain: return WorkKind::toolchain_cache_write;
+    case CacheKind::count: return WorkKind::compile_cache_write;
+    }
+    return WorkKind::compile_cache_write;
+}
+
+class ScopedCacheRead {
+public:
+    explicit ScopedCacheRead(const CacheKind kind) noexcept
+        : collector_(current_collector()),
+          kind_(kind),
+          started_(collector_ != nullptr ? EvidenceClock::now() : EvidenceClock::time_point{}) {}
+
+    ~ScopedCacheRead() noexcept {
+        if (collector_ != nullptr) {
+            collector_->add_work(
+                cache_read_work_kind(kind_),
+                EvidenceClock::now() - started_);
+        }
+    }
+
+    ScopedCacheRead(const ScopedCacheRead&) = delete;
+    ScopedCacheRead& operator=(const ScopedCacheRead&) = delete;
+
+    void opened(const std::uint64_t bytes) noexcept {
+        if (!opened_ && collector_ != nullptr) {
+            collector_->record_cache_read(kind_, bytes);
+        }
+        opened_ = true;
+    }
+
+private:
+    Collector* collector_{};
+    CacheKind kind_{};
+    EvidenceClock::time_point started_{};
+    bool opened_{false};
+};
+
+class ScopedCacheWrite {
+public:
+    explicit ScopedCacheWrite(const CacheKind kind) noexcept
+        : collector_(current_collector()),
+          kind_(kind),
+          started_(collector_ != nullptr ? EvidenceClock::now() : EvidenceClock::time_point{}) {}
+
+    ~ScopedCacheWrite() noexcept {
+        if (collector_ != nullptr) {
+            collector_->add_work(
+                cache_write_work_kind(kind_),
+                EvidenceClock::now() - started_);
+        }
+    }
+
+    ScopedCacheWrite(const ScopedCacheWrite&) = delete;
+    ScopedCacheWrite& operator=(const ScopedCacheWrite&) = delete;
+
+    void opened(const std::uint64_t bytes) noexcept {
+        if (!opened_ && collector_ != nullptr) {
+            collector_->record_cache_write(kind_, bytes);
+        }
+        opened_ = true;
+    }
+
+private:
+    Collector* collector_{};
+    CacheKind kind_{};
+    EvidenceClock::time_point started_{};
+    bool opened_{false};
+};
+
+inline void record_background_threads(const std::uint64_t count) noexcept {
+    if (Collector* collector = current_collector()) {
+        collector->record_background_threads(count);
+    }
+}
+
+inline void record_process_launch(const ProcessKind kind) noexcept {
+    if (Collector* collector = current_collector()) {
+        collector->record_process_launch(kind);
+    }
+}
+
+inline void record_snapshot_evidence_reuse(
+    const FilesystemKind kind,
+    const std::uint64_t count = 1) noexcept {
+    if (Collector* collector = current_collector()) {
+        collector->record_snapshot_evidence_reuse(kind, count);
+    }
+}
+
+} // namespace mqb::performance

--- a/cpp/src/app/diagnostics/PerformanceTimings.cpp
+++ b/cpp/src/app/diagnostics/PerformanceTimings.cpp
@@ -1,12 +1,75 @@
 #include "PerformanceTimings.hpp"
 
+#include <algorithm>
+#include <array>
+#include <cstdint>
 #include <iomanip>
 #include <iostream>
 #include <locale>
+#include <memory>
 #include <sstream>
+#include <streambuf>
+#include <string_view>
 
 namespace mqb::app::performance {
 namespace {
+
+using Evidence = mqb::performance::EvidenceSnapshot;
+
+constexpr std::array<std::string_view, mqb::performance::wall_kind_count> wall_names{
+    "project_setup",
+    "artifact_layout",
+    "toolchain_discovery",
+    "target_validation",
+    "reporting",
+};
+
+constexpr std::array<std::string_view, mqb::performance::work_kind_count> work_names{
+    "compile_inspection",
+    "compile_execution",
+    "compile_cache_read",
+    "compile_cache_write",
+    "link_inspection",
+    "link_execution",
+    "link_resolution",
+    "link_cache_read",
+    "link_cache_write",
+    "archive_inspection",
+    "archive_execution",
+    "archive_cache_read",
+    "archive_cache_write",
+    "discovery_cache_read",
+    "discovery_cache_write",
+    "toolchain_cache_read",
+    "toolchain_cache_write",
+    "module_scan_execution",
+    "filesystem_snapshot_compile",
+    "filesystem_snapshot_link",
+    "filesystem_snapshot_archive",
+    "filesystem_snapshot_discovery",
+    "filesystem_snapshot_toolchain",
+    "filesystem_snapshot_module_scan",
+    "filesystem_snapshot_other",
+};
+
+constexpr std::array<std::string_view, mqb::performance::cache_kind_count> cache_names{
+    "compile",
+    "link",
+    "archive",
+    "discovery",
+    "toolchain",
+};
+
+constexpr std::array<std::string_view, mqb::performance::filesystem_kind_count>
+filesystem_names{
+    "compile",
+    "link",
+    "archive",
+    "discovery",
+    "toolchain",
+    "module_scan",
+    "other",
+};
 
 [[nodiscard]] double milliseconds(const std::chrono::nanoseconds duration) noexcept {
     return std::chrono::duration<double, std::milli>{duration}.count();
@@ -14,26 +77,182 @@ namespace {
 
 void append_text_phase(
     std::ostringstream& output,
-    const char* const label,
+    const std::string_view label,
     const std::chrono::nanoseconds duration) {
-    output << "  " << std::left << std::setw(17) << label
+    output << "  " << std::left << std::setw(31) << label
            << std::right << std::fixed << std::setprecision(3)
            << std::setw(12) << milliseconds(duration) << " ms\n";
 }
 
+template <std::size_t Size>
+[[nodiscard]] std::uint64_t sum(
+    const std::array<std::uint64_t, Size>& values) noexcept {
+    std::uint64_t result = 0;
+    for (const std::uint64_t value : values) result += value;
+    return result;
+}
+
+[[nodiscard]] std::chrono::nanoseconds filesystem_work_total(
+    const Evidence& evidence) noexcept {
+    using mqb::performance::WorkKind;
+    std::chrono::nanoseconds result{};
+    for (const WorkKind kind : {
+             WorkKind::filesystem_snapshot_compile,
+             WorkKind::filesystem_snapshot_link,
+             WorkKind::filesystem_snapshot_archive,
+             WorkKind::filesystem_snapshot_discovery,
+             WorkKind::filesystem_snapshot_toolchain,
+             WorkKind::filesystem_snapshot_module_scan,
+             WorkKind::filesystem_snapshot_other}) {
+        result += evidence.work[static_cast<std::size_t>(kind)];
+    }
+    return result;
+}
+
+void append_json_durations(
+    std::ostringstream& output,
+    const auto& names,
+    const auto& durations) {
+    for (std::size_t index = 0; index < names.size(); ++index) {
+        if (index != 0) output << ',';
+        output << '\"' << names[index] << "\":"
+               << milliseconds(durations[index]);
+    }
+}
+
+void append_json_cache_breakdown(
+    std::ostringstream& output,
+    const Evidence& evidence) {
+    for (std::size_t index = 0; index < cache_names.size(); ++index) {
+        if (index != 0) output << ',';
+        output << '\"' << cache_names[index] << "\":{"
+               << "\"files_opened\":" << evidence.cache_files_opened[index] << ','
+               << "\"bytes_read\":" << evidence.cache_bytes_read[index] << ','
+               << "\"files_written\":" << evidence.cache_files_written[index] << ','
+               << "\"bytes_written\":" << evidence.cache_bytes_written[index]
+               << '}';
+    }
+}
+
+void append_json_filesystem_breakdown(
+    std::ostringstream& output,
+    const Evidence& evidence) {
+    for (std::size_t index = 0; index < filesystem_names.size(); ++index) {
+        if (index != 0) output << ',';
+        output << '\"' << filesystem_names[index] << "\":{"
+               << "\"snapshot_requests\":"
+               << evidence.filesystem_snapshot_requests[index] << ','
+               << "\"unique_paths_probed\":"
+               << evidence.unique_filesystem_paths_probed[index] << ','
+               << "\"snapshot_evidence_reuses\":"
+               << evidence.snapshot_evidence_reuses[index]
+               << '}';
+    }
+}
+
+class CountingStreambuf final : public std::streambuf {
+public:
+    CountingStreambuf(
+        std::streambuf* destination,
+        mqb::performance::Collector& collector) noexcept
+        : destination_(destination), collector_(&collector) {}
+
+protected:
+    int_type overflow(const int_type character) override {
+        if (traits_type::eq_int_type(character, traits_type::eof())) {
+            return traits_type::not_eof(character);
+        }
+        const auto started = mqb::performance::EvidenceClock::now();
+        const int_type result = destination_->sputc(traits_type::to_char_type(character));
+        collector_->add_wall(
+            mqb::performance::WallKind::reporting,
+            mqb::performance::EvidenceClock::now() - started);
+        if (!traits_type::eq_int_type(result, traits_type::eof())) {
+            collector_->record_output(
+                1,
+                traits_type::to_char_type(character) == '\n' ? 1 : 0);
+        }
+        return result;
+    }
+
+    std::streamsize xsputn(
+        const char_type* text,
+        const std::streamsize count) override {
+        const auto started = mqb::performance::EvidenceClock::now();
+        const std::streamsize written = destination_->sputn(text, count);
+        collector_->add_wall(
+            mqb::performance::WallKind::reporting,
+            mqb::performance::EvidenceClock::now() - started);
+        if (written > 0) {
+            const auto length = static_cast<std::size_t>(written);
+            const auto lines = static_cast<std::uint64_t>(
+                std::count(text, text + length, '\n'));
+            collector_->record_output(
+                static_cast<std::uint64_t>(length),
+                lines);
+        }
+        return written;
+    }
+
+    int sync() override {
+        const auto started = mqb::performance::EvidenceClock::now();
+        const int result = destination_->pubsync();
+        collector_->add_wall(
+            mqb::performance::WallKind::reporting,
+            mqb::performance::EvidenceClock::now() - started);
+        return result;
+    }
+
+private:
+    std::streambuf* destination_{};
+    mqb::performance::Collector* collector_{};
+};
+
 } // namespace
 
-std::string render(const Snapshot& snapshot, const Format format) {
-    if (format == Format::disabled) {
-        return {};
+struct Session::OutputObservers {
+    explicit OutputObservers(mqb::performance::Collector& collector)
+        : cout_original(std::cout.rdbuf()),
+          cerr_original(std::cerr.rdbuf()),
+          clog_original(std::clog.rdbuf()),
+          cout_observer(std::make_unique<CountingStreambuf>(cout_original, collector)),
+          cerr_observer(std::make_unique<CountingStreambuf>(cerr_original, collector)),
+          clog_observer(std::make_unique<CountingStreambuf>(clog_original, collector)) {
+        std::cout.rdbuf(cout_observer.get());
+        std::cerr.rdbuf(cerr_observer.get());
+        std::clog.rdbuf(clog_observer.get());
     }
+
+    ~OutputObservers() noexcept {
+        try {
+            std::cout.flush();
+            std::cerr.flush();
+            std::clog.flush();
+        } catch (...) {
+        }
+        std::cout.rdbuf(cout_original);
+        std::cerr.rdbuf(cerr_original);
+        std::clog.rdbuf(clog_original);
+    }
+
+    std::streambuf* cout_original{};
+    std::streambuf* cerr_original{};
+    std::streambuf* clog_original{};
+    std::unique_ptr<CountingStreambuf> cout_observer;
+    std::unique_ptr<CountingStreambuf> cerr_observer;
+    std::unique_ptr<CountingStreambuf> clog_observer;
+};
+
+std::string render(const Snapshot& snapshot, const Format format) {
+    if (format == Format::disabled) return {};
 
     std::ostringstream output;
     output.imbue(std::locale::classic());
 
     if (format == Format::json) {
+        const Evidence& evidence = snapshot.evidence;
         output << std::fixed << std::setprecision(3)
-               << "{\"type\":\"mqb.timings\",\"schema_version\":1,\"unit\":\"ms\",\"phases\":{"
+               << "{\"type\":\"mqb.timings\",\"schema_version\":2,\"unit\":\"ms\",\"phases\":{"
                << "\"discovery\":" << milliseconds(snapshot.discovery) << ','
                << "\"dependency_scan\":" << milliseconds(snapshot.target.dependency_scan) << ','
                << "\"compile_queue\":" << milliseconds(snapshot.target.compile_queue) << ','
@@ -48,7 +267,56 @@ std::string render(const Snapshot& snapshot, const Format format) {
                << "\"link\":{\"hits\":" << snapshot.cache.link_hits
                << ",\"misses\":" << snapshot.cache.link_misses << "},"
                << "\"archive\":{\"hits\":" << snapshot.cache.archive_hits
-               << ",\"misses\":" << snapshot.cache.archive_misses << "}}}\n";
+               << ",\"misses\":" << snapshot.cache.archive_misses << "}},"
+               << "\"attribution\":{\"wall\":{"
+               ;
+        append_json_durations(output, wall_names, evidence.wall);
+        output << "},\"work\":{"
+               << "\"filesystem_snapshot\":"
+               << milliseconds(filesystem_work_total(evidence));
+        if (!work_names.empty()) output << ',';
+        append_json_durations(output, work_names, evidence.work);
+        output << "}},\"counters\":{"
+               << "\"cache_files_opened\":" << sum(evidence.cache_files_opened) << ','
+               << "\"cache_bytes_read\":" << sum(evidence.cache_bytes_read) << ','
+               << "\"cache_files_written\":" << sum(evidence.cache_files_written) << ','
+               << "\"cache_bytes_written\":" << sum(evidence.cache_bytes_written) << ','
+               << "\"filesystem_snapshot_requests\":"
+               << sum(evidence.filesystem_snapshot_requests) << ','
+               << "\"unique_filesystem_paths_probed\":"
+               << evidence.unique_filesystem_paths_total << ','
+               << "\"snapshot_evidence_reuses\":"
+               << sum(evidence.snapshot_evidence_reuses) << ','
+               << "\"background_threads_created\":"
+               << evidence.background_threads_created << ','
+               << "\"cl_processes_launched\":"
+               << evidence.processes_launched[
+                      static_cast<std::size_t>(mqb::performance::ProcessKind::compiler)] << ','
+               << "\"link_processes_launched\":"
+               << evidence.processes_launched[
+                      static_cast<std::size_t>(mqb::performance::ProcessKind::linker)] << ','
+               << "\"lib_processes_launched\":"
+               << evidence.processes_launched[
+                      static_cast<std::size_t>(mqb::performance::ProcessKind::librarian)] << ','
+               << "\"output_lines_emitted\":" << evidence.output_lines_emitted << ','
+               << "\"output_bytes_emitted\":" << evidence.output_bytes_emitted
+               << "},\"counter_breakdown\":{\"cache\":{"
+               ;
+        append_json_cache_breakdown(output, evidence);
+        output << "},\"filesystem\":{"
+               ;
+        append_json_filesystem_breakdown(output, evidence);
+        output << "},\"process\":{"
+               << "\"compiler\":"
+               << evidence.processes_launched[
+                      static_cast<std::size_t>(mqb::performance::ProcessKind::compiler)] << ','
+               << "\"linker\":"
+               << evidence.processes_launched[
+                      static_cast<std::size_t>(mqb::performance::ProcessKind::linker)] << ','
+               << "\"librarian\":"
+               << evidence.processes_launched[
+                      static_cast<std::size_t>(mqb::performance::ProcessKind::librarian)]
+               << "}}}\n";
         return output.str();
     }
 
@@ -61,18 +329,70 @@ std::string render(const Snapshot& snapshot, const Format format) {
     append_text_phase(output, "archive", snapshot.target.archive);
     append_text_phase(output, "run-startup", snapshot.run_startup);
     append_text_phase(output, "total", snapshot.total);
-    output << "  cache             compile " << snapshot.cache.compile_hits << " hit / "
+    output << "  cache                         compile "
+           << snapshot.cache.compile_hits << " hit / "
            << snapshot.cache.compile_misses << " miss; link "
            << snapshot.cache.link_hits << " hit / " << snapshot.cache.link_misses
            << " miss; archive " << snapshot.cache.archive_hits << " hit / "
            << snapshot.cache.archive_misses << " miss\n";
+
+    output << "[attribution wall]\n";
+    for (std::size_t index = 0; index < wall_names.size(); ++index) {
+        append_text_phase(output, wall_names[index], snapshot.evidence.wall[index]);
+    }
+    output << "[attribution cumulative work]\n";
+    append_text_phase(
+        output,
+        "filesystem_snapshot",
+        filesystem_work_total(snapshot.evidence));
+    for (std::size_t index = 0; index < work_names.size(); ++index) {
+        append_text_phase(output, work_names[index], snapshot.evidence.work[index]);
+    }
+    output << "[counters]\n"
+           << "  cache files opened:           "
+           << sum(snapshot.evidence.cache_files_opened) << '\n'
+           << "  cache bytes read:             "
+           << sum(snapshot.evidence.cache_bytes_read) << '\n'
+           << "  filesystem snapshot requests: "
+           << sum(snapshot.evidence.filesystem_snapshot_requests) << '\n'
+           << "  unique filesystem paths:      "
+           << snapshot.evidence.unique_filesystem_paths_total << '\n'
+           << "  snapshot evidence reuses:     "
+           << sum(snapshot.evidence.snapshot_evidence_reuses) << '\n'
+           << "  background threads created:   "
+           << snapshot.evidence.background_threads_created << '\n'
+           << "  cl/link/lib launches:         "
+           << snapshot.evidence.processes_launched[0] << '/'
+           << snapshot.evidence.processes_launched[1] << '/'
+           << snapshot.evidence.processes_launched[2] << '\n'
+           << "  output lines/bytes:           "
+           << snapshot.evidence.output_lines_emitted << '/'
+           << snapshot.evidence.output_bytes_emitted << '\n';
     return output.str();
 }
 
-Session::~Session() noexcept {
-    if (format_ == Format::disabled) {
-        return;
+Session::Session(
+    const Format format,
+    const Clock::time_point application_started) noexcept
+    : format_(format), application_started_(application_started) {
+    if (format_ == Format::disabled) return;
+    try {
+        activation_ = std::make_unique<mqb::performance::Activation>(evidence_);
+        output_observers_ = std::make_unique<OutputObservers>(evidence_);
+    } catch (...) {
+        output_observers_.reset();
+        activation_.reset();
+        format_ = Format::disabled;
     }
+}
+
+Session::~Session() noexcept {
+    if (format_ == Format::disabled) return;
+
+    // Restore streams and deactivate observation before rendering. The timing
+    // record itself is therefore excluded from reporting and output counters.
+    output_observers_.reset();
+    activation_.reset();
     try {
         std::clog << render(snapshot(), format_) << std::flush;
     } catch (...) {
@@ -93,27 +413,18 @@ void Session::add_target(const orchestration::TargetTimings& timings) noexcept {
 }
 
 void Session::record_compile(const bool compiled) noexcept {
-    if (compiled) {
-        ++accumulated_.cache.compile_misses;
-    } else {
-        ++accumulated_.cache.compile_hits;
-    }
+    if (compiled) ++accumulated_.cache.compile_misses;
+    else ++accumulated_.cache.compile_hits;
 }
 
 void Session::record_link(const bool linked) noexcept {
-    if (linked) {
-        ++accumulated_.cache.link_misses;
-    } else {
-        ++accumulated_.cache.link_hits;
-    }
+    if (linked) ++accumulated_.cache.link_misses;
+    else ++accumulated_.cache.link_hits;
 }
 
 void Session::record_archive(const bool archived) noexcept {
-    if (archived) {
-        ++accumulated_.cache.archive_misses;
-    } else {
-        ++accumulated_.cache.archive_hits;
-    }
+    if (archived) ++accumulated_.cache.archive_misses;
+    else ++accumulated_.cache.archive_hits;
 }
 
 void Session::record_run_startup(const std::chrono::nanoseconds duration) noexcept {
@@ -124,6 +435,7 @@ Snapshot Session::snapshot(const Clock::time_point now) const noexcept {
     Snapshot result = accumulated_;
     result.total = std::chrono::duration_cast<std::chrono::nanoseconds>(
         now - application_started_);
+    result.evidence = evidence_.snapshot();
     return result;
 }
 

--- a/cpp/src/app/diagnostics/PerformanceTimings.hpp
+++ b/cpp/src/app/diagnostics/PerformanceTimings.hpp
@@ -2,8 +2,10 @@
 
 #include <chrono>
 #include <cstddef>
+#include <memory>
 #include <string>
 
+#include "mqb/core/PerformanceEvidence.hpp"
 #include "mqb/orchestration/TargetTimings.hpp"
 
 namespace mqb::app::performance {
@@ -31,6 +33,7 @@ struct Snapshot {
     std::chrono::nanoseconds run_startup{};
     std::chrono::nanoseconds total{};
     CacheCounters cache;
+    mqb::performance::EvidenceSnapshot evidence;
 };
 
 [[nodiscard]] std::string render(const Snapshot& snapshot, Format format);
@@ -39,8 +42,7 @@ class Session {
 public:
     explicit Session(
         Format format,
-        Clock::time_point application_started = Clock::now()) noexcept
-        : format_(format), application_started_(application_started) {}
+        Clock::time_point application_started = Clock::now()) noexcept;
 
     ~Session() noexcept;
 
@@ -58,9 +60,14 @@ public:
         Clock::time_point now = Clock::now()) const noexcept;
 
 private:
+    struct OutputObservers;
+
     Format format_{Format::disabled};
     Clock::time_point application_started_{};
     Snapshot accumulated_;
+    mqb::performance::Collector evidence_;
+    std::unique_ptr<mqb::performance::Activation> activation_;
+    std::unique_ptr<OutputObservers> output_observers_;
 };
 
 } // namespace mqb::app::performance

--- a/cpp/src/app/project/ProjectSetup.cpp
+++ b/cpp/src/app/project/ProjectSetup.cpp
@@ -8,6 +8,7 @@
 #include <utility>
 #include <vector>
 
+#include "mqb/core/PerformanceEvidence.hpp"
 #include "mqb/msvc/MsvcDefaultLibraryPolicy.hpp"
 #include "mqb/msvc/MsvcParameterEngine.hpp"
 
@@ -207,6 +208,8 @@ std::expected<ProjectSetup, ProjectSetupError>
 prepare_project(
     mqb::cli::Options& options,
     const std::filesystem::path& invocation_directory) {
+    mqb::performance::ScopedWall evidence{
+        mqb::performance::WallKind::project_setup};
     std::optional<mqb::config::ProjectConfig> project_config;
     auto located_config = mqb::config::ProjectConfigLoader::find_upwards(invocation_directory);
     if (!located_config) {

--- a/cpp/src/core/cache/ArchiveCacheFile.cpp
+++ b/cpp/src/core/cache/ArchiveCacheFile.cpp
@@ -14,6 +14,8 @@
 #include <utility>
 #include <vector>
 
+#include "mqb/core/PerformanceEvidence.hpp"
+
 namespace mqb {
 namespace {
 
@@ -53,6 +55,8 @@ constexpr std::size_t max_objects = 100000u;
 
 std::expected<std::optional<ArchiveCacheEntry>, ArchiveCacheFileError>
 ArchiveCacheFile::load(const fs::path& file) {
+    mqb::performance::ScopedCacheRead evidence{
+        mqb::performance::CacheKind::archive};
     std::error_code ec;
     if (!fs::exists(file, ec)) {
         if (ec) return std::unexpected(error(
@@ -60,9 +64,18 @@ ArchiveCacheFile::load(const fs::path& file) {
         return std::optional<ArchiveCacheEntry>{};
     }
 
-    std::ifstream stream{file, std::ios::binary};
+    std::ifstream stream{file, std::ios::binary | std::ios::ate};
     if (!stream) return std::unexpected(error(
         ArchiveCacheFileErrorCode::file_open_failed, file, "failed to open archive cache file"));
+    const std::streampos end = stream.tellg();
+    const std::uint64_t size = end == std::streampos{-1}
+        ? 0u
+        : static_cast<std::uint64_t>(static_cast<std::streamoff>(end));
+    stream.clear();
+    stream.seekg(0, std::ios::beg);
+    if (!stream) return std::unexpected(error(
+        ArchiveCacheFileErrorCode::file_open_failed, file, "failed to seek archive cache file"));
+    evidence.opened(size);
 
     std::string loaded_magic;
     unsigned int version = 0;
@@ -131,6 +144,8 @@ ArchiveCacheFile::load(const fs::path& file) {
 
 std::expected<void, ArchiveCacheFileError>
 ArchiveCacheFile::save(const fs::path& file, const ArchiveCacheEntry& entry) {
+    mqb::performance::ScopedCacheWrite evidence{
+        mqb::performance::CacheKind::archive};
     if (entry.objects.size() > max_objects) {
         return std::unexpected(error(
             ArchiveCacheFileErrorCode::file_write_failed, file, "archive cache object count exceeds safety limit"));
@@ -148,6 +163,7 @@ ArchiveCacheFile::save(const fs::path& file, const ArchiveCacheEntry& entry) {
         std::ofstream stream{temporary, std::ios::binary | std::ios::trunc};
         if (!stream) return std::unexpected(error(
             ArchiveCacheFileErrorCode::file_open_failed, temporary, "failed to open temporary archive cache"));
+        evidence.opened(0);
         stream << magic << ' ' << format_version << '\n'
                << std::quoted(path_to_utf8(entry.librarian.librarian)) << '\n'
                << std::quoted(entry.librarian.version) << '\n'

--- a/cpp/src/core/cache/CompileCacheFile.cpp
+++ b/cpp/src/core/cache/CompileCacheFile.cpp
@@ -21,6 +21,7 @@
 #include "mqb/core/Artifact.hpp"
 #include "mqb/core/BuildSignature.hpp"
 #include "mqb/core/FileSnapshot.hpp"
+#include "mqb/core/PerformanceEvidence.hpp"
 #include "mqb/core/ToolchainIdentity.hpp"
 #include "mqb/core/TranslationUnit.hpp"
 
@@ -521,6 +522,8 @@ deserialize(const fs::path& file, const std::span<const std::uint8_t> bytes) {
 
 std::expected<std::optional<CompileCacheEntry>, CompileCacheFileError>
 CompileCacheFile::load(const fs::path& file) {
+    mqb::performance::ScopedCacheRead evidence{
+        mqb::performance::CacheKind::compile};
     std::error_code error_code;
     const bool exists = fs::exists(file, error_code);
     if (error_code) {
@@ -556,6 +559,7 @@ CompileCacheFile::load(const fs::path& file) {
             0,
             "failed to open cache file"));
     }
+    evidence.opened(static_cast<std::uint64_t>(size));
     std::vector<std::uint8_t> bytes(static_cast<std::size_t>(size));
     if (!bytes.empty()) {
         stream.read(
@@ -577,6 +581,8 @@ CompileCacheFile::load(const fs::path& file) {
 
 std::expected<void, CompileCacheFileError>
 CompileCacheFile::save(const fs::path& file, const CompileCacheEntry& entry) {
+    mqb::performance::ScopedCacheWrite evidence{
+        mqb::performance::CacheKind::compile};
     auto bytes = serialize(file, entry);
     if (!bytes) return std::unexpected(bytes.error());
 
@@ -602,6 +608,7 @@ CompileCacheFile::save(const fs::path& file, const CompileCacheEntry& entry) {
                 0,
                 "failed to open temporary cache file for writing"));
         }
+        evidence.opened(static_cast<std::uint64_t>(bytes->size()));
         if (!bytes->empty()) {
             stream.write(
                 reinterpret_cast<const char*>(bytes->data()),

--- a/cpp/src/core/cache/LinkCacheFile.cpp
+++ b/cpp/src/core/cache/LinkCacheFile.cpp
@@ -17,6 +17,7 @@
 
 #include "mqb/core/BuildSignature.hpp"
 #include "mqb/core/LinkerIdentity.hpp"
+#include "mqb/core/PerformanceEvidence.hpp"
 
 namespace mqb {
 namespace {
@@ -367,6 +368,8 @@ deserialize(const fs::path& file, const std::span<const std::uint8_t> bytes) {
 
 std::expected<std::optional<LinkCacheEntry>, LinkCacheFileError>
 LinkCacheFile::load(const fs::path& file) {
+    mqb::performance::ScopedCacheRead evidence{
+        mqb::performance::CacheKind::link};
     std::error_code error_code;
     const bool exists = fs::exists(file, error_code);
     if (error_code) {
@@ -392,6 +395,7 @@ LinkCacheFile::load(const fs::path& file) {
         return std::unexpected(make_error(
             LinkCacheFileErrorCode::file_open_failed, file, 0, "failed to open link cache file"));
     }
+    evidence.opened(static_cast<std::uint64_t>(size));
 
     std::vector<std::uint8_t> bytes(static_cast<std::size_t>(size));
     if (!bytes.empty()) {
@@ -412,6 +416,8 @@ LinkCacheFile::load(const fs::path& file) {
 
 std::expected<void, LinkCacheFileError>
 LinkCacheFile::save(const fs::path& file, const LinkCacheEntry& entry) {
+    mqb::performance::ScopedCacheWrite evidence{
+        mqb::performance::CacheKind::link};
     auto bytes = serialize(file, entry);
     if (!bytes) return std::unexpected(bytes.error());
 
@@ -434,6 +440,7 @@ LinkCacheFile::save(const fs::path& file, const LinkCacheEntry& entry) {
                 0,
                 "failed to open temporary link cache file"));
         }
+        evidence.opened(static_cast<std::uint64_t>(bytes->size()));
         if (!bytes->empty()) {
             stream.write(
                 reinterpret_cast<const char*>(bytes->data()),

--- a/cpp/src/core/planning/ProjectArtifactLayout.cpp
+++ b/cpp/src/core/planning/ProjectArtifactLayout.cpp
@@ -8,6 +8,7 @@
 #include <string_view>
 #include <utility>
 
+#include "mqb/core/PerformanceEvidence.hpp"
 #include "mqb/platform/windows/PathIdentity.hpp"
 
 namespace mqb {
@@ -178,6 +179,8 @@ namespace fs = std::filesystem;
 
 std::expected<ProjectArtifactLayout, ArtifactLayoutError>
 ProjectArtifactLayout::create(fs::path project_root) {
+    mqb::performance::ScopedWall evidence{
+        mqb::performance::WallKind::artifact_layout};
     if (project_root.empty()) {
         return std::unexpected(failure(
             ArtifactLayoutErrorCode::empty_project_root,
@@ -193,6 +196,8 @@ ProjectArtifactLayout::create(fs::path project_root) {
 
 std::expected<SourceArtifacts, ArtifactLayoutError>
 ProjectArtifactLayout::for_source(const fs::path& source) const {
+    mqb::performance::ScopedWall evidence{
+        mqb::performance::WallKind::artifact_layout};
     if (source.empty()) {
         return std::unexpected(failure(
             ArtifactLayoutErrorCode::empty_source,
@@ -223,6 +228,8 @@ ProjectArtifactLayout::for_precompiled_header(
     const std::string_view target_name,
     const BuildConfiguration configuration,
     const Architecture architecture) const {
+    mqb::performance::ScopedWall evidence{
+        mqb::performance::WallKind::artifact_layout};
     const fs::path target_path = path_from_utf8(target_name);
     if (!valid_target_name(target_name)) {
         return std::unexpected(failure(
@@ -248,6 +255,8 @@ std::expected<TargetArtifacts, ArtifactLayoutError>
 ProjectArtifactLayout::for_target(
     const std::string_view target_name,
     const TargetKind target_kind) const {
+    mqb::performance::ScopedWall evidence{
+        mqb::performance::WallKind::artifact_layout};
     const fs::path target_path = path_from_utf8(target_name);
     if (!valid_target_name(target_name)) {
         return std::unexpected(failure(

--- a/cpp/src/discovery/cache/DiscoveryCache.cpp
+++ b/cpp/src/discovery/cache/DiscoveryCache.cpp
@@ -17,6 +17,8 @@
 #include <utility>
 #include <vector>
 
+#include "mqb/core/PerformanceEvidence.hpp"
+
 namespace mqb::discovery::detail {
 namespace {
 
@@ -313,6 +315,9 @@ private:
 [[nodiscard]] bool snapshot_matches(
     const FileSnapshot& snapshot,
     const bool directory) noexcept {
+    mqb::performance::ScopedFilesystemProbe evidence{
+        snapshot.path,
+        mqb::performance::FilesystemKind::discovery};
     std::error_code error_code;
     const auto status = fs::status(snapshot.path, error_code);
     if (error_code) return false;
@@ -341,6 +346,8 @@ private:
 }
 
 [[nodiscard]] std::optional<DiscoveryCacheRecord> load_record(const fs::path& file) {
+    mqb::performance::ScopedCacheRead evidence{
+        mqb::performance::CacheKind::discovery};
     std::error_code error_code;
     if (!fs::is_regular_file(file, error_code) || error_code) return std::nullopt;
     const auto size = fs::file_size(file, error_code);
@@ -348,6 +355,7 @@ private:
 
     std::ifstream stream{file, std::ios::binary};
     if (!stream) return std::nullopt;
+    evidence.opened(static_cast<std::uint64_t>(size));
     std::vector<std::uint8_t> bytes(static_cast<std::size_t>(size));
     if (!bytes.empty()) {
         stream.read(
@@ -379,6 +387,8 @@ std::optional<Result> try_reuse_discovery_cache(
 void save_discovery_cache_best_effort(
     const fs::path& cache_file,
     const DiscoveryCacheRecord& record) noexcept {
+    mqb::performance::ScopedCacheWrite evidence{
+        mqb::performance::CacheKind::discovery};
     try {
         auto bytes = serialize(record);
         if (!bytes) return;
@@ -393,6 +403,7 @@ void save_discovery_cache_best_effort(
         {
             std::ofstream stream{temporary, std::ios::binary | std::ios::trunc};
             if (!stream) return;
+            evidence.opened(static_cast<std::uint64_t>(bytes->size()));
             if (!bytes->empty()) {
                 stream.write(
                     reinterpret_cast<const char*>(bytes->data()),

--- a/cpp/src/discovery/indexing/SourceIndex.cpp
+++ b/cpp/src/discovery/indexing/SourceIndex.cpp
@@ -7,6 +7,7 @@
 #include <system_error>
 #include <utility>
 
+#include "mqb/core/PerformanceEvidence.hpp"
 #include "mqb/core/TranslationUnitClassifier.hpp"
 #include "DiscoveryPath.hpp"
 
@@ -44,6 +45,9 @@ read_text(const fs::path& path) {
 [[nodiscard]] std::optional<FileSnapshot> snapshot_path(
     const fs::path& path,
     const bool directory) {
+    mqb::performance::ScopedFilesystemProbe evidence{
+        path,
+        mqb::performance::FilesystemKind::discovery};
     std::error_code error_code;
     const auto status = fs::status(path, error_code);
     if (error_code) return std::nullopt;

--- a/cpp/src/msvc/linker/MsvcLibraryResolver.cpp
+++ b/cpp/src/msvc/linker/MsvcLibraryResolver.cpp
@@ -11,6 +11,7 @@
 #include <utility>
 #include <vector>
 
+#include "mqb/core/PerformanceEvidence.hpp"
 #include "mqb/platform/windows/PathIdentity.hpp"
 
 namespace mqb::msvc {
@@ -182,6 +183,9 @@ void add_search_directory(
     }
 
     std::error_code error_code;
+    mqb::performance::ScopedFilesystemProbe seal_evidence{
+        observation_seal_file,
+        mqb::performance::FilesystemKind::link};
     const auto sealed = fs::last_write_time(observation_seal_file, error_code);
     if (error_code) {
         return true;
@@ -189,6 +193,9 @@ void add_search_directory(
 
     for (const auto& directory : search_directories) {
         error_code.clear();
+        mqb::performance::ScopedFilesystemProbe directory_evidence{
+            directory,
+            mqb::performance::FilesystemKind::link};
         const auto modified = fs::last_write_time(directory, error_code);
         // Missing/inaccessible search roots need the conservative path. A root
         // can become available later and introduce a higher-priority library.
@@ -200,6 +207,9 @@ void add_search_directory(
 }
 
 [[nodiscard]] bool regular_file(const fs::path& path) {
+    mqb::performance::ScopedFilesystemProbe evidence{
+        path,
+        mqb::performance::FilesystemKind::link};
     std::error_code error_code;
     return fs::is_regular_file(path, error_code) && !error_code;
 }
@@ -290,6 +300,8 @@ MsvcLibraryResolver::resolve(
     const MsvcToolchain& toolchain,
     const LinkOptions& options,
     const fs::path& requested_working_directory) {
+    mqb::performance::ScopedWork evidence{
+        mqb::performance::WorkKind::link_resolution};
     return resolve_requests(
         toolchain,
         options.libraries,
@@ -304,6 +316,8 @@ MsvcLibraryResolver::resolve_available(
     const std::span<const std::string> libraries,
     const std::span<const fs::path> library_directories,
     const fs::path& requested_working_directory) {
+    mqb::performance::ScopedWork evidence{
+        mqb::performance::WorkKind::link_resolution};
     return resolve_requests(
         toolchain,
         libraries,
@@ -319,6 +333,8 @@ MsvcLibraryResolver::refresh_observed(
     const std::span<const fs::path> library_directories,
     const fs::path& requested_working_directory,
     const fs::path& observation_seal_file) {
+    mqb::performance::ScopedWork evidence{
+        mqb::performance::WorkKind::link_resolution};
     auto working_directory = resolve_working_directory(requested_working_directory);
     if (!working_directory) {
         return std::unexpected(working_directory.error());

--- a/cpp/src/msvc/toolchain/MsvcToolchainLocator.cpp
+++ b/cpp/src/msvc/toolchain/MsvcToolchainLocator.cpp
@@ -8,6 +8,7 @@
 #include "ToolchainDiscoveryPrimitives.hpp"
 #include "VisualStudioToolchainCache.hpp"
 #include "VisualStudioToolchainDiscovery.hpp"
+#include "mqb/core/PerformanceEvidence.hpp"
 #include "mqb/msvc/MsvcToolchainEnvironmentIdentity.hpp"
 
 namespace mqb::msvc {
@@ -16,6 +17,10 @@ namespace fs = std::filesystem;
 
 std::expected<MsvcToolchain, ToolchainError>
 MsvcToolchainLocator::discover(const DiscoveryOptions& options) const {
+    mqb::performance::ScopedWall evidence{
+        mqb::performance::WallKind::toolchain_discovery};
+    mqb::performance::ScopedFilesystemDomain filesystem_domain{
+        mqb::performance::FilesystemKind::toolchain};
     if (options.preference != ToolchainPreference::visual_studio) {
         for (const auto& portable_root : options.portable_roots) {
             std::error_code error_code;

--- a/cpp/src/msvc/toolchain/VisualStudioToolchainCache.cpp
+++ b/cpp/src/msvc/toolchain/VisualStudioToolchainCache.cpp
@@ -16,6 +16,7 @@
 
 #include "ToolchainDiscoveryPrimitives.hpp"
 #include "VisualStudioToolchainDiscovery.hpp"
+#include "mqb/core/PerformanceEvidence.hpp"
 #include "mqb/msvc/MsvcToolchainEnvironmentIdentity.hpp"
 #include "mqb/platform/windows/PathIdentity.hpp"
 
@@ -316,6 +317,8 @@ void append_unique_existing_root(std::vector<fs::path>& roots, fs::path root) {
 [[nodiscard]] std::optional<MsvcToolchain> try_reuse_visual_studio_cache(
     const fs::path& cache_file,
     const DiscoveryOptions& options) {
+    mqb::performance::ScopedCacheRead evidence{
+        mqb::performance::CacheKind::toolchain};
     try {
         std::error_code error_code;
         if (!fs::is_regular_file(cache_file, error_code) || error_code) return std::nullopt;
@@ -327,6 +330,7 @@ void append_unique_existing_root(std::vector<fs::path>& roots, fs::path root) {
         if (modified > now || now - modified > max_cache_age) return std::nullopt;
         std::ifstream stream{cache_file, std::ios::binary};
         if (!stream) return std::nullopt;
+        evidence.opened(static_cast<std::uint64_t>(size));
         auto record = read_record(stream);
         if (!record || !cache_key_matches(*record, options) || record->binary_stamp.empty()) return std::nullopt;
 
@@ -378,6 +382,8 @@ void save_visual_studio_cache_best_effort(
     const fs::path& cache_file,
     const DiscoveryOptions& options,
     const MsvcToolchain& toolchain) noexcept {
+    mqb::performance::ScopedCacheWrite evidence{
+        mqb::performance::CacheKind::toolchain};
     try {
         if (toolchain.source != ToolchainSource::visual_studio || toolchain.reused) return;
         const fs::path root = stable_path(toolchain.vc_tools_root);
@@ -411,7 +417,11 @@ void save_visual_studio_cache_best_effort(
         temporary += ".tmp." + std::to_string(std::chrono::steady_clock::now().time_since_epoch().count());
         {
             std::ofstream stream{temporary, std::ios::binary | std::ios::trunc};
-            if (!stream || !write_record(stream, record)) {
+            if (!stream) {
+                return;
+            }
+            evidence.opened(0);
+            if (!write_record(stream, record)) {
                 stream.close();
                 fs::remove(temporary, error_code);
                 return;

--- a/cpp/src/orchestration/incremental/IncrementalFileSnapshot.hpp
+++ b/cpp/src/orchestration/incremental/IncrementalFileSnapshot.hpp
@@ -5,6 +5,7 @@
 #include <system_error>
 
 #include "mqb/core/FileSnapshot.hpp"
+#include "mqb/core/PerformanceEvidence.hpp"
 
 namespace mqb::orchestration::detail {
 
@@ -40,6 +41,7 @@ struct IncrementalFileSnapshotResult {
         return missing_file_snapshot(path);
     }
 
+    mqb::performance::ScopedFilesystemProbe evidence{path};
     std::error_code error_code;
     const fs::file_status status = fs::status(path, error_code);
     if (error_code) {
@@ -93,6 +95,8 @@ struct IncrementalFileSnapshotResult {
     if (path.empty()) {
         return missing_file_snapshot(path);
     }
+
+    mqb::performance::ScopedFilesystemProbe evidence{path};
 
     // Compile-cache dependencies intentionally admit both regular files and
     // directories, and FileSnapshot identity is existence + last-write time.

--- a/cpp/src/orchestration/incremental/MsvcIncrementalArchiveCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalArchiveCoordinator.cpp
@@ -13,6 +13,7 @@
 #include "mqb/core/BuildPlanner.hpp"
 #include "mqb/core/BuildSignature.hpp"
 #include "mqb/core/FileSnapshot.hpp"
+#include "mqb/core/PerformanceEvidence.hpp"
 
 #include "IncrementalFileSnapshot.hpp"
 
@@ -62,6 +63,10 @@ void snapshot_inputs(
 inspect_archive(
     const IncrementalArchiveRequest& request,
     const msvc::MsvcToolchain& toolchain) {
+    mqb::performance::ScopedWork evidence{
+        mqb::performance::WorkKind::archive_inspection};
+    mqb::performance::ScopedFilesystemDomain filesystem_domain{
+        mqb::performance::FilesystemKind::archive};
     ArchiveInspectionState state;
 
     auto librarian_identity = msvc::MsvcLibrarian::identity(toolchain);

--- a/cpp/src/orchestration/incremental/MsvcIncrementalCompileCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalCompileCoordinator.cpp
@@ -13,6 +13,7 @@
 #include "mqb/core/BuildPlanner.hpp"
 #include "mqb/core/CompileCache.hpp"
 #include "mqb/core/CompileCacheFile.hpp"
+#include "mqb/core/PerformanceEvidence.hpp"
 #include "mqb/msvc/MsvcCompileExecutor.hpp"
 #include "mqb/msvc/MsvcIncludeSearchFreshness.hpp"
 #include "mqb/msvc/MsvcSourceDependenciesReader.hpp"
@@ -88,6 +89,8 @@ void seal_module_scan_evidence(
     const IncrementalCompileRequest& request,
     const msvc::MsvcToolchain& toolchain,
     std::vector<IncrementalCompileWarning>& warnings) {
+    mqb::performance::ScopedFilesystemDomain filesystem_domain{
+        mqb::performance::FilesystemKind::module_scan};
     if (!request.module_scan_output) {
         return;
     }
@@ -160,6 +163,10 @@ void seal_module_scan_evidence(
 
 std::expected<IncrementalCompileInspection, IncrementalCompileError>
 MsvcIncrementalCompileCoordinator::inspect(const IncrementalCompileRequest& request) const {
+    mqb::performance::ScopedWork evidence{
+        mqb::performance::WorkKind::compile_inspection};
+    mqb::performance::ScopedFilesystemDomain filesystem_domain{
+        mqb::performance::FilesystemKind::compile};
     IncrementalCompileInspection result;
 
     // An upstream coordinator may already own the invalidation decision (for

--- a/cpp/src/orchestration/incremental/MsvcIncrementalLinkCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalLinkCoordinator.cpp
@@ -15,6 +15,7 @@
 #include "mqb/core/FileSnapshot.hpp"
 #include "mqb/core/LinkCache.hpp"
 #include "mqb/core/LinkCacheFile.hpp"
+#include "mqb/core/PerformanceEvidence.hpp"
 #include "mqb/msvc/MsvcAddressSanitizerPolicy.hpp"
 #include "mqb/msvc/MsvcBaseAddressPolicy.hpp"
 #include "mqb/msvc/MsvcDefaultLibraryPolicy.hpp"
@@ -174,6 +175,10 @@ void collect_existing_side_output(
 inspect_link(
     const IncrementalLinkRequest& request,
     const msvc::MsvcToolchain& toolchain) {
+    mqb::performance::ScopedWork evidence{
+        mqb::performance::WorkKind::link_inspection};
+    mqb::performance::ScopedFilesystemDomain filesystem_domain{
+        mqb::performance::FilesystemKind::link};
     LinkInspectionState state;
 
     auto linker_identity = msvc::MsvcLinker::identity(toolchain);

--- a/cpp/src/orchestration/incremental/MsvcIncrementalStaticTargetCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalStaticTargetCoordinator.cpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "mqb/core/Artifact.hpp"
+#include "mqb/core/PerformanceEvidence.hpp"
 #include "mqb/core/TranslationUnit.hpp"
 #include "mqb/orchestration/BoundedWorkScheduler.hpp"
 #include "mqb/platform/windows/PathIdentity.hpp"
@@ -61,6 +62,8 @@ using PathIdentitySet = std::unordered_set<std::string>;
 
 std::expected<IncrementalStaticTargetResult, IncrementalStaticTargetError>
 MsvcIncrementalStaticTargetCoordinator::run(const IncrementalStaticTargetRequest& request) const {
+    mqb::performance::ScopedWall validation_evidence{
+        mqb::performance::WallKind::target_validation};
     if (request.sources.empty()) {
         return std::unexpected(failure(
             IncrementalStaticTargetErrorCode::no_sources,
@@ -125,6 +128,7 @@ MsvcIncrementalStaticTargetCoordinator::run(const IncrementalStaticTargetRequest
     std::vector<std::optional<CompileAttempt>> attempts(request.sources.size());
     timings.compile_queue = std::chrono::duration_cast<std::chrono::nanoseconds>(
         Clock::now() - queue_started);
+    validation_evidence.finish();
 
     const auto compile_started = Clock::now();
     const auto scheduled = BoundedWorkScheduler::run(

--- a/cpp/src/orchestration/incremental/MsvcIncrementalTargetCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalTargetCoordinator.cpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "mqb/core/Artifact.hpp"
+#include "mqb/core/PerformanceEvidence.hpp"
 #include "mqb/core/TranslationUnit.hpp"
 #include "mqb/msvc/MsvcAddressSanitizerPolicy.hpp"
 #include "mqb/msvc/MsvcFuzzerPolicy.hpp"
@@ -68,6 +69,8 @@ using PathIdentitySet = std::unordered_set<std::string>;
 
 std::expected<IncrementalTargetResult, IncrementalTargetError>
 MsvcIncrementalTargetCoordinator::run(const IncrementalTargetRequest& request) const {
+    mqb::performance::ScopedWall validation_evidence{
+        mqb::performance::WallKind::target_validation};
     if (request.sources.empty()) {
         return std::unexpected(failure(
             IncrementalTargetErrorCode::no_sources,
@@ -132,6 +135,7 @@ MsvcIncrementalTargetCoordinator::run(const IncrementalTargetRequest& request) c
     std::vector<std::optional<CompileAttempt>> attempts(request.sources.size());
     timings.compile_queue = std::chrono::duration_cast<std::chrono::nanoseconds>(
         Clock::now() - queue_started);
+    validation_evidence.finish();
 
     const auto compile_started = Clock::now();
     const auto scheduled = BoundedWorkScheduler::run(

--- a/cpp/src/orchestration/modules/ModuleTargetPreparation.cpp
+++ b/cpp/src/orchestration/modules/ModuleTargetPreparation.cpp
@@ -11,6 +11,7 @@
 #include "ModuleTargetArtifactRegistry.hpp"
 #include "ModuleTargetScanner.hpp"
 #include "StandardLibraryModuleProvider.hpp"
+#include "mqb/core/PerformanceEvidence.hpp"
 #include "mqb/modules/ModuleDependencyGraph.hpp"
 
 namespace mqb::orchestration::detail {
@@ -45,6 +46,8 @@ using Clock = std::chrono::steady_clock;
 
 [[nodiscard]] std::expected<void, IncrementalModuleTargetError>
 validate_request(const IncrementalModuleTargetRequest& request) {
+    mqb::performance::ScopedWall evidence{
+        mqb::performance::WallKind::target_validation};
     if (request.sources.empty()) {
         return std::unexpected(failure(
             IncrementalModuleTargetErrorCode::no_sources,
@@ -60,6 +63,8 @@ validate_request(const IncrementalModuleTargetRequest& request) {
 
 [[nodiscard]] std::expected<ModuleTargetArtifactRegistry, IncrementalModuleTargetError>
 register_requested_artifacts(const IncrementalModuleTargetRequest& request) {
+    mqb::performance::ScopedWall evidence{
+        mqb::performance::WallKind::target_validation};
     ModuleTargetArtifactRegistry artifacts{request.sources.size()};
     for (const auto& source : request.sources) {
         if (auto registered = artifacts.add_requested_source(source); !registered) {
@@ -78,6 +83,8 @@ finish_preparation(
     ModuleTargetArtifactRegistry& artifacts,
     std::vector<modules::ScannedModuleUnit> scanned_units,
     std::vector<ModuleCompileSourceRequest> compile_sources) {
+    mqb::performance::ScopedWall evidence{
+        mqb::performance::WallKind::target_validation};
     auto plan = modules::ModuleDependencyGraphBuilder::build(
         scanned_units,
         request.compiler_options.external_module_providers);

--- a/cpp/src/orchestration/modules/MsvcIncrementalModuleScanCoordinator.cpp
+++ b/cpp/src/orchestration/modules/MsvcIncrementalModuleScanCoordinator.cpp
@@ -15,6 +15,7 @@
 #include "mqb/core/CompileCache.hpp"
 #include "mqb/core/CompileCacheFile.hpp"
 #include "mqb/core/FileSnapshot.hpp"
+#include "mqb/core/PerformanceEvidence.hpp"
 #include "mqb/msvc/MsvcIncludeSearchFreshness.hpp"
 #include "mqb/platform/windows/PathIdentity.hpp"
 
@@ -67,6 +68,9 @@ void add_reason(
 [[nodiscard]] std::optional<FileSnapshot> snapshot_regular_file(
     const fs::path& path) {
     if (path.empty()) return std::nullopt;
+    mqb::performance::ScopedFilesystemProbe evidence{
+        path,
+        mqb::performance::FilesystemKind::module_scan};
     std::error_code error_code;
     const auto status = fs::status(path, error_code);
     if (error_code || !fs::is_regular_file(status)) return std::nullopt;
@@ -82,6 +86,9 @@ void add_reason(
 [[nodiscard]] std::optional<FileSnapshot> snapshot_file_or_directory(
     const fs::path& path) {
     if (path.empty()) return std::nullopt;
+    mqb::performance::ScopedFilesystemProbe evidence{
+        path,
+        mqb::performance::FilesystemKind::module_scan};
     std::error_code error_code;
     const auto modified = fs::last_write_time(path, error_code);
     if (error_code) return std::nullopt;

--- a/cpp/src/orchestration/scheduling/BoundedWorkScheduler.cpp
+++ b/cpp/src/orchestration/scheduling/BoundedWorkScheduler.cpp
@@ -9,6 +9,8 @@
 #include <utility>
 #include <vector>
 
+#include "mqb/core/PerformanceEvidence.hpp"
+
 namespace mqb::orchestration {
 namespace {
 
@@ -109,6 +111,7 @@ BoundedWorkScheduler::run(
     background_workers.reserve(worker_count - 1);
     for (std::size_t worker_index = 1; worker_index < worker_count; ++worker_index) {
         background_workers.emplace_back(worker_loop);
+        mqb::performance::record_background_threads(1);
     }
 
     worker_loop();

--- a/cpp/src/platform/windows/WindowsProcessRunner.cpp
+++ b/cpp/src/platform/windows/WindowsProcessRunner.cpp
@@ -19,6 +19,7 @@
 #include <utility>
 #include <vector>
 
+#include "mqb/core/PerformanceEvidence.hpp"
 #include "mqb/platform/windows/CommandLine.hpp"
 
 namespace mqb::platform::windows {
@@ -478,6 +479,58 @@ void read_pipe(HANDLE handle, std::string& output, std::optional<DWORD>& read_er
     }
 }
 
+[[nodiscard]] bool ascii_starts_with_ignore_case(
+    const std::string_view value,
+    const std::string_view prefix) noexcept {
+    if (value.size() < prefix.size()) return false;
+    for (std::size_t index = 0; index < prefix.size(); ++index) {
+        unsigned char left = static_cast<unsigned char>(value[index]);
+        unsigned char right = static_cast<unsigned char>(prefix[index]);
+        if (left >= 'A' && left <= 'Z') left = static_cast<unsigned char>(left + ('a' - 'A'));
+        if (right >= 'A' && right <= 'Z') right = static_cast<unsigned char>(right + ('a' - 'A'));
+        if (left != right) return false;
+    }
+    return true;
+}
+
+struct InstrumentedProcess {
+    mqb::performance::ProcessKind process_kind;
+    mqb::performance::WorkKind work_kind;
+};
+
+[[nodiscard]] std::optional<InstrumentedProcess> classify_instrumented_process(
+    const process::ProcessSpec& spec) {
+    const std::string executable =
+        mqb::platform::windows::path_identity_key(spec.executable.filename());
+    if (executable == "link.exe") {
+        return InstrumentedProcess{
+            .process_kind = mqb::performance::ProcessKind::linker,
+            .work_kind = mqb::performance::WorkKind::link_execution,
+        };
+    }
+    if (executable == "lib.exe") {
+        return InstrumentedProcess{
+            .process_kind = mqb::performance::ProcessKind::librarian,
+            .work_kind = mqb::performance::WorkKind::archive_execution,
+        };
+    }
+    if (executable != "cl.exe") return std::nullopt;
+
+    const bool dependency_scan = std::any_of(
+        spec.arguments.begin(),
+        spec.arguments.end(),
+        [](const std::string& argument) {
+            return ascii_starts_with_ignore_case(argument, "/scanDependencies")
+                || ascii_starts_with_ignore_case(argument, "-scanDependencies");
+        });
+    return InstrumentedProcess{
+        .process_kind = mqb::performance::ProcessKind::compiler,
+        .work_kind = dependency_scan
+            ? mqb::performance::WorkKind::module_scan_execution
+            : mqb::performance::WorkKind::compile_execution,
+    };
+}
+
 } // namespace
 
 std::expected<process::ProcessResult, process::ProcessError>
@@ -605,6 +658,12 @@ WindowsProcessRunner::run(const process::ProcessSpec& spec) {
         startup = &extended_startup.StartupInfo;
     }
 
+    const auto instrumented_process = classify_instrumented_process(spec);
+    std::optional<mqb::performance::ScopedWork> execution_evidence;
+    if (mqb::performance::current_collector() != nullptr && instrumented_process) {
+        execution_evidence.emplace(instrumented_process->work_kind);
+    }
+
     PROCESS_INFORMATION process_info{};
     const auto launch_started = std::chrono::steady_clock::now();
     const BOOL created = ::CreateProcessW(
@@ -625,6 +684,10 @@ WindowsProcessRunner::run(const process::ProcessSpec& spec) {
             ProcessErrorCode::launch_failed,
             ::GetLastError(),
             "CreateProcessW failed"));
+    }
+    if (instrumented_process) {
+        mqb::performance::record_process_launch(
+            instrumented_process->process_kind);
     }
 
     UniqueHandle process_handle{process_info.hProcess};

--- a/docs/PERFORMANCE_GOVERNANCE.md
+++ b/docs/PERFORMANCE_GOVERNANCE.md
@@ -73,3 +73,14 @@ Structural performance tests remain useful when they prove deterministic propert
 ## Benchmark evolution
 
 When a new optimization targets a scenario not represented by the standard harness, add a deterministic fixture/scenario to `benchmark_mqb.ps1` and make the comparator consume it automatically. Additional scenarios may extend the evidence set, but the standard scenarios are an append-only compatibility floor: do not remove an existing core scenario merely because a new optimization does not improve it.
+
+## Attributable timing schema v2 and paired execution
+
+`--timings=json` schema version 2 preserves the complete schema-v1 `phases` and `cache` objects and appends two different attribution classes:
+
+- `attribution.wall` contains wall-clock intervals such as project setup, artifact layout, toolchain discovery, target validation, and CLI reporting;
+- `attribution.work` contains cumulative work that may overlap across parallel translation units, including inspection, execution, cache I/O, link resolution, and filesystem snapshots. These values must not be summed into a 100% wall-clock breakdown.
+
+The record also appends deterministic counters and per-domain breakdowns for cache opens/bytes, filesystem snapshot requests/unique paths/reuses, background-thread creation, MSVC process launches, and emitted output. The final timing record is emitted only after the output observer is detached, so it does not count itself as reporting output.
+
+Performance comparison now uses alternating paired execution (`baseline -> candidate`, then `candidate -> baseline`, repeated) and reports the median paired delta, paired MAD, and nearest-rank paired P95. Standard scenarios remain append-only; the contract additionally includes 129-TU common-header warm builds, automatic versus `-j 1`, and timings-enabled versus timings-disabled no-op builds.

--- a/docs/PERFORMANCE_GOVERNANCE_ZH.md
+++ b/docs/PERFORMANCE_GOVERNANCE_ZH.md
@@ -73,3 +73,14 @@ Structural performance test 仍然有价值，例如它们可以证明“warm mo
 ## Benchmark 演进
 
 当新优化针对标准 harness 尚未覆盖的场景时，应向 `benchmark_mqb.ps1` 增加 deterministic fixture/scenario，并让 comparator 自动消费它。额外 scenario 可以扩展 evidence set，但标准 scenario 是 append-only compatibility floor：不能仅仅因为一个新优化没有改善某个旧核心场景，就把该场景从标准集合中删除。
+
+## 可归因 timing schema v2 与配对执行
+
+`--timings=json` schema v2 完整保留 schema v1 的 `phases` 与 `cache` 对象，并增量增加两类不可混淆的归因数据：
+
+- `attribution.wall` 是 project setup、artifact layout、toolchain discovery、target validation、CLI reporting 等墙钟区间；
+- `attribution.work` 是可在多个 TU 间并行重叠的累计工作量，包括 inspection、execution、cache I/O、link resolution 与 filesystem snapshot。不得把这些字段相加成总和为 100% 的墙钟占比。
+
+记录同时增加确定性总计数器和按域 breakdown：cache 打开次数/读取字节、filesystem snapshot 请求/唯一路径/证据复用、后台线程创建、MSVC 进程启动及输出行数/字节数。最终 timing 记录会在输出 observer 脱离后再写出，因此不会把自身计入 reporting 和 output counters。
+
+性能比较改为交替配对执行（`baseline -> candidate`、`candidate -> baseline`，循环重复），报告 paired delta 中位数、paired MAD 和 nearest-rank paired P95。标准场景保持 append-only，并新增 129-TU 公共头 warm build、automatic 与 `-j 1`、timings enabled/disabled no-op 场景。

--- a/tests/native/benchmark_mqb.ps1
+++ b/tests/native/benchmark_mqb.ps1
@@ -52,6 +52,9 @@ function Invoke-TimedMqb {
     }
 
     $timing = $timingLine | ConvertFrom-Json
+    $attribution = if ($null -ne $timing.PSObject.Properties['attribution']) { $timing.attribution } else { $null }
+    $counters = if ($null -ne $timing.PSObject.Properties['counters']) { $timing.counters } else { $null }
+    $counterBreakdown = if ($null -ne $timing.PSObject.Properties['counter_breakdown']) { $timing.counter_breakdown } else { $null }
     return [PSCustomObject]@{
         iteration = $Iteration
         scenario = $Scenario
@@ -69,6 +72,63 @@ function Invoke-TimedMqb {
         link_misses = [int]$timing.cache.link.misses
         archive_hits = [int]$timing.cache.archive.hits
         archive_misses = [int]$timing.cache.archive.misses
+        measurement_source = 'mqb.timings'
+        timing_schema_version = [int]$timing.schema_version
+        attribution = $attribution
+        counters = $counters
+        counter_breakdown = $counterBreakdown
+    }
+}
+
+function Invoke-UntimedMqb {
+    param(
+        [Parameter(Mandatory = $true)][string]$Scenario,
+        [Parameter(Mandatory = $true)][int]$Iteration,
+        [Parameter(Mandatory = $true)][string]$WorkingDirectory,
+        [Parameter(Mandatory = $true)][string[]]$Arguments
+    )
+
+    $stopwatch = [Diagnostics.Stopwatch]::StartNew()
+    Push-Location $WorkingDirectory
+    try {
+        $output = @(& $MqbPath @Arguments 2>&1)
+        $exitCode = $LASTEXITCODE
+    }
+    finally {
+        Pop-Location
+        $stopwatch.Stop()
+    }
+    if ($exitCode -ne 0) {
+        foreach ($line in $output) { Write-Host $line }
+        throw "Benchmark scenario '$Scenario' failed with exit code $exitCode"
+    }
+    $timingLine = @($output | ForEach-Object { [string]$_ } |
+        Where-Object { $_ -like '{"type":"mqb.timings"*' })
+    if ($timingLine.Count -ne 0) {
+        throw "Benchmark scenario '$Scenario' unexpectedly emitted timing JSON"
+    }
+    return [PSCustomObject]@{
+        iteration = $Iteration
+        scenario = $Scenario
+        total_ms = [double]$stopwatch.Elapsed.TotalMilliseconds
+        discovery_ms = 0.0
+        dependency_scan_ms = 0.0
+        compile_queue_ms = 0.0
+        compile_ms = 0.0
+        link_ms = 0.0
+        archive_ms = 0.0
+        run_startup_ms = 0.0
+        compile_hits = -1
+        compile_misses = -1
+        link_hits = -1
+        link_misses = -1
+        archive_hits = -1
+        archive_misses = -1
+        measurement_source = 'external_stopwatch'
+        timing_schema_version = 0
+        attribution = $null
+        counters = $null
+        counter_breakdown = $null
     }
 }
 
@@ -133,9 +193,10 @@ int main() { return helper_value() == shared_value() + 2 ? 0 : 1; }
         $results.Add((Invoke-TimedMqb -Scenario 'build-run' -Iteration $iteration -WorkingDirectory $ordinaryRoot -Arguments ($ordinaryArgs + @('--run'))))
         $results.Add((Invoke-TimedMqb -Scenario 'link-only' -Iteration $iteration -WorkingDirectory $ordinaryRoot -Arguments ($ordinaryArgs + @('--linker-arg', '/MAP'))))
 
-        # Scale fixture for target setup/validation. All source and artifact
-        # identities are unique, so the compile_queue phase exposes how target
-        # registration grows without mixing in duplicate-error handling.
+        # Preserve the historical scale fixture: unique source/artifact identities
+        # and no shared header dependency. This keeps target-scale-* comparable
+        # with earlier performance evidence while the dedicated fixture below
+        # measures dependency-occurrence amplification.
         $targetScaleRoot = Join-Path $benchmarkRoot "target-scale-$iteration"
         New-Item -ItemType Directory -Path $targetScaleRoot | Out-Null
         Set-Content -LiteralPath (Join-Path $targetScaleRoot 'main.cpp') -Encoding utf8 -Value @'
@@ -161,11 +222,47 @@ int main() { return 0; }
         Assert-CompileCacheCounts -Sample $targetScaleNoOp -ExpectedHits $targetScaleUnitCount -ExpectedMisses 0
         $results.Add($targetScaleNoOp)
 
+        $targetScaleAuto = Invoke-TimedMqb -Scenario 'target-scale-no-op-auto' -Iteration $iteration -WorkingDirectory $targetScaleRoot -Arguments ($targetScaleArguments + @('-j', 'auto'))
+        Assert-CompileCacheCounts -Sample $targetScaleAuto -ExpectedHits $targetScaleUnitCount -ExpectedMisses 0
+        $results.Add($targetScaleAuto)
+
+        $targetScaleJ1 = Invoke-TimedMqb -Scenario 'target-scale-no-op-j1' -Iteration $iteration -WorkingDirectory $targetScaleRoot -Arguments ($targetScaleArguments + @('-j', '1'))
+        Assert-CompileCacheCounts -Sample $targetScaleJ1 -ExpectedHits $targetScaleUnitCount -ExpectedMisses 0
+        $results.Add($targetScaleJ1)
+
         $lastScaleSource = 'unit_{0:D3}.cpp' -f ($TargetScaleSourceCount - 1)
         Add-Content -LiteralPath (Join-Path $targetScaleRoot $lastScaleSource) -Encoding utf8 -Value "// target-scale mutation $iteration"
         $targetScaleSingle = Invoke-TimedMqb -Scenario 'target-scale-single-tu' -Iteration $iteration -WorkingDirectory $targetScaleRoot -Arguments $targetScaleArguments
         Assert-CompileCacheCounts -Sample $targetScaleSingle -ExpectedHits ($targetScaleUnitCount - 1) -ExpectedMisses 1
         $results.Add($targetScaleSingle)
+
+        # Dedicated 129-TU common-header fixture. It retains the same target size
+        # while making repeated dependency evidence visible independently of the
+        # historical unique-source scale scenarios above.
+        $commonHeaderRoot = Join-Path $benchmarkRoot "target-scale-common-header-$iteration"
+        New-Item -ItemType Directory -Path $commonHeaderRoot | Out-Null
+        Set-Content -LiteralPath (Join-Path $commonHeaderRoot 'common.hpp') -Encoding utf8 -Value @'
+#pragma once
+inline int target_scale_common() { return 1; }
+'@
+        Set-Content -LiteralPath (Join-Path $commonHeaderRoot 'main.cpp') -Encoding utf8 -Value @'
+#include "common.hpp"
+int main() { return target_scale_common() == 1 ? 0 : 1; }
+'@
+        $commonHeaderArgs = [System.Collections.Generic.List[string]]::new()
+        $commonHeaderArgs.Add('main.cpp')
+        for ($sourceIndex = 0; $sourceIndex -lt $TargetScaleSourceCount; ++$sourceIndex) {
+            $sourceName = 'unit_{0:D3}.cpp' -f $sourceIndex
+            Set-Content -LiteralPath (Join-Path $commonHeaderRoot $sourceName) -Encoding utf8 -Value "#include `"common.hpp`"`nint target_scale_common_${sourceIndex}() { return target_scale_common() + $sourceIndex; }"
+            $commonHeaderArgs.Add($sourceName)
+        }
+        $commonHeaderArgs.Add('--output')
+        $commonHeaderArgs.Add('target_scale_common_header_bench')
+        $commonHeaderArguments = $commonHeaderArgs.ToArray()
+        $null = Invoke-UntimedMqb -Scenario 'target-scale-common-header-prime' -Iteration $iteration -WorkingDirectory $commonHeaderRoot -Arguments ($commonHeaderArguments + @('-j', 'auto'))
+        $targetScaleCommonHeader = Invoke-TimedMqb -Scenario 'target-scale-common-header-no-op' -Iteration $iteration -WorkingDirectory $commonHeaderRoot -Arguments ($commonHeaderArguments + @('-j', 'auto'))
+        Assert-CompileCacheCounts -Sample $targetScaleCommonHeader -ExpectedHits $targetScaleUnitCount -ExpectedMisses 0
+        $results.Add($targetScaleCommonHeader)
 
         # Dedicated smart-discovery fixture. Only the entry TU is passed to MQB;
         # helper.cpp must be found through the shared local header graph. The
@@ -191,6 +288,15 @@ int main() { return helper_value() == 42 ? 0 : 1; }
 
         Add-Content -LiteralPath (Join-Path $discoveryRoot 'src/common.hpp') -Encoding utf8 -Value "// discovery invalidation $iteration"
         $results.Add((Invoke-TimedMqb -Scenario 'discovery-header' -Iteration $iteration -WorkingDirectory $discoveryRoot -Arguments $discoveryArgs))
+
+        $timingRoot = Join-Path $benchmarkRoot "timings-$iteration"
+        New-Item -ItemType Directory -Path $timingRoot | Out-Null
+        Set-Content -LiteralPath (Join-Path $timingRoot 'helper.cpp') -Encoding utf8 -Value 'int timing_helper() { return 42; }'
+        Set-Content -LiteralPath (Join-Path $timingRoot 'main.cpp') -Encoding utf8 -Value 'int timing_helper(); int main() { return timing_helper() == 42 ? 0 : 1; }'
+        $timingArgs = @('main.cpp', 'helper.cpp', '--output', 'timing_bench', '-j', '1')
+        $null = Invoke-UntimedMqb -Scenario 'timings-prime' -Iteration $iteration -WorkingDirectory $timingRoot -Arguments $timingArgs
+        $results.Add((Invoke-TimedMqb -Scenario 'timings-enabled-no-op' -Iteration $iteration -WorkingDirectory $timingRoot -Arguments $timingArgs))
+        $results.Add((Invoke-UntimedMqb -Scenario 'timings-disabled-no-op' -Iteration $iteration -WorkingDirectory $timingRoot -Arguments $timingArgs))
 
         $moduleRoot = Join-Path $benchmarkRoot "modules-$iteration"
         New-Item -ItemType Directory -Path $moduleRoot | Out-Null
@@ -244,7 +350,7 @@ if (-not [string]::IsNullOrWhiteSpace($OutputPath)) {
         New-Item -ItemType Directory -Path $parent -Force | Out-Null
     }
     [PSCustomObject]@{
-        schema_version = 2
+        schema_version = 3
         generated_utc = [DateTime]::UtcNow.ToString('o')
         mqb = $MqbPath
         iterations = $Iterations

--- a/tests/native/compare_mqb_benchmarks.ps1
+++ b/tests/native/compare_mqb_benchmarks.ps1
@@ -2,7 +2,7 @@
 param(
     [Parameter(Mandatory = $true)][string]$BaselineMqbPath,
     [Parameter(Mandatory = $true)][string]$CandidateMqbPath,
-    [ValidateRange(1, 20)][int]$Iterations = 5,
+    [ValidateRange(1, 20)][int]$Iterations = 4,
     [string]$OutputPath
 )
 
@@ -18,17 +18,50 @@ $RequiredScenarios = @(
     'link-only',
     'target-scale-cold',
     'target-scale-no-op',
+    'target-scale-no-op-auto',
+    'target-scale-no-op-j1',
+    'target-scale-common-header-no-op',
     'target-scale-single-tu',
     'discovery-cold',
     'discovery-no-op',
     'discovery-header',
     'modules-cold',
-    'modules-no-op'
+    'modules-no-op',
+    'timings-enabled-no-op',
+    'timings-disabled-no-op'
 )
 
 function Get-FullPath {
     param([Parameter(Mandatory = $true)][string]$Path)
     return [System.IO.Path]::GetFullPath($Path)
+}
+
+function Get-Median {
+    param([Parameter(Mandatory = $true)][double[]]$Values)
+    if ($Values.Count -eq 0) { return $null }
+    $sorted = @($Values | Sort-Object)
+    $middle = [int][Math]::Floor($sorted.Count / 2)
+    if (($sorted.Count % 2) -eq 0) {
+        return ($sorted[$middle - 1] + $sorted[$middle]) / 2.0
+    }
+    return $sorted[$middle]
+}
+
+function Get-Mad {
+    param([Parameter(Mandatory = $true)][double[]]$Values)
+    $median = Get-Median -Values $Values
+    if ($null -eq $median) { return $null }
+    $deviations = @($Values | ForEach-Object { [Math]::Abs([double]$_ - [double]$median) })
+    return Get-Median -Values $deviations
+}
+
+function Get-P95 {
+    param([Parameter(Mandatory = $true)][double[]]$Values)
+    if ($Values.Count -eq 0) { return $null }
+    $sorted = @($Values | Sort-Object)
+    $rank = [Math]::Ceiling(0.95 * $sorted.Count)
+    $index = [Math]::Max(0, [int]$rank - 1)
+    return [double]$sorted[$index]
 }
 
 function Get-DeltaPercent {
@@ -40,34 +73,30 @@ function Get-DeltaPercent {
     return (($Candidate - $Baseline) / $Baseline) * 100.0
 }
 
+function Round-Nullable {
+    param($Value, [int]$Digits = 3)
+    if ($null -eq $Value) { return $null }
+    return [Math]::Round([double]$Value, $Digits)
+}
+
 function Assert-BenchmarkContract {
     param(
         [Parameter(Mandatory = $true)][string]$Label,
-        [Parameter(Mandatory = $true)]$Report,
-        [Parameter(Mandatory = $true)][int]$ExpectedIterations
+        [Parameter(Mandatory = $true)]$Report
     )
 
-    if ([int]$Report.schema_version -lt 2) {
-        throw "$Label benchmark schema is too old: expected schema_version >= 2, got $($Report.schema_version)"
+    if ([int]$Report.schema_version -lt 3) {
+        throw "$Label benchmark schema is too old: expected schema_version >= 3, got $($Report.schema_version)"
     }
-    if ([int]$Report.iterations -ne $ExpectedIterations) {
-        throw "$Label benchmark iteration contract mismatch: expected $ExpectedIterations, got $($Report.iterations)"
-    }
-
-    $summaryRows = @($Report.summary)
-    $sampleRows = @($Report.samples)
-    if ($summaryRows.Count -eq 0) {
-        throw "$Label benchmark produced no summary rows"
+    if ([int]$Report.iterations -ne 1) {
+        throw "$Label paired benchmark invocation must contain exactly one fixture iteration"
     }
 
     $summaryByScenario = @{}
-    foreach ($row in $summaryRows) {
+    foreach ($row in @($Report.summary)) {
         $scenario = [string]$row.scenario
-        if ([string]::IsNullOrWhiteSpace($scenario)) {
-            throw "$Label benchmark contains a summary row with an empty scenario name"
-        }
-        if ($summaryByScenario.ContainsKey($scenario)) {
-            throw "$Label benchmark contains duplicate summary scenario '$scenario'"
+        if ([string]::IsNullOrWhiteSpace($scenario) -or $summaryByScenario.ContainsKey($scenario)) {
+            throw "$Label benchmark contains an empty or duplicate summary scenario '$scenario'"
         }
         $summaryByScenario[$scenario] = $row
     }
@@ -76,36 +105,45 @@ function Assert-BenchmarkContract {
         if (-not $summaryByScenario.ContainsKey($scenario)) {
             throw "$Label benchmark is missing required scenario '$scenario'"
         }
-
-        $summaryRow = $summaryByScenario[$scenario]
-        $summarySamples = [int]$summaryRow.samples
-        if ($summarySamples -ne $ExpectedIterations) {
-            throw "$Label benchmark scenario '$scenario' summary has $summarySamples samples; expected $ExpectedIterations"
+        $samples = @($Report.samples | Where-Object { [string]$_.scenario -eq $scenario })
+        if ($samples.Count -ne 1) {
+            throw "$Label benchmark scenario '$scenario' has $($samples.Count) raw samples; expected 1"
         }
-        if ($null -eq $summaryRow.PSObject.Properties['median_compile_queue_ms']) {
-            throw "$Label benchmark scenario '$scenario' summary is missing median_compile_queue_ms"
-        }
-
-        $rawSamples = @($sampleRows | Where-Object { [string]$_.scenario -eq $scenario })
-        if ($rawSamples.Count -ne $ExpectedIterations) {
-            throw "$Label benchmark scenario '$scenario' has $($rawSamples.Count) raw samples; expected $ExpectedIterations"
-        }
-        foreach ($sample in $rawSamples) {
-            if ($null -eq $sample.PSObject.Properties['compile_queue_ms']) {
-                throw "$Label benchmark scenario '$scenario' contains a raw sample without compile_queue_ms"
-            }
-        }
-
-        $iterationsSeen = @($rawSamples | ForEach-Object { [int]$_.iteration } | Sort-Object -Unique)
-        if ($iterationsSeen.Count -ne $ExpectedIterations) {
-            throw "$Label benchmark scenario '$scenario' does not contain one distinct sample for every iteration"
-        }
-        for ($iteration = 1; $iteration -le $ExpectedIterations; ++$iteration) {
-            if ($iteration -notin $iterationsSeen) {
-                throw "$Label benchmark scenario '$scenario' is missing iteration $iteration"
+        foreach ($property in @('total_ms', 'discovery_ms', 'compile_queue_ms', 'measurement_source')) {
+            if ($null -eq $samples[0].PSObject.Properties[$property]) {
+                throw "$Label benchmark scenario '$scenario' is missing '$property'"
             }
         }
     }
+}
+
+function Invoke-OneReport {
+    param(
+        [Parameter(Mandatory = $true)][string]$Label,
+        [Parameter(Mandatory = $true)][string]$MqbPath,
+        [Parameter(Mandatory = $true)][string]$Path
+    )
+
+    Write-Host "=== $Label ==="
+    & $benchmarkScript -MqbPath $MqbPath -Iterations 1 -OutputPath $Path | Out-Host
+    if ($LASTEXITCODE -notin @(0, $null)) {
+        throw "$Label failed with exit code $LASTEXITCODE"
+    }
+    $report = Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json
+    Assert-BenchmarkContract -Label $Label -Report $report
+    return $report
+}
+
+function Get-SampleByScenario {
+    param(
+        [Parameter(Mandatory = $true)]$Report,
+        [Parameter(Mandatory = $true)][string]$Scenario
+    )
+    $matches = @($Report.samples | Where-Object { [string]$_.scenario -eq $Scenario })
+    if ($matches.Count -ne 1) {
+        throw "Scenario '$Scenario' did not resolve to exactly one sample"
+    }
+    return $matches[0]
 }
 
 $BaselineMqbPath = Get-FullPath $BaselineMqbPath
@@ -124,82 +162,90 @@ if (-not (Test-Path -LiteralPath $benchmarkScript -PathType Leaf)) {
     throw "Benchmark harness not found: $benchmarkScript"
 }
 
-$tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("mqb-benchmark-compare-" + [Guid]::NewGuid().ToString('N'))
+$tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("mqb-benchmark-paired-" + [Guid]::NewGuid().ToString('N'))
 New-Item -ItemType Directory -Path $tempRoot | Out-Null
-$baselineJson = Join-Path $tempRoot 'baseline.json'
-$candidateJson = Join-Path $tempRoot 'candidate.json'
+$pairs = [System.Collections.Generic.List[object]]::new()
+$executionOrder = [System.Collections.Generic.List[string]]::new()
 
 try {
-    Write-Host '=== Baseline MQB benchmark ==='
-    & $benchmarkScript -MqbPath $BaselineMqbPath -Iterations $Iterations -OutputPath $baselineJson
-    if ($LASTEXITCODE -notin @(0, $null)) {
-        throw "Baseline benchmark failed with exit code $LASTEXITCODE"
-    }
+    for ($pairIndex = 1; $pairIndex -le $Iterations; ++$pairIndex) {
+        $baselinePath = Join-Path $tempRoot "pair-$pairIndex-baseline.json"
+        $candidatePath = Join-Path $tempRoot "pair-$pairIndex-candidate.json"
+        $baselineFirst = ($pairIndex % 2) -eq 1
+        $orientation = if ($baselineFirst) { 'baseline-candidate' } else { 'candidate-baseline' }
+        $executionOrder.Add($orientation)
 
-    Write-Host "`n=== Candidate MQB benchmark ==="
-    & $benchmarkScript -MqbPath $CandidateMqbPath -Iterations $Iterations -OutputPath $candidateJson
-    if ($LASTEXITCODE -notin @(0, $null)) {
-        throw "Candidate benchmark failed with exit code $LASTEXITCODE"
-    }
+        if ($baselineFirst) {
+            $baseline = Invoke-OneReport -Label "Pair $pairIndex baseline" -MqbPath $BaselineMqbPath -Path $baselinePath
+            $candidate = Invoke-OneReport -Label "Pair $pairIndex candidate" -MqbPath $CandidateMqbPath -Path $candidatePath
+        }
+        else {
+            $candidate = Invoke-OneReport -Label "Pair $pairIndex candidate" -MqbPath $CandidateMqbPath -Path $candidatePath
+            $baseline = Invoke-OneReport -Label "Pair $pairIndex baseline" -MqbPath $BaselineMqbPath -Path $baselinePath
+        }
 
-    $baseline = Get-Content -LiteralPath $baselineJson -Raw | ConvertFrom-Json
-    $candidate = Get-Content -LiteralPath $candidateJson -Raw | ConvertFrom-Json
+        foreach ($scenario in $RequiredScenarios) {
+            $baseSample = Get-SampleByScenario -Report $baseline -Scenario $scenario
+            $candidateSample = Get-SampleByScenario -Report $candidate -Scenario $scenario
+            $baseTotal = [double]$baseSample.total_ms
+            $candidateTotal = [double]$candidateSample.total_ms
+            $baseDiscovery = [double]$baseSample.discovery_ms
+            $candidateDiscovery = [double]$candidateSample.discovery_ms
+            $baseQueue = [double]$baseSample.compile_queue_ms
+            $candidateQueue = [double]$candidateSample.compile_queue_ms
 
-    Assert-BenchmarkContract -Label 'Baseline' -Report $baseline -ExpectedIterations $Iterations
-    Assert-BenchmarkContract -Label 'Candidate' -Report $candidate -ExpectedIterations $Iterations
-
-    $candidateByScenario = @{}
-    foreach ($row in @($candidate.summary)) {
-        $candidateByScenario[[string]$row.scenario] = $row
+            $pairs.Add([PSCustomObject]@{
+                pair = $pairIndex
+                orientation = $orientation
+                scenario = $scenario
+                baseline_total_ms = $baseTotal
+                candidate_total_ms = $candidateTotal
+                total_delta_ms = $candidateTotal - $baseTotal
+                total_delta_pct = Get-DeltaPercent -Baseline $baseTotal -Candidate $candidateTotal
+                baseline_discovery_ms = $baseDiscovery
+                candidate_discovery_ms = $candidateDiscovery
+                discovery_delta_ms = $candidateDiscovery - $baseDiscovery
+                baseline_compile_queue_ms = $baseQueue
+                candidate_compile_queue_ms = $candidateQueue
+                compile_queue_delta_ms = $candidateQueue - $baseQueue
+                baseline = $baseSample
+                candidate = $candidateSample
+            })
+        }
     }
 
     $comparison = @(
-        foreach ($baselineRow in @($baseline.summary)) {
-            $scenario = [string]$baselineRow.scenario
-            if (-not $candidateByScenario.ContainsKey($scenario)) {
-                throw "Candidate benchmark is missing scenario '$scenario'"
-            }
-            $candidateRow = $candidateByScenario[$scenario]
-            $baselineTotal = [double]$baselineRow.median_total_ms
-            $candidateTotal = [double]$candidateRow.median_total_ms
-            $baselineDiscovery = [double]$baselineRow.median_discovery_ms
-            $candidateDiscovery = [double]$candidateRow.median_discovery_ms
-            $baselineCompileQueue = [double]$baselineRow.median_compile_queue_ms
-            $candidateCompileQueue = [double]$candidateRow.median_compile_queue_ms
-            $totalDeltaPct = Get-DeltaPercent -Baseline $baselineTotal -Candidate $candidateTotal
-            $discoveryDeltaPct = Get-DeltaPercent -Baseline $baselineDiscovery -Candidate $candidateDiscovery
-            $compileQueueDeltaPct = Get-DeltaPercent -Baseline $baselineCompileQueue -Candidate $candidateCompileQueue
+        foreach ($scenario in $RequiredScenarios) {
+            $scenarioPairs = @($pairs | Where-Object { [string]$_.scenario -eq $scenario } | Sort-Object pair)
+            $baseTotals = [double[]]@($scenarioPairs | ForEach-Object { [double]$_.baseline_total_ms })
+            $candidateTotals = [double[]]@($scenarioPairs | ForEach-Object { [double]$_.candidate_total_ms })
+            $totalDeltas = [double[]]@($scenarioPairs | ForEach-Object { [double]$_.total_delta_ms })
+            $totalDeltaPcts = [double[]]@($scenarioPairs | Where-Object { $null -ne $_.total_delta_pct } | ForEach-Object { [double]$_.total_delta_pct })
+            $discoveryDeltas = [double[]]@($scenarioPairs | ForEach-Object { [double]$_.discovery_delta_ms })
+            $queueDeltas = [double[]]@($scenarioPairs | ForEach-Object { [double]$_.compile_queue_delta_ms })
 
             [PSCustomObject]@{
                 scenario = $scenario
-                baseline_total_ms = [Math]::Round($baselineTotal, 3)
-                candidate_total_ms = [Math]::Round($candidateTotal, 3)
-                total_delta_ms = [Math]::Round(($candidateTotal - $baselineTotal), 3)
-                total_delta_pct = if ($null -eq $totalDeltaPct) { $null } else { [Math]::Round($totalDeltaPct, 2) }
-                baseline_discovery_ms = [Math]::Round($baselineDiscovery, 3)
-                candidate_discovery_ms = [Math]::Round($candidateDiscovery, 3)
-                discovery_delta_ms = [Math]::Round(($candidateDiscovery - $baselineDiscovery), 3)
-                discovery_delta_pct = if ($null -eq $discoveryDeltaPct) { $null } else { [Math]::Round($discoveryDeltaPct, 2) }
-                baseline_compile_queue_ms = [Math]::Round($baselineCompileQueue, 3)
-                candidate_compile_queue_ms = [Math]::Round($candidateCompileQueue, 3)
-                compile_queue_delta_ms = [Math]::Round(($candidateCompileQueue - $baselineCompileQueue), 3)
-                compile_queue_delta_pct = if ($null -eq $compileQueueDeltaPct) { $null } else { [Math]::Round($compileQueueDeltaPct, 2) }
+                pairs = $scenarioPairs.Count
+                baseline_median_total_ms = Round-Nullable (Get-Median -Values $baseTotals)
+                candidate_median_total_ms = Round-Nullable (Get-Median -Values $candidateTotals)
+                paired_median_total_delta_ms = Round-Nullable (Get-Median -Values $totalDeltas)
+                paired_mad_total_delta_ms = Round-Nullable (Get-Mad -Values $totalDeltas)
+                paired_p95_total_delta_ms = Round-Nullable (Get-P95 -Values $totalDeltas)
+                paired_median_total_delta_pct = Round-Nullable -Value (Get-Median -Values $totalDeltaPcts) -Digits 2
+                paired_median_discovery_delta_ms = Round-Nullable (Get-Median -Values $discoveryDeltas)
+                paired_mad_discovery_delta_ms = Round-Nullable (Get-Mad -Values $discoveryDeltas)
+                paired_p95_discovery_delta_ms = Round-Nullable (Get-P95 -Values $discoveryDeltas)
+                paired_median_compile_queue_delta_ms = Round-Nullable (Get-Median -Values $queueDeltas)
+                paired_mad_compile_queue_delta_ms = Round-Nullable (Get-Mad -Values $queueDeltas)
+                paired_p95_compile_queue_delta_ms = Round-Nullable (Get-P95 -Values $queueDeltas)
             }
         }
     )
 
-    $extraCandidateScenarios = @(
-        $candidateByScenario.Keys | Where-Object {
-            $_ -notin @($baseline.summary | ForEach-Object { [string]$_.scenario })
-        }
-    )
-    if ($extraCandidateScenarios.Count -ne 0) {
-        throw "Candidate benchmark has scenarios absent from baseline: $($extraCandidateScenarios -join ', ')"
-    }
-
-    Write-Host "`n=== Median wall-clock comparison ==="
-    $comparison | Sort-Object scenario | Format-Table -AutoSize
-    Write-Host 'Negative deltas mean the candidate is faster. Timings are review evidence, not CI pass/fail thresholds.'
+    Write-Host "`n=== Paired ABBA comparison ==="
+    $comparison | Format-Table -AutoSize
+    Write-Host 'Negative deltas mean the candidate is faster. P95 is the nearest-rank upper-tail paired delta.'
 
     if (-not [string]::IsNullOrWhiteSpace($OutputPath)) {
         $parent = Split-Path -Parent $OutputPath
@@ -207,16 +253,18 @@ try {
             New-Item -ItemType Directory -Path $parent -Force | Out-Null
         }
         [PSCustomObject]@{
-            schema_version = 2
+            schema_version = 3
             generated_utc = [DateTime]::UtcNow.ToString('o')
-            iterations = $Iterations
+            pair_count = $Iterations
+            pairing = 'alternating baseline-candidate / candidate-baseline'
+            p95_method = 'nearest-rank'
+            execution_order = $executionOrder
             required_scenarios = $RequiredScenarios
             baseline_mqb = $BaselineMqbPath
             candidate_mqb = $CandidateMqbPath
-            comparison = @($comparison | Sort-Object scenario)
-            baseline = $baseline
-            candidate = $candidate
-        } | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath $OutputPath -Encoding utf8
+            comparison = $comparison
+            paired_samples = $pairs
+        } | ConvertTo-Json -Depth 16 | Set-Content -LiteralPath $OutputPath -Encoding utf8
         Write-Host "Benchmark comparison JSON: $OutputPath"
     }
 }

--- a/tests/native/verify_performance_instrumentation.ps1
+++ b/tests/native/verify_performance_instrumentation.ps1
@@ -1,0 +1,197 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$MqbPath
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+
+$MqbPath = [System.IO.Path]::GetFullPath($MqbPath)
+if (-not (Test-Path -LiteralPath $MqbPath -PathType Leaf)) {
+    throw "MQB executable not found: $MqbPath"
+}
+
+function Invoke-MqbCapture {
+    param(
+        [Parameter(Mandatory = $true)][string]$WorkingDirectory,
+        [Parameter(Mandatory = $true)][string[]]$Arguments,
+        [switch]$ExpectTimings
+    )
+
+    Push-Location $WorkingDirectory
+    try {
+        $output = @(& $MqbPath @Arguments 2>&1)
+        $exitCode = $LASTEXITCODE
+    }
+    finally {
+        Pop-Location
+    }
+    if ($exitCode -ne 0) {
+        $output | ForEach-Object { Write-Host $_ }
+        throw "MQB exited with code $exitCode"
+    }
+
+    $timingLines = @($output | ForEach-Object { [string]$_ } |
+        Where-Object { $_ -like '{"type":"mqb.timings"*' })
+    if ($ExpectTimings) {
+        if ($timingLines.Count -ne 1) {
+            throw "Expected exactly one timing record, got $($timingLines.Count)"
+        }
+        $timing = $timingLines[0] | ConvertFrom-Json
+        return [PSCustomObject]@{
+            output = @($output | ForEach-Object { [string]$_ })
+            timing = $timing
+        }
+    }
+    if ($timingLines.Count -ne 0) {
+        throw 'Timing-disabled invocation unexpectedly emitted a timing record'
+    }
+    return [PSCustomObject]@{
+        output = @($output | ForEach-Object { [string]$_ })
+        timing = $null
+    }
+}
+
+function Assert-Property {
+    param(
+        [Parameter(Mandatory = $true)]$Object,
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][string]$Context
+    )
+    if ($null -eq $Object.PSObject.Properties[$Name]) {
+        throw "$Context is missing property '$Name'"
+    }
+}
+
+$root = Join-Path ([System.IO.Path]::GetTempPath()) ("mqb-performance-contract-" + [Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $root | Out-Null
+
+try {
+    Set-Content -LiteralPath (Join-Path $root 'common.hpp') -Encoding utf8 -Value @'
+#pragma once
+inline int shared_contract_value() { return 42; }
+'@
+    Set-Content -LiteralPath (Join-Path $root 'main.cpp') -Encoding utf8 -Value @'
+#include "common.hpp"
+int main() { return shared_contract_value() == 42 ? 0 : 1; }
+'@
+
+    $arguments = [System.Collections.Generic.List[string]]::new()
+    $arguments.Add('main.cpp')
+    for ($index = 0; $index -lt 128; ++$index) {
+        $name = 'unit_{0:D3}.cpp' -f $index
+        Set-Content -LiteralPath (Join-Path $root $name) -Encoding utf8 -Value @"
+#include "common.hpp"
+int performance_contract_${index}() { return shared_contract_value() + $index; }
+"@
+        $arguments.Add($name)
+    }
+    $arguments.Add('--output')
+    $arguments.Add('performance_contract')
+    $baseArguments = $arguments.ToArray()
+
+    # Prime all caches. Correctness is checked again through the instrumented hit.
+    $null = Invoke-MqbCapture -WorkingDirectory $root -Arguments ($baseArguments + @('-j', '4'))
+
+    $parallel = Invoke-MqbCapture `
+        -WorkingDirectory $root `
+        -Arguments ($baseArguments + @('-j', '4', '--timings=json')) `
+        -ExpectTimings
+    $timing = $parallel.timing
+
+    if ([int]$timing.schema_version -ne 2) {
+        throw "Expected mqb.timings schema 2, got $($timing.schema_version)"
+    }
+    foreach ($name in @('phases', 'cache', 'attribution', 'counters', 'counter_breakdown')) {
+        Assert-Property -Object $timing -Name $name -Context 'timing record'
+    }
+    foreach ($name in @('wall', 'work')) {
+        Assert-Property -Object $timing.attribution -Name $name -Context 'attribution'
+    }
+    foreach ($name in @(
+        'project_setup', 'artifact_layout', 'toolchain_discovery',
+        'target_validation', 'reporting')) {
+        Assert-Property -Object $timing.attribution.wall -Name $name -Context 'wall attribution'
+    }
+    foreach ($name in @(
+        'compile_inspection', 'compile_execution', 'compile_cache_read',
+        'compile_cache_write', 'link_inspection', 'link_execution',
+        'link_resolution', 'archive_inspection', 'archive_execution',
+        'filesystem_snapshot')) {
+        Assert-Property -Object $timing.attribution.work -Name $name -Context 'work attribution'
+    }
+    foreach ($name in @(
+        'cache_files_opened', 'cache_bytes_read',
+        'filesystem_snapshot_requests', 'unique_filesystem_paths_probed',
+        'snapshot_evidence_reuses', 'background_threads_created',
+        'cl_processes_launched', 'link_processes_launched',
+        'lib_processes_launched', 'output_lines_emitted',
+        'output_bytes_emitted')) {
+        Assert-Property -Object $timing.counters -Name $name -Context 'counter record'
+    }
+
+    if ([int]$timing.cache.compile.hits -ne 129 -or [int]$timing.cache.compile.misses -ne 0) {
+        throw 'Warm 129-TU contract did not produce 129 compile hits / 0 misses'
+    }
+    if ([int]$timing.cache.link.hits -ne 1 -or [int]$timing.cache.link.misses -ne 0) {
+        throw 'Warm 129-TU contract did not produce 1 link hit / 0 misses'
+    }
+    if ([int64]$timing.counters.cl_processes_launched -ne 0 `
+        -or [int64]$timing.counters.link_processes_launched -ne 0 `
+        -or [int64]$timing.counters.lib_processes_launched -ne 0) {
+        throw 'All-hit contract launched an MSVC compiler/linker/librarian process'
+    }
+    if ([int64]$timing.counters.background_threads_created -ne 3) {
+        throw "Fixed -j 4 all-hit target should create exactly 3 background threads; got $($timing.counters.background_threads_created)"
+    }
+    if ([int64]$timing.counters.cache_files_opened -lt 130) {
+        throw "Expected at least 129 compile-cache reads plus link-cache evidence; got $($timing.counters.cache_files_opened)"
+    }
+    if ([int64]$timing.counters.cache_bytes_read -le 0) {
+        throw 'Warm cache evidence reported zero bytes read'
+    }
+    if ([int64]$timing.counters.filesystem_snapshot_requests -le 0) {
+        throw 'Warm target reported zero filesystem snapshot requests'
+    }
+    if ([int64]$timing.counters.unique_filesystem_paths_probed `
+        -ge [int64]$timing.counters.filesystem_snapshot_requests) {
+        throw 'Common-header fixture did not expose repeated filesystem evidence'
+    }
+    if ([double]$timing.attribution.work.compile_inspection -le 0.0 `
+        -or [double]$timing.attribution.work.compile_cache_read -le 0.0 `
+        -or [double]$timing.attribution.work.link_inspection -le 0.0) {
+        throw 'Warm-path attribution did not record compile/link inspection and cache-read work'
+    }
+    if ([double]$timing.attribution.work.compile_execution -ne 0.0 `
+        -or [double]$timing.attribution.work.link_execution -ne 0.0 `
+        -or [double]$timing.attribution.work.archive_execution -ne 0.0) {
+        throw 'All-hit contract reported execution work despite launching no build tools'
+    }
+
+    $nonTimingLines = @($parallel.output | Where-Object { $_ -notlike '{"type":"mqb.timings"*' })
+    if ([int64]$timing.counters.output_lines_emitted -ne $nonTimingLines.Count) {
+        throw "Timing record leaked into output counters or line accounting drifted: counter=$($timing.counters.output_lines_emitted), non-timing-lines=$($nonTimingLines.Count)"
+    }
+
+    $serial = Invoke-MqbCapture `
+        -WorkingDirectory $root `
+        -Arguments ($baseArguments + @('-j', '1', '--timings=json')) `
+        -ExpectTimings
+    if ([int64]$serial.timing.counters.background_threads_created -ne 0) {
+        throw 'Fixed -j 1 warm target created a background thread'
+    }
+    if ([int]$serial.timing.cache.compile.hits -ne 129 `
+        -or [int]$serial.timing.cache.link.hits -ne 1) {
+        throw 'Changing execution policy from -j 4 to -j 1 polluted cache identity'
+    }
+
+    $disabled = Invoke-MqbCapture -WorkingDirectory $root -Arguments ($baseArguments + @('-j', '1'))
+    if ($null -ne $disabled.timing) {
+        throw 'Timing-disabled contract unexpectedly returned timing data'
+    }
+
+    Write-Host 'Performance instrumentation contract passed.'
+}
+finally {
+    Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue
+}


### PR DESCRIPTION
## Summary

Begins the v5.5.0 **Target-wide Warm Path Closure** track with measurement and attribution before product optimization.

- preserve the existing `mqb.timings` phase/cache field meanings while publishing additive schema-v2 attribution
- distinguish non-overlapping wall-clock intervals from cumulative work that may overlap across parallel translation units
- add deterministic counters and per-domain breakdowns for cache I/O, filesystem snapshots, scheduler threads, MSVC process launches, and CLI output
- switch base/candidate comparison from whole-suite ordering to alternating paired ABBA execution
- report paired median, median absolute deviation, and nearest-rank P95 from candidate-minus-baseline pair deltas
- add 129-TU common-header, automatic-vs-`-j1`, and timings-enabled/disabled benchmark scenarios
- add a deterministic Windows contract for all-hit process/thread/cache/snapshot/output evidence

## Schema-v2 boundaries

The existing compatibility floor remains intact:

```text
phases.discovery
dependency_scan
compile_queue
compile
link
archive
run_startup
total

cache.compile/link/archive hits and misses
```

New evidence is additive:

```text
attribution.wall.*
attribution.work.*
counters.*
counter_breakdown.*
```

`attribution.wall` contains non-overlapping invocation intervals such as project setup, artifact layout, toolchain discovery, target validation, and reporting.

`attribution.work` contains cumulative work such as compile/link/archive inspection and execution, cache reads/writes, link resolution, and filesystem snapshots. These values may overlap under parallel execution and must not be summed into a 100% wall-clock allocation.

The final `mqb.timings` record is emitted after output observation is stopped, so it does not count itself in reporting duration, output lines, or output bytes.

## Deterministic contract

For a primed 129-TU common-header target:

- 129 compile hits / 0 misses
- 1 link hit / 0 misses
- 0 `cl.exe`, `link.exe`, and `lib.exe` launches
- fixed `-j 4` creates exactly 3 scheduler background threads
- fixed `-j 1` creates 0 scheduler background threads
- filesystem snapshot requests exceed unique probed paths, exposing shared-evidence duplication
- compile/link execution work remains zero on the all-hit path
- switching `-j 4` to `-j 1` does not alter cache identity
- timing-disabled invocation emits no timing record

## Paired ABBA evidence and attribution

Exact comparison:

- base: `39c09e651239612aa919e0ae0839d14dd8c18cfa`
- candidate: `c380067aa05e3c51d9a6b36061d1a91fd9499774`
- four pairs in alternating `base → candidate`, `candidate → base`, `base → candidate`, `candidate → base` order

Candidate medians and deterministic counts:

| Scenario | Total | Snapshot work | Cache-read work | Snapshot requests | Unique paths | Threads |
|---|---:|---:|---:|---:|---:|---:|
| `target-scale-no-op-auto` | 29.421 ms | 16.811 ms | 15.682 ms | 402 | 273 | 3 |
| `target-scale-no-op-j1` | 39.815 ms | 11.282 ms | 8.488 ms | 402 | 273 | 0 |
| `target-scale-common-header-no-op` | 45.472 ms | 68.038 ms | 19.790 ms | 1,821 | 283 | 3 |

The common-header fixture exposes the dominant structural duplication:

- 1,821 snapshot requests collapse to only 283 unique invocation-wide paths: a 6.43× request/identity ratio
- 1,538 requests are repeated observations of an already-seen path
- compile inspection alone performs 1,677 requests for 269 unique paths
- snapshot cumulative work is about 3.44× cache-read cumulative work in this fixture
- the same target without the common-header fan-out is about 16.05 ms faster end-to-end

The automatic inspection path is about 10.39 ms faster than `-j1` on this runner, despite creating three background threads. The evidence therefore does **not** support removing inspection parallelism as the immediate next intervention.

Reporting is not the dominant cost in the common-header fixture: the candidate emits 131 lines / 3,570 bytes, while measured reporting wall time is about 0.056 ms. Output summarization remains useful product work, but it is not the evidence-selected next optimization.

Cache I/O remains material—131 files and 305,784 bytes in the common-header no-op—but is smaller than repeated filesystem snapshot work. A target-wide cache pack or single-open redesign is therefore not the first structural follow-up.

The schema-v2 observer necessarily adds measurement work when `--timings` is enabled. The paired report retains those deltas rather than hiding them; future performance PRs compare v2-instrumented base and candidate on both sides, so observer cost is shared by the pair. Timing-disabled behavior remains unchanged.

## Evidence-selected next step

The unique next performance PR is:

> **deduplicate target-wide filesystem evidence during compile inspection, with a race-safe revalidation barrier and conservative fallback**

It should reduce dependency-occurrence scaling toward unique-path scaling while preserving every existing freshness rule. It must not simultaneously introduce a target cache pack, daemon, watcher, content hashing, or link-resolution persistence.

Miss-only execution scheduling and compile-output evidence handoff remain subsequent structural steps. In particular, the current data says to retain parallel inspection until shared-evidence measurements show whether a caller-only all-hit inspection can meet the latency target.

## Compatibility and correctness boundaries

- `VERSION` remains `5.4.0`
- no cache wire-format change
- no build signature or freshness-rule change
- no scheduler-policy change
- no compiler/linker/librarian recipe change
- no default diagnostic-output behavior change
- no toolchain-selection change
- no tag or release operation

## Validation

Exact head `c380067aa05e3c51d9a6b36061d1a91fd9499774` passed:

- Native C++
- Native Release, including Stage 0 → Stage 1 → Stage 2 self-host closure and package/installer validation
- Build Plan Evidence
- Compilation Database Evidence
- Final Closure Cross-Stage
- Incremental Inspection Evidence
- PCH Inspection Evidence
- Module Scan Inspection Evidence
- Module Compile Inspection Evidence
- Module Target Inspection Evidence
- Documentation
- Performance Evidence, including the deterministic instrumentation contract and paired ABBA report

No review comments or unresolved review threads are present.

## Scope exclusions

This PR collects evidence only. It does **not** implement target-wide evidence reuse, miss-only scheduling, single-open cache reading, object-snapshot handoff, link-resolution reuse, discovery multi-key persistence, or any release operation.