### PR TITLE
perf: bound toolchain cache decoding without weakening trust checks

### DIFF
--- a/.github/workflows/toolchain-cache-evidence.yml
+++ b/.github/workflows/toolchain-cache-evidence.yml
@@ -1,0 +1,67 @@
+name: Toolchain Cache Evidence
+on:
+  pull_request:
+    paths:
+      - 'cpp/src/msvc/toolchain/VisualStudioToolchainCache.cpp'
+      - 'cpp/include/mqb/core/BoundedCacheReader.hpp'
+      - 'cpp/tests/msvc/toolchain/toolchain_cache_reader_tests.cpp'
+      - 'tests/native/compare_toolchain_cache.py'
+      - 'tests/native/compare_reporting.py'
+      - '.github/workflows/toolchain-cache-evidence.yml'
+  workflow_dispatch:
+    inputs:
+      base_ref:
+        description: Baseline ref resolved before building
+        required: true
+        default: main
+permissions:
+  contents: read
+concurrency:
+  group: toolchain-cache-evidence-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+jobs:
+  compare:
+    runs-on: windows-latest
+    timeout-minutes: 35
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          path: candidate
+          persist-credentials: false
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.base.sha || inputs.base_ref }}
+          path: baseline
+          persist-credentials: false
+      - name: Build both exact Release trees with the pinned seed
+        shell: pwsh
+        run: |
+          $root = Join-Path $PWD 'candidate'
+          $seed = & (Join-Path $root 'tests/native/acquire_seed.ps1') -RepoRoot $root -OutputRoot (Join-Path $PWD 'toolchain-seed')
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          foreach ($side in @('baseline', 'candidate')) {
+            $root = Join-Path $PWD $side
+            $version = (Get-Content (Join-Path $root 'VERSION') -Raw).Trim()
+            $mqb = & (Join-Path $root 'tests/native/build_mqb.ps1') -BuilderMqbPath $seed -RepoRoot $root -Version $version -Configuration Release -Clean -OutputPath (Join-Path $PWD "toolchain-out/$side/mqb.exe")
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+            if (-not (Test-Path $mqb -PathType Leaf)) { throw "Missing $side binary" }
+          }
+      - name: Actual toolchain hits, fallback contracts and fixed ABBA
+        shell: pwsh
+        run: |
+          $baseSha = git -C baseline rev-parse HEAD
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $headSha = git -C candidate rev-parse HEAD
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          python candidate/tests/native/compare_toolchain_cache.py --baseline toolchain-out/baseline/mqb.exe --candidate toolchain-out/candidate/mqb.exe --base-sha $baseSha --head-sha $headSha --output toolchain-out/evidence
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: mqb-toolchain-cache-evidence
+          path: toolchain-out/evidence/
+          retention-days: 30
+          if-no-files-found: warn

--- a/cpp/src/msvc/toolchain/VisualStudioToolchainCache.cpp
+++ b/cpp/src/msvc/toolchain/VisualStudioToolchainCache.cpp
@@ -8,6 +8,8 @@
 #include <fstream>
 #include <iomanip>
 #include <optional>
+#include <span>
+#include <spanstream>
 #include <string>
 #include <string_view>
 #include <system_error>
@@ -16,6 +18,7 @@
 
 #include "ToolchainDiscoveryPrimitives.hpp"
 #include "VisualStudioToolchainDiscovery.hpp"
+#include "mqb/core/BoundedCacheReader.hpp"
 #include "mqb/core/PerformanceEvidence.hpp"
 #include "mqb/msvc/MsvcToolchainEnvironmentIdentity.hpp"
 #include "mqb/platform/windows/PathIdentity.hpp"
