### PR TITLE
perf: bound archive cache transport and preserve v1 write compatibility

### DIFF
--- a/.github/workflows/archive-evidence.yml
+++ b/.github/workflows/archive-evidence.yml
@@ -1,0 +1,73 @@
+name: Archive Cache Evidence
+
+on:
+  pull_request:
+    paths:
+      - 'cpp/src/core/cache/ArchiveCacheFile.cpp'
+      - 'cpp/include/mqb/core/BoundedCacheReader.hpp'
+      - 'cpp/tests/core/cache/archive_cache_file_tests.cpp'
+      - 'tests/native/compare_archive.py'
+      - 'tests/native/compare_reporting.py'
+      - '.github/workflows/archive-evidence.yml'
+  workflow_dispatch:
+    inputs:
+      base_ref:
+        description: Baseline ref resolved before building
+        required: true
+        default: main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: archive-evidence-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compare:
+    name: Static archive contracts and independent ABBA
+    runs-on: windows-latest
+    timeout-minutes: 40
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          path: candidate
+          persist-credentials: false
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.base.sha || inputs.base_ref }}
+          path: baseline
+          persist-credentials: false
+      - name: Build exact baseline and candidate with the same seed
+        shell: pwsh
+        run: |
+          $root = Join-Path $env:GITHUB_WORKSPACE 'candidate'
+          $seed = & (Join-Path $root 'tests/native/acquire_seed.ps1') -RepoRoot $root -OutputRoot (Join-Path $env:GITHUB_WORKSPACE 'archive-seed')
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          foreach ($side in @('baseline', 'candidate')) {
+            $root = Join-Path $env:GITHUB_WORKSPACE $side
+            $version = (Get-Content (Join-Path $root 'VERSION') -Raw).Trim()
+            $mqb = & (Join-Path $root 'tests/native/build_mqb.ps1') -BuilderMqbPath $seed -RepoRoot $root -Version $version -Configuration Release -Clean -OutputPath (Join-Path $env:GITHUB_WORKSPACE "archive-out/$side/mqb.exe")
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+            if (-not (Test-Path $mqb -PathType Leaf)) { throw "Missing $side binary" }
+          }
+      - name: Static warm, cold, mutation and bad-cache recovery evidence
+        shell: pwsh
+        run: |
+          $baseSha = git -C baseline rev-parse HEAD
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $headSha = git -C candidate rev-parse HEAD
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          python candidate/tests/native/compare_archive.py --baseline archive-out/baseline/mqb.exe --candidate archive-out/candidate/mqb.exe --base-sha $baseSha --head-sha $headSha --output archive-out/evidence
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+      - name: Retain all raw observations, including partial failures
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: mqb-archive-evidence
+          path: archive-out/evidence/
+          retention-days: 30
+          if-no-files-found: warn

--- a/cpp/src/core/cache/ArchiveCacheFile.cpp
+++ b/cpp/src/core/cache/ArchiveCacheFile.cpp
@@ -1,5 +1,6 @@
 #include "mqb/core/ArchiveCacheFile.hpp"
 
+#include <algorithm>
 #include <chrono>
 #include <cstdint>
 #include <expected>
@@ -8,12 +9,16 @@
 #include <iomanip>
 #include <limits>
 #include <optional>
+#include <span>
+#include <spanstream>
+#include <streambuf>
 #include <string>
 #include <string_view>
 #include <system_error>
 #include <utility>
 #include <vector>
 
