### PR TITLE
perf: bound compile cache reads to one opened stream

### DIFF
--- a/cpp/include/mqb/core/BoundedCacheReader.hpp
+++ b/cpp/include/mqb/core/BoundedCacheReader.hpp
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <expected>
+#include <istream>
+#include <limits>
+#include <vector>
+
+namespace mqb {
+
+enum class BoundedCacheReadErrorCode {
+    size_query_failed,
+    size_limit_exceeded,
+    read_failed,
+    trailing_data,
+};
+
+struct BoundedCacheReadError {
+    BoundedCacheReadErrorCode code;
+    std::size_t offset{};
+};
+
+// Read a newly opened, seekable binary stream without querying its pathname.
+// The cache owner retains open/missing/error policy and payload validation.
+// on_sized preserves its existing sized-read observation point, including
+// short reads; it is not a second open or a count of operating-system calls.
+// EOF rejects observed growth. This is not an atomic snapshot of concurrent
+// in-place writes and does not replace any dependency freshness checks.
+template <typename OnSized>
+[[nodiscard]] std::expected<std::vector<std::uint8_t>, BoundedCacheReadError>
+read_bounded_cache_stream(
+    std::istream& stream,
+    const std::size_t limit,
+    OnSized&& on_sized) {
+    stream.seekg(0, std::ios::end);
+    const auto end = stream.tellg();
+    if (!stream || end < std::istream::pos_type{0}) {
+        return std::unexpected(BoundedCacheReadError{
+            .code = BoundedCacheReadErrorCode::size_query_failed});
+    }
+    const auto size = static_cast<std::uintmax_t>(static_cast<std::streamoff>(end));
+    if (size > limit
+        || size > static_cast<std::uintmax_t>(
+            std::numeric_limits<std::streamsize>::max())) {
+        return std::unexpected(BoundedCacheReadError{
+            .code = BoundedCacheReadErrorCode::size_limit_exceeded});
+    }
+
+    on_sized(static_cast<std::uint64_t>(size));
+    stream.seekg(0, std::ios::beg);
+    if (!stream) {
+        return std::unexpected(BoundedCacheReadError{
+            .code = BoundedCacheReadErrorCode::read_failed});
+    }
+    std::vector<std::uint8_t> bytes(static_cast<std::size_t>(size));
+    if (!bytes.empty()) {
+        const auto count = static_cast<std::streamsize>(bytes.size());
+        stream.read(reinterpret_cast<char*>(bytes.data()), count);
+        if (!stream || stream.gcount() != count) {
+            return std::unexpected(BoundedCacheReadError{
+                .code = BoundedCacheReadErrorCode::read_failed,
+                .offset = static_cast<std::size_t>(stream.gcount()),
+            });
+        }
+    }
+
+    const auto tail = stream.peek();
+    if (stream.bad() || (stream.fail() && !stream.eof())) {
+        return std::unexpected(BoundedCacheReadError{
+            .code = BoundedCacheReadErrorCode::read_failed,
+            .offset = bytes.size(),
+        });
+    }
+    if (tail != std::istream::traits_type::eof()) {
+        return std::unexpected(BoundedCacheReadError{
+            .code = BoundedCacheReadErrorCode::trailing_data,
+            .offset = bytes.size(),
+        });
+    }
+    return bytes;
+}
+
+} // namespace mqb

--- a/cpp/src/core/cache/CompileCacheFile.cpp
+++ b/cpp/src/core/cache/CompileCacheFile.cpp
@@ -20,6 +20,7 @@
 
 #include "mqb/core/Artifact.hpp"
 #include "mqb/core/BuildSignature.hpp"
+#include "mqb/core/BoundedCacheReader.hpp"
 #include "mqb/core/FileSnapshot.hpp"
 #include "mqb/core/PerformanceEvidence.hpp"
 #include "mqb/core/ToolchainIdentity.hpp"
