### PR TITLE
test: establish cumulative v5.4.0 release performance evidence

### DIFF
--- a/.github/workflows/release-cumulative-evidence.yml
+++ b/.github/workflows/release-cumulative-evidence.yml
@@ -1,0 +1,99 @@
+name: Release Cumulative Evidence
+
+on:
+  pull_request:
+    paths:
+      - 'tests/native/compare_release_cumulative.py'
+      - 'tests/native/compare_reporting.py'
+      - '.github/workflows/release-cumulative-evidence.yml'
+  workflow_dispatch:
+    inputs:
+      candidate_ref:
+        description: Candidate ref resolved and recorded before building
+        required: true
+        default: '6f24bb4d2f5e323eb7b3823c3acf367dcccf9446'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-cumulative-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compare:
+    name: Released v5.4.0 versus accepted candidate
+    runs-on: windows-latest
+    timeout-minutes: 45
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout exact evidence harness
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          path: harness
+          persist-credentials: false
+      - name: Checkout immutable released v5.4.0 source
+        uses: actions/checkout@v7
+        with:
+          ref: d041668de836b9eb9a36e2d6b96ff2114c5c358a
+          path: baseline
+          persist-credentials: false
+      - name: Checkout accepted candidate, separate from harness
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.candidate_ref || '6f24bb4d2f5e323eb7b3823c3acf367dcccf9446' }}
+          path: candidate
+          persist-credentials: false
+      - name: Verify schema handling and build both exact Release trees
+        shell: pwsh
+        run: |
+          python harness/tests/native/compare_release_cumulative.py --self-test
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $candidate = Join-Path $PWD 'candidate'
+          $seed = & (Join-Path $candidate 'tests/native/acquire_seed.ps1') -RepoRoot $candidate -OutputRoot (Join-Path $PWD 'cumulative-seed')
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          foreach ($side in @('baseline', 'candidate')) {
+            $root = Join-Path $PWD $side
+            $version = (Get-Content (Join-Path $root 'VERSION') -Raw).Trim()
+            $mqb = & (Join-Path $root 'tests/native/build_mqb.ps1') -BuilderMqbPath $seed -RepoRoot $root -Version $version -Configuration Release -Clean -OutputPath (Join-Path $PWD "cumulative-out/$side/mqb.exe")
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+            if (-not (Test-Path -LiteralPath $mqb -PathType Leaf)) { throw "Missing $side MQB" }
+          }
+      - name: Fixed timings-OFF cumulative ABBA and separate correctness audits
+        shell: pwsh
+        run: |
+          $baseSha = git -C baseline rev-parse HEAD
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $headSha = git -C candidate rev-parse HEAD
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $baseTree = git -C baseline rev-parse 'HEAD^{tree}'
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $headTree = git -C candidate rev-parse 'HEAD^{tree}'
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $harnessSha = git -C harness rev-parse HEAD
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          python harness/tests/native/compare_release_cumulative.py --baseline cumulative-out/baseline/mqb.exe --candidate cumulative-out/candidate/mqb.exe --base-sha $baseSha --head-sha $headSha --base-tree $baseTree --head-tree $headTree --harness-sha $harnessSha --output cumulative-out/evidence
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+      - name: Retain exact harness, source identity and all observations
+        if: always()
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force cumulative-out/provenance | Out-Null
+          git -C harness rev-parse HEAD | Set-Content cumulative-out/provenance/harness-sha.txt
+          git -C baseline rev-parse HEAD | Set-Content cumulative-out/provenance/baseline-sha.txt
+          git -C candidate rev-parse HEAD | Set-Content cumulative-out/provenance/candidate-sha.txt
+          Copy-Item harness/tests/native/compare_release_cumulative.py cumulative-out/provenance/
+          Copy-Item harness/tests/native/compare_reporting.py cumulative-out/provenance/
+          Get-FileHash cumulative-out/baseline/mqb.exe, cumulative-out/candidate/mqb.exe -Algorithm SHA256 -ErrorAction Continue | ConvertTo-Json | Set-Content cumulative-out/provenance/binary-hashes.json
+      - name: Upload raw evidence, including failures and adverse samples
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: mqb-release-cumulative-evidence
+          path: |
+            cumulative-out/evidence/
+            cumulative-out/provenance/
+          retention-days: 90
+          if-no-files-found: warn

