### PR TITLE
test: validate default MSVC endpoint and natural-drain cancellation boundary

### DIFF
--- a/.github/workflows/msvc-default-endpoint.yml
+++ b/.github/workflows/msvc-default-endpoint.yml
@@ -1,0 +1,126 @@
+name: MSVC Default Endpoint Evidence
+
+on:
+  pull_request:
+    paths:
+      - 'cpp/**'
+      - 'tests/native/collect_msvc_service_ownership.ps1'
+      - '.github/workflows/msvc-default-endpoint.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: msvc-default-endpoint-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build exact ownership probe
+    runs-on: windows-latest
+    timeout-minutes: 30
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Build candidate and probe with MQB, without measuring ownership
+        shell: pwsh
+        run: |
+          $seed = & (Join-Path $PWD 'tests/native/acquire_seed.ps1') `
+            -RepoRoot $PWD -OutputRoot (Join-Path $PWD 'native-seed')
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $mqb = & (Join-Path $PWD 'tests/native/build_mqb.ps1') `
+            -BuilderMqbPath $seed -RepoRoot $PWD `
+            -Version ((Get-Content -LiteralPath 'VERSION' -Raw).Trim()) `
+            -Configuration Release -Clean -OutputPath (Join-Path $PWD 'native-out/endpoint/mqb.exe')
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          & (Join-Path $PWD 'tests/native/collect_msvc_service_ownership.ps1') `
+            -MqbPath $mqb -RepoRoot $PWD -BuildOnly `
+            -OutputRoot (Join-Path $PWD '.mqb/default-endpoint-build')
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          New-Item -ItemType Directory -Path 'native-out/endpoint-input' -Force | Out-Null
+          Copy-Item -LiteralPath $mqb -Destination 'native-out/endpoint-input/mqb.exe'
+          Copy-Item -LiteralPath '.mqb/bin/msvc_service_ownership_probe.exe' -Destination 'native-out/endpoint-input/'
+          Copy-Item -LiteralPath '.mqb/default-endpoint-build/probe.identity.json' -Destination 'native-out/endpoint-input/'
+      - uses: actions/upload-artifact@v7
+        with:
+          name: exact-default-endpoint-input
+          path: native-out/endpoint-input/*
+          if-no-files-found: error
+          retention-days: 30
+      - name: Retain probe build diagnostics
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: default-endpoint-build-evidence
+          path: .mqb/default-endpoint-build/**
+          include-hidden-files: true
+          if-no-files-found: warn
+          retention-days: 30
+
+  observe:
+    name: Default endpoint ownership and natural drain
+    needs: build
+    # A DIFFERENT disposable VM: no seed/candidate/probe compilation on this host.
+    runs-on: windows-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - uses: actions/download-artifact@v8
+        with:
+          name: exact-default-endpoint-input
+          path: native-input
+      - name: Verify default-endpoint refusal guards
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $probe = Join-Path $PWD 'native-input/msvc_service_ownership_probe.exe'
+          $root = Join-Path $PWD '.mqb/default-endpoint-guards'
+          New-Item -ItemType Directory -Path $root | Out-Null
+          Remove-Item Env:MQB_OWNERSHIP_DISPOSABLE_HOST -ErrorAction SilentlyContinue
+          $output = @(& $probe --default-case (Join-Path $root 'no-authorization') zi-debug A-started cancel guard 2>&1)
+          $code = $LASTEXITCODE
+          $output | Set-Content -LiteralPath (Join-Path $root 'no-authorization.txt') -Encoding utf8
+          if ($code -eq 0 -or "$output" -notmatch 'explicitly disposable host') { throw 'Missing-host-authorization guard failed.' }
+          $env:MQB_OWNERSHIP_DISPOSABLE_HOST = '1'
+          $env:_MSPDBSRV_ENDPOINT_ = 'must-not-be-used'
+          $output = @(& $probe --default-case (Join-Path $root 'override') zi-debug A-started cancel guard 2>&1)
+          $code = $LASTEXITCODE
+          $output | Set-Content -LiteralPath (Join-Path $root 'override.txt') -Encoding utf8
+          if ($code -eq 0 -or "$output" -notmatch 'ambient endpoint override') { throw 'Ambient endpoint refusal guard failed.' }
+          Remove-Item Env:_MSPDBSRV_ENDPOINT_
+          if (@(Get-ChildItem -LiteralPath $root -Recurse -File -Filter 'toolchain.txt').Count -ne 0) { throw 'Refused case performed discovery.' }
+          @{ missing_authorization_rejected = $true; endpoint_override_rejected = $true } |
+            ConvertTo-Json | Set-Content -LiteralPath (Join-Path $root 'guards.json') -Encoding utf8
+      - name: Observe fixed 56-case default endpoint matrix
+        shell: pwsh
+        env:
+          MQB_OWNERSHIP_DISPOSABLE_HOST: '1'
+        run: |
+          & (Join-Path $PWD 'tests/native/collect_msvc_service_ownership.ps1') `
+            -MqbPath (Join-Path $PWD 'native-input/mqb.exe') -RepoRoot $PWD `
+            -PrebuiltProbePath (Join-Path $PWD 'native-input/msvc_service_ownership_probe.exe') `
+            -ProbeIdentityPath (Join-Path $PWD 'native-input/probe.identity.json') `
+            -EndpointMode default -OutputRoot (Join-Path $PWD '.mqb/msvc-default-endpoint-evidence')
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+      - name: Retain all default endpoint observations and diagnostics
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: msvc-default-endpoint-evidence
+          path: |
+            .mqb/default-endpoint-guards/**
+            .mqb/msvc-default-endpoint-evidence/**
+            !.mqb/msvc-default-endpoint-evidence/**/*.obj
+            !.mqb/msvc-default-endpoint-evidence/**/*.pdb
+            !.mqb/msvc-default-endpoint-evidence/**/*.pch
+            !.mqb/msvc-default-endpoint-evidence/**/*.ifc
+            !.mqb/msvc-default-endpoint-evidence/**/*.exe
+          include-hidden-files: true
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/msvc-default-endpoint.yml
+++ b/.github/workflows/msvc-default-endpoint.yml
@@ -97,6 +97,8 @@ jobs:
           if (@(Get-ChildItem -LiteralPath $root -Recurse -File -Filter 'toolchain.txt').Count -ne 0) { throw 'Refused case performed discovery.' }
           @{ missing_authorization_rejected = $true; endpoint_override_rejected = $true } |
             ConvertTo-Json | Set-Content -LiteralPath (Join-Path $root 'guards.json') -Encoding utf8