@@ -524,57 +525,66 @@ std::expected<std::optional<CompileCacheEntry>, CompileCacheFileError>
 CompileCacheFile::load(const fs::path& file) {
     mqb::performance::ScopedCacheRead evidence{
         mqb::performance::CacheKind::compile};
-    std::error_code error_code;
-    const bool exists = fs::exists(file, error_code);
-    if (error_code) {
-        return std::unexpected(make_error(
-            CompileCacheFileErrorCode::file_open_failed,
-            file,
-            0,
-            "failed to query cache file"));
-    }
-    if (!exists) return std::optional<CompileCacheEntry>{};
-
-    const auto size = fs::file_size(file, error_code);
-    if (error_code) {
-        return std::unexpected(make_error(
-            CompileCacheFileErrorCode::file_read_failed,
-            file,
-            0,
-            "failed to query cache file size"));
-    }
-    if (size > max_cache_file_size) {
-        return std::unexpected(make_error(
-            CompileCacheFileErrorCode::corrupt_data,
-            file,
-            0,
-            "cache file exceeds safety size limit"));
-    }
-
+    // Existing files take one payload open, with length and bytes obtained from
+    // that same stream. Path queries are only a failed-open diagnostic fallback.
     std::ifstream stream{file, std::ios::binary};
     if (!stream) {
+        std::error_code error_code;
+        const bool exists = fs::exists(file, error_code);
+        if (error_code) {
+            return std::unexpected(make_error(
+                CompileCacheFileErrorCode::file_open_failed, file, 0,
+                "failed to query cache file"));
+        }
+        if (!exists) return std::optional<CompileCacheEntry>{};
+
+        // Preserve the previous size-query/oversize error categories for an
+        // existing but unopenable path (including a directory). Never reopen.
+        const auto size = fs::file_size(file, error_code);
+        if (error_code) {
+            return std::unexpected(make_error(
+                CompileCacheFileErrorCode::file_read_failed, file, 0,
+                "failed to query cache file size"));
+        }
+        if (size > max_cache_file_size) {
+            return std::unexpected(make_error(
+                CompileCacheFileErrorCode::corrupt_data, file, 0,
+                "cache file exceeds safety size limit"));
+        }
         return std::unexpected(make_error(
-            CompileCacheFileErrorCode::file_open_failed,
-            file,
-            0,
+            CompileCacheFileErrorCode::file_open_failed, file, 0,
             "failed to open cache file"));
     }
-    evidence.opened(static_cast<std::uint64_t>(size));
-    std::vector<std::uint8_t> bytes(static_cast<std::size_t>(size));
-    if (!bytes.empty()) {
-        stream.read(
-            reinterpret_cast<char*>(bytes.data()),
-            static_cast<std::streamsize>(bytes.size()));
-    }
-    if (!stream && !bytes.empty()) {
+
+    auto bytes = read_bounded_cache_stream(
+        stream, max_cache_file_size,
+        [&](const std::uint64_t size) { evidence.opened(size); });
+    if (!bytes) {
+        const auto& failure = bytes.error();
+        switch (failure.code) {
+        case BoundedCacheReadErrorCode::size_query_failed:
+            return std::unexpected(make_error(
+                CompileCacheFileErrorCode::file_read_failed, file, failure.offset,
+                "failed to query cache file size"));
+        case BoundedCacheReadErrorCode::size_limit_exceeded:
+            return std::unexpected(make_error(
+                CompileCacheFileErrorCode::corrupt_data, file, failure.offset,
+                "cache file exceeds safety size limit"));
+        case BoundedCacheReadErrorCode::read_failed:
+            return std::unexpected(make_error(
+                CompileCacheFileErrorCode::file_read_failed, file, failure.offset,
+                "failed to read complete cache file"));
+        case BoundedCacheReadErrorCode::trailing_data:
+            return std::unexpected(make_error(
+                CompileCacheFileErrorCode::corrupt_data, file, failure.offset,
+                "cache file grew while being read"));
+        }
         return std::unexpected(make_error(
-            CompileCacheFileErrorCode::file_read_failed,
-            file,
-            static_cast<std::size_t>(stream.gcount()),
-            "failed to read complete cache file"));
+            CompileCacheFileErrorCode::file_read_failed, file, failure.offset,
+            "unrecognized bounded cache read failure"));
     }
 