--- a/docs/V5_5_CUMULATIVE_EVIDENCE.md
+++ b/docs/V5_5_CUMULATIVE_EVIDENCE.md
@@ -1,0 +1,84 @@
+# v5.5.0 cumulative release-source evidence
+
+## Decision boundary
+
+This iteration changes only the evidence harness, a read-only workflow and this
+record. VERSION remains 5.4.0. No product source, cache/freshness policy, output,
+release metadata, tag or publication step changes. This is not the release PR.
+
+The cumulative baseline is the actual released v5.4.0 commit
+`d041668de836b9eb9a36e2d6b96ff2114c5c358a`, not a later commit that happens to
+have the same VERSION. The initial accepted candidate is
+`6f24bb4d2f5e323eb7b3823c3acf367dcccf9446` (tree
+`00c5b8e600ca188d3ce6158f002390307ee3c887`). It includes accepted #157, #159,
+#160 and earlier mainline improvements; rejected #158/#161 are not reinstated.
+
+## Reproducible experiment
+
+Release Cumulative Evidence checks out the harness, historical baseline and
+accepted candidate separately. The same checksum-verified historical MQB seed
+builds both unmodified product trees in Release mode on one Windows runner,
+using each tree's own build driver and VERSION. This compares release SOURCE
+rebuilt with a common toolchain, not a downloaded historical package against a
+newly built binary. Exact commits, trees, binary hashes and runner identity are
+retained. A manual run can select a future candidate without changing the fixed
+historical baseline; the resolved candidate remains explicit in its evidence.
+
+All 584 scored pairs have timings OFF, identical A/B fixture/cache pathnames and
+external process start-through-completion/pipe-drain timing. The fixed matrix is:
+
+- Twelve warm cases, forty alternating AB/BA pairs each: small default/verbose,
+  common-header129 default/verbose/serial, private-header129 default, static129
+  default/verbose, modules, PCH, genuine persistent discovery and build-then-run.
+- Four rebuild cases, twenty pairs each: common129 and static129 single-TU,
+  common129 public-header, and missing executable repair.
+- Four cold cases, six pairs each: small, common129, static129 and modules.
+
+Source mutations use identical bytes within a pair and actual advancing write
+timestamps, not manufactured future times. Only the cold cases reset project
+build state. Counts and orientation are fixed before execution; no adverse
+sample is dropped and no run/mode/PR percentages are pooled or added.
+
+Paired median deltas, paired-percent medians, MAD, nearest-rank P95, extremes and
+a deterministic 5000-resample paired-median interval are reported. The practical
+adverse flag is fixed: paired median exceeds max(0.5 ms for warm / 5 ms otherwise,
+3% of baseline median), with the interval entirely positive. This is a review
+flag, not automatic release authorization or proof that unflagged cases never
+regress. Serial correlation and small cold samples limit inference. Pipes are
+not a real terminal benchmark; six-pair P95 is the maximum observed sample.
+
+## Schema and correctness
+
+Separate, unscored audits read old schema 1 and current schema 2. Both must report
+expected compile/link/archive hits. Only schema 2 provides tool/cache-write and
+filesystem counters; missing historical data remains null/unavailable. Old
+product code is never instrumented retroactively. Phase boundaries changed, so
+internal totals are not the cumulative end-to-end comparison. Candidate-only
+attribution may guide the remaining route but overlapping work times are not
+elapsed I/O shares or evidence for a cache pack.
+
+Warm cases require no build-action lines, identical stderr and unchanged full
+project cache/artifact metadata inventories, saved before and after. Current
+schema audits also require zero compiler/linker/librarian launches and no cache
+writes. Old schema cannot directly prove zero OS processes; hits, output and
+metadata are the available historical observations. Default report wording is
+intentionally different after #159, so stdout is retained rather than forced to
+match. No error diagnostic is hidden to pass a benchmark.
+
+Rebuild scope and subsequent full hits are checked. Both binaries must preserve
+visible compiler failure/exit 4 and recovery; produced fixture programs are
+executed as a separate correctness check. Raw stdout/stderr, every invocation,
+audit and completed scenario survive a later failure. A failed run has no pass
+marker and is never represented as a complete release gate.
+
+## Remaining route
+
+Numeric results and acceptance belong in the PR evidence record after the run,
+not invented in advance. If cumulative evidence is acceptable, freeze the v5.5
+performance scope and prepare the independent release PR. Object snapshot
+handoff still needs a freshness-equivalent late observation and net probe
+reduction; link resolution and multi-key discovery still need measured need.
+No candidate is mandatory merely because it appeared in the original list.
+Cache packs retain the isolated residual-I/O threshold; daemon/watcher/USN
+remain v6.0. Final VERSION/changelog or release-note preparation is separate,
+and the exact release commit still needs the full native/self-host/package gate.