+          # Both native failures above are expected and independently asserted.
+          exit 0
       - name: Observe fixed 56-case default endpoint matrix
         shell: pwsh
         env:

--- a/cpp/tests/platform/windows/msvc_service_ownership_probe.cpp
+++ b/cpp/tests/platform/windows/msvc_service_ownership_probe.cpp
@@ -245,8 +245,11 @@ std::string prefix(const std::string& profile) {
     return "";
 }
 RunResult compile(const MsvcToolchain& tc, const fs::path& dir, const std::string& profile,
-                  const std::string& stem) {
+                  const std::string& stem, bool large_object = false) {
     auto args = flags(dir, profile);
+    // The fixed 24k-function /ZI drain fixture exceeds ordinary COFF sections.
+    // Keep its input/debug/PDB behavior; widen only its object section indices.
+    if (large_object) args.push_back("/bigobj");
     if (pch(profile)) {
         args.push_back("/Yucommon.hpp"); args.push_back("/Fp" + path_text(dir / "common.pch"));
     }
@@ -312,12 +315,12 @@ int root(int argc, wchar_t** argv, bool drain) {
     // Fixture watchdog only; not a product cancellation deadline.
     require(::WaitForSingleObject(release.value, 120000) == WAIT_OBJECT_0, "root fixture watchdog");
     if (!drain) return 0;
-    const auto first = compile(tc, dir, profile, "work0");
+    const auto first = compile(tc, dir, profile, "work0", true);
     const auto status = ::WaitForSingleObject(cancel.value, 0);
     require(status == WAIT_TIMEOUT || status == WAIT_OBJECT_0, "admission cancellation wait failed");
     const bool stopped = status == WAIT_OBJECT_0;
     int pending_exit = -2;
-    if (!stopped) pending_exit = exit_code(compile(tc, dir, profile, "work1"));
+    if (!stopped) pending_exit = exit_code(compile(tc, dir, profile, "work1", true));
     write(dir / "drain.json", "{\"stop_observed\":" + std::string{stopped ? "true" : "false"}
           + ",\"work_compiles_dispatched\":" + (stopped ? "1" : "2")
           + ",\"first_compile_exit\":" + std::to_string(exit_code(first))

--- a/cpp/tests/platform/windows/msvc_service_ownership_probe.cpp
+++ b/cpp/tests/platform/windows/msvc_service_ownership_probe.cpp
@@ -134,6 +134,24 @@ std::vector<Process> census(const wchar_t* name, std::optional<DWORD> parent = {
     return result;
 }
 bool same(const Process& a, const Process& b) { return a.pid == b.pid && a.created == b.created; }
+std::string identities(const std::vector<Process>& processes) {
+    std::string result = "[";
+    for (const auto& p : processes) {
+        if (result.size() != 1) result += ',';
+        result += "{\"pid\":" + std::to_string(p.pid) + ",\"created\":" + std::to_string(p.created)
+            + ",\"image\":" + quoted(path_text(p.image)) + "}";
+    }
+    return result + ']';
+}
+void require_default_host() {
+    wchar_t value[2]{};
+    require(::GetEnvironmentVariableW(L"MQB_OWNERSHIP_DISPOSABLE_HOST", value, 2) == 1 && value[0] == L'1',
+            "default endpoint experiment requires an explicitly disposable host");
+    ::SetLastError(ERROR_SUCCESS);
+    const auto size = ::GetEnvironmentVariableW(L"_MSPDBSRV_ENDPOINT_", value, 2);
+    require(size == 0 && ::GetLastError() == ERROR_ENVVAR_NOT_FOUND,
+            "default endpoint experiment rejects an ambient endpoint override");
+}
 std::vector<Process> new_servers(const std::vector<Process>& before, const fs::path& compiler) {
     auto now = census(L"mspdbsrv.exe");
     std::vector<Process> result;
@@ -260,11 +278,11 @@ void prepare(const MsvcToolchain& tc, const fs::path& dir, const std::string& pr
     success(compile(tc, dir, profile, "warm"), "warm compiler control");
     require(fs::exists(dir / "compiler.pdb"), "control must create real compiler PDB");
 }
-void workload(const fs::path& dir, const std::string& profile) {
+void workload(const fs::path& dir, const std::string& profile, unsigned functions = 6000) {
     // Fixed input, not repeatedly enlarged until overlap or a favorable result.
     for (unsigned worker = 0; worker != 2; ++worker) {
         std::string source = prefix(profile);
-        for (unsigned i = 0; i != 6000; ++i) {
+        for (unsigned i = 0; i != functions; ++i) {
             auto id = std::to_string(worker) + "_" + std::to_string(i);
             source += "struct T" + id + " { int a; int b; };\n__declspec(noinline) int f" + id
                 + "(int x) { T" + id + " t{x, x+1}; return t.a+t.b; }\n";
@@ -275,32 +293,53 @@ void workload(const fs::path& dir, const std::string& profile) {
     }
 }
 
-int root(int argc, wchar_t** argv) {
-    require(argc == 7, "root arguments");
+int root(int argc, wchar_t** argv, bool drain) {
+    require(argc == (drain ? 8 : 7), "root arguments");
     MsvcToolchain tc;
     tc.identity.compiler = argv[2]; // Environment already supplied by the measured parent.
     const fs::path dir{argv[3]};
+    const auto profile = utf8(argv[4]);
     Handle ready{::OpenEventW(EVENT_MODIFY_STATE, FALSE, argv[5])};
     Handle release{::OpenEventW(SYNCHRONIZE, FALSE, argv[6])};
-    require(bool(ready) && bool(release), "root event open failed");
-    prepare(tc, dir, utf8(argv[4]));
+    Handle cancel{drain ? ::OpenEventW(SYNCHRONIZE, FALSE, argv[7]) : nullptr};
+    require(bool(ready) && bool(release) && (!drain || bool(cancel)), "root event open failed");
+    prepare(tc, dir, profile);
+    // The drain fixture has one active and one pending TU. Fixed input, never
+    // enlarged/retried to obtain overlap. Neither compiler receives a kill token.
+    if (drain) workload(dir, profile, 24000);
     write(dir / "root.pid", std::to_string(::GetCurrentProcessId()));
     require(::SetEvent(ready.value) != FALSE, "root ready failed");
     // Fixture watchdog only; not a product cancellation deadline.
     require(::WaitForSingleObject(release.value, 120000) == WAIT_OBJECT_0, "root fixture watchdog");
-    return 0;
+    if (!drain) return 0;
+    const auto first = compile(tc, dir, profile, "work0");
+    const auto status = ::WaitForSingleObject(cancel.value, 0);
+    require(status == WAIT_TIMEOUT || status == WAIT_OBJECT_0, "admission cancellation wait failed");
+    const bool stopped = status == WAIT_OBJECT_0;
+    int pending_exit = -2;
+    if (!stopped) pending_exit = exit_code(compile(tc, dir, profile, "work1"));
+    write(dir / "drain.json", "{\"stop_observed\":" + std::string{stopped ? "true" : "false"}
+          + ",\"work_compiles_dispatched\":" + (stopped ? "1" : "2")
+          + ",\"first_compile_exit\":" + std::to_string(exit_code(first))
+          + ",\"pending_compile_exit\":" + std::to_string(pending_exit)
+          + ",\"safe_to_transfer_write_lease\":false}\n");
+    // Missing the active boundary is a failed fixture, not evidence of safe cancellation.
+    return stopped && exit_code(first) == 0 ? 0 : 1;
 }
 
-int measure(int argc, wchar_t** argv) {
+int measure(int argc, wchar_t** argv, bool default_endpoint) {
     require(argc == 7, "measure arguments");
+    if (default_endpoint) require_default_host();
     const fs::path dir = fs::absolute(argv[2]);
     const std::string profile = utf8(argv[3]), origin = utf8(argv[4]), ending = utf8(argv[5]);
-    const std::wstring endpoint = argv[6];
+    const std::wstring fixture_id = argv[6];
+    const bool drain = ending == "drain";
     require(profile == "zi-debug" || profile == "ZI-debug" || profile == "zi-release"
             || profile == "pch-debug" || profile == "pch-release"
             || profile == "modules-debug" || profile == "modules-release", "unknown profile");
     require(origin == "preexisting" || origin == "A-started", "unknown origin");
-    require(ending == "cancel" || ending == "normal" || ending == "unmanaged-normal", "unknown ending");
+    require(ending == "cancel" || ending == "normal" || ending == "unmanaged-normal"
+            || (default_endpoint && drain), "unknown ending");
     fs::create_directories(dir);
     WindowsProcessRunner runner;
     mqb::msvc::DiscoveryOptions options;
@@ -312,37 +351,48 @@ int measure(int argc, wchar_t** argv) {
         throw std::runtime_error("MSVC discovery failed; see discovery.error.txt");
     }
     auto tc = std::move(*discovered);
-    // Test isolation only, not a supported product-service ownership policy.
+    // Private endpoints are still fixture isolation only. The default mode
+    // removes the override; fixture_id then names events, never the PDB endpoint.
     for (const char* name : {"_MSPDBSRV_ENDPOINT_", "CL", "_CL_", "LINK", "_LINK_"}) {
         std::erase_if(tc.environment, [&](const auto& e) { return _stricmp(e.name.c_str(), name) == 0; });
-        tc.environment.push_back({name, name == std::string{"_MSPDBSRV_ENDPOINT_"} ? utf8(endpoint) : "",
-                                  name != std::string{"_MSPDBSRV_ENDPOINT_"}});
+        const bool private_endpoint = !default_endpoint && name == std::string{"_MSPDBSRV_ENDPOINT_"};
+        tc.environment.push_back({name, private_endpoint ? utf8(fixture_id) : "", !private_endpoint});
     }
     write(dir / "toolchain.txt", path_text(tc.identity.compiler) + '\n' + tc.identity.version + '\n'
-          + tc.identity.binary_stamp + "\nendpoint=" + utf8(endpoint) + '\n');
+          + tc.identity.binary_stamp + "\nendpoint=" + (default_endpoint ? "<unset/default>" : utf8(fixture_id)) + '\n');
     auto before = census(L"mspdbsrv.exe");
+    write(dir / "baseline-servers.json", identities(before) + '\n');
+    require(!default_endpoint || before.empty(), "default endpoint is not pristine after discovery");
     if (origin == "preexisting") prepare(tc, dir / "seed", profile);
-    const auto ready_name = L"Local\\MQB-ownership-ready-" + endpoint;
-    const auto release_name = L"Local\\MQB-ownership-release-" + endpoint;
+    const auto ready_name = L"Local\\MQB-ownership-ready-" + fixture_id;
+    const auto release_name = L"Local\\MQB-ownership-release-" + fixture_id;
+    const auto cancel_name = L"Local\\MQB-ownership-cancel-" + fixture_id;
     Handle ready{::CreateEventW(nullptr, TRUE, FALSE, ready_name.c_str())};
     Handle release{::CreateEventW(nullptr, TRUE, FALSE, release_name.c_str())};
-    require(bool(ready) && bool(release), "fixture events failed");
+    Handle admission_cancel{drain ? ::CreateEventW(nullptr, TRUE, FALSE, cancel_name.c_str()) : nullptr};
+    require(bool(ready) && bool(release) && (!drain || bool(admission_cancel)), "fixture events failed");
     std::stop_source stop;
     ProcessSpec a;
     a.executable = self();
-    a.arguments = {"--root", path_text(tc.identity.compiler), path_text(dir / "A"), profile,
+    a.arguments = {drain ? "--drain-root" : "--root", path_text(tc.identity.compiler), path_text(dir / "A"), profile,
                    utf8(ready_name), utf8(release_name)};
+    if (drain) a.arguments.push_back(utf8(cancel_name));
     a.environment = tc.environment;
-    if (ending != "unmanaged-normal") a.cancellation = stop.get_token();
+    if (ending == "normal" || ending == "cancel") a.cancellation = stop.get_token();
     auto a_future = std::async(std::launch::async, [&] {
         auto result = runner.run(a);
         save_result(dir, "A", result); // Also preserve early-root failures before readiness.
         return result;
     });
     struct Release {
-        Handle& event; std::stop_source& stop; std::future<RunResult>& future;
-        ~Release() { stop.request_stop(); ::SetEvent(event.value); if (future.valid()) future.wait(); }
-    } release_on_error{release, stop, a_future};
+        Handle& event; Handle& cancel; std::stop_source& stop; std::future<RunResult>& future;
+        ~Release() {
+            stop.request_stop();
+            if (cancel) ::SetEvent(cancel.value);
+            ::SetEvent(event.value);
+            if (future.valid()) future.wait();
+        }
+    } release_on_error{release, admission_cancel, stop, a_future};
     bool is_ready = false;
     for (unsigned attempt = 0; attempt != 600; ++attempt) {
         const auto status = ::WaitForSingleObject(ready.value, 100);
@@ -359,6 +409,22 @@ int measure(int argc, wchar_t** argv) {
     require(after_b.size() == 1 && same(server, after_b[0]), "B did not retain the same observed endpoint service");
     auto warm_owners = pdb_owners(dir / "B/compiler.pdb", server);
     workload(dir / "B", profile);
+    std::vector<Process> active_a;
+    if (drain) {
+        DWORD root_pid{};
+        std::ifstream pid_file(dir / "A/root.pid");
+        require(bool(pid_file >> root_pid) && root_pid != 0, "A root identity unavailable");
+        require(::SetEvent(release.value) != FALSE, "start A drain workload failed");
+        const auto deadline = std::chrono::steady_clock::now() + 15s;
+        do {
+            // PID only filters observations; it never authorizes termination.
+            active_a = census(L"cl.exe", root_pid);
+            if (!active_a.empty() || a_future.wait_for(0ms) == std::future_status::ready) break;
+            std::this_thread::sleep_for(10ms);
+        } while (std::chrono::steady_clock::now() < deadline);
+        for (const auto& p : active_a)
+            require(_wcsicmp(p.image.c_str(), tc.identity.compiler.c_str()) == 0, "A compiler image mismatch");
+    }
     auto b0 = std::async(std::launch::async, [&] { return compile(tc, dir / "B", profile, "work0"); });
     auto b1 = std::async(std::launch::async, [&] { return compile(tc, dir / "B", profile, "work1"); });
     std::vector<Process> active;
@@ -369,23 +435,25 @@ int measure(int argc, wchar_t** argv) {
         if (b0.wait_for(0ms) == std::future_status::ready && b1.wait_for(0ms) == std::future_status::ready) break;
         std::this_thread::sleep_for(10ms);
     } while (std::chrono::steady_clock::now() < deadline);
-    std::string observed_compilers = "[";
-    for (const auto& process : active) {
-        require(_wcsicmp(process.image.c_str(), tc.identity.compiler.c_str()) == 0,
-                "observed child compiler image differs from selected toolchain");
-        if (observed_compilers.size() != 1) observed_compilers += ',';
-        observed_compilers += "{\"pid\":" + std::to_string(process.pid)
-            + ",\"created\":" + std::to_string(process.created)
-            + ",\"image\":" + quoted(path_text(process.image)) + "}";
-    }
-    observed_compilers += ']';
+    for (const auto& p : active)
+        require(_wcsicmp(p.image.c_str(), tc.identity.compiler.c_str()) == 0, "B compiler image mismatch");
     const auto active_owners = pdb_owners(dir / "B/compiler.pdb", server);
-    bool overlap = std::any_of(active.begin(), active.end(), [](const auto& p) { return alive(p.handle.value); });
-    // No claim that a live cl.exe proves an RPC is in flight at this instant.
+    const auto a_owners_at_request = drain ? pdb_owners(dir / "A/compiler.pdb", server) : Owners{};
+    const bool a_overlap = std::any_of(active_a.begin(), active_a.end(), [](const auto& p) { return alive(p.handle.value); });
+    const bool overlap = std::any_of(active.begin(), active.end(), [](const auto& p) { return alive(p.handle.value); });
+    // These are retained-handle observations, not proof of an in-flight PDB RPC.
+    const auto requested = std::chrono::steady_clock::now();
     if (ending == "cancel") stop.request_stop();
+    else if (drain) require(::SetEvent(admission_cancel.value) != FALSE, "stop A admission failed");
     else require(::SetEvent(release.value) != FALSE, "release A failed");
     auto a_result = a_future.get();
-    const bool service_survived = alive(server.handle.value); // Immediate retained-handle observation.
+    const auto settled = std::chrono::steady_clock::now();
+    const bool service_survived = alive(server.handle.value);
+    // The surviving service can still own PDB resources after the A client exits.
+    // An empty snapshot is not a durable no-writer certificate either.
+    const auto a_owners_after = default_endpoint ? pdb_owners(dir / "A/compiler.pdb", server) : Owners{};
+    const bool a_handles_signaled = std::all_of(active_a.begin(), active_a.end(), [](const auto& p) { return !alive(p.handle.value); });
+    const bool pending_dispatched = fs::exists(dir / "A/work1.argv.txt");
     auto b0_result = b0.get(), b1_result = b1.get();
     int linked = -2, executed = -2;
     if (exit_code(b0_result) == 0 && exit_code(b1_result) == 0) {
@@ -405,14 +473,29 @@ int measure(int argc, wchar_t** argv) {
         ? a_result->termination == mqb::process::ProcessTermination::cancelled && a_result->exit_code != 0
         : a_result->termination == mqb::process::ProcessTermination::exited && a_result->exit_code == 0);
     const bool b_ok = exit_code(b0_result) == 0 && exit_code(b1_result) == 0 && linked == 0 && executed == 0;
+    const bool drain_ok = !drain || (service_survived && b_ok && a_overlap && overlap
+        && a_handles_signaled && !pending_dispatched && fs::exists(dir / "A/work0.obj"));
     const bool control_ok = ending != "unmanaged-normal" || (service_survived && b_ok);
-    std::string report = "{\n\"schema\":1,\"profile\":" + quoted(profile) + ",\"origin\":" + quoted(origin)
+    std::string report = "{\n\"schema\":2,\"profile\":" + quoted(profile) + ",\"origin\":" + quoted(origin)
         + ",\"ending\":" + quoted(ending) + ",\"server_pid\":" + std::to_string(server.pid)
         + ",\"server_created\":" + std::to_string(server.created)
         + ",\"server_image\":" + quoted(path_text(server.image))
         + ",\"server_survived_A\":" + (service_survived ? "true" : "false")
         + ",\"B_compiler_overlap_observed\":" + (overlap ? "true" : "false")
-        + ",\"B_observed_compilers\":" + observed_compilers
+        + ",\"B_observed_compilers\":" + identities(active)
+        + ",\"endpoint_mode\":" + quoted(default_endpoint ? "default" : "private")
+        + ",\"request_to_A_result_ms\":" + std::to_string(std::chrono::duration<double, std::milli>(settled - requested).count())
+        + ",\"drain_requested\":" + (drain ? "true" : "false")
+        + ",\"A_observed_compilers\":" + identities(active_a)
+        + ",\"A_compiler_overlap_observed\":" + (a_overlap ? "true" : "false")
+        + ",\"A_observed_compilers_signaled\":" + (drain ? (a_handles_signaled ? "true" : "false") : "null")
+        + ",\"A_pending_compile_dispatched\":" + (drain ? (pending_dispatched ? "true" : "false") : "null")
+        + ",\"A_pdb_owner_at_request_error\":" + (drain ? std::to_string(a_owners_at_request.error) : "null")
+        + ",\"A_pdb_owners_at_request\":" + a_owners_at_request.identities
+        + ",\"A_pdb_owner_after_A_error\":" + (default_endpoint ? std::to_string(a_owners_after.error) : "null")
+        + ",\"A_pdb_owners_after_A\":" + a_owners_after.identities
+        + ",\"A_pdb_service_owner_after_A\":" + (default_endpoint ? (a_owners_after.includes_server ? "true" : "false") : "null")
+        + ",\"drain_control_ok\":" + (drain_ok ? "true" : "false")
         + ",\"warm_pdb_owner_error\":" + std::to_string(warm_owners.error)
         + ",\"warm_pdb_owners\":" + warm_owners.identities
         + ",\"active_pdb_owner_error\":" + std::to_string(active_owners.error)
@@ -427,28 +510,51 @@ int measure(int argc, wchar_t** argv) {
         + ",\"safe_to_integrate_cancellation\":false,\"safe_to_transfer_write_lease\":false\n}\n";
     write(dir / "observation.json", report);
     std::cout << report;
-    return lifecycle_ok && control_ok ? 0 : 1;
+    return lifecycle_ok && control_ok && drain_ok ? 0 : 1;
 }
 } // namespace
 
 int wmain(int argc, wchar_t** argv) {
     try {
-        require(argc >= 2, "use --case/--measure/--root");
+        require(argc >= 2, "use --case/--default-case/--measure/--root");
         const std::wstring mode = argv[1];
-        if (mode == L"--root") return root(argc, argv);
-        if (mode == L"--measure") return measure(argc, argv);
-        require(mode == L"--case" && argc == 7, "case arguments");
-        // A fixture-wide outer Job bounds *both* projects and their dedicated
-        // endpoint. The inner A Job is the policy under test. No global service
-        // termination, PID-authorized kill, or product environment changes.
+        if (mode == L"--root" || mode == L"--drain-root") return root(argc, argv, mode == L"--drain-root");
+        if (mode == L"--measure" || mode == L"--measure-default") return measure(argc, argv, mode == L"--measure-default");
+        const bool default_endpoint = mode == L"--default-case";
+        require((mode == L"--case" || default_endpoint) && argc == 7, "case arguments");
+        const fs::path dir = fs::absolute(argv[2]);
+        fs::create_directories(dir);
+        if (default_endpoint) {
+            require_default_host();
+            const auto before = census(L"mspdbsrv.exe");
+            write(dir / "default-preflight.json", identities(before) + '\n');
+            // Never terminate a pre-existing host service to manufacture a clean test.
+            require(before.empty(), "default endpoint host is not clean; experiment refused");
+        }
+        // A fixture-wide outer Job bounds BOTH projects. For default endpoints
+        // it is authorized only on a disposable clean host, never a developer PC.
+        // No global service termination, PID-authorized kill, or product changes.
         ProcessSpec spec;
         spec.executable = self();
-        spec.arguments = {"--measure"};
+        spec.arguments = {default_endpoint ? "--measure-default" : "--measure"};
         for (int i = 2; i < argc; ++i) spec.arguments.push_back(utf8(argv[i]));
         std::stop_source lifetime;
         spec.cancellation = lifetime.get_token();
         WindowsProcessRunner runner;
         auto result = runner.run(spec);
+        if (default_endpoint) {
+            const auto remaining = census(L"mspdbsrv.exe");
+            const bool clean = result.has_value() && remaining.empty();
+            write(dir / "default-envelope.json", "{\"endpoint_override_absent\":true,\"remaining_servers\":"
+                  + identities(remaining) + ",\"outer_lifecycle_verified\":" + (result ? "true" : "false")
+                  + ",\"cleanup_verified\":" + (clean ? "true" : "false") + "}\n");
+            if (!clean) {
+                if (result) { std::cout << result->stdout_text; std::cerr << result->stderr_text; }
+                else std::cerr << result.error().message << '\n';
+                std::cerr << "DEFAULT_ENDPOINT_CLEANUP_UNPROVEN: do not run another case\n";
+                return 1;
+            }
+        }
         if (!result) { std::cerr << "OUTER_CLEANUP_ERROR " << result.error().message << '\n'; return 1; }
         std::cout << result->stdout_text;
         std::cerr << result->stderr_text;

--- a/tests/native/collect_msvc_service_ownership.ps1
+++ b/tests/native/collect_msvc_service_ownership.ps1
@@ -3,11 +3,27 @@ param(
     [Parameter(Mandatory = $true)][string]$MqbPath,
     [Parameter(Mandatory = $true)][string]$RepoRoot,
     [string]$OutputRoot,
-    [ValidateSet('Debug', 'Release')][string]$Configuration = 'Release'
+    [ValidateSet('Debug', 'Release')][string]$Configuration = 'Release',
+    [switch]$BuildOnly,
+    [string]$PrebuiltProbePath,
+    [string]$ProbeIdentityPath,
+    [ValidateSet('private', 'default')][string]$EndpointMode = 'private'
 )
 
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version 2.0
+$prebuilt = -not [string]::IsNullOrWhiteSpace($PrebuiltProbePath)
+if ($BuildOnly -and ($prebuilt -or $EndpointMode -eq 'default')) { throw 'BuildOnly requires a private build-only invocation.' }
+if ($prebuilt -ne (-not [string]::IsNullOrWhiteSpace($ProbeIdentityPath))) { throw 'Prebuilt probe and identity must be supplied together.' }
+if ($EndpointMode -eq 'default') {
+    # Default endpoint experiments must never compile their own tooling on the
+    # measurement host, or terminate pre-existing developer services.
+    if (-not $prebuilt -or $env:MQB_OWNERSHIP_DISPOSABLE_HOST -ne '1' -or
+        $env:GITHUB_ACTIONS -ne 'true' -or $env:RUNNER_ENVIRONMENT -ne 'github-hosted') {
+        throw 'Default endpoints require a prebuilt probe and an explicitly disposable GitHub-hosted runner.'
+    }
+    if (Test-Path Env:_MSPDBSRV_ENDPOINT_) { throw 'Default endpoint requires no ambient endpoint override.' }
+}
 $RepoRoot = [System.IO.Path]::GetFullPath($RepoRoot)
 $MqbPath = [System.IO.Path]::GetFullPath($MqbPath)
 if (-not (Test-Path -LiteralPath $MqbPath -PathType Leaf)) { throw "Missing MQB: $MqbPath" }
@@ -28,7 +44,10 @@ try {
     $version = (Get-Content -LiteralPath (Join-Path $RepoRoot 'VERSION') -Raw).Trim()
     if ($version -ne '5.5.0') { throw "This M1b experiment requires unchanged VERSION 5.5.0, got $version" }
     $identity = [ordered]@{
-        schema = 1
+        schema = 2
+        endpoint_mode = $EndpointMode
+        build_only = [bool]$BuildOnly
+        prebuilt_probe = $prebuilt
         source_head = $head
         version = $version
         candidate_path = $MqbPath
@@ -41,8 +60,10 @@ try {
         github_run_attempt = $env:GITHUB_RUN_ATTEMPT
         runner_image = $env:ImageVersion
         utc_started = [DateTime]::UtcNow.ToString('o')
-        isolation = 'Unique fixture-only _MSPDBSRV_ENDPOINT_, shared by A and B; outer request Job owns entire disposable fixture.'
-        limitation = 'Not default-endpoint validation, RPC-in-flight proof, owner-crash recovery, or write-lease release proof.'
+        isolation = $(if ($EndpointMode -eq 'default') {
+            'Unmodified default endpoint on a separate clean disposable runner; no bootstrap compiler; reject any pre-existing server; outer Job bounds A+B.'
+        } else { 'Unique fixture-only _MSPDBSRV_ENDPOINT_ shared by A+B, bounded by outer Job.' })
+        limitation = 'Retained process/resource snapshots are not RPC-in-flight, owner-crash recovery, or write-lease release proof.'
     }
     $identity | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath (Join-Path $OutputRoot 'identity.json') -Encoding utf8
 
@@ -53,33 +74,56 @@ try {
         ForEach-Object { [System.IO.Path]::GetRelativePath((Join-Path $RepoRoot 'cpp'), $_.FullName).Replace('\', '/') } |
         Where-Object { $_ -ne 'src/app/main.cpp' } | Sort-Object -Unique)
     if (@(Compare-Object $actualSources $sharedSources).Count -ne 0) { throw 'Production source manifest drift.' }
-    $arguments = [System.Collections.Generic.List[string]]::new()
-    $arguments.Add('cpp/tests/platform/windows/msvc_service_ownership_probe.cpp')
-    foreach ($source in $sharedSources) { $arguments.Add('cpp/' + $source) }
-    $arguments.AddRange([string[]]@('--env', 'vs', '--no-discover', '--std', [string]$config.build.standard))
-    $arguments.Add($(if ($Configuration -eq 'Debug') { '--debug' } else { '--release' }))
-    $arguments.Add('--runtime')
-    $arguments.Add($(if ($Configuration -eq 'Debug') { 'MTd' } else { 'MT' }))
-    foreach ($include in @($config.build.include_dirs)) { $arguments.Add('-I'); $arguments.Add('cpp/' + $include) }
-    foreach ($arg in @($config.build.compiler_args)) { $arguments.Add('--compiler-arg'); $arguments.Add([string]$arg) }
-    $arguments.AddRange([string[]]@('-D', 'MQB_VERSION="ownership-probe"', '--lib', 'shell32.lib', '--lib', 'Rstrtmgr.lib', '-o', 'msvc_service_ownership_probe'))
-    $arguments | Set-Content -LiteralPath (Join-Path $OutputRoot 'probe-build.argv.txt') -Encoding utf8
-    $output = @(& $MqbPath @arguments 2>&1)
-    $buildExit = $LASTEXITCODE
-    $output | Set-Content -LiteralPath (Join-Path $OutputRoot 'probe-build.output.txt') -Encoding utf8
-    foreach ($line in $output) { Write-Host $line }
-    if ($buildExit -ne 0) { throw "Probe build failed with $buildExit" }
-    $probe = Join-Path $RepoRoot '.mqb/bin/msvc_service_ownership_probe.exe'
-    if (-not (Test-Path -LiteralPath $probe -PathType Leaf)) { throw 'Probe executable missing.' }
+    if (-not $prebuilt) {
+        $arguments = [System.Collections.Generic.List[string]]::new()
+        $arguments.Add('cpp/tests/platform/windows/msvc_service_ownership_probe.cpp')
+        foreach ($source in $sharedSources) { $arguments.Add('cpp/' + $source) }
+        $arguments.AddRange([string[]]@('--env', 'vs', '--no-discover', '--std', [string]$config.build.standard))
+        $arguments.Add($(if ($Configuration -eq 'Debug') { '--debug' } else { '--release' }))
+        $arguments.Add('--runtime')
+        $arguments.Add($(if ($Configuration -eq 'Debug') { 'MTd' } else { 'MT' }))
+        foreach ($include in @($config.build.include_dirs)) { $arguments.Add('-I'); $arguments.Add('cpp/' + $include) }
+        foreach ($arg in @($config.build.compiler_args)) { $arguments.Add('--compiler-arg'); $arguments.Add([string]$arg) }
+        $arguments.AddRange([string[]]@('-D', 'MQB_VERSION="ownership-probe"', '--lib', 'shell32.lib', '--lib', 'Rstrtmgr.lib', '-o', 'msvc_service_ownership_probe'))
+        $arguments | Set-Content -LiteralPath (Join-Path $OutputRoot 'probe-build.argv.txt') -Encoding utf8
+        $output = @(& $MqbPath @arguments 2>&1)
+        $buildExit = $LASTEXITCODE
+        $output | Set-Content -LiteralPath (Join-Path $OutputRoot 'probe-build.output.txt') -Encoding utf8
+        foreach ($line in $output) { Write-Host $line }
+        if ($buildExit -ne 0) { throw "Probe build failed with $buildExit" }
+        $probe = Join-Path $RepoRoot '.mqb/bin/msvc_service_ownership_probe.exe'
+        if (-not (Test-Path -LiteralPath $probe -PathType Leaf)) { throw 'Probe executable missing.' }
+    } else {
+        $probe = [System.IO.Path]::GetFullPath($PrebuiltProbePath)
+        $provenance = Get-Content -LiteralPath $ProbeIdentityPath -Raw | ConvertFrom-Json
+        if ($provenance.source_head -ne $head -or $provenance.version -ne $version -or
+            $provenance.configuration -ne $Configuration -or
+            $provenance.candidate_sha256 -ne $identity.candidate_sha256 -or
+            $provenance.probe_sha256 -ne (Get-FileHash -LiteralPath $probe -Algorithm SHA256).Hash) {
+            throw 'Prebuilt probe source/configuration/binary identity mismatch.'
+        }
+        Copy-Item -LiteralPath $ProbeIdentityPath -Destination (Join-Path $OutputRoot 'origin-probe.identity.json')
+    }
+    [ordered]@{
+        schema = 1; source_head = $head; version = $version; configuration = $Configuration
+        candidate_sha256 = $identity.candidate_sha256
+        probe_sha256 = (Get-FileHash -LiteralPath $probe -Algorithm SHA256).Hash
+        github_run_id = $env:GITHUB_RUN_ID; github_run_attempt = $env:GITHUB_RUN_ATTEMPT
+    } | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $OutputRoot 'probe.identity.json') -Encoding utf8
     Get-FileHash -LiteralPath $probe -Algorithm SHA256 | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $OutputRoot 'probe-binary.json') -Encoding utf8
+
+    if ($BuildOnly) { Write-Host 'Exact-source probe built; no ownership experiment ran on the build host.'; return }
 
     # This is a fixed diagnostic matrix, not a repeat-until-green policy.
     $profiles = @('zi-debug', 'ZI-debug', 'zi-release', 'pch-debug', 'pch-release', 'modules-debug', 'modules-release')
     $origins = @('preexisting', 'A-started')
     $endings = @('unmanaged-normal', 'normal', 'cancel')
+    if ($EndpointMode -eq 'default') { $endings += 'drain' }
+    $expectedCases = $profiles.Count * $origins.Count * $endings.Count
+    $aborted = $false
     $rows = [System.Collections.Generic.List[object]]::new()
     $failed = 0
-    foreach ($profile in $profiles) {
+    :caseMatrix foreach ($profile in $profiles) {
         foreach ($origin in $origins) {
             foreach ($ending in $endings) {
                 # /Zi and /ZI are different compiler modes, but their short
@@ -88,8 +132,9 @@ try {
                 $name = "$directoryProfile-$origin-$ending"
                 $caseRoot = Join-Path $OutputRoot $name
                 New-Item -ItemType Directory -Path $caseRoot | Out-Null
-                $endpoint = 'mqb-' + [guid]::NewGuid().ToString('N')
-                $caseArgs = @('--case', $caseRoot, $profile, $origin, $ending, $endpoint)
+                $fixtureId = 'mqb-' + [guid]::NewGuid().ToString('N')
+                $mode = if ($EndpointMode -eq 'default') { '--default-case' } else { '--case' }
+                $caseArgs = @($mode, $caseRoot, $profile, $origin, $ending, $fixtureId)
                 $caseArgs | Set-Content -LiteralPath (Join-Path $caseRoot 'case.argv.txt') -Encoding utf8
                 Write-Host "=== MSVC ownership: $name ==="
                 $timer = [System.Diagnostics.Stopwatch]::StartNew()
@@ -116,19 +161,41 @@ try {
                             [System.IO.Path]::GetRelativePath($caseRoot, $_.FullName)
                         }
                     })
+                $cleanupVerified = $null
+                $envelopeError = $null
+                if ($EndpointMode -eq 'default') {
+                    try {
+                        $envelope = Get-Content -LiteralPath (Join-Path $caseRoot 'default-envelope.json') -Raw | ConvertFrom-Json
+                        $cleanupVerified = $envelope.cleanup_verified -eq $true -and
+                            $envelope.endpoint_override_absent -eq $true -and
+                            $envelope.outer_lifecycle_verified -eq $true -and @($envelope.remaining_servers).Count -eq 0
+                    } catch { $envelopeError = $_.Exception.Message }
+                }
                 $collectionOk = $caseExit -eq 0 -and $null -ne $observation -and
-                    $null -eq $parseError -and $toolErrors.Count -eq 0
+                    $null -eq $parseError -and $toolErrors.Count -eq 0 -and ($EndpointMode -ne 'default' -or $cleanupVerified -eq $true)
+                if ($null -ne $observation -and ($observation.schema -ne 2 -or $observation.endpoint_mode -ne $EndpointMode)) {
+                    $collectionOk = $false
+                    $parseError = 'Unexpected observation schema or endpoint mode.'
+                }
+                if ($EndpointMode -eq 'default' -and $cleanupVerified -ne $true) { $aborted = $true }
                 if (-not $collectionOk) { $failed++ }
                 $row = [ordered]@{
                     case = $name; exit_code = $caseExit; elapsed_ms = $timer.Elapsed.TotalMilliseconds
                     collection_ok = $collectionOk; tool_infrastructure_errors = $toolErrors
                     observation = $observation; parse_error = $parseError
+                    cleanup_verified = $cleanupVerified; envelope_error = $envelopeError
                 }
                 $rows.Add($row)
                 $row | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath (Join-Path $caseRoot 'case.result.json') -Encoding utf8
                 # Checkpoint the complete prefix, including adverse/inconclusive cases.
-                [ordered]@{ schema = 1; expected_cases = 42; completed_cases = $rows.Count; failed_cases = $failed; cases = $rows } |
-                    ConvertTo-Json -Depth 14 | Set-Content -LiteralPath (Join-Path $OutputRoot 'summary.json') -Encoding utf8
+                [ordered]@{
+                    schema = 2; endpoint_mode = $EndpointMode; expected_cases = $expectedCases
+                    completed_cases = $rows.Count; failed_cases = $failed
+                    aborted_after_unproven_cleanup = $aborted; cases = $rows
+                } | ConvertTo-Json -Depth 14 | Set-Content -LiteralPath (Join-Path $OutputRoot 'summary.json') -Encoding utf8
+                # A failed outer lifecycle is not permission to test/kill another
+                # request on the same default endpoint. Keep the incomplete prefix.
+                if ($aborted) { Write-Warning 'Default endpoint cleanup unproven; remaining cases not attempted.'; break caseMatrix }
             }
         }
     }
@@ -142,7 +209,7 @@ try {
             sha256 = (Get-FileHash -LiteralPath $_.FullName -Algorithm SHA256).Hash
         } })
     $binaries | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath (Join-Path $OutputRoot 'generated-binary-hashes.json') -Encoding utf8
-    Write-Host "Collected $($rows.Count)/42 cases; $failed collection/control failures. This never authorizes CLI cancellation or lease transfer."
-    if ($rows.Count -ne 42 -or $failed -ne 0) { exit 1 }
+    Write-Host "Collected $($rows.Count)/$expectedCases cases; $failed collection/control failures. This never authorizes CLI cancellation or lease transfer."
+    if ($rows.Count -ne $expectedCases -or $failed -ne 0 -or $aborted) { exit 1 }
 }
 finally { Pop-Location }


### PR DESCRIPTION
## Scope / exact source

Continue #164 M1b from merged #166; **one evidence-only iteration**, not cancellation integration or M1b completion.

- Exact base: `7af2d9ccad13b9bcee916c9caaa903ad45d76d20`.
- Submitted head: `3ba37df3deb6b8a398e62919ad67e26401921e19`.
- Extend the existing real-MSVC probe and collector; add one default-endpoint workflow. No production source/header/manifest, existing native-test inventory, benchmark harness, freshness, CLI or VERSION change.
- **VERSION remains 5.5.0. No historical tag/asset change or release publication.**
- Temporary `perf:` title requests the existing independent exact-base/head ABBA workflow, not a speedup claim. Retitle `test:` only after measured evidence completes.

## What is now measured

The existing **42 private-endpoint** cases remain a separate regression run. The new workflow has **56 fixed default-endpoint cases**: the same seven real compiler profiles (`/Zi` Debug, `/ZI` Debug, `/Zi` Release, PCH Debug/Release, Modules Debug/Release), two service origins, and four A endings: unmanaged normal control, managed normal completion, managed cancellation, and **stop-admission/natural-drain**.

The default endpoint is genuinely unmodified: `_MSPDBSRV_ENDPOINT_` is absent rather than assigned a fixture name. Probe/candidate compilation runs on a **different Windows VM** from measurement. The measurement job verifies the exact source/configuration and both executable SHA-256 values before using the prebuilt probe. It requires an explicitly disposable GitHub-hosted runner, rejects an ambient endpoint override and any pre-existing MSPDBSRV, rechecks after toolchain discovery, and never globally kills a service to manufacture a clean baseline. A fixture-wide outer Job contains A+B only on this disposable host. A failed outer lifecycle / remaining service aborts further default-endpoint cases and retains the incomplete prefix. This is not a product lease-recovery policy.

The new **drain** fixture keeps A unmanaged, launches one real fixed 24,000-function compile and holds a second TU pending. After observing the retained A compiler handle and overlapping B compiler work, an event requests that A stop admitting work. Its in-flight compiler completes naturally; the pending TU must not be dispatched. B performs its original two real `/FS` compiles, link and execution. Neither compiler receives a terminating cancellation token. The other endings preserve the #166 counterexample experiment; this is not blanket per-cl Job integration.

Record A/B retained compiler identities/liveness, original service survival, PDB resource owners at request/after A returns, natural completion and suppressed pending dispatch, complete original B diagnostics, and a separately labeled recovery compile. Request-to-A-result elapsed includes process/capture/diagnostic overhead and is **not** a production cancellation latency or RPC duration benchmark. The drain and managed fixtures do not have identical A workloads; no timing comparison between their policies will be claimed.

## Predeclared acceptance gates — before CI measurement

1. Complete Native C++ Debug, Native Release (all shards, self-host, package validation), documentation, and exact final diff review. Verify the PR test-merge tree matches the reviewed candidate tree. Product files, freshness rules and VERSION must remain unchanged. No local Windows/MSVC execution is claimed from this Linux editing environment.
2. Both default-endpoint refusal guards pass before discovery. **56/56** default cases complete without infrastructure/control/cleanup failure, with verified source/binary provenance; **14/14** unmanaged controls preserve the original server and original B compile/link/run. All **14 drain controls** must observe active A and B compilers, wait for the retained A compiler to signal, suppress pending A dispatch, preserve the original service, and succeed on the original A in-flight compile and B compile/link/run. Missing overlap is an unproven/failed fixture, not successful cancellation. The existing **42/42 private cases** must also collect with all 14 unmanaged controls passing.
3. Managed cases may produce adverse B compiler results: retain and analyze them rather than retry/suppress them. Restart Manager snapshots can be incomplete or empty; they are not RPC-in-flight evidence, complete remaining-writer enumeration, or durable quiescence certificates. Never substitute a recovery compile, parent exit, cancellation error, or service restart for the original result.
4. Independent unchanged ABBA: **19 scenarios × four pairs**, AB/BA/AB/BA. All **72 instrumented pairs** must preserve complete semantic counters/breakdowns and compile/link/archive hit/miss identity. Four timings-off external no-op pairs have no instrumentation counters, not zero counters. The predeclared paired-median external no-op regression gate is **worse by both 1 ms and 10%**. Preserve every favorable/adverse sample and all initial failures; no same-head repeat-until-green. No speedup/zero-overhead claim. The historical v5.5.0 cold-tail debt remains open.

## Safety limits and handoff

All observations continue to state `safe_to_integrate_cancellation=false` and `safe_to_transfer_write_lease=false`. A live compiler is not proof an RPC is in flight. Waiting for an observed compiler handle does not enumerate all external service writers. The fixed stop-admission fixture is not a concurrent production scheduler, crash-recovery protocol, lease, or CLI Ctrl+C implementation. Owner-crash/uncertain-cleanup and stronger write-completion evidence remain open. No transaction/build-run/session/daemon changes are bundled here.

Raw inputs, argv/stdout/stderr and JSON (including adverse/incomplete observations) are archived for 30 days. Generated fixture binaries have post-case SHA-256 inventories, not cancellation-instant snapshots; their bytes are excluded from diagnostic ZIPs. The exact prebuilt probe input is a separate artifact. Keep #164 as the single roadmap/status entry point.

**Decision pending actual exact-head evidence. Do not auto-merge on green collection status alone.**