+#include "mqb/core/BoundedCacheReader.hpp"
 #include "mqb/core/PerformanceEvidence.hpp"
 
 namespace mqb {
@@ -23,6 +28,62 @@ namespace fs = std::filesystem;
 constexpr std::string_view magic = "MQBARCHIVE";
 constexpr unsigned int format_version = 1;
 constexpr std::size_t max_objects = 100000u;
+constexpr std::size_t max_cache_bytes = 64u * 1024u * 1024u;
+
+// Serialize the unchanged quoted-text grammar once, with a bound before any
+// growth. No directory or temporary file is touched for an oversized record.
+// Unlike ostringstream, vector capacity growth is explicitly capped as well.
+class BoundedArchiveBuffer final : public std::streambuf {
+public:
+    [[nodiscard]] std::span<const char> bytes() const noexcept { return bytes_; }
+
+protected:
+    std::streamsize xsputn(const char* data, const std::streamsize count) override {
+        if (count < 0 || static_cast<std::uintmax_t>(count) > max_cache_bytes - bytes_.size()) {
+            return 0;
+        }
+        const auto size = static_cast<std::size_t>(count);
+        if (size == 0) return 0;
+        const auto required = bytes_.size() + size;
+        if (required > bytes_.capacity()) {
+            const auto grown = std::max(std::size_t{4096}, bytes_.capacity() * 2);
+            bytes_.reserve(std::min(max_cache_bytes, std::max(required, grown)));
+        }
+        bytes_.insert(bytes_.end(), data, data + size);
+        return count;
+    }
+
+    int_type overflow(const int_type value) override {
+        if (traits_type::eq_int_type(value, traits_type::eof())) {
+            return traits_type::not_eof(value);
+        }
+        const char ch = traits_type::to_char_type(value);
+        return xsputn(&ch, 1) == 1 ? value : traits_type::eof();
+    }
+
+private:
+    std::vector<char> bytes_;
+};
+
+// Match std::quoted's default escaping without an unbounded temporary escaped
+// string. All serialized bytes pass through the same bounded destination.
+void write_quoted(std::ostream& out, const std::string_view text) {
+    if (!out) return;
+    out.put('"');
+    std::size_t begin = 0;
+    while (out) {
+        const auto escaped = text.find_first_of("\\\"", begin);
+        if (escaped == std::string_view::npos) {
+            out.write(text.data() + begin, static_cast<std::streamsize>(text.size() - begin));
+            break;
+        }
+        out.write(text.data() + begin, static_cast<std::streamsize>(escaped - begin));
+        out.put('\\');
+        out.put(text[escaped]);
+        begin = escaped + 1;
+    }
+    out.put('"');
+}
 
 [[nodiscard]] ArchiveCacheFileError error(
     const ArchiveCacheFileErrorCode code,
@@ -57,25 +118,33 @@ std::expected<std::optional<ArchiveCacheEntry>, ArchiveCacheFileError>
 ArchiveCacheFile::load(const fs::path& file) {
     mqb::performance::ScopedCacheRead evidence{
         mqb::performance::CacheKind::archive};
-    std::error_code ec;
-    if (!fs::exists(file, ec)) {
-        if (ec) return std::unexpected(error(
-            ArchiveCacheFileErrorCode::file_open_failed, file, "failed to query archive cache file"));
-        return std::optional<ArchiveCacheEntry>{};
+    std::ifstream file_stream{file, std::ios::binary};
+    if (!file_stream) {
+        // Missing remains a normal miss. Query only after a failed open and
+        // never reopen; retain the archive owner's historical error category.
+        std::error_code ec;
+        const bool exists = fs::exists(file, ec);
+        if (!ec && !exists) return std::optional<ArchiveCacheEntry>{};
+        return std::unexpected(error(
+            ArchiveCacheFileErrorCode::file_open_failed, file,
+            ec ? "failed to query archive cache file" : "failed to open archive cache file"));
     }
-
-    std::ifstream stream{file, std::ios::binary | std::ios::ate};
-    if (!stream) return std::unexpected(error(
-        ArchiveCacheFileErrorCode::file_open_failed, file, "failed to open archive cache file"));
-    const std::streampos end = stream.tellg();
-    const std::uint64_t size = end == std::streampos{-1}
-        ? 0u
-        : static_cast<std::uint64_t>(static_cast<std::streamoff>(end));
-    stream.clear();
-    stream.seekg(0, std::ios::beg);
-    if (!stream) return std::unexpected(error(
-        ArchiveCacheFileErrorCode::file_open_failed, file, "failed to seek archive cache file"));
-    evidence.opened(size);
+    auto bytes = read_bounded_cache_stream(
+        file_stream, max_cache_bytes,
+        [&evidence](const std::uint64_t size) { evidence.opened(size); });
+    if (!bytes) {
+        const bool corrupt = bytes.error().code == BoundedCacheReadErrorCode::size_limit_exceeded
+            || bytes.error().code == BoundedCacheReadErrorCode::trailing_data;
+        return std::unexpected(error(
+            corrupt ? ArchiveCacheFileErrorCode::corrupt_data
+                    : ArchiveCacheFileErrorCode::file_read_failed,
+            file, corrupt ? "archive cache exceeds size limit or grew during read"
+                          : "failed to read complete archive cache file"));
+    }
+    // The owned payload outlives its read-only span stream. No second payload
+    // copy or repeated external stream access is needed for formatted decoding.
+    std::ispanstream stream{std::span<const char>{
+        reinterpret_cast<const char*>(bytes->data()), bytes->size()}};
 
     std::string loaded_magic;
     unsigned int version = 0;
@@ -151,6 +220,30 @@ ArchiveCacheFile::save(const fs::path& file, const ArchiveCacheEntry& entry) {
             ArchiveCacheFileErrorCode::file_write_failed, file, "archive cache object count exceeds safety limit"));
     }
 
+    BoundedArchiveBuffer buffer;
+    std::ostream encoded{&buffer};
+    encoded << magic << ' ' << format_version << '\n';
+    const auto field = [&encoded](const std::string_view value) {
+        write_quoted(encoded, value);
+        encoded.put('\n');
+    };
+    field(path_to_utf8(entry.librarian.librarian));
+    field(entry.librarian.version);
+    field(entry.librarian.binary_stamp);
+    encoded << entry.signature.digest().high << ' ' << entry.signature.digest().low << '\n';
+    field(path_to_utf8(entry.output));
+    encoded << entry.objects.size() << '\n';
+    for (const auto& object : entry.objects) {
+        if (!encoded) break;
+        field(path_to_utf8(object));
+    }
+    if (!encoded) {
+        return std::unexpected(error(
+            ArchiveCacheFileErrorCode::file_write_failed, file,
+            "archive cache exceeds safety size limit"));
+    }
+    const auto bytes = buffer.bytes();
+
     std::error_code ec;
     if (!file.parent_path().empty()) {
         fs::create_directories(file.parent_path(), ec);
@@ -163,17 +256,10 @@ ArchiveCacheFile::save(const fs::path& file, const ArchiveCacheEntry& entry) {
         std::ofstream stream{temporary, std::ios::binary | std::ios::trunc};
         if (!stream) return std::unexpected(error(
             ArchiveCacheFileErrorCode::file_open_failed, temporary, "failed to open temporary archive cache"));
+        // Keep the existing write-counter convention. Accepted payload bytes
+        // were historically not counted for archives; do not reattribute them.
         evidence.opened(0);
-        stream << magic << ' ' << format_version << '\n'
-               << std::quoted(path_to_utf8(entry.librarian.librarian)) << '\n'
-               << std::quoted(entry.librarian.version) << '\n'
-               << std::quoted(entry.librarian.binary_stamp) << '\n'
-               << entry.signature.digest().high << ' ' << entry.signature.digest().low << '\n'
-               << std::quoted(path_to_utf8(entry.output)) << '\n'
-               << entry.objects.size() << '\n';
-        for (const auto& object : entry.objects) {
-            stream << std::quoted(path_to_utf8(object)) << '\n';
-        }
+        stream.write(bytes.data(), static_cast<std::streamsize>(bytes.size()));
         stream.flush();
         if (!stream) {
             stream.close();

--- a/cpp/tests/core/cache/archive_cache_file_tests.cpp
+++ b/cpp/tests/core/cache/archive_cache_file_tests.cpp
@@ -1,0 +1,164 @@
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <iterator>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <system_error>
+
+#include "mqb/core/ArchiveCacheFile.hpp"
+
+namespace {
+namespace fs = std::filesystem;
+constexpr std::size_t limit = 64u * 1024u * 1024u;
+int failures = 0;
+void expect(const bool condition, const std::string_view message) {
+    if (!condition) { ++failures; std::cerr << "FAIL: " << message << '\n'; }
+}
+struct TempTree {
+    fs::path root = fs::temp_directory_path() / ("mqb_archive_transport_" + std::to_string(
+        std::chrono::steady_clock::now().time_since_epoch().count()));
+    TempTree() { fs::create_directories(root); }
+    ~TempTree() { std::error_code ec; fs::remove_all(root, ec); }
+};
+std::string path_text(const fs::path& path) {
+    const auto bytes = path.lexically_normal().generic_u8string();
+    return {reinterpret_cast<const char*>(bytes.data()), bytes.size()};
+}
+std::string legacy_bytes(const mqb::ArchiveCacheEntry& entry) {
+    // Exact v1 writer grammar; keep a compatibility oracle independent of the
+    // new bounded buffer, including quotes, escapes and whitespace.
+    std::ostringstream out;
+    out << "MQBARCHIVE 1\n" << std::quoted(path_text(entry.librarian.librarian)) << '\n'
+        << std::quoted(entry.librarian.version) << '\n'
+        << std::quoted(entry.librarian.binary_stamp) << '\n'
+        << entry.signature.digest().high << ' ' << entry.signature.digest().low << '\n'
+        << std::quoted(path_text(entry.output)) << '\n' << entry.objects.size() << '\n';
+    for (const auto& object : entry.objects) out << std::quoted(path_text(object)) << '\n';
+    return out.str();
+}
+std::string read_bytes(const fs::path& file) {
+    std::ifstream in{file, std::ios::binary};
+    return {std::istreambuf_iterator<char>{in}, std::istreambuf_iterator<char>{}};
+}
+void write_bytes(const fs::path& file, const std::string_view bytes) {
+    std::ofstream out{file, std::ios::binary | std::ios::trunc};
+    out.write(bytes.data(), static_cast<std::streamsize>(bytes.size()));
+    expect(static_cast<bool>(out), "fixture write must succeed");
+}
+void expect_entry(const fs::path& file, const mqb::ArchiveCacheEntry& entry) {
+    const auto loaded = mqb::ArchiveCacheFile::load(file);
+    expect(loaded && *loaded, "valid legacy-format archive must load");
+    if (!loaded || !*loaded) return;
+    const auto& got = **loaded;
+    expect(got.librarian.librarian == entry.librarian.librarian
+        && got.librarian.version == entry.librarian.version
+        && got.librarian.binary_stamp == entry.librarian.binary_stamp
+        && got.signature == entry.signature && got.objects == entry.objects
+        && got.output == entry.output, "all fields, order and binary string bytes must round-trip");
+}
+void expect_corrupt(const fs::path& file, const std::string_view bytes) {
+    write_bytes(file, bytes);
+    const auto loaded = mqb::ArchiveCacheFile::load(file);
+    expect(!loaded && loaded.error().code == mqb::ArchiveCacheFileErrorCode::corrupt_data,
+           "malformed existing cache must be corrupt, never missing");
+}
+}
+
+int main() {
+    TempTree tree;
+    const fs::path file = tree.root / "record.archivecache";
+    mqb::ArchiveCacheEntry entry{
+        .librarian = {.librarian = "tools/lib.exe", .version = "14.51",
+                      .binary_stamp = std::string{"stamp\0", 6} + "\"\\\r\n"},
+        .signature = mqb::BuildSignature::from_digest({42, 99}),
+        .objects = {"obj/a.obj", fs::path{u8"obj/空 格.obj"}, "obj/third.obj"},
+        .output = "bin/archive.lib",
+    };
+    const auto missing = mqb::ArchiveCacheFile::load(file);
+    expect(missing && !*missing, "missing archive remains a normal miss");
+    const auto directory = mqb::ArchiveCacheFile::load(tree.root);
+    expect(!directory, "a directory must not be accepted as a cache miss or payload");
+    std::uint32_t random = 0x159160u;
+    for (unsigned trial = 0; trial < 256; ++trial) {
+        auto varied = entry;
+        varied.librarian.binary_stamp.clear();
+        for (unsigned index = 0; index < trial; ++index) {
+            random = random * 1664525u + 1013904223u;
+            varied.librarian.binary_stamp.push_back(static_cast<char>(random >> 24));
+        }
+        expect(mqb::ArchiveCacheFile::save(file, varied).has_value(), "binary stamp fixture must save");
+        expect(read_bytes(file) == legacy_bytes(varied), "bounded escaping must match legacy writer byte-for-byte");
+        expect_entry(file, varied);
+    }
+    const auto original = legacy_bytes(entry);
+    write_bytes(file, original);
+    expect_entry(file, entry);
+    expect(mqb::ArchiveCacheFile::save(file, entry).has_value(), "valid save should succeed");
+    expect(read_bytes(file) == original, "new writer must retain exact v1 serialized bytes");
+    write_bytes(file, original + " \r\n\t");
+    expect_entry(file, entry);
+    expect_corrupt(file, "");
+    expect_corrupt(file, "WRONG 1\n");
+    expect_corrupt(file, original.substr(0, original.size() - 3));
+    expect_corrupt(file, original + "unexpected");
+    expect_corrupt(file, original + std::string(1, '\0'));
+    auto unsupported = original;
+    unsupported.replace(11, 1, "2");
+    write_bytes(file, unsupported);
+    const auto old_version = mqb::ArchiveCacheFile::load(file);
+    expect(!old_version && old_version.error().code == mqb::ArchiveCacheFileErrorCode::unsupported_version,
+           "unsupported version must keep its typed error");
+    expect_corrupt(file, "MQBARCHIVE 1\n\"lib\"\n\"v\"\n\"s\"\n1 2\n\"out\"\n100001\n");
+    write_bytes(file, "x");
+    fs::resize_file(file, limit + 1);
+    const auto too_large = mqb::ArchiveCacheFile::load(file);
+    expect(!too_large && too_large.error().code == mqb::ArchiveCacheFileErrorCode::corrupt_data,
+           "over-limit file must be rejected before payload allocation/decoding");
+    expect(mqb::ArchiveCacheFile::save(file, entry).has_value(), "valid save must repair corrupt cache");
+    expect_entry(file, entry);
+    fs::remove(file);
+    const auto removed = mqb::ArchiveCacheFile::load(file);
+    expect(removed && !*removed, "removed cache is a new miss");
+    entry.librarian.binary_stamp = "replacement";
+    expect(mqb::ArchiveCacheFile::save(file, entry).has_value(), "same pathname can be recreated");
+    expect_entry(file, entry);
+    const auto prior = read_bytes(file);
+
+    // Escaping counts against the byte limit. An oversized save must preserve
+    // the prior cache and must not even create a new destination directory.
+    auto large = entry;
+    large.librarian.binary_stamp.assign(limit / 2, '\\');
+    const auto rejected = mqb::ArchiveCacheFile::save(file, large);
+    expect(!rejected && rejected.error().code == mqb::ArchiveCacheFileErrorCode::file_write_failed,
+           "escaped serialized bytes, not just input string length, enforce the write bound");
+    expect(read_bytes(file) == prior, "over-limit save must not replace prior valid cache");
+    large.librarian.binary_stamp.clear();
+    large.objects.assign(100001, "a.obj");
+    const auto new_path = tree.root / "untouched" / "cache";
+    expect(!mqb::ArchiveCacheFile::save(new_path, large), "oversized object count must fail");
+    expect(!fs::exists(new_path.parent_path()), "failed serialization must precede directory creation");
+    large.objects = entry.objects;
+    large.librarian.binary_stamp.clear();
+    const auto overhead = legacy_bytes(large).size();
+    large.librarian.binary_stamp.assign(limit - overhead, 'a');
+    expect(mqb::ArchiveCacheFile::save(file, large).has_value(), "exact 64 MiB serialized boundary is writable");
+    expect(fs::file_size(file) == limit, "exact-limit output has exactly the permitted size");
+    expect_entry(file, large);
+    large.librarian.binary_stamp.push_back('a');
+    expect(!mqb::ArchiveCacheFile::save(new_path, large), "one byte past exact limit must fail");
+    expect(!fs::exists(new_path.parent_path()), "byte-limit failure must not create directories");
+    expect(fs::file_size(file) == limit, "failed save elsewhere leaves existing boundary cache intact");
+    std::size_t files = 0;
+    for (const auto& item : fs::directory_iterator{tree.root}) {
+        ++files;
+        expect(item.path() == file, "no temporary cache residue may remain");
+    }
+    expect(files == 1, "only the accepted cache file should exist");
+    if (failures) { std::cerr << failures << " test(s) failed\n"; return 1; }
+    std::cout << "mqb_archive_cache_file_tests passed\n";
+}

--- a/docs/BOUNDED_ARCHIVE_CACHE.md
+++ b/docs/BOUNDED_ARCHIVE_CACHE.md
@@ -1,0 +1,113 @@
+# Bounded archive-cache transport
+
+## Scope
+
+This v5.5.0 development iteration follows the accepted compile-reader (#157)
+and reporting (#159) changes. The rejected link/discovery experiment (#158) is
+not included. VERSION remains 5.4.0; no release metadata is changed.
+
+Only archive-cache transport and its write-size contract change. The shared
+bounded reader is reused without modification. Archive signatures, object
+freshness, librarian invocation, retry/fallback, link/discovery/toolchain
+loaders, and CLI reporting remain unchanged. This is not a cache pack.
+
+## Why this remaining reader is different
+
+The previous archive loader sized its opened stream but imposed no total-byte
+limit, then decoded quoted fields directly from the file stream. Its writer
+also had no serialized-byte bound. A singleton reader optimization alone need
+not be worthwhile: #158 was closed after its incremental evidence showed too
+little benefit. Here a consistent read/write safety boundary is independently
+valuable, and moving formatted decoding to a bounded in-memory payload is
+measured on actual static-library targets rather than inferred from executable
+link scenarios.
+
+## Read contract
+
+Open the file once in binary mode. The existing shared reader obtains length
+and payload from that same stream, rejects sizes over 64 MiB before payload
+allocation, requires a complete read and rejects observed growth or EOF I/O
+failure. A read-only C++23 span stream then exposes the owned bytes to the
+unchanged archive v1 formatted decoder, without a second payload copy.
+
+A failed open still distinguishes an ordinary missing cache from an error via
+diagnostic-only pathname checks. Existing empty files are corrupt, not misses.
+Magic/version/object-count validation, object order, lexical path treatment,
+quoted fields and trailing-whitespace acceptance are retained. No earlier
+object snapshot is substituted for the coordinator's later observation.
+
+This is not an atomic filesystem snapshot against arbitrary concurrent
+in-place or timestamp-preserving edits. It also does not cap total process
+memory at 64 MiB: decoded strings/paths and caller-owned records still consume
+memory. The bound applies to serialized payload bytes and the writer's buffer
+growth requests, not allocator overhead or all model allocations.
+
+## Write contract and compatibility
+
+Serialize the same v1 text grammar into a private bounded stream buffer before
+creating directories or touching a temporary/destination file. Capacity growth
+requests and writes are capped by the same 64 MiB limit. Quoted fields are
+escaped directly into this destination in bounded spans, avoiding an unbounded
+escaped temporary. Quotes, backslashes, whitespace, UTF-8 and embedded NUL bytes
+retain the original std::quoted representation. Accepted bytes are written in
+one operation through the existing temporary-file replacement sequence.
+
+The object-count limit remains 100000. The byte limit counts the serialized
+representation, including escaping and delimiters. An over-limit save fails
+with file_write_failed and leaves the prior cache untouched; an over-limit
+read is corrupt_data. An exactly 64 MiB valid record is accepted by both sides.
+
+The total-byte bound is an intentional new policy: an older archive cache over
+64 MiB is no longer reusable even when its object count is permitted. The
+unchanged coordinator warns and re-archives instead of treating it as fresh.
+If the current record itself cannot fit, the successful build remains usable
+but cache saving reports a warning. The archive format version is not bumped
+because accepted v1 bytes and semantics are unchanged.
+
+The historical archive write instrumentation used opened(0). That convention
+is retained, rather than silently changing byte-accounting definitions in the
+same experiment. Read work still includes decoding; neither work time nor
+payload-open counters represent isolated OS I/O cost or syscall counts.
+
+## Validation
+
+A new native archive-cache executable adds an independent legacy-writer oracle,
+256 deterministic binary-string cases, exact field/order round trips, Unicode
+paths, empty/truncated/trailing/unsupported-version/count failures, missing and
+recreated files, over-limit read rejection, escaped-size overflow, prior-cache
+preservation, no temporary residue, and exact-limit read/write consistency.
+The native inventory becomes 79 tests; no product translation unit is added.
+Shared-reader mutation/seek/EOF tests remain in the accepted compile-cache suite.
+
+Supplemental GCC C++23 warning-as-error and ASan/UBSan tests pass locally with
+an external no-op performance-counter test shim. Those are not claimed as
+Windows/MSVC product validation. Required product gates remain the complete
+Debug/Release suites, self-host and packaged-artifact checks.
+
+## Independent evidence
+
+The unchanged original 19-scenario Performance Evidence workflow remains in
+place. Archive Cache Evidence separately builds the exact PR base and head
+with one pinned MQB seed. It reuses the existing external process recorder,
+without modifying that recorder or product instrumentation.
+
+Eight static-library warm scenarios cover 2/129 TUs, default/verbose output,
+timings on/off and j1, with 24 alternating AB/BA pairs each. Two more scenarios
+measure 129-TU cold builds and single-TU rebuilds with six pairs each: 204 pairs
+in total. Every row has external process start-through-completion/drain timing;
+internal work is auxiliary and never added to elapsed time. Cold and mutation
+samples are not pooled with warm samples.
+
+Warm pre/postconditions require expected hits, no tool launches or cache writes,
+unchanged project cache/artifact metadata and matching human transcripts.
+Instrumented pairs require equal counters and hit/miss counts; unavailable
+fields remain unavailable. Separate candidate-only contracts corrupt, truncate,
+append to, oversize and remove the archive cache, requiring a real re-archive
+without TU recompilation and a subsequent warm hit. Malformed-cache warnings
+must stay visible.
+
+All raw stdout/stderr, exact Git and binary identities, adverse samples and
+partial failures are retained. Captured pipes do not establish interactive
+terminal performance. Numeric results and final gate status belong in the PR
+record, not assumed in this design note. No cumulative v5.4.0 speedup can be
+obtained by adding percentages from this or prior iterations.

--- a/tests/native/assert_cpp_layout.ps1
+++ b/tests/native/assert_cpp_layout.ps1
@@ -192,6 +192,7 @@ $coreLeafFiles = [ordered]@{
 Assert-LeafLayout -Root (Join-Path $srcRoot 'core') -LeafFiles $coreLeafFiles
 Assert-LeafLayout -Root (Join-Path $testsRoot 'core') -LeafFiles ([ordered]@{
     'cache' = @(
+        'archive_cache_file_tests.cpp',
         'compile_cache_file_tests.cpp', 'compile_cache_tests.cpp',
         'link_cache_file_tests.cpp', 'link_state_tests.cpp',
         'module_scan_cache_tests.cpp'

--- a/tests/native/compare_archive.py
+++ b/tests/native/compare_archive.py
@@ -1,0 +1,147 @@
+"""Independent archive transport ABBA; reuse the existing external recorder.
+
+No product freshness changes, no dropped pairs, no synthetic future timestamps.
+Cold/mutation rows are separate from no-op rows; overlapping read work is not an
+elapsed I/O percentage. Captured pipes are not an interactive terminal.
+"""
+from __future__ import annotations
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import platform
+import shutil
+import tempfile
+import compare_reporting as h
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--self-test', action='store_true')
+    parser.add_argument('--baseline', type=Path)
+    parser.add_argument('--candidate', type=Path)
+    parser.add_argument('--base-sha')
+    parser.add_argument('--head-sha')
+    parser.add_argument('--output', type=Path)
+    args = parser.parse_args()
+    h.self_test()
+    if args.self_test:
+        return
+    h.require(os.name == 'nt', 'Product evidence requires Windows/MSVC')
+    h.require(all([args.baseline, args.candidate, args.output, args.base_sha, args.head_sha]),
+              'Missing exact binary/source identity or output directory')
+    base, candidate, output = args.baseline.resolve(), args.candidate.resolve(), args.output.resolve()
+    h.require(base.is_file() and candidate.is_file(), 'Exact binaries missing')
+    h.require(not output.exists(), 'Refusing to overwrite earlier evidence')
+    recorder = h.Recorder(output)
+    result = {'base_sha': args.base_sha, 'head_sha': args.head_sha,
+              'baseline_binary_sha256': hashlib.sha256(base.read_bytes()).hexdigest(),
+              'candidate_binary_sha256': hashlib.sha256(candidate.read_bytes()).hexdigest(),
+              'platform': platform.platform(), 'image_version': os.environ.get('ImageVersion'),
+              'definition': __doc__, 'scenarios': []}
+    def save() -> None:
+        (output / 'archive-comparison.json').write_text(json.dumps(result, indent=2), encoding='utf-8')
+    def add(name, pairs) -> None:
+        result['scenarios'].append({'name': name, 'summary': h.summarize(pairs), 'pairs': pairs})
+        save()
+    def order(index):
+        rows = [('baseline', base), ('candidate', candidate)]
+        return rows if index % 2 == 0 else list(reversed(rows))
+    save()
+    with tempfile.TemporaryDirectory(prefix='mqb-archive-') as temporary:
+        root = Path(temporary)
+        cases = [h.fixture(root, 'static2', 2, static=True), h.fixture(root, 'static129', 129, static=True)]
+        for case in cases:
+            recorder.run(base, case, case.name + '-prime-A')
+            recorder.run(candidate, case, case.name + '-prime-B')
+            for verbose, timed, jobs in [(False, False, 'auto'), (True, False, 'auto'),
+                                         (False, True, 'auto'), (False, False, '1')]:
+                name = f'{case.name}-{"verbose" if verbose else "default"}-{"timed" if timed else "off"}-j{jobs}'
+                def run(binary, label, audit=False):
+                    return recorder.run(binary, case, label, verbose=verbose, timings=timed or audit, jobs=jobs)
+                audit_a = run(base, name + '-pre-A', True)
+                audit_b = run(candidate, name + '-pre-B', True)
+                h.assert_warm(audit_a, case, candidate=False)
+                h.assert_warm(audit_b, case, candidate=True)
+                h.require(h.semantic_counters(audit_a) == h.semantic_counters(audit_b), 'Warm precondition differs')
+                before = h.state(case)
+                pairs = []
+                for index in range(24):
+                    pair = {'pair': index + 1, 'orientation': 'AB' if index % 2 == 0 else 'BA'}
+                    for side, binary in order(index):
+                        row = run(binary, f'{name}-{index + 1}-{side}')
+                        if timed:
+                            h.assert_warm(row, case, candidate=side == 'candidate')
+                        human = recorder.human(row, 'stdout')
+                        h.require(b'[compile]' not in human and b'[archive]' not in human,
+                                  'A measured warm invocation executed build work')
+                        pair[side] = row
+                    for channel in ['stdout', 'stderr']:
+                        h.require(pair['baseline'][f'human_{channel}_sha256'] == pair['candidate'][f'human_{channel}_sha256'],
+                                  'Archive transport changed the human transcript')
+                    h.require(h.semantic_counters(pair['baseline']) == h.semantic_counters(pair['candidate']),
+                              'Archive transport changed measured counters/hits')
+                    pairs.append(pair)
+                h.require(before == h.state(case), 'Warm measurement modified cache/artifact metadata')
+                post_a = run(base, name + '-post-A', True)
+                post_b = run(candidate, name + '-post-B', True)
+                h.assert_warm(post_a, case, candidate=False)
+                h.assert_warm(post_b, case, candidate=True)
+                h.require(h.semantic_counters(post_a) == h.semantic_counters(post_b), 'Warm postcondition differs')
+                add(name, pairs)
+        case = cases[1]
+        for kind in ['cold', 'single-tu']:
+            pairs = []
+            for index in range(6):
+                pair = {'pair': index + 1, 'orientation': 'AB' if index % 2 == 0 else 'BA'}
+                for side, binary in order(index):
+                    if kind == 'cold':
+                        shutil.rmtree(case.root / '.mqb')
+                    else:
+                        unit = case.root / 'unit_000.cpp'
+                        before = unit.stat().st_mtime_ns
+                        unit.write_text(unit.read_text(encoding='utf-8') + '\n// mutation\n', encoding='utf-8')
+                        h.require(unit.stat().st_mtime_ns > before, 'Actual mutation timestamp did not advance')
+                    row = recorder.run(binary, case, f'{kind}-{index + 1}-{side}', timings=True)
+                    expected_misses = case.units if kind == 'cold' else 1
+                    h.require(row['timing']['cache']['compile'] == {'hits': case.units - expected_misses, 'misses': expected_misses},
+                              'Unexpected rebuild scope')
+                    h.require(row['timing']['cache']['archive'] == {'hits': 0, 'misses': 1}, 'Required archive was skipped')
+                    h.require(case.output.is_file(), 'Static-library output missing')
+                    pair[side] = row
+                h.require(h.semantic_counters(pair['baseline']) == h.semantic_counters(pair['candidate']),
+                          'Rebuild counters differ')
+                pairs.append(pair)
+            add('static129-' + kind, pairs)
+        case = cases[0]
+        cache = case.root / '.mqb/cache/archive/report.archivecache'
+        h.require(cache.is_file(), 'Archive cache fixture missing')
+        for damage in ['empty', 'truncated', 'trailing', 'oversized', 'missing']:
+            if damage == 'empty':
+                cache.write_bytes(b'')
+            elif damage == 'truncated':
+                cache.write_bytes(cache.read_bytes()[:-3])
+            elif damage == 'trailing':
+                with cache.open('ab') as stream:
+                    stream.write(b'\x00')
+            elif damage == 'oversized':
+                with cache.open('r+b') as stream:
+                    stream.truncate(64 * 1024 * 1024 + 1)
+            else:
+                cache.unlink()
+            repaired = recorder.run(candidate, case, 'repair-' + damage, timings=True)
+            h.require(repaired['timing']['cache']['compile'] == {'hits': case.units, 'misses': 0},
+                      'Bad archive cache must not force compilation')
+            h.require(repaired['timing']['cache']['archive'] == {'hits': 0, 'misses': 1},
+                      'Unusable archive cache must cause a real re-archive')
+            if damage != 'missing':
+                h.require(b'warning:' in recorder.human(repaired, 'stderr'), 'Cache failure warning was suppressed')
+            warm = recorder.run(candidate, case, 'repaired-warm-' + damage, timings=True)
+            h.assert_warm(warm, case, candidate=True)
+    (output / 'passed.txt').write_text('All archive contracts and 204 independent ABBA pairs passed.\n', encoding='utf-8')
+    print(json.dumps([{k: v for k, v in row.items() if k != 'pairs'} for row in result['scenarios']], indent=2))
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/native/run_native_tests.ps1
+++ b/tests/native/run_native_tests.ps1
@@ -84,8 +84,8 @@ if ($includeDirs.Count -eq 0) { throw 'Native test config has no include_dirs.' 
 $allTestFiles = @(Get-ChildItem -LiteralPath $cppRoot -Recurse -File -Filter '*_tests.cpp' |
     Where-Object { $_.FullName -notmatch '[\\/]\.mqb[\\/]' } |
     Sort-Object FullName)
-if ($allTestFiles.Count -ne 78) {
-    throw "Native test manifest drift: expected 78 *_tests.cpp files, found $($allTestFiles.Count)."
+if ($allTestFiles.Count -ne 79) {
+    throw "Native test manifest drift: expected 79 *_tests.cpp files, found $($allTestFiles.Count)."
 }
 
 function Get-TestRelativePath {
@@ -124,7 +124,7 @@ $testWeightOverrides = [ordered]@{
 $relativeTestPaths = @($allTestFiles | ForEach-Object { Get-TestRelativePath -File $_ })
 foreach ($weightedPath in $testWeightOverrides.Keys) {
     if ($weightedPath -notin $relativeTestPaths) {
-        throw "Native test weight override is stale or missing from the 78-test manifest: $weightedPath"
+        throw "Native test weight override is stale or missing from the 79-test manifest: $weightedPath"
     }
 }
 


### PR DESCRIPTION
## Final status: merged with an explicit integrity/performance tradeoff

**Merged as `6f24bb4d2f5e323eb7b3823c3acf367dcccf9446`** after the owner's delegated review. The previous rebuild-performance hold is closed. VERSION remains **5.4.0**; no tag, changelog or GitHub Release publication.

- Original measured head: `bf70ed1024ab37ced2393e73edc4ed8e3c4868bb`.
- Up-to-date integration head: `36edabdcf2e2e50af41c77c50de2a58102a50ebb`, which includes main `4bab036f8ca8b2982acaa8969572329ceba5579a` without changing source bytes.
- Original head, integration head and merged main have **identical tree `00c5b8e600ca188d3ce6158f002390307ee3c887`**.
- Seven files, no new product translation unit. Rejected #158 remains excluded.

At merge time the latest required Native C++ #683/documentation checks had passed, and this exact source tree had already passed full Native Release/self-host/package #583. Repeat integration Release #584 was still executing at that moment; it subsequently completed successfully. No rule was bypassed, and that chronology is retained rather than rewriting the earlier gate status.

## Accepted implementation and compatibility boundary

Archive cache reads now use the unchanged shared bounded reader: one binary stream, same-stream length/read, 64 MiB pre-allocation bound, exact read and observed-growth/EOF-error checks. The v1 quoted-text decoder reads owned bytes through a read-only C++23 span stream, without a second whole-payload copy.

The writer serializes unchanged v1 bytes into a bounded private buffer before creating directories or touching the temporary/destination file. Escaped/delimiter bytes count against the same 64 MiB bound. Oversized saves preserve previous cache contents and unused destination directories. Exactly 64 MiB is accepted; one extra byte is rejected. The 100000-object limit, field/order semantics, accepted whitespace and normal replacement/cleanup remain.

The new total-byte limit intentionally rejects older oversized archive records. The unchanged coordinator warns/re-archives; a too-large new record cannot be cached but does not invalidate an otherwise successful build. This is not a total-process-memory limit or an atomic snapshot against arbitrary concurrent in-place or timestamp-preserving modification.

No archive signature, object freshness, librarian invocation, retry, scheduling, output or other loader changed. Historical write instrumentation `opened(0)` remains; cache-read work includes decoding and is not pure elapsed I/O share.

## Final correctness gates

- Native C++ **#683 / 34182430480: success**, including Debug jobs and native policy/freshness checks.
- Native Release **#584 / 34182430523: complete success**, all four Release jobs and self-host/package job **101925809405**, including runtime-only staging, validation and artifact upload. `publish-release` skipped.
- Earlier same-tree Native C++ #681 and full Release/package #583 remain successful historical gates.
- Archive Cache Evidence **#2 / 34182430477: success**; original #1 also passed all corruption/reuse contracts.
- Performance Evidence **#517 / 34182430506: successful collection** of the unchanged general harness, not a blanket performance pass. Readiness-triggered runs are separate and are not the fixed decision experiment.
- Documentation, compilation database, build plan, cross-stage, incremental, PCH and module checks passed on the integration head.

The 79-test native inventory includes legacy std::quoted byte oracles, 256 deterministic binary-stamp cases, Unicode/space paths, malformed/count/version/EOF checks, exact-limit read/write, escaped overflow, old-cache preservation and no temporary residue. Real-build damage cases require an archive miss without TU recompilation, followed by a genuine no-write/no-tool hit. No freshness assertions were weakened.

## Fixed follow-up that resolves the decision

[Archive Merge Decision #2 / run 34182041180](https://github.com/Iviesever/msvc-quick-build/actions/runs/34182041180), [artifact 10039349724](https://github.com/Iviesever/msvc-quick-build/actions/runs/34182041180/artifacts/10039349724).

Verified ZIP SHA-256: **`f71e87dc5292218d51d181756b6d68ae522be44f4a839641f6f02b9e43d13061`**.

Exact main `4bab036...` versus original candidate `bf70ed1...`, one Windows runner, fixed 40 alternating single-TU rebuild pairs with timings OFF. A/B writes use equal source bytes/length within a pair and actual later timestamps, never manufactured future timestamps. Each result contains exactly one compile and one archive. Post-rebuild audits require full hits, no tools/writes, equal semantic counters and unchanged cache/artifact metadata. Per-audit inventories and raw transcripts are retained.

| Measurement | Paired median delta | Paired median percent | MAD | Observed P95 | Faster pairs |
|---|---:|---:|---:|---:|---:|
| static129 single-TU rebuild, timings OFF | **-0.42615 ms** | **-0.34397%** | 3.7734 ms | +7.6024 ms | 21/40 |
| 32 real public cache-save calls per batch | **-0.5542 ms/batch** | **-1.49076%** | 3.72545 ms | +70.0751 ms | 14/24 |

The save probe measures serialization **plus real temporary-file replacement**, not isolated formatting or external process time. The batch median difference divided by 32 is about -0.0173 ms per call; it is not a measured median of individual call durations. Probe and rebuild clocks are not interchangeable. All 322 recorder transcript hashes, 48 probe outputs, exact identities and paired statistics were independently checked.

The predeclared practical rebuild flag (median above both 5 ms and 3%, with at least 30/40 slower pairs) was not triggered. That does not prove zero regression or characterize production tails. The fixed experiment is close to neutral and does not reproduce a large typical cost; actual save API batches likewise show no large typical increase. This supports accepting the bounded persistence contract, not advertising speedup.

The first harness attempt, run 34181612981, failed before measurements because historical seed v5.0.0-rc.2 interpreted modern `build` as a source filename. Only that harness invocation was corrected. Product heads, probe source, sample counts and decision rules were unchanged. No favorable-only rerun was used.

## Earlier adverse and integration evidence remains separate

Original Archive Cache Evidence #1: [run 34148454489 / artifact 10028667979](https://github.com/Iviesever/msvc-quick-build/actions/runs/34148454489/artifacts/10028667979), digest `762eeb16fa9684d9fee8fa6a8ff04b36a12c8692ffdb5979b192dcaca61675d7`. All 204 pairs remain, including timings-ON single-TU **+38.1584 ms / +22.33%, 1/6 faster**, cold **+92.0604 ms / +2.15%**, and approximately neutral large warm samples. Read/write attribution cannot explain away that total difference; no OS cause was proved.

Automatic integration Archive Evidence #2: [run 34182430477 / artifact 10039492780](https://github.com/Iviesever/msvc-quick-build/actions/runs/34182430477/artifacts/10039492780), digest **`a5ecdb5e7b368b9997e2f46a1b95407edbaa598bc866f1c1459bc68cf0244ce3`**. Same source trees, exact recorded main/integration SHAs, all 204 pairs and 908 transcript hashes independently checked. Single-TU timings-ON is **-4.2411 ms / -4.1856%, 4/6 faster**, but P95/max is **+50.3611 ms**. Cold median is -4.8877 ms / -0.0769% with a +6295.0658 ms maximum. Large warm timings-OFF default is -0.0690 ms / -0.3113%, verbose +0.1506 ms / +0.6773%, and timings-ON default +0.3312 ms / +1.4618%. These mixed results are retained, not pooled with the fixed timings-OFF decision or used to prove an OS explanation.

Original general Performance #512 [artifact 10028705604](https://github.com/Iviesever/msvc-quick-build/actions/runs/34148454314/artifacts/10028705604), digest `67d71399687613a0d9d67fafff8390158b3922f55111ea26665bb372feacf07d`, remains an unaffected-path control: its instrumented executable/module scenarios have zero archive payload opens and zero librarian launches. Favorable controls are not attributed to this patch or used to cancel its static rebuild observations.

## Remaining route

The decision is **accepted and merged**, not another indefinite hold. #161 independently binds toolchain v9 decoding to its existing byte limit while retaining all trust checks. It must not repeat #160's attribution. #158 is still rejected. Object handoff remains freshness-gated; cache packs require isolated residual I/O evidence; residency remains v6.0. Final cumulative performance must compare the accepted combination against released v5.4.0, followed by a separate VERSION/changelog/release-preparation PR.