@@ -322,15 +325,22 @@ void append_unique_existing_root(std::vector<fs::path>& roots, fs::path root) {
     try {
         std::error_code error_code;
         if (!fs::is_regular_file(cache_file, error_code) || error_code) return std::nullopt;
-        const auto size = fs::file_size(cache_file, error_code);
-        if (error_code || size > max_cache_size) return std::nullopt;
         const auto modified = fs::last_write_time(cache_file, error_code);
         if (error_code) return std::nullopt;
         const auto now = fs::file_time_type::clock::now();
         if (modified > now || now - modified > max_cache_age) return std::nullopt;
-        std::ifstream stream{cache_file, std::ios::binary};
-        if (!stream) return std::nullopt;
-        evidence.opened(static_cast<std::uint64_t>(size));
+        // Preserve the ordinary-file and age policies above. Bind the byte
+        // limit to the opened stream, not a pathname queried before the open.
+        std::ifstream file_stream{cache_file, std::ios::binary};
+        if (!file_stream) return std::nullopt;
+        auto bytes = mqb::read_bounded_cache_stream(
+            file_stream, static_cast<std::size_t>(max_cache_size),
+            [&evidence](const std::uint64_t size) { evidence.opened(size); });
+        if (!bytes) return std::nullopt;
+        // The payload owns the storage for the complete unchanged v9 decoder.
+        // No second payload copy and no unbounded formatted file read.
+        std::ispanstream stream{std::span<const char>{
+            reinterpret_cast<const char*>(bytes->data()), bytes->size()}};
         auto record = read_record(stream);
         if (!record || !cache_key_matches(*record, options) || record->binary_stamp.empty()) return std::nullopt;
 

--- a/cpp/tests/msvc/toolchain/toolchain_cache_reader_tests.cpp
+++ b/cpp/tests/msvc/toolchain/toolchain_cache_reader_tests.cpp
@@ -1,0 +1,115 @@
+#include <chrono>
+#include <expected>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <string>
+#include <string_view>
+#include <system_error>
+
+#include "mqb/msvc/MsvcToolchainLocator.hpp"
+#include "mqb/platform/windows/WindowsProcessRunner.hpp"
+
+namespace {
+namespace fs = std::filesystem;
+int failures = 0;
+void expect(bool condition, std::string_view message) {
+    if (!condition) { ++failures; std::cerr << "FAIL: " << message << '\n'; }
+}
+struct TempTree {
+    fs::path root = fs::temp_directory_path() / ("mqb_toolchain_reader_" + std::to_string(
+        std::chrono::steady_clock::now().time_since_epoch().count()));
+    ~TempTree() { std::error_code ec; fs::remove_all(root, ec); }
+};
+class RejectingRunner final : public mqb::process::ProcessRunner {
+public:
+    std::expected<mqb::process::ProcessResult, mqb::process::ProcessError>
+    run(const mqb::process::ProcessSpec&) override {
+        ++calls;
+        return std::unexpected(mqb::process::ProcessError{
+            .code = mqb::process::ProcessErrorCode::launch_failed,
+            .message = "cache miss attempted discovery"});
+    }
+    unsigned int calls{};
+};
+}
+
+int main() {
+    TempTree tree;
+    const fs::path cache = tree.root / ".mqb/cache/toolchain/vs.mqbcache";
+    mqb::msvc::DiscoveryOptions options;
+    options.preference = mqb::msvc::ToolchainPreference::visual_studio;
+    options.target_architecture = mqb::Architecture::x64;
+    options.host_architecture = mqb::Architecture::x64;
+    options.cache_file = cache;
+    mqb::platform::windows::WindowsProcessRunner real_runner;
+    mqb::msvc::MsvcToolchainLocator initial_locator{real_runner};
+    const auto initial = initial_locator.discover(options);
+    expect(initial.has_value(), "real Visual Studio discovery must create the validated fixture");
+    if (!initial) { std::cerr << initial.error().message << '\n'; return 1; }
+    std::ifstream input{cache, std::ios::binary};
+    const std::string valid{std::istreambuf_iterator<char>{input}, std::istreambuf_iterator<char>{}};
+    input.close();
+    expect(valid.starts_with("MQB_TOOLCHAIN_CACHE_V9\n"), "fixture must have the current grammar");
+    if (valid.empty()) return 1;
+    const auto write = [&](const std::string& bytes) {
+        std::ofstream out{cache, std::ios::binary | std::ios::trunc};
+        out.write(bytes.data(), static_cast<std::streamsize>(bytes.size()));
+        out.close();
+        expect(static_cast<bool>(out), "fixture replacement must succeed");
+    };
+    const auto check = [&](bool hit) {
+        RejectingRunner runner;
+        mqb::msvc::MsvcToolchainLocator locator{runner};
+        const auto result = locator.discover(options);
+        if (hit) {
+            expect(result && result->reused && runner.calls == 0,
+                   "valid v9 transport must reuse without a discovery process");
+            if (result) {
+                expect(result->identity.compiler == initial->identity.compiler
+                    && result->identity.binary_stamp == initial->identity.binary_stamp
+                    && result->linker == initial->linker && result->librarian == initial->librarian,
+                    "bounded transport must preserve selected tools and environment identity");
+            }
+        } else {
+            expect(!result && runner.calls != 0,
+                   "invalid transport must request real discovery, not be accepted or suppress fallback");
+        }
+    };
+    const auto malformed = [&](const std::string& bytes) {
+        write(bytes); check(false); write(valid); check(true);
+    };
+    check(true);
+    malformed("");
+    malformed(valid.substr(0, valid.size() / 2));
+    malformed(valid + std::string(1, '\0'));
+    malformed(valid + "unexpected");
+    auto old_format = valid;
+    old_format.replace(0, std::string{"MQB_TOOLCHAIN_CACHE_V9"}.size(), "MQB_TOOLCHAIN_CACHE_V8");
+    malformed(old_format);
+    constexpr std::size_t limit = 1024u * 1024u;
+    expect(valid.size() < limit, "fixture must fit the existing 1 MiB limit");
+    if (valid.size() < limit) {
+        auto boundary = valid;
+        boundary.resize(limit, ' '); // Existing grammar accepts trailing whitespace.
+        write(boundary); check(true);
+        boundary.push_back(' ');
+        malformed(boundary); // Grammar remains valid, transport exceeds the limit.
+    }
+    write(valid);
+    fs::last_write_time(cache, fs::file_time_type::clock::now() - std::chrono::minutes{31});
+    check(false);
+    fs::last_write_time(cache, fs::file_time_type::clock::now() + std::chrono::minutes{2});
+    check(false);
+    write(valid); check(true);
+    fs::remove(cache); check(false);
+    write(valid); check(true);
+    fs::remove(cache);
+    fs::create_directory(cache);
+    check(false); // Keep the ordinary-file guard; a directory never becomes payload.
+    fs::remove(cache);
+    write(valid); check(true);
+    if (failures) { std::cerr << failures << " test(s) failed\n"; return 1; }
+    std::cout << "mqb_toolchain_cache_reader_tests passed\n";
+}

--- a/docs/BOUNDED_TOOLCHAIN_CACHE_READER.md
+++ b/docs/BOUNDED_TOOLCHAIN_CACHE_READER.md
@@ -1,0 +1,84 @@
+# Bounded Visual Studio toolchain cache reads
+
+## Scope
+
+This v5.5.0 development iteration changes only the transport feeding the existing
+v9 toolchain-cache decoder. VERSION remains 5.4.0. It neither reinstates the
+rejected link/discovery experiment (#158) nor adds a cache pack or resident service.
+
+The old loader checked the pathname's size and then decoded directly from an
+opened file stream. If the file changed between that query and decoding, the
+preflight did not impose a bound on the actual bytes read; quoted-string checks
+happen after formatted extraction. The new path uses the already accepted
+`BoundedCacheReader.hpp` to size and read the same opened stream, then exposes
+its owned payload to the unchanged decoder through a read-only C++23 span stream.
+No second whole-payload copy is required. It also removes the pathname size query
+and formatted disk-stream extraction, but a speedup is not assumed.
+
+## Preserved decisions and boundaries
+
+The ordinary-file guard and last-write-time age validation still precede opening.
+The original 1 MiB limit applies to the actual buffered payload before allocation.
+Empty payloads, short reads, observed growth and EOF I/O errors fall back to
+ordinary discovery. Exactly 1 MiB of valid v9 data, including allowed trailing
+whitespace, is accepted; an extra byte is not. Field/count limits remain 256 KiB
+and 64 entries. Serialized grammar and cache version do not change.
+
+All key matching, exact ambient PATH comparison, latest-toolset selection, tool
+existence, compiler binary stamp, INCLUDE/LIB/LIBPATH trust, trusted SDK/root
+validation, standard-library module discovery and environment identity sealing
+remain unchanged. Explicit discovery overrides, ambient adoption, save behavior,
+replacement and error fallback also remain unchanged. No source/object freshness
+comparison, process invocation policy or reporting change belongs to this PR.
+
+The same-stream byte bound does not make the pathname age check atomic with the
+open and is not a guarantee against arbitrary concurrent in-place or timestamp-
+preserving modification. Existing freshness/trust validation is retained, not
+replaced by the transport snapshot. The bound is on serialized bytes, not total
+process memory. This PR does not add a total-byte bound to the toolchain writer;
+its existing field/count limits and best-effort behavior are unchanged.
+
+`ScopedCacheRead::opened` retains its healthy sized-payload observation point.
+The overall toolchain-cache work field includes decoding AND trust validation;
+its duration is not pure disk I/O and cannot justify a cache-pack threshold.
+Payload-open counters do not count pathname metadata calls.
+
+## Tests
+
+A dedicated native toolchain-reader test first obtains a real validated Visual
+Studio fixture. A rejecting process runner then requires a hit without any
+subprocess, identical selected tools and sealed identity. Empty, truncated,
+trailing NUL/non-whitespace, stale-version, missing, directory and over-limit
+payloads must attempt normal discovery rather than fabricate a usable hit.
+Every repairable case is followed by a restored valid hit. Exact-byte-limit,
+expired (31 minutes), future-timestamp and restoration cases are explicit.
+
+The shared reader's existing deterministic seek/short-read/growth/EOF tests
+remain in the compile-cache suite. Existing Visual Studio tests for environment,
+PATH, SDK roots, versions and related trust semantics are unchanged. No test
+shim is committed; Windows native CI is the product validation source.
+
+## Independent performance evidence
+
+The unchanged general 19-scenario Performance Evidence harness remains in place.
+A focused read-only Toolchain Cache Evidence workflow additionally builds exact
+base/head Release binaries using one pinned MQB seed. It reuses the existing
+external process recorder with common fixtures and cache pathnames.
+
+Two- and 129-TU targets are measured separately with timings OFF and ON: four
+scenarios, 24 alternating AB/BA pairs each. Warm pre/post audits require all
+compile/link hits, one toolchain payload read, no cache writes or tool launches.
+Instrumented pairs require equal non-output counters and hit counts; human
+transcripts must match. Full before/after artifact/cache metadata inventories
+are retained and must be equal. Missing instrumentation is unavailable, not zero.
+
+Five additional real-build cases damage only the toolchain payload and require
+successful ordinary rediscovery/resealing without TU recompilation or relinking,
+then a true warm hit. These are correctness contracts, not a discovery-miss speed
+claim. The native test separately proves that a hit does not invoke discovery.
+
+All raw stdout/stderr, Git and binary identities, adverse observations and paired
+statistics are retained. Pipe measurements are not interactive-terminal evidence.
+A green workflow means successful collection/validation, not universal speedup.
+Do not combine overlapping timings, pool runs or add successive PR percentages.
+Native Debug/Release and self-host/package checks remain independent gates.

--- a/docs/BOUNDED_TOOLCHAIN_CACHE_READER.md
+++ b/docs/BOUNDED_TOOLCHAIN_CACHE_READER.md
@@ -73,8 +73,12 @@ transcripts must match. Full before/after artifact/cache metadata inventories
 are retained and must be equal. Missing instrumentation is unavailable, not zero.
 
 Five additional real-build cases damage only the toolchain payload and require
-successful ordinary rediscovery/resealing without TU recompilation or relinking,
-then a true warm hit. These are correctness contracts, not a discovery-miss speed
+successful ordinary rediscovery/resealing with the same compile/link decisions,
+non-output counters and diagnostics as the exact baseline, then a true warm hit.
+Each side starts with a verified full hit on identical fixture paths. Source hashes
+are checked for equality; post-repair inventories are retained. Rediscovery may
+invalidate filesystem evidence; this test must not demand suppressed recompilation when the baseline
+correctly rebuilds. These are correctness contracts, not a discovery-miss speed
 claim. The native test separately proves that a hit does not invoke discovery.
 
 All raw stdout/stderr, Git and binary identities, adverse observations and paired

--- a/tests/native/assert_cpp_layout.ps1
+++ b/tests/native/assert_cpp_layout.ps1
@@ -249,7 +249,7 @@ Assert-LeafLayout -Root (Join-Path $testsRoot 'msvc') -LeafFiles ([ordered]@{
         'module_dependency_scanner_tests.cpp'
     )
     'parameters' = @('msvc_parameter_capabilities_tests.cpp', 'msvc_parameter_engine_tests.cpp')
-    'toolchain' = @('portable_tests.cpp', 'visual_studio_tests.cpp')
+    'toolchain' = @('portable_tests.cpp', 'visual_studio_tests.cpp', 'toolchain_cache_reader_tests.cpp')
 })
 
 $orchestrationLeafFiles = [ordered]@{

--- a/tests/native/compare_toolchain_cache.py
+++ b/tests/native/compare_toolchain_cache.py
@@ -1,0 +1,113 @@
+"""Same-definition toolchain warm-cache ABBA and real fallback checks.
+
+Exact binaries, common fixtures, externally measured elapsed time, no discarded
+samples. Timed work includes all toolchain trust validation, not isolated I/O.
+"""
+from __future__ import annotations
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import platform
+import tempfile
+import compare_reporting as h
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--self-test', action='store_true')
+    parser.add_argument('--baseline', type=Path)
+    parser.add_argument('--candidate', type=Path)
+    parser.add_argument('--base-sha')
+    parser.add_argument('--head-sha')
+    parser.add_argument('--output', type=Path)
+    args = parser.parse_args()
+    h.self_test()
+    if args.self_test:
+        return
+    h.require(os.name == 'nt', 'Windows/MSVC required for product evidence')
+    h.require(all([args.baseline, args.candidate, args.output, args.base_sha, args.head_sha]), 'Missing exact identity/paths')
+    base, candidate, output = args.baseline.resolve(), args.candidate.resolve(), args.output.resolve()
+    h.require(base.is_file() and candidate.is_file() and not output.exists(), 'Missing binaries or existing evidence')
+    recorder = h.Recorder(output)
+    report = {'base_sha': args.base_sha, 'head_sha': args.head_sha,
+              'baseline_binary_sha256': hashlib.sha256(base.read_bytes()).hexdigest(),
+              'candidate_binary_sha256': hashlib.sha256(candidate.read_bytes()).hexdigest(),
+              'platform': platform.platform(), 'image_version': os.environ.get('ImageVersion'),
+              'definition': __doc__, 'scenarios': []}
+    def save() -> None:
+        (output / 'toolchain-comparison.json').write_text(json.dumps(report, indent=2), encoding='utf-8')
+    def warm(row, case) -> None:
+        h.assert_warm(row, case, candidate=True)
+        cache = row['timing']['counter_breakdown']['cache']['toolchain']
+        h.require(cache['files_opened'] == 1 and cache['files_written'] == 0,
+                  'Expected one reused toolchain cache payload, not discovery/resealing')
+    save()
+    with tempfile.TemporaryDirectory(prefix='mqb-toolchain-') as tmp:
+        root = Path(tmp)
+        cases = [h.fixture(root, 'small2', 2), h.fixture(root, 'scale129', 129)]
+        for case in cases:
+            recorder.run(base, case, case.name + '-prime-A')
+            recorder.run(candidate, case, case.name + '-prime-B')
+            for timed in (False, True):
+                name = f'{case.name}-toolchain-hit-{"timed" if timed else "off"}'
+                audits = [recorder.run(binary, case, name + '-pre-' + side, timings=True)
+                          for side, binary in [('A', base), ('B', candidate)]]
+                for row in audits:
+                    warm(row, case)
+                h.require(h.semantic_counters(audits[0]) == h.semantic_counters(audits[1]), 'Precondition counters differ')
+                before = h.state(case)
+                (output / (name + '-before.json')).write_text(json.dumps(before, indent=2), encoding='utf-8')
+                pairs = []
+                for index in range(24):
+                    pair = {'pair': index + 1, 'orientation': 'AB' if index % 2 == 0 else 'BA'}
+                    sides = [('baseline', base), ('candidate', candidate)]
+                    for side, binary in sides if index % 2 == 0 else sides[::-1]:
+                        row = recorder.run(binary, case, f'{name}-{index+1}-{side}', timings=timed)
+                        if timed:
+                            warm(row, case)
+                        text = recorder.human(row, 'stdout')
+                        h.require(b'[compile]' not in text and b'[link]' not in text, 'Unexpected build in warm sample')
+                        pair[side] = row
+                    h.require(h.semantic_counters(pair['baseline']) == h.semantic_counters(pair['candidate']),
+                              'Non-output counters or hits differ')
+                    for channel in ('stdout', 'stderr'):
+                        h.require(pair['baseline'][f'human_{channel}_sha256'] == pair['candidate'][f'human_{channel}_sha256'],
+                                  'Toolchain transport changed human output')
+                    pairs.append(pair)
+                after = h.state(case)
+                (output / (name + '-after.json')).write_text(json.dumps(after, indent=2), encoding='utf-8')
+                h.require(before == after, 'Warm matrix mutated cache or artifacts')
+                for side, binary in [('A', base), ('B', candidate)]:
+                    warm(recorder.run(binary, case, name + '-post-' + side, timings=True), case)
+                report['scenarios'].append({'name': name, 'summary': h.summarize(pairs), 'pairs': pairs})
+                save()
+        # Product-level fallback uses real discovery; the native reader test
+        # separately forbids processes on hits and requires fallback on misses.
+        case = cases[0]
+        files = list((case.root / '.mqb/cache/toolchain').glob('*.mqbcache'))
+        h.require(len(files) == 1, 'Expected exactly one toolchain cache fixture')
+        cache = files[0]
+        for damage in ('empty', 'truncated', 'trailing', 'oversized', 'missing'):
+            if damage == 'empty': cache.write_bytes(b'')
+            elif damage == 'truncated': cache.write_bytes(cache.read_bytes()[:20])
+            elif damage == 'trailing':
+                with cache.open('ab') as stream: stream.write(b'\0')
+            elif damage == 'oversized':
+                with cache.open('r+b') as stream: stream.truncate(1024 * 1024 + 1)
+            else: cache.unlink()
+            row = recorder.run(candidate, case, 'repair-' + damage, timings=True)
+            h.require(row['timing']['cache']['compile'] == {'hits': case.units, 'misses': 0}
+                      and row['timing']['cache']['link'] == {'hits': 1, 'misses': 0},
+                      'Toolchain rediscovery changed build identity or skipped required checks')
+            h.require(row['timing']['counter_breakdown']['cache']['toolchain']['files_written'] == 1,
+                      'Unusable toolchain cache was not resealed by discovery')
+            warm(recorder.run(candidate, case, 'repaired-hit-' + damage, timings=True), case)
+    (output / 'passed.txt').write_text('All 96 pairs and real toolchain fallback contracts completed.\n', encoding='utf-8')
+    print(json.dumps([{key: value for key, value in row.items() if key != 'pairs'}
+                      for row in report['scenarios']], indent=2))
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/native/compare_toolchain_cache.py
+++ b/tests/native/compare_toolchain_cache.py
@@ -90,21 +90,41 @@ def main() -> None:
         files = list((case.root / '.mqb/cache/toolchain').glob('*.cache'))
         h.require(len(files) == 1, 'Expected exactly one toolchain cache fixture')
         cache = files[0]
+        report['fallback_contracts'] = []
         for damage in ('empty', 'truncated', 'trailing', 'oversized', 'missing'):
-            if damage == 'empty': cache.write_bytes(b'')
-            elif damage == 'truncated': cache.write_bytes(cache.read_bytes()[:20])
-            elif damage == 'trailing':
-                with cache.open('ab') as stream: stream.write(b'\0')
-            elif damage == 'oversized':
-                with cache.open('r+b') as stream: stream.truncate(1024 * 1024 + 1)
-            else: cache.unlink()
-            row = recorder.run(candidate, case, 'repair-' + damage, timings=True)
-            h.require(row['timing']['cache']['compile'] == {'hits': case.units, 'misses': 0}
-                      and row['timing']['cache']['link'] == {'hits': 1, 'misses': 0},
-                      'Toolchain rediscovery changed build identity or skipped required checks')
-            h.require(row['timing']['counter_breakdown']['cache']['toolchain']['files_written'] == 1,
-                      'Unusable toolchain cache was not resealed by discovery')
-            warm(recorder.run(candidate, case, 'repaired-hit-' + damage, timings=True), case)
+            pair = {'damage': damage}
+            source_hashes = {path.name: hashlib.sha256(path.read_bytes()).hexdigest()
+                             for path in case.root.glob('*.cpp')}
+            # Compare the actual baseline behavior, rather than assuming a
+            # rediscovery cannot invalidate compiler filesystem evidence.
+            # Each side starts with a verified full hit on the same fixture.
+            for side, binary in [('baseline', base), ('candidate', candidate)]:
+                warm(recorder.run(binary, case, f'pre-repair-{damage}-{side}', timings=True), case)
+                if damage == 'empty': cache.write_bytes(b'')
+                elif damage == 'truncated': cache.write_bytes(cache.read_bytes()[:20])
+                elif damage == 'trailing':
+                    with cache.open('ab') as stream: stream.write(b'\0')
+                elif damage == 'oversized':
+                    with cache.open('r+b') as stream: stream.truncate(1024 * 1024 + 1)
+                else: cache.unlink()
+                row = recorder.run(binary, case, f'repair-{damage}-{side}', timings=True)
+                h.require(row['timing']['counter_breakdown']['cache']['toolchain']['files_written'] == 1,
+                          'Unusable toolchain cache was not resealed by discovery')
+                pair[side] = row
+                warm(recorder.run(binary, case, f'repaired-hit-{damage}-{side}', timings=True), case)
+                state_after = h.state(case)
+                (output / f'repair-{damage}-{side}-state.json').write_text(
+                    json.dumps(state_after, indent=2), encoding='utf-8')
+                h.require(source_hashes == {path.name: hashlib.sha256(path.read_bytes()).hexdigest()
+                                          for path in case.root.glob('*.cpp')},
+                          'Fallback contract altered source contents')
+            h.require(h.semantic_counters(pair['baseline']) == h.semantic_counters(pair['candidate']),
+                      'Rediscovery changed baseline build decisions or non-output counters')
+            for channel in ('stdout', 'stderr'):
+                h.require(pair['baseline'][f'human_{channel}_sha256'] == pair['candidate'][f'human_{channel}_sha256'],
+                          'Rediscovery changed baseline diagnostics or rebuild reasons')
+            report['fallback_contracts'].append(pair)
+            save()
     (output / 'passed.txt').write_text('All 96 pairs and real toolchain fallback contracts completed.\n', encoding='utf-8')
     print(json.dumps([{key: value for key, value in row.items() if key != 'pairs'}
                       for row in report['scenarios']], indent=2))

--- a/tests/native/run_native_tests.ps1
+++ b/tests/native/run_native_tests.ps1
@@ -84,8 +84,8 @@ if ($includeDirs.Count -eq 0) { throw 'Native test config has no include_dirs.' 
 $allTestFiles = @(Get-ChildItem -LiteralPath $cppRoot -Recurse -File -Filter '*_tests.cpp' |
     Where-Object { $_.FullName -notmatch '[\\/]\.mqb[\\/]' } |
     Sort-Object FullName)
-if ($allTestFiles.Count -ne 79) {
-    throw "Native test manifest drift: expected 79 *_tests.cpp files, found $($allTestFiles.Count)."
+if ($allTestFiles.Count -ne 80) {
+    throw "Native test manifest drift: expected 80 *_tests.cpp files, found $($allTestFiles.Count)."
 }
 
 function Get-TestRelativePath {
@@ -124,7 +124,7 @@ $testWeightOverrides = [ordered]@{
 $relativeTestPaths = @($allTestFiles | ForEach-Object { Get-TestRelativePath -File $_ })
 foreach ($weightedPath in $testWeightOverrides.Keys) {
     if ($weightedPath -notin $relativeTestPaths) {
-        throw "Native test weight override is stale or missing from the 79-test manifest: $weightedPath"
+        throw "Native test weight override is stale or missing from the 80-test manifest: $weightedPath"
     }
 }
 


### PR DESCRIPTION
## Final decision: closed without merge for v5.5.0

The owner delegated the merge decision. **Do not include this implementation in v5.5.0.** The targeted experiment did not establish a useful end-to-end speedup, while the general harness contains adverse modes. This is a completed performance-candidate decision, not an indefinite Draft hold, a claim of a proven causal regression, or an invented correctness failure.

The branch and all code/evidence remain available. Main keeps its existing toolchain loader. Do not silently cherry-pick this patch into later performance work; any future integrity-focused adoption needs an explicit rationale of its own. #160 was independently accepted and merged; this rejection does not reopen it or revive rejected #158.

- Current main/base: **`6f24bb4d2f5e323eb7b3823c3acf367dcccf9446`**.
- Final tested head: **`ba7fd2b5562747eeadea13290515a000b51b5485`**.
- Candidate tree: **`3b35693c3b84cf8b07f2d5b9c0dbcd7bd65b4a8e`**.
- Branch: `perf/bounded-toolchain-cache`.
- Seven files, 423 additions / 9 deletions; the production loader itself changes only **15 added / 5 removed lines**. No new product TU.
- VERSION stays **5.4.0**; no tag, changelog or Release publication.

## Evaluated implementation and boundaries

The patch removes the pathname size query, reads at most the existing 1 MiB limit through the accepted same-stream bounded reader, then feeds owned bytes to the unchanged v9 decoder through read-only `std::ispanstream`, without a second whole-payload copy. It strengthens the actual extraction bound if the cache changes between preflight and decoding; the original normal-file 1 MiB preflight limit already exists on main.

Ordinary-file and 30-minute/future-age checks, cache-key matching, exact PATH comparison, latest-toolset selection, executable presence, compiler binary stamp, INCLUDE/LIB/LIBPATH and SDK/root trust, environment sealing, module discovery, overrides, ambient adoption and save/replacement behavior remain unchanged. The decoder and all post-decoder trust/save/adoption code are byte-identical to baseline. The same-stream byte bound is not an atomic age/open snapshot and does not guarantee correctness against arbitrary timestamp-preserving in-place changes. The writer's existing field/count limits are unchanged; this patch does not add a total writer-byte bound.

Unlike archive's previously missing total read/write boundary, this candidate strengthens an existing bounded normal-file policy, and did not demonstrate performance value. That distinction, its measured cost/uncertainty, and the v5.5.0 performance focus justify declining it now. This does not deny the potential value of stronger malformed/concurrent-file handling in a separately justified hardening change.

## Final focused evidence: successful collection and baseline-equivalent fallback

[Toolchain Cache Evidence #3 / run 34184169371](https://github.com/Iviesever/msvc-quick-build/actions/runs/34184169371), [artifact 10040049198](https://github.com/Iviesever/msvc-quick-build/actions/runs/34184169371/artifacts/10040049198).

Verified ZIP SHA-256: **`ed6c1617b8471c2ff588214ae55901a0ffdea40c2f72ed51fb342eef9a36e1b0`**.

Exact base/head Release binaries built using the same pinned seed. Four separate scenarios, 24 alternating AB/BA pairs each, externally measured process start-through-completion/pipe-drain time, identical fixture/cache paths. **96 pairs, 242 calls, all 484 raw transcript hashes, the pass marker and five complete fallback comparisons were independently checked.** Git and binary identities are recorded; before/after warm inventories are serialized and equal. No samples are discarded or pooled across modes/runs.

Paired candidate-minus-baseline medians; negative means faster:

| Scenario | Delta ms | Delta percent | MAD ms | Observed P95 ms | Faster pairs |
|---|---:|---:|---:|---:|---:|
| small2, timings OFF | **+0.03495** | **+0.3932%** | 0.11585 | +0.5422 | 8/24 |
| small2, timings ON | **+0.03095** | **+0.3239%** | 0.20100 | +0.9774 | 9/24 |
| scale129, timings OFF | **+0.20530** | **+0.5123%** | 0.66700 | +3.5078 | 11/24 |
| scale129, timings ON | **+0.25245** | **+0.6120%** | 0.83775 | +4.7053 | 9/24 |

These targeted medians are approximately neutral/slightly adverse, not convincing acceleration and not proof of a material regression. Toolchain-cache read work also does not show a gain in the final run: paired medians **+0.0175 ms** (small2) and **+0.0105 ms** (scale129), with 10/24 lower pairs in each. That work includes parsing and all trust validation; it is not isolated I/O share or a cache-pack justification. P95 is an empirical order statistic, not an operational tail guarantee.

All 48 instrumented warm pairs have identical counters, counter breakdowns and cache hits. The other 48 remain unavailable, not zero. Healthy toolchain reuse reads one payload, writes none, launches no tools, and retains identical human output and cache/artifact metadata.

### Rediscovery comparison: no freshness weakening

Five damage cases (empty, truncated, trailing NUL, oversized, missing) are run on both exact binaries. Every case starts from a verified hit, reseals the toolchain cache, produces identical compile/link decisions, non-output counters, diagnostics and rebuild reasons, preserves source contents, then reaches a verified no-tool/no-write hit. Post-repair inventories are retained; source hashes are checked, not falsely claimed serialized.

**Both baseline and candidate rebuild two TUs and relink in all five cases**, reporting dependency changes during the real rediscovery path. This confirms that the earlier requirement of zero recompilation was an invalid test assumption, not a new reader regression. This evidence does not identify the particular changed filesystem dependency or prove a broader root cause; it proves matched behavior on the tested baseline/candidate. No product freshness check was deleted or suppressed to make the test pass.

## General 19-scenario evidence: mixed and explicitly retained

Final-head [Performance #523 / run 34184169381](https://github.com/Iviesever/msvc-quick-build/actions/runs/34184169381), [artifact 10040091733](https://github.com/Iviesever/msvc-quick-build/actions/runs/34184169381/artifacts/10040091733), digest **`f4df3eaef6d7d63d531fcf9806803cd0460f3375c2190b3cbd17c8b56a00b048`**.

The unchanged general harness collected all 19 scenarios/four pairs. Paired summaries were independently recomputed with its original rounding, and all 72 instrumented pairs have equal counters/hit counts; four uninstrumented pairs remain unavailable. The legacy JSON omits Git/binary SHAs, so its identity comes from workflow checkout/run metadata, not invented JSON fields.

Selected paired results:

- scale129 no-op **-6.0505 ms / -14.11%, 4/4 faster**; auto **-1.9095 ms / -5.30%**.
- j1 no-op **+5.1575 ms / +10.53%, 1/4 faster**; common-header no-op **+3.5220 ms / +8.68%, 0/4 faster**.
- small timings-OFF no-op **+3.5851 ms / +27.72%, 1/4 faster**.
- module no-op **+2.0870 ms / +37.44%**; scale single-TU **+71.942 ms / +54.70%**.
- Ordinary cold **-3.51%**, scale cold **+7.48%**. Neither favorable nor adverse multi-stage differences are attributed wholesale to a singleton reader.

Prior-head [Performance #521 / artifact 10039878118](https://github.com/Iviesever/msvc-quick-build/actions/runs/34183472274/artifacts/10039878118), digest **`2f94b638427976b8129814e7bf5ce034aec91cf7efab25b707a226498ddbeb35`**, is retained separately: scale no-op +10.10%, j1 +17.82%, common-header +4.37%, small timings-OFF -7.26%. The product code is identical across those heads; run-to-run changes do not establish an OS cause or prove the patch harmless. They are not averaged away or used to select only a favorable run.

## Earlier incomplete validation attempts and exact corrections

Product code and native tests have not changed since initial head `75574fc...`. Only benchmark/documentation corrections and main integration followed.

1. Toolchain Evidence #1 / run **34182764295**, artifact **10039581130**, digest `ada05fe99d53d1e234417348344a417ea3dc7a4fc3ce1848a4d6c2611f6246f0`: all 96 warm pairs completed, then the damage fixture searched the standalone locator's `.mqbcache` extension rather than the application's `vs-x64.cache`. Corrected the fixture lookup, preserving the exactly-one-file requirement. 212 calls / 424 hashes verified; no completed damage contracts or pass marker.
2. Toolchain Evidence #2 / run **34183472350**, artifact **10039826961**, digest `b1db4bea36c632cde526542b679b02c8cfa4c60bab3bbfdaa6fca131b007cbff`: all 96 warm pairs completed, then real empty-cache rediscovery contradicted the test's assumed no-recompile behavior. Replaced that assumption with the stricter side-by-side baseline-equivalence contract above. 213 calls / 426 hashes verified; no complete damage-contract pass marker.

Those measured warm vectors remain valid observations, but **neither entire workflow passed**. Timings-OFF small/scale paired percentages were -1.67%/-0.17% in #1 and -1.21%/+0.71% in #2. They are not relabelled as final-head data or pooled with #3. Each retains equal warm metadata inventories and all 48 instrumented counter pairs. Superseded/cancelled jobs are not additional successful measurements.

A separate PCH #64 job failed with HTTP403 API rate limiting while acquiring the unchanged historical seed, before product testing. Retrying that failed job succeeded. No seed/check policy was weakened; final-head PCH #65 passed normally.

## Native tests and gate status at decision

The proposed native inventory is 80 tests (main remains at 79 because this PR is rejected). The new native test obtains a real Visual Studio fixture and uses a rejecting runner to require zero-process hits and actual discovery attempts for invalid payloads. It covers exact 1 MiB acceptance/one-byte-over rejection, old/future timestamps, damaged/v8/missing/directory payloads and valid restoration. Existing environment/PATH/SDK tests and the shared reader's deterministic seek/short-read/growth/EOF tests remain unchanged.

On exact final head `ba7fd2b...`, Toolchain Evidence #3, Performance Evidence #523, documentation, compilation database, build plan, cross-stage, incremental, PCH and module evidence checks passed. **Native C++ #687 / 34184169375 and Native Release #587 / 34184169374 are still running at this update; their full completion/package status is not claimed yet.** The merge rejection is based on insufficient performance value, not a supposed failure of those pending jobs.

All seven final diff blobs match the locally reviewed files; parser/statistics self-tests and `git diff --check` pass. These are source checks, not substituted Windows validation. No product shim, new source-TU or unapproved loader change is committed.

## Consequence for the remaining route

Main remains at accepted #160 (`6f24bb4...`) with #157/#159 already included. Stop mechanically converting singleton readers or adding stacked candidates to complete a checklist. Next priority is cumulative, timings-OFF end-to-end evidence against **released v5.4.0**, with correct old/new schema handling and retained adverse modes, followed by an explicit remaining-candidate/release decision. Do not sum these PR percentages. Object handoff must preserve the later freshness boundary, multi-key discovery/cache packs remain evidence-gated, and resident processes remain v6.0. VERSION/changelog changes belong only to the separate final release-preparation PR.