### PR TITLE
perf: bound link and discovery cache reads to opened streams

### DIFF
--- a/cpp/src/core/cache/LinkCacheFile.cpp
+++ b/cpp/src/core/cache/LinkCacheFile.cpp
@@ -15,6 +15,7 @@
 #include <utility>
 #include <vector>
 
+#include "mqb/core/BoundedCacheReader.hpp"
 #include "mqb/core/BuildSignature.hpp"
 #include "mqb/core/LinkerIdentity.hpp"
 #include "mqb/core/PerformanceEvidence.hpp"
@@ -370,46 +371,59 @@ std::expected<std::optional<LinkCacheEntry>, LinkCacheFileError>
 LinkCacheFile::load(const fs::path& file) {
     mqb::performance::ScopedCacheRead evidence{
         mqb::performance::CacheKind::link};
-    std::error_code error_code;
-    const bool exists = fs::exists(file, error_code);
-    if (error_code) {
-        return std::unexpected(make_error(
-            LinkCacheFileErrorCode::file_open_failed, file, 0, "failed to query link cache file"));
-    }
-    if (!exists) {
-        return std::optional<LinkCacheEntry>{};
-    }
-
-    const auto size = fs::file_size(file, error_code);
-    if (error_code) {
-        return std::unexpected(make_error(
-            LinkCacheFileErrorCode::file_read_failed, file, 0, "failed to query link cache file size"));
-    }
-    if (size > max_cache_file_size) {
-        return std::unexpected(make_error(
-            LinkCacheFileErrorCode::corrupt_data, file, 0, "link cache file exceeds safety size limit"));
-    }
-
+    // Size and payload belong to the same opened stream. Pathname queries
+    // remain diagnostic-only after a failed open, preserving miss/error policy.
     std::ifstream stream{file, std::ios::binary};
     if (!stream) {
+        std::error_code error_code;
+        const bool exists = fs::exists(file, error_code);
+        if (error_code) {
+            return std::unexpected(make_error(
+                LinkCacheFileErrorCode::file_open_failed, file, 0, "failed to query link cache file"));
+        }
+        if (!exists) return std::optional<LinkCacheEntry>{};
+        const auto size = fs::file_size(file, error_code);
+        if (error_code) {
+            return std::unexpected(make_error(
+                LinkCacheFileErrorCode::file_read_failed, file, 0, "failed to query link cache file size"));
+        }
+        if (size > max_cache_file_size) {
+            return std::unexpected(make_error(
+                LinkCacheFileErrorCode::corrupt_data, file, 0, "link cache file exceeds safety size limit"));
+        }
         return std::unexpected(make_error(
             LinkCacheFileErrorCode::file_open_failed, file, 0, "failed to open link cache file"));
     }
-    evidence.opened(static_cast<std::uint64_t>(size));
 
-    std::vector<std::uint8_t> bytes(static_cast<std::size_t>(size));
-    if (!bytes.empty()) {
-        stream.read(reinterpret_cast<char*>(bytes.data()), static_cast<std::streamsize>(bytes.size()));
-    }
-    if (!stream && !bytes.empty()) {
+    auto bytes = read_bounded_cache_stream(
+        stream, max_cache_file_size,
+        [&evidence](const std::uint64_t size) { evidence.opened(size); });
+    if (!bytes) {
+        const auto failure = bytes.error();
+        switch (failure.code) {
+        case BoundedCacheReadErrorCode::size_query_failed:
+            return std::unexpected(make_error(
+                LinkCacheFileErrorCode::file_read_failed, file, failure.offset,
+                "failed to query link cache stream size"));
+        case BoundedCacheReadErrorCode::size_limit_exceeded:
+            return std::unexpected(make_error(
+                LinkCacheFileErrorCode::corrupt_data, file, failure.offset,
+                "link cache file exceeds safety size limit"));
+        case BoundedCacheReadErrorCode::trailing_data:
+            return std::unexpected(make_error(
+                LinkCacheFileErrorCode::corrupt_data, file, failure.offset,
+                "link cache file grew while reading"));
+        case BoundedCacheReadErrorCode::read_failed:
+            return std::unexpected(make_error(
+                LinkCacheFileErrorCode::file_read_failed, file, failure.offset,
+                "failed to read complete link cache file"));
+        }
         return std::unexpected(make_error(
-            LinkCacheFileErrorCode::file_read_failed,
-            file,
-            static_cast<std::size_t>(stream.gcount()),
-            "failed to read complete link cache file"));
+            LinkCacheFileErrorCode::file_read_failed, file, failure.offset,
+            "failed to read link cache file"));
     }
 