-    auto entry = deserialize(file, bytes);
+    auto entry = deserialize(file, *bytes);
     if (!entry) return std::unexpected(entry.error());
     return std::optional<CompileCacheEntry>{std::move(*entry)};
 }

--- a/cpp/tests/core/cache/compile_cache_file_tests.cpp
+++ b/cpp/tests/core/cache/compile_cache_file_tests.cpp
@@ -410,10 +410,20 @@ int main() {
                && empty_result.error().code == mqb::CompileCacheFileErrorCode::invalid_magic,
            "empty existing cache must not become a missing-cache result");
 
+    // Mirror the historical pathname-size preflight for this non-file case.
+    // MSVC can obtain a directory size, then reject it when opening the stream;
+    // other libraries reject the size query itself. Neither is a cache miss.
+    std::error_code directory_size_error;
+    const auto directory_size = fs::file_size(fixture.path(), directory_size_error);
+    const auto directory_error_code = directory_size_error
+        ? mqb::CompileCacheFileErrorCode::file_read_failed
+        : directory_size > 64u * 1024u * 1024u
+            ? mqb::CompileCacheFileErrorCode::corrupt_data
+            : mqb::CompileCacheFileErrorCode::file_open_failed;
     const auto directory_result = mqb::CompileCacheFile::load(fixture.path());
     expect(!directory_result
-               && directory_result.error().code == mqb::CompileCacheFileErrorCode::file_read_failed,
-           "directory cache path must retain its size-query failure category");
+               && directory_result.error().code == directory_error_code,
+           "directory cache path must retain its platform's historical failure category");
 
     const fs::path oversized_file = fixture.path() / "oversized.mqbcache";
     write_bytes(oversized_file, {});

--- a/cpp/tests/core/cache/compile_cache_file_tests.cpp
+++ b/cpp/tests/core/cache/compile_cache_file_tests.cpp
@@ -4,11 +4,15 @@
 #include <fstream>
 #include <iostream>
 #include <iterator>
+#include <optional>
+#include <sstream>
+#include <string>
 #include <string_view>
 #include <vector>
 
 #include "mqb/core/Artifact.hpp"
 #include "mqb/core/BuildSignature.hpp"
+#include "mqb/core/BoundedCacheReader.hpp"
 #include "mqb/core/CompileCache.hpp"
 #include "mqb/core/CompileCacheFile.hpp"
 #include "mqb/core/CompilerOptions.hpp"
@@ -287,9 +291,110 @@ void expect_round_trip(
     }
 }
 
