### PR TITLE
test: validate real MSVC service ownership before cancellation integration

### DIFF
--- a/.github/workflows/msvc-service-ownership.yml
+++ b/.github/workflows/msvc-service-ownership.yml
@@ -1,0 +1,72 @@
+name: MSVC Service Ownership Evidence
+
+on:
+  pull_request:
+    paths:
+      - 'cpp/**'
+      - 'tests/native/collect_msvc_service_ownership.ps1'
+      - '.github/workflows/msvc-service-ownership.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: msvc-service-ownership-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  observe:
+    name: Real MSVC ownership matrix
+    runs-on: windows-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout exact candidate source
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Acquire pinned historical MQB seed
+        id: seed
+        shell: pwsh
+        run: |
+          $seed = & (Join-Path $PWD 'tests/native/acquire_seed.ps1') `
+            -RepoRoot $PWD -OutputRoot (Join-Path $PWD 'native-seed')
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          "path=$seed" >> $env:GITHUB_OUTPUT
+
+      - name: Build exact candidate with MQB
+        shell: pwsh
+        run: |
+          $mqb = & (Join-Path $PWD 'tests/native/build_mqb.ps1') `
+            -BuilderMqbPath '${{ steps.seed.outputs.path }}' -RepoRoot $PWD `
+            -Version ((Get-Content -LiteralPath 'VERSION' -Raw).Trim()) `
+            -Configuration Release -Clean `
+            -OutputPath (Join-Path $PWD 'native-out/ownership/mqb.exe')
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          if (-not (Test-Path -LiteralPath $mqb -PathType Leaf)) { throw 'Candidate MQB missing.' }
+
+      - name: Observe fixed real-tool ownership matrix
+        shell: pwsh
+        run: |
+          & (Join-Path $PWD 'tests/native/collect_msvc_service_ownership.ps1') `
+            -MqbPath (Join-Path $PWD 'native-out/ownership/mqb.exe') -RepoRoot $PWD `
+            -OutputRoot (Join-Path $PWD '.mqb/msvc-ownership-evidence')
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Retain diagnostics and unfavorable observations
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: msvc-service-ownership-evidence
+          path: |
+            .mqb/msvc-ownership-evidence/**
+            !.mqb/msvc-ownership-evidence/**/*.obj
+            !.mqb/msvc-ownership-evidence/**/*.pdb
+            !.mqb/msvc-ownership-evidence/**/*.pch
+            !.mqb/msvc-ownership-evidence/**/*.ifc
+            !.mqb/msvc-ownership-evidence/**/*.exe
+          include-hidden-files: true
+          if-no-files-found: warn
+          retention-days: 30

--- a/cpp/tests/platform/windows/msvc_service_ownership_probe.cpp
+++ b/cpp/tests/platform/windows/msvc_service_ownership_probe.cpp
@@ -1,0 +1,460 @@
+// Diagnostic-only M1b experiment. Never used by the production CLI.
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#include <tlhelp32.h>
+#include <restartmanager.h>
+
+#include <algorithm>
+#include <chrono>
+#include <expected>
+#include <filesystem>
+#include <fstream>
+#include <future>
+#include <iostream>
+#include <optional>
+#include <stdexcept>
+#include <stop_token>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "mqb/msvc/MsvcToolchainLocator.hpp"
+#include "mqb/platform/windows/CommandLine.hpp"
+#include "mqb/platform/windows/WindowsProcessRunner.hpp"
+
+namespace {
+namespace fs = std::filesystem;
+using mqb::platform::windows::WindowsProcessRunner;
+using mqb::process::ProcessSpec;
+using mqb::process::ProcessResult;
+using RunResult = std::expected<ProcessResult, mqb::process::ProcessError>;
+using mqb::msvc::MsvcToolchain;
+using namespace std::chrono_literals;
+
+struct Handle {
+    HANDLE value{};
+    explicit Handle(HANDLE h = nullptr) : value(h) {}
+    ~Handle() { if (*this) ::CloseHandle(value); }
+    Handle(const Handle&) = delete;
+    Handle& operator=(const Handle&) = delete;
+    Handle(Handle&& h) noexcept : value(std::exchange(h.value, nullptr)) {}
+    Handle& operator=(Handle&& h) noexcept {
+        if (this != &h) {
+            if (*this) ::CloseHandle(value);
+            value = std::exchange(h.value, nullptr);
+        }
+        return *this;
+    }
+    explicit operator bool() const { return value && value != INVALID_HANDLE_VALUE; }
+};
+
+void require(bool ok, const std::string& message) {
+    if (!ok) throw std::runtime_error(message);
+}
+std::string utf8(const std::wstring& s) {
+    auto result = mqb::platform::windows::utf16_to_utf8(s);
+    require(result.has_value(), "UTF-16 conversion failed");
+    return *result;
+}
+std::string path_text(const fs::path& p) { return utf8(p.wstring()); }
+fs::path self() {
+    std::wstring buffer(32768, L'\0');
+    auto n = ::GetModuleFileNameW(nullptr, buffer.data(), static_cast<DWORD>(buffer.size()));
+    require(n > 0 && n < buffer.size(), "GetModuleFileName failed");
+    buffer.resize(n);
+    return fs::path{buffer};
+}
+void write(const fs::path& path, const std::string& text) {
+    std::ofstream out(path, std::ios::binary);
+    out << text;
+    out.flush();
+    require(bool(out), "cannot write " + path_text(path));
+}
+std::string quoted(const std::string& value) {
+    std::string result = "\"";
+    for (unsigned char c : value) {
+        if (c == '\\' || c == '"') { result += '\\'; result += static_cast<char>(c); }
+        else if (c == '\n') result += "\\n";
+        else if (c == '\r') result += "\\r";
+        else if (c == '\t') result += "\\t";
+        else if (c < 32) {
+            constexpr char hex[] = "0123456789abcdef";
+            result += "\\u00"; result += hex[c >> 4]; result += hex[c & 15];
+        } else result += static_cast<char>(c);
+    }
+    return result + '"';
+}
+unsigned long long ticks(FILETIME t) {
+    return (static_cast<unsigned long long>(t.dwHighDateTime) << 32) | t.dwLowDateTime;
+}
+bool alive(HANDLE h) {
+    auto result = ::WaitForSingleObject(h, 0);
+    require(result == WAIT_TIMEOUT || result == WAIT_OBJECT_0, "process wait failed");
+    return result == WAIT_TIMEOUT;
+}
+struct Process {
+    DWORD pid{};
+    unsigned long long created{};
+    fs::path image;
+    Handle handle;
+};
+std::vector<Process> census(const wchar_t* name, std::optional<DWORD> parent = {}) {
+    Handle snapshot{::CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0)};
+    require(bool(snapshot), "process snapshot failed");
+    PROCESSENTRY32W entry{};
+    entry.dwSize = sizeof(entry);
+    std::vector<Process> result;
+    BOOL more = ::Process32FirstW(snapshot.value, &entry);
+    while (more) {
+        if (_wcsicmp(entry.szExeFile, name) == 0 &&
+            (!parent || entry.th32ParentProcessID == *parent)) {
+            Handle handle{::OpenProcess(SYNCHRONIZE | PROCESS_QUERY_LIMITED_INFORMATION,
+                                         FALSE, entry.th32ProcessID)};
+            if (!handle) {
+                // A disappearing process is not a retained identity. Record failure,
+                // rather than inferring that an unopenable PID is our service.
+                throw std::runtime_error("cannot retain observed process: " + std::to_string(::GetLastError()));
+            }
+            FILETIME created{}, exited{}, kernel{}, user{};
+            require(::GetProcessTimes(handle.value, &created, &exited, &kernel, &user) != FALSE,
+                    "GetProcessTimes failed");
+            std::wstring image(32768, L'\0');
+            DWORD n = static_cast<DWORD>(image.size());
+            require(::QueryFullProcessImageNameW(handle.value, 0, image.data(), &n) != FALSE,
+                    "QueryFullProcessImageName failed");
+            image.resize(n);
+            result.push_back(Process{entry.th32ProcessID, ticks(created), fs::path{image}, std::move(handle)});
+        }
+        more = ::Process32NextW(snapshot.value, &entry);
+    }
+    require(::GetLastError() == ERROR_NO_MORE_FILES, "process enumeration incomplete");
+    return result;
+}
+bool same(const Process& a, const Process& b) { return a.pid == b.pid && a.created == b.created; }
+std::vector<Process> new_servers(const std::vector<Process>& before, const fs::path& compiler) {
+    auto now = census(L"mspdbsrv.exe");
+    std::vector<Process> result;
+    for (auto& process : now) {
+        if (_wcsicmp(process.image.parent_path().c_str(), compiler.parent_path().c_str()) != 0) continue;
+        if (std::none_of(before.begin(), before.end(), [&](const auto& p) { return same(p, process); }))
+            result.push_back(std::move(process));
+    }
+    return result;
+}
+
+struct Owners { DWORD error{}; bool includes_server{}; std::string identities{"[]"}; };
+Owners pdb_owners(const fs::path& pdb, const Process& server) {
+    DWORD session{};
+    wchar_t key[CCH_RM_SESSION_KEY + 1]{};
+    DWORD error = ::RmStartSession(&session, 0, key);
+    if (error != ERROR_SUCCESS) return {error, false, "[]"};
+    struct End { DWORD session; ~End() { ::RmEndSession(session); } } end{session};
+    const auto path = pdb.wstring();
+    LPCWSTR resource = path.c_str();
+    error = ::RmRegisterResources(session, 1, &resource, 0, nullptr, 0, nullptr);
+    if (error != ERROR_SUCCESS) return {error, false, "[]"};
+    std::vector<RM_PROCESS_INFO> processes(8);
+    UINT count{}, needed{};
+    DWORD reasons{};
+    for (unsigned attempt = 0; attempt != 4; ++attempt) {
+        count = static_cast<UINT>(processes.size());
+        error = ::RmGetList(session, &needed, &count, processes.data(), &reasons);
+        if (error != ERROR_MORE_DATA) break;
+        if (needed > 4096) return {ERROR_MORE_DATA, false, "[]"};
+        processes.resize(std::max<std::size_t>(needed, processes.size() * 2));
+    }
+    if (error != ERROR_SUCCESS) return {error, false, "[]"};
+    Owners result;
+    result.identities = "[";
+    for (UINT i = 0; i < count; ++i) {
+        const auto& p = processes[i].Process;
+        if (i) result.identities += ',';
+        result.identities += "{\"pid\":" + std::to_string(p.dwProcessId)
+            + ",\"created\":" + std::to_string(ticks(p.ProcessStartTime)) + "}";
+        result.includes_server |= p.dwProcessId == server.pid && ticks(p.ProcessStartTime) == server.created;
+    }
+    result.identities += ']';
+    return result;
+}
+
+void save_result(const fs::path& dir, const std::string& label, const RunResult& result) {
+    if (result) {
+        write(dir / (label + ".stdout.txt"), result->stdout_text);
+        write(dir / (label + ".stderr.txt"), result->stderr_text);
+        write(dir / (label + ".result.json"), "{\"exit_code\":" + std::to_string(result->exit_code)
+              + ",\"cancelled\":" + (result->termination == mqb::process::ProcessTermination::cancelled ? "true" : "false") + "}\n");
+    } else {
+        write(dir / (label + ".error.txt"), result.error().message + " native=" + std::to_string(result.error().native_code));
+        write(dir / (label + ".result.json"), "{\"infrastructure_error\":true,\"native_code\":"
+              + std::to_string(result.error().native_code) + "}\n");
+    }
+}
+RunResult invoke(const MsvcToolchain& toolchain, const fs::path& executable,
+                 const fs::path& dir, const std::string& label, std::vector<std::string> arguments) {
+    ProcessSpec spec;
+    spec.executable = executable;
+    spec.arguments = std::move(arguments);
+    spec.working_directory = dir;
+    spec.environment = toolchain.environment;
+    std::string command = path_text(executable) + '\n';
+    for (const auto& arg : spec.arguments) command += arg + '\n';
+    write(dir / (label + ".argv.txt"), command);
+    WindowsProcessRunner runner;
+    auto result = runner.run(spec); // Deliberately unmanaged real compiler / linker.
+    save_result(dir, label, result);
+    return result;
+}
+int exit_code(const RunResult& r) { return r ? r->exit_code : -1; }
+void success(const RunResult& r, const std::string& label) {
+    require(r.has_value(), label + ": process infrastructure error");
+    require(r->exit_code == 0, label + ": compiler control failed (see complete diagnostics)");
+}
+bool pch(const std::string& profile) { return profile.starts_with("pch-"); }
+bool modules(const std::string& profile) { return profile.starts_with("modules-"); }
+std::vector<std::string> flags(const fs::path& dir, const std::string& profile) {
+    return {"/nologo", "/c", "/std:c++latest", "/EHsc", "/FS",
+            profile.starts_with("ZI-") ? "/ZI" : "/Zi",
+            profile.ends_with("release") ? "/O2" : "/Od",
+            profile.ends_with("release") ? "/MT" : "/MTd",
+            "/Fd" + path_text(dir / "compiler.pdb")};
+}
+std::string prefix(const std::string& profile) {
+    if (pch(profile)) return "#include \"common.hpp\"\n";
+    if (modules(profile)) return "import ownership;\n";
+    return "";
+}
+RunResult compile(const MsvcToolchain& tc, const fs::path& dir, const std::string& profile,
+                  const std::string& stem) {
+    auto args = flags(dir, profile);
+    if (pch(profile)) {
+        args.push_back("/Yucommon.hpp"); args.push_back("/Fp" + path_text(dir / "common.pch"));
+    }
+    if (modules(profile)) {
+        args.push_back("/reference"); args.push_back("ownership=" + path_text(dir / "ownership.ifc"));
+    }
+    args.push_back("/Fo" + path_text(dir / (stem + ".obj")));
+    args.push_back(path_text(dir / (stem + ".cpp")));
+    return invoke(tc, tc.identity.compiler, dir, stem, std::move(args));
+}
+void prepare(const MsvcToolchain& tc, const fs::path& dir, const std::string& profile) {
+    fs::create_directories(dir);
+    if (pch(profile)) {
+        write(dir / "common.hpp", "#pragma once\nstruct Common { int value; };\n");
+        write(dir / "prefix.cpp", "#include \"common.hpp\"\n");
+        auto args = flags(dir, profile);
+        args.insert(args.end(), {"/Yccommon.hpp", "/Fp" + path_text(dir / "common.pch"),
+                                "/Fo" + path_text(dir / "prefix.obj"), path_text(dir / "prefix.cpp")});
+        success(invoke(tc, tc.identity.compiler, dir, "prefix", std::move(args)), "PCH creation");
+    }
+    if (modules(profile)) {
+        write(dir / "ownership.ixx", "export module ownership;\nexport int answer() { return 42; }\n");
+        auto args = flags(dir, profile);
+        args.insert(args.end(), {"/interface", "/TP", "/ifcOutput", path_text(dir / "ownership.ifc"),
+                                "/Fo" + path_text(dir / "provider.obj"), path_text(dir / "ownership.ixx")});
+        success(invoke(tc, tc.identity.compiler, dir, "provider", std::move(args)), "module creation");
+    }
+    write(dir / "warm.cpp", prefix(profile) + "int warm() { return 42; }\n");
+    success(compile(tc, dir, profile, "warm"), "warm compiler control");
+    require(fs::exists(dir / "compiler.pdb"), "control must create real compiler PDB");
+}
+void workload(const fs::path& dir, const std::string& profile) {
+    // Fixed input, not repeatedly enlarged until overlap or a favorable result.
+    for (unsigned worker = 0; worker != 2; ++worker) {
+        std::string source = prefix(profile);
+        for (unsigned i = 0; i != 6000; ++i) {
+            auto id = std::to_string(worker) + "_" + std::to_string(i);
+            source += "struct T" + id + " { int a; int b; };\n__declspec(noinline) int f" + id
+                + "(int x) { T" + id + " t{x, x+1}; return t.a+t.b; }\n";
+        }
+        if (worker == 0) source += "extern int other(); int main() { return other() == 42 ? 0 : 1; }\n";
+        else source += modules(profile) ? "int other() { return answer(); }\n" : "int other() { return 42; }\n";
+        write(dir / ("work" + std::to_string(worker) + ".cpp"), source);
+    }
+}
+
+int root(int argc, wchar_t** argv) {
+    require(argc == 7, "root arguments");
+    MsvcToolchain tc;
+    tc.identity.compiler = argv[2]; // Environment already supplied by the measured parent.
+    const fs::path dir{argv[3]};
+    Handle ready{::OpenEventW(EVENT_MODIFY_STATE, FALSE, argv[5])};
+    Handle release{::OpenEventW(SYNCHRONIZE, FALSE, argv[6])};
+    require(bool(ready) && bool(release), "root event open failed");
+    prepare(tc, dir, utf8(argv[4]));
+    write(dir / "root.pid", std::to_string(::GetCurrentProcessId()));
+    require(::SetEvent(ready.value) != FALSE, "root ready failed");
+    // Fixture watchdog only; not a product cancellation deadline.
+    require(::WaitForSingleObject(release.value, 120000) == WAIT_OBJECT_0, "root fixture watchdog");
+    return 0;
+}
+
+int measure(int argc, wchar_t** argv) {
+    require(argc == 7, "measure arguments");
+    const fs::path dir = fs::absolute(argv[2]);
+    const std::string profile = utf8(argv[3]), origin = utf8(argv[4]), ending = utf8(argv[5]);
+    const std::wstring endpoint = argv[6];
+    require(profile == "zi-debug" || profile == "ZI-debug" || profile == "zi-release"
+            || profile == "pch-debug" || profile == "pch-release"
+            || profile == "modules-debug" || profile == "modules-release", "unknown profile");
+    require(origin == "preexisting" || origin == "A-started", "unknown origin");
+    require(ending == "cancel" || ending == "normal" || ending == "unmanaged-normal", "unknown ending");
+    fs::create_directories(dir);
+    WindowsProcessRunner runner;
+    mqb::msvc::DiscoveryOptions options;
+    options.preference = mqb::msvc::ToolchainPreference::visual_studio;
+    options.cache_file = fs::path{}; // No shared discovery-cache writes in the experiment.
+    auto discovered = mqb::msvc::MsvcToolchainLocator{runner}.discover(options);
+    if (!discovered) {
+        write(dir / "discovery.error.txt", discovered.error().message);
+        throw std::runtime_error("MSVC discovery failed; see discovery.error.txt");
+    }
+    auto tc = std::move(*discovered);
+    // Test isolation only, not a supported product-service ownership policy.
+    for (const char* name : {"_MSPDBSRV_ENDPOINT_", "CL", "_CL_", "LINK", "_LINK_"}) {
+        std::erase_if(tc.environment, [&](const auto& e) { return _stricmp(e.name.c_str(), name) == 0; });
+        tc.environment.push_back({name, name == std::string{"_MSPDBSRV_ENDPOINT_"} ? utf8(endpoint) : "",
+                                  name != std::string{"_MSPDBSRV_ENDPOINT_"}});
+    }
+    write(dir / "toolchain.txt", path_text(tc.identity.compiler) + '\n' + tc.identity.version + '\n'
+          + tc.identity.binary_stamp + "\nendpoint=" + utf8(endpoint) + '\n');
+    auto before = census(L"mspdbsrv.exe");
+    if (origin == "preexisting") prepare(tc, dir / "seed", profile);
+    const auto ready_name = L"Local\\MQB-ownership-ready-" + endpoint;
+    const auto release_name = L"Local\\MQB-ownership-release-" + endpoint;
+    Handle ready{::CreateEventW(nullptr, TRUE, FALSE, ready_name.c_str())};
+    Handle release{::CreateEventW(nullptr, TRUE, FALSE, release_name.c_str())};
+    require(bool(ready) && bool(release), "fixture events failed");
+    std::stop_source stop;
+    ProcessSpec a;
+    a.executable = self();
+    a.arguments = {"--root", path_text(tc.identity.compiler), path_text(dir / "A"), profile,
+                   utf8(ready_name), utf8(release_name)};
+    a.environment = tc.environment;
+    if (ending != "unmanaged-normal") a.cancellation = stop.get_token();
+    auto a_future = std::async(std::launch::async, [&] {
+        auto result = runner.run(a);
+        save_result(dir, "A", result); // Also preserve early-root failures before readiness.
+        return result;
+    });
+    struct Release {
+        Handle& event; std::stop_source& stop; std::future<RunResult>& future;
+        ~Release() { stop.request_stop(); ::SetEvent(event.value); if (future.valid()) future.wait(); }
+    } release_on_error{release, stop, a_future};
+    bool is_ready = false;
+    for (unsigned attempt = 0; attempt != 600; ++attempt) {
+        const auto status = ::WaitForSingleObject(ready.value, 100);
+        require(status == WAIT_TIMEOUT || status == WAIT_OBJECT_0, "A readiness wait failed");
+        if (status == WAIT_OBJECT_0) { is_ready = true; break; }
+        if (a_future.wait_for(0ms) == std::future_status::ready) break;
+    }
+    require(is_ready, "A did not reach compiled-and-ready boundary; see A/ and A.result.json");
+    auto servers = new_servers(before, tc.identity.compiler);
+    require(servers.size() == 1 && alive(servers[0].handle.value), "cannot attribute exactly one new live MSPDBSRV");
+    const auto& server = servers[0];
+    prepare(tc, dir / "B", profile);
+    auto after_b = new_servers(before, tc.identity.compiler);
+    require(after_b.size() == 1 && same(server, after_b[0]), "B did not retain the same observed endpoint service");
+    auto warm_owners = pdb_owners(dir / "B/compiler.pdb", server);
+    workload(dir / "B", profile);
+    auto b0 = std::async(std::launch::async, [&] { return compile(tc, dir / "B", profile, "work0"); });
+    auto b1 = std::async(std::launch::async, [&] { return compile(tc, dir / "B", profile, "work1"); });
+    std::vector<Process> active;
+    const auto deadline = std::chrono::steady_clock::now() + 15s;
+    do {
+        active = census(L"cl.exe", ::GetCurrentProcessId());
+        if (!active.empty()) break;
+        if (b0.wait_for(0ms) == std::future_status::ready && b1.wait_for(0ms) == std::future_status::ready) break;
+        std::this_thread::sleep_for(10ms);
+    } while (std::chrono::steady_clock::now() < deadline);
+    std::string observed_compilers = "[";
+    for (const auto& process : active) {
+        require(_wcsicmp(process.image.c_str(), tc.identity.compiler.c_str()) == 0,
+                "observed child compiler image differs from selected toolchain");
+        if (observed_compilers.size() != 1) observed_compilers += ',';
+        observed_compilers += "{\"pid\":" + std::to_string(process.pid)
+            + ",\"created\":" + std::to_string(process.created)
+            + ",\"image\":" + quoted(path_text(process.image)) + "}";
+    }
+    observed_compilers += ']';
+    const auto active_owners = pdb_owners(dir / "B/compiler.pdb", server);
+    bool overlap = std::any_of(active.begin(), active.end(), [](const auto& p) { return alive(p.handle.value); });
+    // No claim that a live cl.exe proves an RPC is in flight at this instant.
+    if (ending == "cancel") stop.request_stop();
+    else require(::SetEvent(release.value) != FALSE, "release A failed");
+    auto a_result = a_future.get();
+    const bool service_survived = alive(server.handle.value); // Immediate retained-handle observation.
+    auto b0_result = b0.get(), b1_result = b1.get();
+    int linked = -2, executed = -2;
+    if (exit_code(b0_result) == 0 && exit_code(b1_result) == 0) {
+        std::vector<std::string> args{"/NOLOGO", "/DEBUG", "/INCREMENTAL:NO", "/OUT:" + path_text(dir / "B/result.exe"),
+                                      "/PDB:" + path_text(dir / "B/linked.pdb"), path_text(dir / "B/work0.obj"),
+                                      path_text(dir / "B/work1.obj")};
+        if (modules(profile)) args.push_back(path_text(dir / "B/provider.obj"));
+        if (pch(profile)) args.push_back(path_text(dir / "B/prefix.obj"));
+        auto result = invoke(tc, tc.linker, dir / "B", "link", std::move(args));
+        linked = exit_code(result);
+        if (linked == 0) executed = exit_code(invoke(tc, dir / "B/result.exe", dir / "B", "run", {}));
+    }
+    // Explicit separate recovery attempt, never substitutes for the first B result.
+    write(dir / "B/recovery.cpp", prefix(profile) + "int recovery() { return 43; }\n");
+    const auto recovery = compile(tc, dir / "B", profile, "recovery");
+    const bool lifecycle_ok = a_result && (ending == "cancel"
+        ? a_result->termination == mqb::process::ProcessTermination::cancelled && a_result->exit_code != 0
+        : a_result->termination == mqb::process::ProcessTermination::exited && a_result->exit_code == 0);
+    const bool b_ok = exit_code(b0_result) == 0 && exit_code(b1_result) == 0 && linked == 0 && executed == 0;
+    const bool control_ok = ending != "unmanaged-normal" || (service_survived && b_ok);
+    std::string report = "{\n\"schema\":1,\"profile\":" + quoted(profile) + ",\"origin\":" + quoted(origin)
+        + ",\"ending\":" + quoted(ending) + ",\"server_pid\":" + std::to_string(server.pid)
+        + ",\"server_created\":" + std::to_string(server.created)
+        + ",\"server_image\":" + quoted(path_text(server.image))
+        + ",\"server_survived_A\":" + (service_survived ? "true" : "false")
+        + ",\"B_compiler_overlap_observed\":" + (overlap ? "true" : "false")
+        + ",\"B_observed_compilers\":" + observed_compilers
+        + ",\"warm_pdb_owner_error\":" + std::to_string(warm_owners.error)
+        + ",\"warm_pdb_owners\":" + warm_owners.identities
+        + ",\"active_pdb_owner_error\":" + std::to_string(active_owners.error)
+        + ",\"active_pdb_owners\":" + active_owners.identities
+        + ",\"B_pdb_service_identity_observed\":" + ((warm_owners.includes_server || active_owners.includes_server) ? "true" : "false")
+        + ",\"A_exit\":" + std::to_string(exit_code(a_result))
+        + ",\"B0_exit\":" + std::to_string(exit_code(b0_result)) + ",\"B1_exit\":" + std::to_string(exit_code(b1_result))
+        + ",\"B_link_exit\":" + std::to_string(linked) + ",\"B_run_exit\":" + std::to_string(executed)
+        + ",\"recovery_compile_exit\":" + std::to_string(exit_code(recovery))
+        + ",\"lifecycle_ok\":" + (lifecycle_ok ? "true" : "false")
+        + ",\"unmanaged_control_ok\":" + (control_ok ? "true" : "false")
+        + ",\"safe_to_integrate_cancellation\":false,\"safe_to_transfer_write_lease\":false\n}\n";
+    write(dir / "observation.json", report);
+    std::cout << report;
+    return lifecycle_ok && control_ok ? 0 : 1;
+}
+} // namespace
+
+int wmain(int argc, wchar_t** argv) {
+    try {
+        require(argc >= 2, "use --case/--measure/--root");
+        const std::wstring mode = argv[1];
+        if (mode == L"--root") return root(argc, argv);
+        if (mode == L"--measure") return measure(argc, argv);
+        require(mode == L"--case" && argc == 7, "case arguments");
+        // A fixture-wide outer Job bounds *both* projects and their dedicated
+        // endpoint. The inner A Job is the policy under test. No global service
+        // termination, PID-authorized kill, or product environment changes.
+        ProcessSpec spec;
+        spec.executable = self();
+        spec.arguments = {"--measure"};
+        for (int i = 2; i < argc; ++i) spec.arguments.push_back(utf8(argv[i]));
+        std::stop_source lifetime;
+        spec.cancellation = lifetime.get_token();
+        WindowsProcessRunner runner;
+        auto result = runner.run(spec);
+        if (!result) { std::cerr << "OUTER_CLEANUP_ERROR " << result.error().message << '\n'; return 1; }
+        std::cout << result->stdout_text;
+        std::cerr << result->stderr_text;
+        return result->exit_code;
+    } catch (const std::exception& e) {
+        std::cerr << "PROBE_INFRASTRUCTURE_FAILURE " << e.what() << '\n';
+        return 1;
+    }
+}

--- a/tests/native/collect_msvc_service_ownership.ps1
+++ b/tests/native/collect_msvc_service_ownership.ps1
@@ -82,7 +82,10 @@ try {
     foreach ($profile in $profiles) {
         foreach ($origin in $origins) {
             foreach ($ending in $endings) {
-                $name = "$profile-$origin-$ending"
+                # /Zi and /ZI are different compiler modes, but their short
+                # names alone collide on a case-insensitive output filesystem.
+                $directoryProfile = if ($profile -ceq 'ZI-debug') { 'zi-edit-and-continue-debug' } else { $profile }
+                $name = "$directoryProfile-$origin-$ending"
                 $caseRoot = Join-Path $OutputRoot $name
                 New-Item -ItemType Directory -Path $caseRoot | Out-Null
                 $endpoint = 'mqb-' + [guid]::NewGuid().ToString('N')
@@ -105,9 +108,20 @@ try {
                 # B failures are the result of the policy under test, not a reason
                 # to suppress their data. Missing evidence / failed unmanaged
                 # controls / process-infrastructure failures do fail collection.
-                if ($caseExit -ne 0 -or $null -eq $observation -or $null -ne $parseError) { $failed++ }
+                $toolErrors = @(Get-ChildItem -LiteralPath $caseRoot -Recurse -File -Filter '*.result.json' |
+                    ForEach-Object {
+                        $result = Get-Content -LiteralPath $_.FullName -Raw | ConvertFrom-Json
+                        $property = $result.PSObject.Properties['infrastructure_error']
+                        if ($null -ne $property -and $property.Value -eq $true) {
+                            [System.IO.Path]::GetRelativePath($caseRoot, $_.FullName)
+                        }
+                    })
+                $collectionOk = $caseExit -eq 0 -and $null -ne $observation -and
+                    $null -eq $parseError -and $toolErrors.Count -eq 0
+                if (-not $collectionOk) { $failed++ }
                 $row = [ordered]@{
                     case = $name; exit_code = $caseExit; elapsed_ms = $timer.Elapsed.TotalMilliseconds
+                    collection_ok = $collectionOk; tool_infrastructure_errors = $toolErrors
                     observation = $observation; parse_error = $parseError
                 }
                 $rows.Add($row)

--- a/tests/native/collect_msvc_service_ownership.ps1
+++ b/tests/native/collect_msvc_service_ownership.ps1
@@ -1,0 +1,134 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$MqbPath,
+    [Parameter(Mandatory = $true)][string]$RepoRoot,
+    [string]$OutputRoot,
+    [ValidateSet('Debug', 'Release')][string]$Configuration = 'Release'
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+$RepoRoot = [System.IO.Path]::GetFullPath($RepoRoot)
+$MqbPath = [System.IO.Path]::GetFullPath($MqbPath)
+if (-not (Test-Path -LiteralPath $MqbPath -PathType Leaf)) { throw "Missing MQB: $MqbPath" }
+if ([string]::IsNullOrWhiteSpace($OutputRoot)) {
+    $OutputRoot = Join-Path $RepoRoot ('.mqb/msvc-ownership-evidence/' + [guid]::NewGuid().ToString('N'))
+}
+$OutputRoot = [System.IO.Path]::GetFullPath($OutputRoot)
+# Never erase an earlier run, failure, or unfavorable observation.
+if (Test-Path -LiteralPath $OutputRoot) { throw "Evidence directory already exists: $OutputRoot" }
+New-Item -ItemType Directory -Path $OutputRoot -Force | Out-Null
+
+Push-Location $RepoRoot
+try {
+    $head = (& git rev-parse HEAD).Trim()
+    if ($LASTEXITCODE -ne 0) { throw 'Cannot resolve source HEAD.' }
+    $status = @(& git status --porcelain --untracked-files=no)
+    if ($LASTEXITCODE -ne 0 -or $status.Count -ne 0) { throw 'Tracked source must be clean.' }
+    $version = (Get-Content -LiteralPath (Join-Path $RepoRoot 'VERSION') -Raw).Trim()
+    if ($version -ne '5.5.0') { throw "This M1b experiment requires unchanged VERSION 5.5.0, got $version" }
+    $identity = [ordered]@{
+        schema = 1
+        source_head = $head
+        version = $version
+        candidate_path = $MqbPath
+        candidate_sha256 = (Get-FileHash -LiteralPath $MqbPath -Algorithm SHA256).Hash
+        configuration = $Configuration
+        os = [System.Environment]::OSVersion.VersionString
+        powershell = $PSVersionTable.PSVersion.ToString()
+        processor_count = [System.Environment]::ProcessorCount
+        github_run_id = $env:GITHUB_RUN_ID
+        github_run_attempt = $env:GITHUB_RUN_ATTEMPT
+        runner_image = $env:ImageVersion
+        utc_started = [DateTime]::UtcNow.ToString('o')
+        isolation = 'Unique fixture-only _MSPDBSRV_ENDPOINT_, shared by A and B; outer request Job owns entire disposable fixture.'
+        limitation = 'Not default-endpoint validation, RPC-in-flight proof, owner-crash recovery, or write-lease release proof.'
+    }
+    $identity | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath (Join-Path $OutputRoot 'identity.json') -Encoding utf8
+
+    & (Join-Path $RepoRoot 'tests/native/assert_cpp_layout.ps1') -CppRoot (Join-Path $RepoRoot 'cpp')
+    $config = Get-Content -LiteralPath (Join-Path $RepoRoot 'cpp/mqb.json') -Raw | ConvertFrom-Json
+    $sharedSources = @($config.discovery.extra_sources | ForEach-Object { $_.Replace('\', '/') } | Sort-Object -Unique)
+    $actualSources = @(Get-ChildItem -LiteralPath (Join-Path $RepoRoot 'cpp/src') -File -Recurse -Filter '*.cpp' |
+        ForEach-Object { [System.IO.Path]::GetRelativePath((Join-Path $RepoRoot 'cpp'), $_.FullName).Replace('\', '/') } |
+        Where-Object { $_ -ne 'src/app/main.cpp' } | Sort-Object -Unique)
+    if (@(Compare-Object $actualSources $sharedSources).Count -ne 0) { throw 'Production source manifest drift.' }
+    $arguments = [System.Collections.Generic.List[string]]::new()
+    $arguments.Add('cpp/tests/platform/windows/msvc_service_ownership_probe.cpp')
+    foreach ($source in $sharedSources) { $arguments.Add('cpp/' + $source) }
+    $arguments.AddRange([string[]]@('--env', 'vs', '--no-discover', '--std', [string]$config.build.standard))
+    $arguments.Add($(if ($Configuration -eq 'Debug') { '--debug' } else { '--release' }))
+    $arguments.Add('--runtime')
+    $arguments.Add($(if ($Configuration -eq 'Debug') { 'MTd' } else { 'MT' }))
+    foreach ($include in @($config.build.include_dirs)) { $arguments.Add('-I'); $arguments.Add('cpp/' + $include) }
+    foreach ($arg in @($config.build.compiler_args)) { $arguments.Add('--compiler-arg'); $arguments.Add([string]$arg) }
+    $arguments.AddRange([string[]]@('-D', 'MQB_VERSION="ownership-probe"', '--lib', 'shell32.lib', '--lib', 'Rstrtmgr.lib', '-o', 'msvc_service_ownership_probe'))
+    $arguments | Set-Content -LiteralPath (Join-Path $OutputRoot 'probe-build.argv.txt') -Encoding utf8
+    $output = @(& $MqbPath @arguments 2>&1)
+    $buildExit = $LASTEXITCODE
+    $output | Set-Content -LiteralPath (Join-Path $OutputRoot 'probe-build.output.txt') -Encoding utf8
+    foreach ($line in $output) { Write-Host $line }
+    if ($buildExit -ne 0) { throw "Probe build failed with $buildExit" }
+    $probe = Join-Path $RepoRoot '.mqb/bin/msvc_service_ownership_probe.exe'
+    if (-not (Test-Path -LiteralPath $probe -PathType Leaf)) { throw 'Probe executable missing.' }
+    Get-FileHash -LiteralPath $probe -Algorithm SHA256 | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $OutputRoot 'probe-binary.json') -Encoding utf8
+
+    # This is a fixed diagnostic matrix, not a repeat-until-green policy.
+    $profiles = @('zi-debug', 'ZI-debug', 'zi-release', 'pch-debug', 'pch-release', 'modules-debug', 'modules-release')
+    $origins = @('preexisting', 'A-started')
+    $endings = @('unmanaged-normal', 'normal', 'cancel')
+    $rows = [System.Collections.Generic.List[object]]::new()
+    $failed = 0
+    foreach ($profile in $profiles) {
+        foreach ($origin in $origins) {
+            foreach ($ending in $endings) {
+                $name = "$profile-$origin-$ending"
+                $caseRoot = Join-Path $OutputRoot $name
+                New-Item -ItemType Directory -Path $caseRoot | Out-Null
+                $endpoint = 'mqb-' + [guid]::NewGuid().ToString('N')
+                $caseArgs = @('--case', $caseRoot, $profile, $origin, $ending, $endpoint)
+                $caseArgs | Set-Content -LiteralPath (Join-Path $caseRoot 'case.argv.txt') -Encoding utf8
+                Write-Host "=== MSVC ownership: $name ==="
+                $timer = [System.Diagnostics.Stopwatch]::StartNew()
+                $caseOutput = @(& $probe @caseArgs 2>&1)
+                $caseExit = $LASTEXITCODE
+                $timer.Stop()
+                $caseOutput | Set-Content -LiteralPath (Join-Path $caseRoot 'case.output.txt') -Encoding utf8
+                foreach ($line in $caseOutput) { Write-Host $line }
+                $observationPath = Join-Path $caseRoot 'observation.json'
+                $observation = $null
+                $parseError = $null
+                if (Test-Path -LiteralPath $observationPath -PathType Leaf) {
+                    try { $observation = Get-Content -LiteralPath $observationPath -Raw | ConvertFrom-Json }
+                    catch { $parseError = $_.Exception.Message }
+                }
+                # B failures are the result of the policy under test, not a reason
+                # to suppress their data. Missing evidence / failed unmanaged
+                # controls / process-infrastructure failures do fail collection.
+                if ($caseExit -ne 0 -or $null -eq $observation -or $null -ne $parseError) { $failed++ }
+                $row = [ordered]@{
+                    case = $name; exit_code = $caseExit; elapsed_ms = $timer.Elapsed.TotalMilliseconds
+                    observation = $observation; parse_error = $parseError
+                }
+                $rows.Add($row)
+                $row | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath (Join-Path $caseRoot 'case.result.json') -Encoding utf8
+                # Checkpoint the complete prefix, including adverse/inconclusive cases.
+                [ordered]@{ schema = 1; expected_cases = 42; completed_cases = $rows.Count; failed_cases = $failed; cases = $rows } |
+                    ConvertTo-Json -Depth 14 | Set-Content -LiteralPath (Join-Path $OutputRoot 'summary.json') -Encoding utf8
+            }
+        }
+    }
+    # Raw diagnostics/inputs are uploaded; large generated binaries are identified
+    # by SHA-256 rather than being silently mistaken for retained artifact bytes.
+    $binaries = @(Get-ChildItem -LiteralPath $OutputRoot -Recurse -File |
+        Where-Object { $_.Extension -in @('.obj', '.pdb', '.pch', '.ifc', '.exe') } |
+        ForEach-Object { [ordered]@{
+            path = [System.IO.Path]::GetRelativePath($OutputRoot, $_.FullName)
+            bytes = $_.Length
+            sha256 = (Get-FileHash -LiteralPath $_.FullName -Algorithm SHA256).Hash
+        } })
+    $binaries | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath (Join-Path $OutputRoot 'generated-binary-hashes.json') -Encoding utf8
+    Write-Host "Collected $($rows.Count)/42 cases; $failed collection/control failures. This never authorizes CLI cancellation or lease transfer."
+    if ($rows.Count -ne 42 -or $failed -ne 0) { exit 1 }
+}
+finally { Pop-Location }


### PR DESCRIPTION
## Decision: accept the evidence tool; reject the tested ownership policy

**Final reviewed head:** `c47d75833a15d62905cda45fb608bb77da6b209e`.
**Exact base:** `93b10cf14143f3d5da088a1fe168f4b3d2a027b1` (merged #165).
**Verified head / native test-merge tree:** `1de96aa0fe01fcde71615deefb624dbb37af4a4e`.

[Final source, complete CI, independent ABBA and merge review](https://github.com/Iviesever/msvc-quick-build/pull/166#pullrequestreview-5139969219).
[Real MSVC results, full negative evidence and observability limits](https://github.com/Iviesever/msvc-quick-build/pull/166#issuecomment-5582731186).
[Initial collector defects, source correction and cancelled-head evidence](https://github.com/Iviesever/msvc-quick-build/pull/166#issuecomment-5582456479).

All predeclared gates below have completed: Native Debug #696, complete Native Release/self-host/package #594, Documentation #155, ownership #2 and independent ABBA #537. Publication was skipped. **42/42 cases collected; 14/14 unmanaged controls passed. A-started services died in all 14 managed-ending cases, and 10 original B builds failed. Recovery compiles do not erase those failures.** The title was changed from `perf:` to `test:` only after the separate ABBA finished; this is not a speedup PR. Any title-edited workflow that skips measurement is not substituted for completed ABBA run `34208933416`.

## Scope and exact source

Refs #164, **M1b ownership evidence only**. Do not mark M1b complete from this PR.

- Initial head: `be05806f2ea9a1d8e06baf10e034450d3722101c`; final head above includes the documented collector correction.
- Three new files, 680 additions: a Windows diagnostic probe, its MQB-native collector and a dedicated disposable-runner workflow. Production `cpp/include`, `cpp/src`, `cpp/mqb.json`, existing native inventory (79), caches/freshness and normal CLI are unchanged.
- **VERSION remains 5.5.0. No tag/asset/Release changes.**
- No cancellation propagation, project transaction, build/run split, session, watcher or daemon implementation is folded into this topic.

## Experiment

42 fixed cases: seven real compiler profiles (`/Zi` Debug, `/ZI` Debug, `/Zi` Release, PCH Debug/Release, named Modules Debug/Release), two service origins (preexisting outside A versus started under A), and three A endings (unmanaged normal control, managed normal completion, managed cancellation).

Each disposable fixture has separate A/B output and compiler PDB directories, with **one fixture-only `_MSPDBSRV_ENDPOINT_` shared by A and B**. This Microsoft BuildXL implementation technique isolates the experiment from unrelated services; it is not introduced into production or claimed as a documented MSVC ownership contract. The fixture-wide outer M1a Job contains both projects. The inner A scope is the policy under examination, not a mechanical per-cl production policy. No global service kill, PID-authorized kill, `/Z7` substitution, `/FS` removal, or product environment change.

After A's real compile and B's independent warm compile, retain the observed server process handle and creation identity. Run two fixed 6,000-function B compiler inputs concurrently against B's `/FS` PDB. Record Restart Manager's PDB resource owners (PID plus creation time), retained B compiler identities, server liveness after A's result/diagnostics return, and B's original compile/link/run outcomes. A subsequent recovery compile is a **separate** result and never replaces the initial outcome. Tool argv/stdout/stderr/result files and failed/inconclusive cases are retained. Generated binaries have post-case SHA-256 inventory entries but are excluded from the diagnostic ZIP; those are not snapshots at cancellation.

**Observation limits:** a live compiler is not proof of an in-flight PDB RPC. A shared fixture endpoint is not the untouched default endpoint. Only 14/42 cases observed the exact server as a B PDB resource owner; the remaining 28 are unproven in that dimension. This does not test owner-crash lease recovery or establish disk quiescence. Every observation explicitly sets `safe_to_integrate_cancellation=false` and `safe_to_transfer_write_lease=false`. A helper root keeps the experimental ancestry scope open after compiling; this is not direct per-cl cancellation evidence.

## Original predeclared review gates — not relaxed after measurement

1. Exact-source Native Debug and complete Native Release/self-host/package checks must pass. Production source/manifest/VERSION must remain byte-identical to the base. This Linux editing environment has no MSVC: no local Windows validation is claimed.
2. Ownership collection must finish all 42 cases with raw evidence and no infrastructure/control failure. All 14 unmanaged controls must retain their service and pass the original B compile/link/run. An adverse managed result is valuable evidence **against that policy**, not a reason to suppress the observation. Missing overlap or missing PDB-owner identity is reported as an unproven dimension, never reclassified as successful isolation.
3. Independent unchanged ABBA: 19 scenarios x four pairs. Preserve all favorable/adverse samples, exact base/head, counters and clocks. All 72 instrumented pairs must retain semantic counters/hit-miss identity. Only the four `timings-disabled-no-op` pairs use external timings-off elapsed; other scenario clocks are instrumented. A paired-median external no-op regression exceeding **both 1 ms and 10%** blocks automatic acceptance for investigation. Passing that small sample is not proof of zero overhead; no speedup will be claimed. Historical v5.5.0 cold-tail evidence stays unresolved.
4. Review the complete final diff and all first-run failures before deciding merge or rejection. Workflow collection success is not proof the tested ownership policy is safe.

## Primary platform basis

- Microsoft `/FS`: https://learn.microsoft.com/en-us/cpp/build/reference/fs-force-synchronous-pdb-writes?view=msvc-170
- Microsoft `/Zf`: https://learn.microsoft.com/en-us/cpp/build/reference/zf?view=msvc-170
- Microsoft Restart Manager `RmGetList` (query only; never shutdown): https://learn.microsoft.com/en-us/windows/win32/api/restartmanager/nf-restartmanager-rmgetlist
- Microsoft BuildXL fixture isolation precedent: https://github.com/microsoft/BuildXL/blob/main/Public/Sdk/Experimental/Msvc/Native/Tools/Link/Link.dsc

## Handoff

Continue #164 M1b at default-endpoint/shared-service versus request-private cancellation boundaries, then only evidence-backed cancellation propagation, project single-writer transactions and build/run separation. No parent-death, cancellation error, successful retry or service restart is a safe write-lease-transfer proof. Keep the existing roadmap and VERSION 5.5.0; final VERSION/release PR and publication are separate.