-    auto entry = deserialize(file, bytes);
+    auto entry = deserialize(file, *bytes);
     if (!entry) return std::unexpected(entry.error());
     return std::optional<LinkCacheEntry>{std::move(*entry)};
 }

--- a/cpp/src/discovery/cache/DiscoveryCache.cpp
+++ b/cpp/src/discovery/cache/DiscoveryCache.cpp
@@ -17,6 +17,7 @@
 #include <utility>
 #include <vector>
 
+#include "mqb/core/BoundedCacheReader.hpp"
 #include "mqb/core/PerformanceEvidence.hpp"
 
 namespace mqb::discovery::detail {
@@ -348,22 +349,18 @@ private:
 [[nodiscard]] std::optional<DiscoveryCacheRecord> load_record(const fs::path& file) {
     mqb::performance::ScopedCacheRead evidence{
         mqb::performance::CacheKind::discovery};
+    // Keep discovery's ordinary-file policy; only the redundant pathname
+    // size query is removed. Identity and filesystem freshness stay below.
     std::error_code error_code;
     if (!fs::is_regular_file(file, error_code) || error_code) return std::nullopt;
-    const auto size = fs::file_size(file, error_code);
-    if (error_code || size > max_cache_file_size) return std::nullopt;
 
     std::ifstream stream{file, std::ios::binary};
     if (!stream) return std::nullopt;
-    evidence.opened(static_cast<std::uint64_t>(size));
-    std::vector<std::uint8_t> bytes(static_cast<std::size_t>(size));
-    if (!bytes.empty()) {
-        stream.read(
-            reinterpret_cast<char*>(bytes.data()),
-            static_cast<std::streamsize>(bytes.size()));
-    }
-    if (!stream && !bytes.empty()) return std::nullopt;
-    return deserialize(bytes);
+    auto bytes = read_bounded_cache_stream(
+        stream, max_cache_file_size,
+        [&evidence](const std::uint64_t size) { evidence.opened(size); });
+    if (!bytes) return std::nullopt;
+    return deserialize(*bytes);
 }
 
 } // namespace

--- a/cpp/tests/core/cache/link_cache_file_tests.cpp
+++ b/cpp/tests/core/cache/link_cache_file_tests.cpp
@@ -1,4 +1,6 @@
+#include <array>
 #include <chrono>
+#include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
@@ -32,6 +34,101 @@ struct TempTree {
         fs::remove_all(root, ignored);
     }
 };