+// Override only the size observation; the readable bytes are independent.
+// This models truncation/growth after sizing without sleeps or a racing writer.
+class SizedCacheBuffer : public std::stringbuf {
+public:
+    SizedCacheBuffer(const std::string& bytes, const std::streamoff reported)
+        : std::stringbuf(bytes, std::ios::in), reported_(reported) {}
+
+    bool fail_end{};
+    bool fail_rewind{};
+    bool fail_eof{};
+
+protected:
+    pos_type seekoff(
+        const off_type offset,
+        const std::ios::seekdir direction,
+        const std::ios::openmode mode) override {
+        if ((direction == std::ios::end && fail_end)
+            || (direction == std::ios::beg && fail_rewind)) return pos_type{-1};
+        if (direction == std::ios::cur && offset == 0) return pos_type{reported_};
+        return std::stringbuf::seekoff(offset, direction, mode);
+    }
+
+    int_type underflow() override {
+        if (fail_eof && gptr() == egptr()) {
+            throw std::ios_base::failure{"injected EOF read failure"};
+        }
+        return std::stringbuf::underflow();
+    }
+
+private:
+    std::streamoff reported_;
+};
+
+void test_bounded_cache_reader() {
+    using Code = mqb::BoundedCacheReadErrorCode;
+    const auto check = [](
+        SizedCacheBuffer& buffer,
+        const std::size_t limit,
+        const std::optional<Code> expected_error,
+        const std::size_t expected_offset,
+        const unsigned expected_observations,
+        const std::uint64_t expected_size) {
+        std::istream stream{&buffer};
+        unsigned observations = 0;
+        std::uint64_t observed_size = 0;
+        const auto bytes = mqb::read_bounded_cache_stream(
+            stream, limit, [&](const std::uint64_t size) {
+                ++observations;
+                observed_size = size;
+            });
+        expect(observations == expected_observations,
+               "bounded read should observe its accepted size exactly once");
+        expect(observed_size == expected_size,
+               "bounded read should retain the sized-read byte observation");
+        if (expected_error) {
+            expect(!bytes, "invalid bounded stream should be rejected");
+            if (!bytes) {
+                expect(bytes.error().code == *expected_error,
+                       "bounded stream should retain the precise failure category");
+                expect(bytes.error().offset == expected_offset,
+                       "bounded stream should report its read offset");
+            }
+        } else {
+            expect(bytes.has_value(), "complete bounded stream should load");
+            if (bytes) expect(bytes->size() == expected_size,
+                              "complete payload should have its measured size");
+        }
+    };
+
+    SizedCacheBuffer exact{"abc", 3};
+    check(exact, 3, std::nullopt, 0, 1, 3);
+    SizedCacheBuffer empty{"", 0};
+    check(empty, 0, std::nullopt, 0, 1, 0);
+    SizedCacheBuffer oversized{"abc", 4};
+    check(oversized, 3, Code::size_limit_exceeded, 0, 0, 0);
+    SizedCacheBuffer negative{"abc", -1};
+    check(negative, 3, Code::size_query_failed, 0, 0, 0);
+    SizedCacheBuffer unseekable{"abc", 3};
+    unseekable.fail_end = true;
+    check(unseekable, 3, Code::size_query_failed, 0, 0, 0);
+    SizedCacheBuffer rewind_failed{"abc", 3};
+    rewind_failed.fail_rewind = true;
+    check(rewind_failed, 3, Code::read_failed, 0, 1, 3);
+    SizedCacheBuffer shrunk{"ab", 3};
+    check(shrunk, 3, Code::read_failed, 2, 1, 3);
+    SizedCacheBuffer grown{"abcd", 3};
+    check(grown, 3, Code::trailing_data, 3, 1, 3);
+    SizedCacheBuffer grew_from_empty{"x", 0};
+    check(grew_from_empty, 0, Code::trailing_data, 0, 1, 0);
+    SizedCacheBuffer eof_failed{"abc", 3};
+    eof_failed.fail_eof = true;
+    check(eof_failed, 3, Code::read_failed, 3, 1, 3);
+
+    std::istringstream binary{std::string{"a\0b", 3}, std::ios::in | std::ios::binary};
+    const auto payload = mqb::read_bounded_cache_stream(
+        binary, 3, [](const std::uint64_t) {});
+    expect(payload && *payload == std::vector<std::uint8_t>{'a', 0, 'b'},
+           "bounded read must preserve embedded NUL bytes");
+}
+
 } // namespace
 
 int main() {
+    test_bounded_cache_reader();
     TemporaryDirectory fixture;
     const fs::path file = fixture.path() / "nested/main.mqbcache";
 
@@ -297,6 +402,26 @@ int main() {
     expect(
         missing && !missing->has_value(),
         "missing cache file should be a normal cache miss");
+
+    const fs::path empty_file = fixture.path() / "zero-bytes.mqbcache";
+    write_bytes(empty_file, {});
+    const auto empty_result = mqb::CompileCacheFile::load(empty_file);
+    expect(!empty_result
+               && empty_result.error().code == mqb::CompileCacheFileErrorCode::invalid_magic,
+           "empty existing cache must not become a missing-cache result");
+
+    const auto directory_result = mqb::CompileCacheFile::load(fixture.path());
+    expect(!directory_result
+               && directory_result.error().code == mqb::CompileCacheFileErrorCode::file_read_failed,
+           "directory cache path must retain its size-query failure category");
+
+    const fs::path oversized_file = fixture.path() / "oversized.mqbcache";
+    write_bytes(oversized_file, {});
+    fs::resize_file(oversized_file, 64u * 1024u * 1024u + 1u);
+    const auto oversized_result = mqb::CompileCacheFile::load(oversized_file);
+    expect(!oversized_result
+               && oversized_result.error().code == mqb::CompileCacheFileErrorCode::corrupt_data,
+           "oversized cache must be rejected before allocating its payload");
 
     const auto original = make_entry();
     expect_round_trip(file, original, "ordinary object-only cache entry");

--- a/docs/BOUNDED_COMPILE_CACHE_READER.md
+++ b/docs/BOUNDED_COMPILE_CACHE_READER.md
@@ -1,0 +1,51 @@
+# Bounded compile-cache reads: v5.5.0 development
+
+## Scope and baseline
+
+This iteration starts from `8d9008a6031755feccf15d72a52c9fad137b4ad9`, the merge of PR #156. `VERSION` stays `5.4.0`.
+
+Only the compile-cache read transport changes. Link, archive, discovery and toolchain loaders, cache formats, serializers, signatures, dependency freshness, target scheduling and CLI output are unchanged. This is not a cache pack.
+
+## Why this comes before object handoff or reporting
+
+PR #156's retained Performance Evidence #492 (run `33946302228`, artifact `9963541165`) contains four alternating base/candidate pairs per scenario. Its candidate tree equals this iteration's base tree. The downloaded artifact SHA-256 is `b7fd55600f0e3d40a89bab6a3b10752b56207572834864206c3594b09754ff9f`.
+
+Candidate per-field medians from that historical run, milliseconds:
+
+| Scenario | Total | Compile-cache read work | Link filesystem work | Reporting wall |
+|---|---:|---:|---:|---:|
+| 129-TU no-op | 35.571 | 20.957 | 4.493 | 0.047 |
+| 129-TU common-header no-op | 39.578 | 26.828 | 4.446 | 0.054 |
+| 129-TU j1 no-op | 47.524 | 10.724 | 4.417 | 0.052 |
+
+These are baseline observations, NOT this change's speedup. Parallel work durations overlap and include decoding; they cannot be divided by total wall time to establish a cache-I/O percentage. Piped-output reporting measurements do not establish interactive terminal cost.
+
+The 129-TU fixtures read 129 compile payloads among 131 cache files. The old successful loader queries `exists(path)` and `file_size(path)` before opening each payload. Removing those repeated pathname preflights has a narrow causal scope without moving a dependency observation across compile execution. The new seek/tell/rewind and EOF check also cost work; net acceleration must be established by this PR's independent ABBA run.
+
+## Read contract
+
+The owner opens the binary stream once. Existing readable files obtain their length and bytes from that same stream. Failed-open paths retain diagnostic-only existence/size queries to distinguish a normal missing cache from an existing unreadable path; they never reopen the payload.
+
+`read_bounded_cache_stream` is a toolchain-independent core persistence primitive. It checks the nonnegative stream length and the existing 64 MiB limit before allocation, rewinds, requires an exact read, and rejects observed extra data at EOF. An existing empty file remains invalid magic, not a cache miss. Payload magic/version/count/path/trailing-byte checks remain in the original decoder. Compile cache v2/v3/v4 compatibility and save behavior are unchanged.
+
+The sized-read callback preserves the previous accepted-length instrumentation point. `cache_files_opened` is still a payload-level counter; it is NOT an OS metadata-query counter. Neither a reduced payload-open count nor reduced `filesystem_snapshot_requests` is claimed.
+
+This does not provide an atomic snapshot against arbitrary concurrent in-place or timestamp-preserving writes. Growth seen at the final EOF check and short reads are rejected; no dependency freshness check, target revalidation barrier or conservative retry is removed.
+
+## Regression and merge gates
+
+The existing compile-cache test executable retains all previous tests and adds deterministic stream fixtures for exact/empty/binary payloads, limit rejection, size/seek failures, truncation, growth, growth from empty, EOF I/O failure and sized-read observations. Real-file facade tests cover empty files, directory paths and a file exceeding 64 MiB. No new test executable or product translation unit is added.
+
+Supplemental local validation: standalone standard-library reader cases passed GCC C++23 warning-as-error compilation and AddressSanitizer/UndefinedBehaviorSanitizer. These Linux helper checks do not substitute for Windows/MSVC validation of the complete product.
+
+Required before merge: the original Windows Debug/Release suites, self-host/package gates, deterministic instrumentation, and the unchanged Performance Evidence workflow comparing the exact PR base and head with four alternating pairs across all 19 scenarios. Retain the complete raw JSON, including adverse pairs and tails. For the common-header no-op, expect the established 129 compile hits, one link hit, 131 cache payload opens, zero writes/tool launches and 424 filesystem snapshots to remain. Evaluate total, cache-read work, j1/auto, single-TU rebuild and cold paths together; a lower source-level query count alone is not a speedup result.
+
+At initial submission, native and independent ABBA results are pending. Keep the PR draft until those gates have been examined; do not publish a performance percentage from historical data.
+
+## Remaining development decisions
+
+After evaluating this reader, compare extending it to other cache owners against object-snapshot handoff. Object evidence must have invocation-local ownership, exact path identity and a defined validity boundary after miss execution/revalidation; do not turn public diagnostic `inspect()` results into reusable execution tickets. Keep real freshness checks for linker libraries and side outputs.
+
+Reprofile before changing CLI output or adding link-resolution reuse. Measure actual terminal, redirected and verbose reporting separately. Investigate discovery cache writes and alternating request identities before choosing a multi-key store; a slow discovery sample is not proof of key thrashing. Also retain visibility into artifact-layout work rather than attributing all residual time to cache reads.
+
+Each development PR has one theme and its own exact-base/head ABBA evidence. Consider a persistent cache pack only after isolated remaining cache I/O is credibly at least 25-30% of the relevant elapsed path, not from overlapping work totals. Daemon, watcher, USN and resident processes remain v6.0 work. End with cumulative released-v5.4.0 versus final-candidate evidence, documentation and a separate release-preparation PR; only that final PR changes VERSION/changelog for v5.5.0.


### PR DESCRIPTION
## Final status: merged, with an explicit performance tradeoff

Merged as **`92defbb49b3752dc9dbc11f95fc4a4df3bcdb9a7`** after the owner's delegated final review. The former Draft/package/performance hold is closed. Exact reviewed head is `2c87b47d9fe4945a75077a8ded0bdfed5ca425ab`; original base is `8d9008a6031755feccf15d72a52c9fad137b4ad9`. VERSION stays **5.4.0**. No tag or Release was published by this operation.

### What was accepted

Four files: standard-library bounded-reader helper, compile-cache transport integration, existing compile-cache tests and `docs/BOUNDED_COMPILE_CACHE_READER.md`. Successful loads size/read from one opened stream, keeping the original 64 MiB bound, complete-read/EOF checks, cache v2/v3/v4 decoder and failure fallback. Failed-open pathname queries retain missing/error classification. No dependency freshness, signatures, conservative retry, target scheduling, other cache loaders or CLI output is changed.

Native C++ #672, complete Native Release/self-host/package #575 and the original correctness/evidence workflows passed. The initial platform-specific directory assertion failure was fixed by deriving the strict historical category on the active standard library, not by loosening the test. No unresolved review threads were found.

### Final fixed external decision experiment

[Candidate Merge Decisions run 34146614041](https://github.com/Iviesever/msvc-quick-build/actions/runs/34146614041), [artifact 10028122485](https://github.com/Iviesever/msvc-quick-build/actions/runs/34146614041/artifacts/10028122485), ZIP SHA-256 `7466f9f8c2e11ba8b18b6795232460b849c09ad171fdf62f02a69216ae0afcec`.

The #157 comparison uses exact original main/head Release binaries, not #158/#159 combined. Forty alternating timings-OFF pairs per warm case on one Windows comparison runner, identical fixture/cache pathnames, plus six reset cold pairs. A practical warm-regression flag was fixed before execution: median > max(0.5 ms,3%) and bootstrap median interval entirely positive. None triggered it; that is not proof of zero regression.

| Scenario | Paired median ms | Paired median % | Faster pairs |
|---|---:|---:|---:|
| small default | -0.0981 | -1.10% | 24/40 |
| common129 default auto | -1.1122 | -2.72% | 35/40 |
| common129 default j1 | -2.7542 | -5.00% | 39/40 |
| common129 verbose | -1.4428 | -3.46% | 34/40 |
| static129 default | -1.3783 | -3.35% | 35/40 |
| static129 verbose | -1.7587 | -4.28% | 37/40 |
| PCH default | -0.1468 | -1.42% | 25/40 |
| true discovery persistent hit | -0.0407 | -0.42% | 21/40 |
| common129 cold | **+55.3739** | **+1.20%** | **1/6** |

Auto's bootstrap paired-median interval is [-1.48875,-0.99975] ms; j1's is [-3.04015,-2.36495] ms. Small no-op's interval crosses zero. These are empirical evidence, not production-tail guarantees.

The cold cost is **accepted**, not discarded or explained entirely by overlapping cache-read work. Warm compile-cache work improves consistently across prior and new evidence, and the narrow same-stream transport has integrity value. This justifies merging without advertising cold or universal acceleration. A failed open before missing diagnostics is a known miss-path cost.

All warm cases preserve project cache/artifact metadata and audited non-output counters, with no tools/cache writes. Full metadata inventories were checked for equality but not serialized by this decision harness; raw transcripts, identities and successful assertions are retained. The three-candidate archive contains 978 pairs and 4200 verified raw transcript hashes; only the #157 experiment supports this PR's incremental decision.

### Earlier evidence is not replaced

- [Performance #495](https://github.com/Iviesever/msvc-quick-build/actions/runs/34128610217/artifacts/10021470066), initial implementation `a3cdc8f`, digest `fa77b9ad2831c6baacb329c56984d8be9689bdc417a57a1422f8d9fc80b693df`.
- [Performance #496](https://github.com/Iviesever/msvc-quick-build/actions/runs/34130603058/artifacts/10022245911), reviewed final head, digest `ec13ce6e0ef01fc1af59f820d779af81a1453f4e809f15b07275e960dca1aa7e`.

Both have all 19 original scenarios and four pairs, including adverse samples. Final-head ordinary timings-OFF no-op was +1.143 ms / +10.22%, while common129 compile-cache read work fell by 4.163 ms and cold compile-cache read work increased by 9.437 ms. Work durations overlap and include decoding; they are not elapsed I/O shares. The follow-up does not erase those observations, pool the runs or add their percentages. Skipped metadata runs are not measurements.

### Related decisions

#158 was closed without merge for insufficient incremental benefit; it is not implicitly approved here. #159 has its own product/performance decision and normal up-to-date protected-branch checks. Archive's missing total read/write bound is a separate iteration. Final release preparation remains separate and must compare the released v5.4.0 baseline cumulatively, not sum PR percentages.