--- a/tests/native/compare_release_cumulative.py
+++ b/tests/native/compare_release_cumulative.py
@@ -1,0 +1,279 @@
+"""Cumulative release-source ABBA, not an addition of incremental PR percentages.
+
+Rebuild both unmodified trees with the same seed/toolchain. All scored samples
+have timings OFF and use process start-through-completion/pipe-drain elapsed
+measurement. Separate audits understand schema 1 and 2 without fabricating old
+counters. Fixed sample counts and practical flags; retain every adverse sample.
+"""
+from __future__ import annotations
+
+import argparse
+from dataclasses import replace
+from datetime import datetime, timezone
+import hashlib
+import json
+import math
+import os
+from pathlib import Path
+import platform
+import random
+import re
+import shutil
+import statistics as stats
+import subprocess
+import tempfile
+import time
+
+import compare_reporting as h
+
+RELEASE = 'd041668de836b9eb9a36e2d6b96ff2114c5c358a'
+WARM_PAIRS = 40
+REBUILD_PAIRS = 20
+COLD_PAIRS = 6
+
+
+def dump(path: Path, data) -> None:
+    path.write_text(json.dumps(data, indent=2), encoding='utf-8')
+
+
+def counts(recorder, row):
+    text = recorder.human(row, 'stdout')
+    return {kind: len(re.findall(rb'^\[' + kind.encode() + rb'\] ', text, re.M))
+            for kind in ('compile', 'link', 'archive', 'pch')}
+
+
+def audit_warm(row, case):
+    timing = row['timing']
+    h.require(timing is not None and timing['schema_version'] in (1, 2), 'Unknown timing schema')
+    h.require(timing['cache']['compile'] == {'hits': case.units + int(case.pch), 'misses': 0},
+              f"{row['label']}: not all compile hits: {timing['cache']}")
+    stage = 'archive' if case.static else 'link'
+    h.require(timing['cache'][stage] == {'hits': 1, 'misses': 0}, 'Not a warm final stage')
+    counters = timing.get('counters')
+    if timing['schema_version'] == 1:
+        h.require(counters is None, 'Historical schema unexpectedly gained counters')
+    else:
+        h.require(counters is not None and all(counters[k] == 0 for k in (
+            'cl_processes_launched', 'link_processes_launched', 'lib_processes_launched',
+            'cache_files_written')), 'Candidate warm audit launched tools or wrote caches')
+    return {'schema_version': timing['schema_version'], 'cache': timing['cache'],
+            'counters': counters, 'attribution': timing.get('attribution'),
+            'counter_breakdown': timing.get('counter_breakdown')}
+
+
+def comparison(pairs, *, warm):
+    result = h.summarize(pairs)
+    baseline = stats.median(p['baseline']['external_ms'] for p in pairs)
+    candidate = stats.median(p['candidate']['external_ms'] for p in pairs)
+    values = result['paired_deltas_ms']
+    rng = random.Random(5500)
+    boot = sorted(stats.median(rng.choices(values, k=len(values))) for _ in range(5000))
+    interval = [boot[124], boot[4874]]
+    threshold = max(0.5 if warm else 5.0, baseline * 0.03)
+    result.update(baseline_median_ms=baseline, candidate_median_ms=candidate,
+                  bootstrap_median_interval_ms=interval, practical_threshold_ms=threshold,
+                  practical_regression_flag=result['paired_median_delta_ms'] > threshold and interval[0] > 0,
+                  minimum_delta_ms=min(values), maximum_delta_ms=max(values))
+    return result
+
+
+def write_later(path: Path, data: bytes):
+    previous = path.stat().st_mtime_ns
+    deadline = time.monotonic() + 2
+    while True:
+        path.write_bytes(data)
+        if path.stat().st_mtime_ns > previous:
+            return
+        h.require(time.monotonic() < deadline, 'Actual write timestamp did not advance')
+        time.sleep(0.01)
+
+
+def build_fixtures(root):
+    cases = {
+        'small': h.fixture(root, 'small', 2),
+        'common': h.fixture(root, 'common', 129),
+        'private': h.fixture(root, 'private', 129),
+        'static': h.fixture(root, 'static', 129, static=True),
+        'modules': h.fixture(root, 'modules', 2, modules=True),
+        'pch': h.fixture(root, 'pch', 2, pch=True),
+        'discovery': h.fixture(root, 'discovery', 2),
+    }
+    private = cases['private']
+    for source in sorted(private.root.glob('*.cpp')):
+        header = source.with_suffix('.hpp')
+        header.write_bytes((private.root / 'common.hpp').read_bytes())
+        source.write_text(source.read_text(encoding='utf-8').replace('common.hpp', header.name), encoding='utf-8')
+    discovery = cases['discovery']
+    # A real selected two-TU closure, not no-op compilation after rediscovery.
+    (discovery.root / 'unit_000.hpp').write_text('#pragma once\nint value_0();\n', encoding='utf-8')
+    main = discovery.root / 'main.cpp'
+    main.write_text('#include "unit_000.hpp"\nint main() { return value_0() == 42 ? 0 : 1; }\n', encoding='utf-8')
+    discovery.arguments = [a for a in discovery.arguments if a not in ('unit_000.cpp', '--no-discover')]
+    return cases
+
+
+def self_test():
+    h.self_test()
+    pairs = [{'baseline': {'external_ms': 10.0}, 'candidate': {'external_ms': 11.0}} for _ in range(40)]
+    h.require(comparison(pairs, warm=True)['practical_regression_flag'], 'Regression flag lost')
+    h.require(not comparison(pairs, warm=False)['practical_regression_flag'], 'Rebuild threshold changed')
+    case = h.Fixture('test', Path('.'), [], 2)
+    old = {'label': 'schema1', 'timing': {'schema_version': 1, 'cache': {
+        'compile': {'hits': 2, 'misses': 0}, 'link': {'hits': 1, 'misses': 0}}}}
+    h.require(audit_warm(old, case)['counters'] is None, 'Unavailable historical counters became zero')
+    print('Cumulative schema/statistics tests passed.')
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--self-test', action='store_true')
+    for name in ('baseline', 'candidate', 'output'):
+        parser.add_argument('--' + name, type=Path)
+    for name in ('base-sha', 'head-sha', 'base-tree', 'head-tree', 'harness-sha'):
+        parser.add_argument('--' + name)
+    args = parser.parse_args()
+    self_test()
+    if args.self_test:
+        return
+    h.require(os.name == 'nt', 'Product evidence requires Windows/MSVC')
+    h.require(all(vars(args)[key] for key in vars(args) if key != 'self_test'), 'Missing exact identity/paths')
+    h.require(args.base_sha == RELEASE, 'Baseline must be the immutable released v5.4.0 source')
+    binaries = {'baseline': args.baseline.resolve(), 'candidate': args.candidate.resolve()}
+    h.require(all(p.is_file() for p in binaries.values()), 'Missing binary')
+    output = args.output.resolve()
+    h.require(not output.exists(), 'Refusing to overwrite existing evidence')
+    recorder = h.Recorder(output)
+    (output / 'inventories').mkdir()
+    result = {'schema_version': 1, 'base_sha': args.base_sha, 'head_sha': args.head_sha,
+              'base_tree': args.base_tree, 'head_tree': args.head_tree, 'harness_sha': args.harness_sha,
+              'binary_sha256': {s: h.digest(p.read_bytes()) for s, p in binaries.items()},
+              'created_utc': datetime.now(timezone.utc).isoformat(), 'platform': platform.platform(),
+              'runner_image': os.environ.get('ImageOS'), 'runner_image_version': os.environ.get('ImageVersion'),
+              'definition': __doc__, 'policy': {'warm_pairs': WARM_PAIRS, 'rebuild_pairs': REBUILD_PAIRS,
+              'cold_pairs': COLD_PAIRS, 'bootstrap': '5000 paired-median resamples, seed 5500, percentile interval',
+              'flag': 'paired median > max(0.5ms warm / 5ms rebuild, 3% base median) AND interval lower bound > 0',
+              'scope': 'Rebuilt release source, not the historical packaged executable. Pipes, not a terminal.'},
+              'scenarios': [], 'audits': [], 'behavior_contracts': []}
+    def save():
+        dump(output / 'cumulative.json', result)
+    def run(side, case, label, **kwargs):
+        return recorder.run(binaries[side], case, label + '-' + side, **kwargs)
+    def audit(side, case, label, **kwargs):
+        row = run(side, case, label, timings=True, **kwargs)
+        result['audits'].append({'label': row['label'], **audit_warm(row, case)})
+        return row
+    def sides(index):
+        return ('baseline', 'candidate') if index % 2 == 0 else ('candidate', 'baseline')
+    def add(name, kind, pairs):
+        result['scenarios'].append({'name': name, 'kind': kind,
+            'summary': comparison(pairs, warm=kind == 'warm'), 'pairs': pairs})
+        save()
+    save()
+    with tempfile.TemporaryDirectory(prefix='mqb-cumulative-') as temporary:
+        cases = build_fixtures(Path(temporary))
+        for key, case in cases.items():
+            for side in binaries:
+                run(side, case, key + '-prime')
+            if key == 'discovery':
+                # First builds can change root directory evidence. Seal once
+                # after all artifacts exist, then require zero writes below.
+                for side in binaries:
+                    run(side, case, key + '-seal')
+        warm = [('small', False, 'auto'), ('small', True, 'auto'),
+                ('common', False, 'auto'), ('common', True, 'auto'), ('common', False, '1'),
+                ('private', False, 'auto'), ('static', False, 'auto'), ('static', True, 'auto'),
+                ('modules', False, 'auto'), ('pch', False, 'auto'), ('discovery', False, 'auto'),
+                ('run', False, 'auto')]
+        for key, verbose, jobs in warm:
+            case = cases['small'] if key == 'run' else cases[key]
+            if key == 'run':
+                case = replace(case, arguments=['run', *case.arguments[1:]])
+            name = f'{key}-{"verbose" if verbose else "default"}-j{jobs}'
+            print('Cumulative warm:', name, flush=True)
+            for side in binaries:
+                audit(side, case, name + '-pre', verbose=verbose, jobs=jobs)
+            before = h.state(case)
+            dump(output / 'inventories' / (name + '-before.json'), before)
+            pairs = []
+            for index in range(WARM_PAIRS):
+                pair = {'pair': index + 1, 'orientation': 'AB' if index % 2 == 0 else 'BA'}
+                for side in sides(index):
+                    row = run(side, case, name + '-' + str(index + 1), verbose=verbose, jobs=jobs)
+                    h.require(all(v == 0 for v in counts(recorder, row).values()), 'Measured no-op built an artifact')
+                    pair[side] = row
+                h.require(pair['baseline']['human_stderr_sha256'] == pair['candidate']['human_stderr_sha256'],
+                          'Warm stderr differs between versions')
+                pairs.append(pair)
+            after = h.state(case)
+            dump(output / 'inventories' / (name + '-after.json'), after)
+            h.require(before == after, 'Warm matrix modified cache/artifact metadata')
+            for side in binaries:
+                audit(side, case, name + '-post', verbose=verbose, jobs=jobs)
+            add(name, 'warm', pairs)
+        rebuilds = [('common', 'single-tu'), ('static', 'single-tu'),
+                    ('common', 'public-header'), ('small', 'output-repair')]
+        for key, kind in rebuilds:
+            case = cases[key]
+            name = key + '-' + kind
+            path = case.root / ('common.hpp' if kind == 'public-header' else 'unit_000.cpp')
+            original = path.read_bytes()
+            pairs = []
+            print('Cumulative rebuild:', name, flush=True)
+            for index in range(REBUILD_PAIRS):
+                pair = {'pair': index + 1, 'orientation': 'AB' if index % 2 == 0 else 'BA'}
+                payload = original + f'\n// cumulative pair {index:03d}\n'.encode()
+                pair['mutation_sha256'] = None if kind == 'output-repair' else h.digest(payload)
+                for side in sides(index):
+                    if kind == 'output-repair':
+                        case.output.unlink()
+                    else:
+                        write_later(path, payload)
+                    row = run(side, case, name + '-' + str(index + 1))
+                    expected = 0 if kind == 'output-repair' else case.units if kind == 'public-header' else 1
+                    work = counts(recorder, row)
+                    h.require(work['compile'] == expected and work['archive' if case.static else 'link'] == 1,
+                              f'{name}: incorrect rebuild scope: {work}')
+                    pair[side] = row
+                    audit(side, case, name + '-' + str(index + 1) + '-post')
+                pairs.append(pair)
+            add(name, 'rebuild', pairs)
+        for key in ('small', 'common', 'static', 'modules'):
+            case = cases[key]
+            pairs = []
+            print('Cumulative cold:', key, flush=True)
+            for index in range(COLD_PAIRS):
+                pair = {'pair': index + 1, 'orientation': 'AB' if index % 2 == 0 else 'BA'}
+                for side in sides(index):
+                    shutil.rmtree(case.root / '.mqb')
+                    row = run(side, case, key + '-cold-' + str(index + 1))
+                    work = counts(recorder, row)
+                    h.require(work['compile'] == case.units and work['archive' if case.static else 'link'] == 1,
+                              f'{key}: cold scope incorrect: {work}')
+                    pair[side] = row
+                    audit(side, case, key + '-cold-' + str(index + 1) + '-post')
+                pairs.append(pair)
+            add(key + '-cold', 'cold', pairs)
+        case = cases['small']
+        unit = case.root / 'unit_000.cpp'
+        original = unit.read_bytes()
+        for side in binaries:
+            write_later(unit, b'#error cumulative_visible_failure\n')
+            row = run(side, case, 'compiler-failure', success=False)
+            h.require(row['exit_code'] == 4 and b'cumulative_visible_failure' in
+                      recorder.human(row, 'stdout') + recorder.human(row, 'stderr'), 'Compiler failure lost')
+            write_later(unit, original)
+            run(side, case, 'compiler-recovery')
+            audit(side, case, 'compiler-recovered')
+            for key in ('small', 'common', 'private', 'modules', 'pch', 'discovery'):
+                check = subprocess.run([str(cases[key].output)], cwd=cases[key].root,
+                                       capture_output=True, timeout=30, check=False)
+                h.require(check.returncode == 0, f'{key}: built program returned failure')
+            result['behavior_contracts'].append({'side': side, 'compiler_failure_exit': 4,
+                                                'recovery_and_program_runs': True})
+        save()
+    (output / 'passed.txt').write_text('Cumulative 584 pairs and behavior contracts completed.\n', encoding='utf-8')
+    print(json.dumps([{k: v for k, v in s.items() if k != 'pairs'} for s in result['scenarios']], indent=2))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Decision: accept the cumulative evidence and freeze v5.5.0 product scope