+
+void test_reader_boundaries(const fs::path& root, const mqb::LinkCacheEntry& entry) {
+    const fs::path file = root / "reader-boundaries.linkcache";
+    {
+        std::ofstream stream{file, std::ios::binary | std::ios::trunc};
+        expect(stream.good(), "empty link-cache fixture should open");
+    }
+    const auto empty = mqb::LinkCacheFile::load(file);
+    expect(!empty && empty.error().code == mqb::LinkCacheFileErrorCode::invalid_magic,
+           "an existing empty link cache is invalid magic, not a missing cache");
+
+    // MSVC can size a directory then reject its open; other libraries can
+    // reject the size query. Require the exact historical platform category.
+    std::error_code ec;
+    (void)fs::file_size(root, ec);
+    const auto directory_error = ec
+        ? mqb::LinkCacheFileErrorCode::file_read_failed
+        : mqb::LinkCacheFileErrorCode::file_open_failed;
+    const auto directory = mqb::LinkCacheFile::load(root);
+    expect(!directory && directory.error().code == directory_error,
+           "a directory must keep its historical error category, never become a miss");
+
+    constexpr std::uintmax_t limit = 64u * 1024u * 1024u;
+    fs::resize_file(file, limit + 1u, ec);
+    expect(!ec, "oversized link-cache fixture should resize");
+    if (!ec) {
+        const auto oversized = mqb::LinkCacheFile::load(file);
+        expect(!oversized
+                   && oversized.error().code == mqb::LinkCacheFileErrorCode::corrupt_data
+                   && oversized.error().offset == 0,
+               "over-limit link cache must fail before payload decoding");
+    }
+
+    expect(mqb::LinkCacheFile::save(file, entry).has_value(),
+           "valid link cache should replace oversized evidence");
+    const auto valid_size = fs::file_size(file, ec);
+    expect(!ec, "valid link-cache size should be available");
+    {
+        std::ofstream stream{file, std::ios::binary | std::ios::app};
+        stream.put('\0');
+        expect(stream.good(), "trailing-byte fixture should append");
+    }
+    const auto trailing = mqb::LinkCacheFile::load(file);
+    expect(!trailing
+               && trailing.error().code == mqb::LinkCacheFileErrorCode::corrupt_data
+               && trailing.error().offset == valid_size,
+           "a valid record plus a trailing zero must retain decoder rejection and offset");
+
+    fs::remove(file, ec);
+    expect(!ec, "link cache should be removable");
+    const auto removed = mqb::LinkCacheFile::load(file);
+    expect(removed && !*removed, "a removed link cache should be a normal miss");
+    auto replacement = entry;
+    replacement.linker.binary_stamp = "replacement-stamp";
+    expect(mqb::LinkCacheFile::save(file, replacement).has_value(),
+           "link cache should be recreatable at the same pathname");
+    const auto recreated = mqb::LinkCacheFile::load(file);
+    expect(recreated && *recreated
+               && (*recreated)->linker.binary_stamp == replacement.linker.binary_stamp,
+           "a later open must read replacement bytes, not previous invocation evidence");
+
+    // With both newer field lists empty, v4 ends in two four-byte zero counts.
+    // v3 omits file_inputs; v2 omits both file_inputs and side_outputs.
+    auto legacy_entry = entry;
+    legacy_entry.file_inputs.clear();
+    legacy_entry.side_outputs.clear();
+    for (const auto version : std::array<unsigned int, 2>{2u, 3u}) {
+        expect(mqb::LinkCacheFile::save(file, legacy_entry).has_value(),
+               "legacy fixture seed should save");
+        const auto current_size = fs::file_size(file, ec);
+        expect(!ec && current_size > 8u, "legacy fixture should contain new field counts");
+        if (ec || current_size <= 8u) continue;
+        fs::resize_file(file, current_size - (version == 2u ? 8u : 4u), ec);
+        expect(!ec, "legacy fixture should remove only absent field counts");
+        if (ec) continue;
+        {
+            std::fstream stream{file, std::ios::binary | std::ios::in | std::ios::out};
+            stream.seekp(8, std::ios::beg);
+            const std::array<char, 4> bytes{static_cast<char>(version), 0, 0, 0};
+            stream.write(bytes.data(), static_cast<std::streamsize>(bytes.size()));
+            expect(stream.good(), "legacy fixture version should be written");
+        }
+        const auto legacy = mqb::LinkCacheFile::load(file);
+        expect(legacy && *legacy, "bounded transport must continue accepting link-cache v2/v3");
+        if (legacy && *legacy) {
+            expect((*legacy)->signature == entry.signature
+                       && (*legacy)->objects == entry.objects
+                       && (*legacy)->libraries == entry.libraries
+                       && (*legacy)->output == entry.output
+                       && (*legacy)->file_inputs.empty()
+                       && (*legacy)->side_outputs.empty(),
+                   "legacy link-cache decoding must preserve fields and absent-field defaults");
+        }
+    }
+}
 
 } // namespace
 
@@ -131,6 +228,8 @@ int main() {
     }
     const auto truncated = mqb::LinkCacheFile::load(file);
     expect(!truncated.has_value(), "truncated link cache should be rejected");
+
+    test_reader_boundaries(tree.root, entry);
 
     if (failures != 0) {
         std::cerr << failures << " test(s) failed\n";

--- a/cpp/tests/discovery/source_discovery_cache_tests.cpp
+++ b/cpp/tests/discovery/source_discovery_cache_tests.cpp
@@ -238,6 +238,67 @@ int main() {
     expect(repaired_cache.has_value() && repaired_cache->reused,
            "full fallback after corrupt cache should repair evidence for the next invocation");
 
+    const auto expect_reader_fallback = [&] {
+        const auto fallback = mqb::discovery::SourceDiscovery::discover(request);
+        expect(fallback.has_value() && !fallback->reused,
+               "invalid discovery transport must trigger fresh discovery, never a hit");
+        if (fallback && repaired_cache) {
+            expect(fallback->sources == repaired_cache->sources
+                       && fallback->indexed_files == repaired_cache->indexed_files,
+                   "reader fallback must preserve source ordering and index accounting");
+        }
+        const auto resealed = mqb::discovery::SourceDiscovery::discover(request);
+        expect(resealed.has_value() && resealed->reused,
+               "reader fallback should repair the cache for the next invocation");
+    };
+
+    write_text(default_cache, "");
+    expect_reader_fallback();
+
+    const auto cache_size = fs::file_size(default_cache, error_code);
+    expect(!error_code && cache_size > 12u, "valid discovery cache should be sizeable");
+    if (!error_code && cache_size > 12u) {
+        fs::resize_file(default_cache, cache_size - 1u, error_code);
+        expect(!error_code, "discovery cache should be truncatable");
+        if (!error_code) expect_reader_fallback();
+    }
+
+    {
+        std::ofstream stream{default_cache, std::ios::binary | std::ios::app};
+        stream.put('\0');
+        expect(stream.good(), "discovery trailing-byte fixture should append");
+    }
+    expect_reader_fallback();
+
+    fs::resize_file(default_cache, 64u * 1024u * 1024u + 1u, error_code);
+    expect(!error_code, "oversized discovery-cache fixture should resize");
+    if (!error_code) expect_reader_fallback();
+
+    fs::remove(default_cache, error_code);
+    expect(!error_code, "discovery cache should be removable");
+    if (!error_code) expect_reader_fallback();
+
+    fs::remove(default_cache, error_code);
+    expect(!error_code, "directory-policy fixture should remove only the cache file");
+    if (!error_code) {
+        // A nonempty directory cannot be replaced by best-effort cache repair.
+        // It must not become a cache hit or make fresh discovery fail.
+        const fs::path sentinel = default_cache / "keep.txt";
+        write_text(sentinel, "preserve this directory");
+        const auto directory_cache = mqb::discovery::SourceDiscovery::discover(request);
+        expect(directory_cache.has_value() && !directory_cache->reused,
+               "a directory cache path must retain ordinary-file rejection");
+        if (directory_cache && repaired_cache) {
+            expect(directory_cache->sources == repaired_cache->sources,
+                   "an unusable cache directory must not change source selection");
+        }
+        expect(fs::is_regular_file(sentinel),
+               "best-effort cache repair must preserve a nonempty directory");
+        fs::remove_all(default_cache, error_code);
+        expect(!error_code, "directory-policy fixture should be removable");
+        if (!error_code) expect_reader_fallback();
+    }
+
     mqb::discovery::Request uncached = request;
     uncached.persistent_cache = false;
     const auto disabled_first = mqb::discovery::SourceDiscovery::discover(uncached);

--- a/docs/BOUNDED_LINK_DISCOVERY_CACHE_READERS.md
+++ b/docs/BOUNDED_LINK_DISCOVERY_CACHE_READERS.md
@@ -1,0 +1,89 @@
+# Bounded link and discovery cache readers
+
+## Scope and exact baseline
+
+This iteration is stacked on PR #157 at
+`2c87b47d9fe4945a75077a8ded0bdfed5ca425ab`, not directly on main. It reuses
+`core/BoundedCacheReader.hpp` without changing that helper or compile-cache
+behavior. VERSION remains 5.4.0. This is not release preparation.
+
+Only link and discovery cache transport changes. Cache formats, serializers,
+save/replacement behavior, semantic validation, dependency freshness, CLI
+reporting, scheduling, archive and toolchain loaders remain unchanged.
+
+## Backend contracts
+
+| Backend | Successful read before | Successful read now | Preserved policy |
+|---|---|---|---|
+| Link | pathname exists, pathname size, open/read | one open, bounded same-stream size/read/EOF | missing is a miss; other failures retain typed errors; v2/v3/v4 decoding |
+| Discovery | ordinary-file query, pathname size, open/read | ordinary-file query, one open, bounded same-stream size/read/EOF | ordinary-file guard, best-effort fallback, request identity and all filesystem evidence |
+
+The existing 64 MiB limits apply before allocating the payload. The shared
+reader rejects failed/negative size queries, stream-size overflow, short reads,
+observed growth and EOF I/O failures. Empty existing link caches remain invalid
+magic, not misses. Link pathname queries are diagnostic-only after a failed
+open; the file is not reopened. This can add a failed open on a missing link
+cache and must be considered in cold-path evidence.
+
+Discovery deliberately retains `is_regular_file`. Removing a type policy is not
+necessary to remove a repeated pathname size query. Its source ordering,
+indexed-file accounting, request semantics and file/directory timestamp checks
+are unchanged. Any unusable cache still falls back to fresh discovery and
+best-effort repair. A nonempty directory at the cache pathname is not deleted.
+
+The helper does not provide an atomic snapshot against arbitrary concurrent
+in-place or timestamp-preserving writes. No cross-stage filesystem evidence is
+reused by this change, and no freshness comparison or retry is removed.
+
+## Tests and instrumentation
+
+The existing link-cache test executable adds empty-file and directory error
+contracts, over-limit rejection, trailing-zero rejection with exact decoder
+offset, removal/recreation and actual v2/v3 legacy payloads. Existing v4
+round-trip, invalid magic, unsupported version and truncation tests remain.
+Directory assertions derive the exact historical error category on the active
+standard library rather than assuming POSIX behavior on MSVC.
+
+The existing discovery-cache test executable adds empty, truncated, trailing,
+oversized, missing and nonempty-directory cache cases. Each repairable case
+requires correct fresh results followed by a warm hit. Existing Unicode alias,
+header/source/directory changes, forced-include/request identity, stale-format
+and explicitly disabled-cache tests remain. Deterministic stream failure and
+mutation cases are already covered by the unchanged helper tests from #157.
+No new product translation unit or test executable is introduced.
+
+`ScopedCacheRead::opened` still observes the sized payload. These counters do
+not count pathname metadata calls or failed opens. Normal scenario cache
+hits/misses, payload bytes/opens, filesystem freshness probes, process launches
+and output must be compared between exact base/head runs. A source-level
+reduction in metadata calls is not itself a measured speedup.
+
+## Independent performance decision
+
+The PR's unchanged Performance Evidence workflow builds the exact PR base and
+head with the same pinned MQB seed, then collects four alternating ABBA pairs
+for all existing scenarios on one Windows runner. Using #157's head as the base
+isolates this iteration from its compile-reader improvement. Raw artifacts,
+run IDs and exact commits belong in the PR evidence record; no numeric result
+is assumed in this design note.
+
+Review both internal timings and the existing timing-disabled external no-op,
+as well as cold/miss paths. Report paired deltas, adverse samples and counters.
+Link/discovery cache-read work includes decoding and can overlap other fields;
+it is not an isolated I/O percentage. With only four pairs, nearest-rank P95 is
+the maximum sample, not an established production-tail estimate. Do not pool
+this run with #157 or add successive PR percentages.
+
+Native Debug/Release, self-host/package and independent ABBA evidence remain
+review gates. Keeping both PRs as drafts does not authorize either merge.
+
+## Follow-on boundaries
+
+Archive needs a separate text-reader and writer-size contract with static-library
+evidence; its current loader is not a copy of the binary link/discovery loaders.
+Toolchain trust/age/PATH/newest-toolset/binary validation must remain intact.
+Reporting needs full formatting/loop measurements before invasive object
+evidence handoff is prioritized. Cache packs remain conditional on isolated
+remaining I/O reaching the agreed 25-30% threshold. Resident processes,
+watchers and USN work remain v6.0. Only a final independent release PR updates
+VERSION/changelog after cumulative evidence against the released v5.4.0.


### PR DESCRIPTION
## Final decision: closed without merging

The owner delegated a final decision for #157/#158/#159. **Do not include this patch in v5.5.0 in its present form.** This is a low-value optimization rejected on incremental evidence, not a correctness failure and not an indefinite Draft hold. Its branch and raw evidence remain available. #157 is accepted independently.

Exact experiment: base `2c87b47d9fe4945a75077a8ded0bdfed5ca425ab`, head `c23ea11010c24410cab46ad2d6d17c13a92d42e7`. VERSION remains 5.4.0; no tag or release change.

### Scope that was evaluated

The patch reused #157's bounded single-open helper for link/discovery. Link preserved missing/typed-error policy; discovery retained the regular-file guard and all request/filesystem evidence. Both retained 64 MiB bounds, formats, source ordering and fallback semantics. Native C++ #673, full Native Release/self-host/package #576 and the original ABBA #498 passed. No unresolved review threads were found. The design note remains on the closed branch at `docs/BOUNDED_LINK_DISCOVERY_CACHE_READERS.md`.

### Final fixed external comparison

Candidate Merge Decisions [run 34146614041](https://github.com/Iviesever/msvc-quick-build/actions/runs/34146614041), [artifact 10028122485](https://github.com/Iviesever/msvc-quick-build/actions/runs/34146614041/artifacts/10028122485), ZIP SHA-256 `7466f9f8c2e11ba8b18b6795232460b849c09ad171fdf62f02a69216ae0afcec`.

Forty alternating A/B pairs per warm case on the same Windows runner, timings OFF, same fixture/cache paths, plus six independently reset cold pairs. All raw transcripts and adverse observations are retained. Source/tree/binary identities and before/after artifact metadata are recorded. The true persistent discovery-hit case passes zero-cache-write/zero-tool checks, fixing the previous evidence coverage gap without modifying product freshness.

Paired medians (candidate minus base):

| Case | Delta ms | Delta % | Faster pairs |
|---|---:|---:|---:|
| small default | -0.0158 | -0.18% | 22/40 |
| common129 default auto | +0.2095 | +0.53% | 13/40 |
| common129 default j1 | +0.2953 | +0.57% | 13/40 |
| common129 verbose | +0.1379 | +0.34% | 15/40 |
| static129 default | +0.2505 | +0.63% | 16/40 |
| static129 verbose | +0.4744 | +1.18% | 14/40 |
| PCH default | -0.0653 | -0.63% | 23/40 |
| actual discovery hit | -0.0312 | -0.30% | 21/40 |
| common129 cold | -5.4529 | -0.11% | 3/6 |

These are small, mostly neutral/slightly adverse incremental results. **They do not trigger the predeclared practical regression flag and do not prove a material regression.** In particular static cases do not exercise the changed loaders, so their drift must not be causally attributed to link/discovery transport. Conversely, no convincing incremental end-to-end benefit emerges from the cases that do exercise it. The original #498 reader-work reductions (roughly 0.037/0.014 ms) are retained but are insufficient reason to carry this additional loader/error-mapping surface merely to complete a five-reader checklist.

Original evidence remains [Performance #498](https://github.com/Iviesever/msvc-quick-build/actions/runs/34134838821/artifacts/10023846528), digest `b609bb46f71ac52f1e258d384f2231fbf8e431db448815d95a1786a003a13dc7`; it is not replaced or pooled with the new run. Previously skipped #499 is not a measurement.

### Consequence for the remaining route

Main keeps the existing link/discovery loaders. Do not silently cherry-pick this closed patch into later performance PRs. A future integrity-focused or demonstrably faster redesign needs its own rationale and evidence. Archive is different: it currently lacks a total-byte bound and needs a consistent read/write contract, so that independent iteration can still proceed using #157's accepted helper. Multi-key discovery is not justified: a genuine hit is now measurable without a storage redesign.