The complete fixed experiment supports a large-target no-op improvement relative to the released v5.4.0 source. It does **not** establish universal acceleration or eliminate cold-build tail risk. Accept this evidence-only PR after its completed native/package gates; the separate release-preparation PR still owns VERSION and exact-version release validation.

- PR base / measured accepted product: **`6f24bb4d2f5e323eb7b3823c3acf367dcccf9446`**, product tree `00c5b8e600ca188d3ce6158f002390307ee3c887`.
- Exact harness head: **`f5303c351d983215827483ce9465e4c5d9100e54`**, tree `a0472df3b9e3f322ddff33a8953338b040d7e4a6`.
- Historical performance baseline: **released v5.4.0 `d041668de836b9eb9a36e2d6b96ff2114c5c358a`**, tree `555ebdb27ce8b7c379b03154578f55585601f905`.
- Three new files / 462 additions: cumulative Python harness, read-only workflow and `docs/V5_5_CUMULATIVE_EVIDENCE.md`. No product source, VERSION, changelog, tag or Release change.
- Accepted #157/#159/#160 and earlier mainline improvements are included. Rejected #158/#161 remain excluded. This result is not just the sum or isolated effect of those three accepted PRs.

## Source/binary provenance and completed gates

[Release Cumulative Evidence #1 / run 34187064173](https://github.com/Iviesever/msvc-quick-build/actions/runs/34187064173), [raw artifact 10041161376](https://github.com/Iviesever/msvc-quick-build/actions/runs/34187064173/artifacts/10041161376).

Verified ZIP SHA-256: **`d508c45fcab94ec9e20ec7e05b6dc047c5fc303f450171ac8581e2075fc733a5`**. Artifact retention is 90 days; preserve a copy for long-term release provenance.

Baseline and candidate were checked out separately from the harness and built, unmodified, in Release mode with the same checksum-verified historical MQB seed and Windows toolchain, using each tree's build driver. This compares **rebuilt released source**, not a historical downloadable package against a newly built executable. Windows Server 2025, runner image `win25-vs2026`, version `20260824.214.3`.

Recorded binary SHA-256 values, cross-checked against the independent workflow hash manifest:

```text
baseline:  bad0124f1c6f549a794eb58c5442428c581d6aeb80c1dd304158de9394728c28
candidate: b937f84c91eadc809fd33373eed83f1fca803365683d0518190cb9c16b6fea4f
```

The benchmark binaries themselves are not included in the raw artifact, so local verification cross-checks those two recorded hashes rather than claiming to recompute them from unavailable binaries. Retained harness scripts match their Git blob identities after normalizing the observed Windows checkout CRLF endings to repository LF; the raw CRLF provenance files are preserved unchanged.

On exact harness head `f5303c...`:

- **Native C++ #688 / 34187064127: success.**
- **Native Release #588 / 34187064144: complete success**, Stage 0, all four Release test jobs, self-host/package job **101939277263**, runtime-only staging, exact package validation and artifact upload. `publish-release` skipped.
- **Release Cumulative Evidence #1: success**, all scored pairs and behavior contracts.
- **Documentation #147 / 34187064131: success.**
- General Performance #525 / 34187064130 was **skipped**, not another measurement. Its incremental harness was not changed or used to replace the cumulative experiment.

No unresolved review threads were present at review. No source commit was added after measurement. This evidence PR does not authorize or perform tag/Release publication.

## Fixed experiment and independent verification

All **584 scored pairs have timings OFF**, common A/B fixture/cache pathnames and the same external process start-through-completion/pipe-drain clock:

- 12 warm cases x 40 alternating AB/BA pairs.
- 4 rebuild cases x 20 pairs.
- 4 project-cold cases x 6 pairs.

Project-cold means resetting `.mqb`, not flushing OS caches. Source mutations use identical bytes within each pair and real advancing write timestamps, not future timestamps. Scored A/B argv matches except the executable pathname. The fixed practical adverse flag is paired median greater than max(0.5 ms warm / 5 ms otherwise, 3% baseline median), with a deterministic 5000-resample paired-median interval entirely positive. It is a review aid, not proof that unflagged cases never regress. Pair counts, orientation and thresholds were fixed before execution; no favorable-only rerun or sample deletion.

Independent verification recomputed all 20 scenario summaries, bootstrap intervals and flags; checked actual call ordering, 1446 recorded calls, **2892 raw transcript hashes** and their normalized human-output hashes; verified 12 equal full warm before/after inventories; reparsed 258 timing audit records directly from raw transcripts (129 schema 1, 129 schema 2); and checked the completion marker. No measurement from earlier PRs was pooled or added.

Source-mutation hashes are runner-recorded declarations; fixture source bytes were not archived. The raw artifact does contain all scored/audit invocation arguments, stdout/stderr and warm metadata inventories. Separate final fixture-program checks succeeded but their subprocess transcripts are not part of the 1446-call recorder.

## Complete cumulative results

Deltas are **medians of paired candidate-minus-baseline differences/percentages**, not differences or ratios of independent medians. Negative means faster. All rows use timings-OFF external elapsed time.

| Scenario | Pairs | Paired delta ms | Paired delta % | Faster pairs |
|---|---:|---:|---:|---:|
| small default | 40 | -0.4330 | -3.87 | 36/40 |
| small verbose | 40 | -0.4427 | -3.77 | 36/40 |
| shared-header129 default auto | 40 | **-29.7051** | **-41.29** | **40/40** |
| shared-header129 verbose auto | 40 | -29.1252 | -40.44 | 40/40 |
| shared-header129 default j1 | 40 | **-40.9338** | **-42.55** | **40/40** |
| private-header129 default | 40 | **-27.8579** | **-38.18** | **40/40** |
| static129 default | 40 | **-30.8957** | **-42.11** | **40/40** |
| static129 verbose | 40 | -31.4147 | -40.09 | 38/40 |
| modules default | 40 | -0.5149 | -4.00 | 30/40 |
| PCH default | 40 | -0.7625 | -6.04 | 33/40 |
| genuine discovery persistent hit | 40 | -0.5897 | -4.76 | 35/40 |
| build-then-run | 40 | -0.0492 | -0.27 | 21/40 |
| shared129 single-TU rebuild | 20 | -8.1270 | -2.20 | 10/20 |
| static129 single-TU rebuild | 20 | -38.5721 | -17.69 | 17/20 |
| shared129 public-header rebuild | 20 | **+5.7071** | **+0.17** | 9/20 |
| small missing executable repair | 20 | **+1.2090** | **+2.08** | 9/20 |
| small project-cold | 6 | -0.8620 | -0.05 | 3/6 |
| shared129 project-cold | 6 | **+6.0095** | **+0.12** | 3/6 |
| static129 project-cold | 6 | -12.8693 | -0.25 | 5/6 |
| modules project-cold | 6 | -5.3515 | -0.29 | 4/6 |

Large warm results are consistently favorable in the tested fixtures: shared-default empirical paired-median interval **[-30.63955, -28.20465] ms**, j1 **[-41.7035, -40.3488] ms**, private **[-30.3530, -26.9268] ms**, static-default **[-32.7170, -29.71525] ms**. Small cases show smaller absolute benefits; build-then-run is effectively neutral.

## Adverse observations and limits are not erased

No scenario triggers the predeclared practical flag. **That does not establish zero regression or acceptable production tails.**

Most importantly, shared129 project-cold contains **two large adverse pairs**, not one:

- pair 1: 5026.8598 -> 10380.6252 ms, **+5353.7654 ms**;
- pair 5: 5059.0821 -> 11539.5039 ms, **+6480.4218 ms**.

Its near-neutral median does not negate those observations. With only six cold pairs, P95 is the maximum and the paired-median interval is very wide **[-62.99515, +5917.0936] ms**. The timed-off experiment does not localize an OS/tool cause; none is asserted. This remains a release-risk disclosure, not a reason to advertise cold acceleration. The evidence-only PR adds no product behavior and cannot fix or amplify this tail by merging its documentation.

Public-header rebuild is near neutral/slightly adverse; missing-output repair is also slightly adverse. Executable single-TU rebuild is highly variable: MAD **98.86185 ms**, interval **[-111.7721, +77.4873] ms**, only 10/20 faster despite a favorable median. It is not a demonstrated stable improvement. Static rebuild has a favorable median but still has adverse pairs, maximum **+91.9177 ms**. Static verbose has two slower pairs. All remain in the raw archive and review table.

These synthetic fixtures on one hosted Windows runner are not a guarantee for UE workloads, arbitrary user projects, real terminals or all toolsets. Serial correlation and small rebuild/cold sample sizes constrain bootstrap inference. Different rows/modes are not a single pooled performance score.

## Correctness and attribution boundaries

Both schemas require expected compile/link/archive hit counts in unscored warm audits. Historical schema 1 has **no counters/attribution**: those fields remain unavailable/null, never zero-filled or retrofitted into old product code. Phase definitions changed; internal total/phase values are not substituted for scored external elapsed time.

All warm measurement scopes preserve full project cache/artifact metadata inventories and identical stderr, with no build-action lines. Current schema-2 audits additionally report no compiler/linker/librarian launches or cache writes. The old version cannot directly prove zero OS process launches from counters it never had; hits/output/metadata are the available historical checks. Default stdout differs intentionally after #159 and remains recorded rather than being silently suppressed.

Separate rebuild scopes, subsequent full hits, visible compiler failure with exit 4 and recovery pass. Final produced-program checks pass. No freshness or trust rule was weakened. The genuine discovery-hit fixture is verified by unchanged metadata and current no-write/no-tool audits; it does not merely label no-op compilation after rediscovery as a persistent hit.

Example current unscored shared129 audit retains **129 compile hits, one link hit, 131 cache reads, zero writes, 423 snapshots, 1408 evidence reuses and zero build-tool launches**. The output is three lines. Example work values include target reporting 0.007 ms, link resolution 0.254 ms and layout wall 10.055 ms. These are auxiliary audit observations, not 40-pair scored medians or additive pieces of external elapsed time. Overlapping cache-read work includes decoding and cannot establish the cache-pack threshold.

## Remaining route: production scope frozen, final release PR separate

This cumulative result closes the question of whether the accepted series has useful release-level warm-path value. **Freeze the v5.5.0 product optimization scope here** rather than automatically implementing every original candidate:

- Object handoff is not admitted: current target dependency revalidation occurs after miss execution and link observes objects later. Replacing it with an early compile snapshot would change the freshness boundary; no equivalent net-saving design has been established.
- Link-resolution reuse and multi-key discovery are not mandatory: these fixtures do not demonstrate sufficient residual need; genuine discovery hits work without a storage redesign.
- Rejected singleton-reader patches #158/#161 remain rejected. Archive #160's bounded persistence contract remains accepted independently of speed claims.
- Cache packs still require isolated residual cache I/O >=25-30%; overlapping work durations do not satisfy it. Daemon/watcher/USN/residency remains v6.0.

Next is the **independent release-preparation PR**: preserve this evidence/risk record, document the admitted scope and reporting/archive compatibility boundaries, then change VERSION only there and run the exact-version native/self-host/package contract. Repository policy generates Release notes from GitHub history rather than a parallel source-tree changelog. No automatic v5.5.0 publication is authorized or performed by this evidence PR, and no percentage sum substitutes for the exact accepted-combination measurement.