### PR TITLE
feat: add opt-in scheduler admission stop and natural drain

### DIFF
--- a/cpp/include/mqb/orchestration/BoundedWorkScheduler.hpp
+++ b/cpp/include/mqb/orchestration/BoundedWorkScheduler.hpp
@@ -4,6 +4,7 @@
 #include <expected>
 #include <functional>
 #include <string>
+#include <stop_token>
 
 #include "mqb/orchestration/ParallelismPolicy.hpp"
 
@@ -12,6 +13,7 @@ namespace mqb::orchestration {
 enum class BoundedWorkErrorCode {
     invalid_worker_count,
     callback_threw,
+    worker_start_failed,
 };
 
 struct BoundedWorkError {
@@ -24,6 +26,9 @@ struct BoundedWorkSummary {
     std::size_t started_count{};
     bool stop_requested{false};
     bool stopped_before_all_items{false};
+    // External admission stop observed before deregistration; distinct from a
+    // false callback result. Never implies process or filesystem quiescence.
+    bool admission_stop_observed{false};
 };
 
 class BoundedWorkScheduler {
@@ -52,6 +57,31 @@ public:
         std::size_t item_count,
         ParallelismPolicy policy,
         ParallelismWorkload workload,
+        const std::function<bool(std::size_t)>& work);
+
+    // Opt-in stop-admission / natural-drain boundary. Closing admission is
+    // linearized by the registered stop callback, not by wall-clock callback
+    // entry. An index already admitted may enter work after stop is requested.
+    // All admitted callbacks finish (or throw) and all workers join before
+    // return. Work must own its completion; detached work is NOT drained here.
+    // No process token/Job, hard termination, bounded latency or write-lease
+    // safety is implied. A non-stoppable token delegates to the legacy run.
+    // Valid empty batches are no-ops; already-cancelled nonempty batches have
+    // worker_count/started_count zero. Otherwise worker_count is the resolved
+    // logical ceiling, not a count of necessarily-created background threads.
+    [[nodiscard]] static std::expected<BoundedWorkSummary, BoundedWorkError>
+    run_with_admission_stop(
+        std::size_t item_count,
+        std::size_t max_workers,
+        std::stop_token admission_stop,
+        const std::function<bool(std::size_t)>& work);
+
+    [[nodiscard]] static std::expected<BoundedWorkSummary, BoundedWorkError>
+    run_with_admission_stop(
+        std::size_t item_count,
+        ParallelismPolicy policy,
+        ParallelismWorkload workload,
+        std::stop_token admission_stop,
         const std::function<bool(std::size_t)>& work);
 };
 

--- a/cpp/src/orchestration/scheduling/BoundedWorkScheduler.cpp
+++ b/cpp/src/orchestration/scheduling/BoundedWorkScheduler.cpp
@@ -173,4 +173,146 @@ BoundedWorkScheduler::run(
     return run(item_count, decision.workers, work);
 }
 
+std::expected<BoundedWorkSummary, BoundedWorkError>
+BoundedWorkScheduler::run_with_admission_stop(
+    const std::size_t item_count,
+    const std::size_t max_workers,
+    const std::stop_token admission_stop,
+    const std::function<bool(std::size_t)>& work) {
+    if (!admission_stop.stop_possible()) {
+        return run(item_count, max_workers, work);
+    }
+    if (max_workers == 0) {
+        return std::unexpected(failure(
+            BoundedWorkErrorCode::invalid_worker_count,
+            "bounded work scheduler requires at least one worker"));
+    }
+    if (item_count == 0) {
+        return BoundedWorkSummary{};
+    }
+    if (admission_stop.stop_requested()) {
+        return BoundedWorkSummary{
+            .stop_requested = true,
+            .stopped_before_all_items = true,
+            .admission_stop_observed = true,
+        };
+    }
+
+    const std::size_t worker_count = std::min(item_count, max_workers);
+    std::atomic<std::size_t> next_index{0};
+    std::atomic<std::size_t> started_count{0};
+    std::atomic<bool> stop_requested{false};
+    std::atomic<bool> admission_stop_observed{false};
+    std::atomic<bool> callback_threw{false};
+    bool worker_start_failed = false;
+
+    // Admission and closing use the same atomic's modification order. A claim
+    // made before this exchange is allowed to run even if its callback has not
+    // entered yet. A claim after it cannot succeed. The saturated CAS (rather
+    // than fetch_add past the limit) also works for item_count == SIZE_MAX.
+    const auto close_admission = [&]() noexcept {
+        next_index.exchange(item_count, std::memory_order_acq_rel);
+        stop_requested.store(true, std::memory_order_release);
+    };
+    const auto worker_loop = [&] {
+        for (;;) {
+            std::size_t index = next_index.load(std::memory_order_relaxed);
+            do {
+                if (index == item_count) {
+                    return;
+                }
+            } while (!next_index.compare_exchange_weak(
+                index, index + 1, std::memory_order_relaxed));
+
+            started_count.fetch_add(1, std::memory_order_relaxed);
+            try {
+                if (!work(index)) {
+                    close_admission();
+                }
+            } catch (...) {
+                callback_threw.store(true, std::memory_order_release);
+                close_admission();
+            }
+        }
+    };
+
+    {
+        // No user callback, process operation, wait or lock in this callback.
+        // Destroy registration only AFTER worker drain, and BEFORE observing
+        // the final flags; its destructor also joins an in-flight stop callback.
+        std::stop_callback registration{admission_stop, [&]() noexcept {
+            close_admission();
+            admission_stop_observed.store(true, std::memory_order_release);
+        }};
+        std::vector<std::jthread> background_workers;
+        try {
+            background_workers.reserve(worker_count - 1);
+            for (std::size_t index = 1; index < worker_count; ++index) {
+                if (next_index.load(std::memory_order_relaxed) == item_count) {
+                    break;
+                }
+                // The jthread's private token is deliberately not passed to
+                // work: only admission is cancellable, never an admitted task.
+                background_workers.emplace_back(worker_loop);
+                mqb::performance::record_background_threads(1);
+            }
+        } catch (...) {
+            worker_start_failed = true;
+            close_admission();
+        }
+        if (!worker_start_failed) {
+            worker_loop();
+        }
+        // jthread RAII covers partially started batches on allocation/thread
+        // creation failure too. No scheduler return precedes callback drain.
+        background_workers.clear();
+    }
+
+    if (worker_start_failed) {
+        return std::unexpected(failure(
+            BoundedWorkErrorCode::worker_start_failed,
+            "bounded work scheduler could not start workers; admitted callbacks drained"));
+    }
+    if (callback_threw.load(std::memory_order_acquire)) {
+        return std::unexpected(failure(
+            BoundedWorkErrorCode::callback_threw,
+            "bounded work callback threw an exception"));
+    }
+    const std::size_t started = started_count.load(std::memory_order_relaxed);
+    return BoundedWorkSummary{
+        .worker_count = worker_count,
+        .started_count = started,
+        .stop_requested = stop_requested.load(std::memory_order_acquire),
+        .stopped_before_all_items = started < item_count,
+        .admission_stop_observed = admission_stop_observed.load(std::memory_order_acquire),
+    };
+}
+
+std::expected<BoundedWorkSummary, BoundedWorkError>
+BoundedWorkScheduler::run_with_admission_stop(
+    const std::size_t item_count,
+    const ParallelismPolicy policy,
+    const ParallelismWorkload workload,
+    const std::stop_token admission_stop,
+    const std::function<bool(std::size_t)>& work) {
+    if (!admission_stop.stop_possible()) {
+        return run(item_count, policy, workload, work);
+    }
+    if (!policy.valid()) {
+        return std::unexpected(failure(
+            BoundedWorkErrorCode::invalid_worker_count,
+            "fixed parallelism policy requires at least one worker"));
+    }
+    // No resource query or workers for empty or already-cancelled batches.
+    if (item_count == 0 || admission_stop.stop_requested()) {
+        return run_with_admission_stop(item_count, 1, admission_stop, work);
+    }
+    const ParallelismResourceSnapshot resources = policy.is_automatic()
+        ? ParallelismResourceObserver::observe()
+        : ParallelismResourceSnapshot{};
+    const ParallelismDecision decision = ParallelismResolver::resolve(
+        policy, item_count, resources, workload);
+    return run_with_admission_stop(item_count, decision.workers, admission_stop, work);
+}
+
 } // namespace mqb::orchestration

--- a/cpp/tests/orchestration/scheduling/bounded_work_admission_cases.hpp
+++ b/cpp/tests/orchestration/scheduling/bounded_work_admission_cases.hpp
@@ -1,0 +1,258 @@
+#pragma once
+
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <iostream>
+#include <limits>
+#include <optional>
+#include <semaphore>
+#include <stdexcept>
+#include <stop_token>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "mqb/orchestration/BoundedWorkScheduler.hpp"
+
+namespace mqb::tests {
+
+// Included by the existing scheduler test executable: preserve the native
+// inventory/shard plan while exercising the new, explicitly opted-in path.
+inline int bounded_work_admission_cases() {
+    using namespace mqb::orchestration;
+    using namespace std::chrono_literals;
+    using Result = std::expected<BoundedWorkSummary, BoundedWorkError>;
+    int failures = 0;
+    const auto check = [&](bool ok, const char* message) {
+        if (!ok) {
+            ++failures;
+            std::cerr << "FAIL admission: " << message << '\n';
+        }
+    };
+    const auto no_work = [](std::size_t) { return true; };
+
+    {
+        std::stop_source stop;
+        stop.request_stop();
+        std::size_t calls = 0;
+        const auto work = [&](std::size_t) { ++calls; return true; };
+        const auto cancelled = BoundedWorkScheduler::run_with_admission_stop(
+            20, 4, stop.get_token(), work);
+        check(cancelled && cancelled->worker_count == 0 && cancelled->started_count == 0
+                  && cancelled->stop_requested && cancelled->admission_stop_observed
+                  && cancelled->stopped_before_all_items && calls == 0,
+              "pre-cancelled batch must admit nothing and use no workers");
+        const auto empty = BoundedWorkScheduler::run_with_admission_stop(
+            0, 4, stop.get_token(), work);
+        check(empty && empty->worker_count == 0 && !empty->stop_requested && calls == 0,
+              "valid empty batch is a no-op even with a cancelled token");
+        const auto invalid = BoundedWorkScheduler::run_with_admission_stop(
+            0, 0, stop.get_token(), work);
+        check(!invalid && invalid.error().code == BoundedWorkErrorCode::invalid_worker_count,
+              "cancellation/empty work cannot hide invalid worker count");
+        const auto invalid_policy = BoundedWorkScheduler::run_with_admission_stop(
+            0, ParallelismPolicy::fixed(0), ParallelismWorkload::dependency_scan,
+            stop.get_token(), work);
+        check(!invalid_policy
+                  && invalid_policy.error().code == BoundedWorkErrorCode::invalid_worker_count,
+              "cancellation/empty work cannot hide invalid policy");
+        const auto automatic = BoundedWorkScheduler::run_with_admission_stop(
+            20, ParallelismPolicy::automatic(), ParallelismWorkload::dependency_scan,
+            stop.get_token(), work);
+        check(automatic && automatic->worker_count == 0 && automatic->admission_stop_observed,
+              "pre-cancelled automatic batch must not dispatch");
+    }
+    {
+        std::vector<std::size_t> order;
+        const auto legacy = BoundedWorkScheduler::run_with_admission_stop(
+            10, 1, {}, [&](std::size_t index) { order.push_back(index); return index != 2; });
+        check(legacy && legacy->started_count == 3 && legacy->stop_requested
+                  && !legacy->admission_stop_observed
+                  && order == std::vector<std::size_t>{0, 1, 2},
+              "non-stoppable token must preserve legacy false-callback behavior");
+        const auto policy = BoundedWorkScheduler::run_with_admission_stop(
+            3, ParallelismPolicy::fixed(2), ParallelismWorkload::compilation, {}, no_work);
+        check(policy && policy->started_count == 3 && !policy->admission_stop_observed,
+              "non-stoppable policy overload must preserve legacy behavior");
+    }
+    {
+        std::stop_source stop;
+        std::vector<std::size_t> order;
+        const auto caller = std::this_thread::get_id();
+        bool inline_only = true;
+        const auto complete = BoundedWorkScheduler::run_with_admission_stop(
+            6, 1, stop.get_token(), [&](std::size_t index) {
+                inline_only &= std::this_thread::get_id() == caller;
+                order.push_back(index);
+                return true;
+            });
+        check(complete && complete->started_count == 6 && complete->worker_count == 1
+                  && !complete->stop_requested && !complete->admission_stop_observed
+                  && inline_only && order == std::vector<std::size_t>{0, 1, 2, 3, 4, 5},
+              "uncancelled inline batch preserves monotonic order and caller execution");
+        // Registration must have been removed; requesting stop after return is
+        // safe and cannot retrospectively change the returned summary.
+        check(stop.request_stop() && complete && !complete->admission_stop_observed,
+              "late stop must not retain references to destroyed batch state");
+    }
+    {
+        std::stop_source stop;
+        const auto result = BoundedWorkScheduler::run_with_admission_stop(
+            20, 1, stop.get_token(), [&](std::size_t index) {
+                if (index == 2) stop.request_stop();
+                return true;
+            });
+        check(result && result->started_count == 3 && result->stop_requested
+                  && result->admission_stop_observed && result->stopped_before_all_items,
+              "callback may request admission stop synchronously without deadlock");
+        std::stop_source final_stop;
+        const auto final = BoundedWorkScheduler::run_with_admission_stop(
+            1, 1, final_stop.get_token(), [&](std::size_t) {
+                final_stop.request_stop(); return true;
+            });
+        check(final && final->started_count == 1 && final->admission_stop_observed
+                  && !final->stopped_before_all_items,
+              "stop on final admitted task is not an incomplete batch");
+    }
+    {
+        std::stop_source stop;
+        std::counting_semaphore<3> entered{0};
+        std::counting_semaphore<3> release{0};
+        std::atomic<bool> returned{false};
+        std::atomic<int> finished{0};
+        std::array<std::string, 20> diagnostics;
+        std::optional<Result> result;
+        std::jthread schedule([&] {
+            result = BoundedWorkScheduler::run_with_admission_stop(
+                diagnostics.size(), 3, stop.get_token(), [&](std::size_t index) {
+                    if (index < 3) { entered.release(); release.acquire(); }
+                    diagnostics[index] = "complete-" + std::to_string(index);
+                    finished.fetch_add(1);
+                    return true;
+                });
+            returned.store(true);
+        });
+        bool ready = true;
+        for (int i = 0; i < 3; ++i) ready &= entered.try_acquire_for(10s);
+        check(ready, "three admitted tasks must reach controlled boundary");
+        stop.request_stop();
+        check(!returned.load() && finished.load() == 0,
+              "stop request cannot release a batch while admitted callbacks are blocked");
+        release.release(3);
+        schedule.join();
+        check(result && *result && (*result)->started_count == 3
+                  && (*result)->admission_stop_observed && (*result)->stopped_before_all_items
+                  && finished.load() == 3,
+              "exactly the admitted wave must finish; pending work must not start");
+        check(diagnostics[0] == "complete-0" && diagnostics[1] == "complete-1"
+                  && diagnostics[2] == "complete-2" && diagnostics[3].empty(),
+              "all admitted diagnostic writes must be visible when run returns");
+    }
+    {
+        // Hold two independent batches at the same boundary. Cancelling A may
+        // not quench B's remaining indices, even on the same scheduler API.
+        std::stop_source a_stop, b_stop;
+        std::counting_semaphore<2> entered{0}, release{0};
+        std::optional<Result> a, b;
+        std::array<int, 7> a_calls{}, b_calls{};
+        const auto run = [&](std::stop_source& stop, std::array<int, 7>& calls,
+                             std::optional<Result>& result) {
+            result = BoundedWorkScheduler::run_with_admission_stop(
+                calls.size(), 1, stop.get_token(), [&](std::size_t index) {
+                    ++calls[index];
+                    if (index == 0) { entered.release(); release.acquire(); }
+                    return true;
+                });
+        };
+        std::jthread ta([&] { run(a_stop, a_calls, a); });
+        std::jthread tb([&] { run(b_stop, b_calls, b); });
+        const bool first_ready = entered.try_acquire_for(10s);
+        const bool second_ready = entered.try_acquire_for(10s);
+        check(first_ready && second_ready, "both independent batches must enter");
+        a_stop.request_stop();
+        release.release(2);
+        ta.join(); tb.join();
+        check(a && *a && (*a)->started_count == 1 && (*a)->admission_stop_observed,
+              "A must stop its own pending admissions");
+        check(b && *b && (*b)->started_count == b_calls.size()
+                  && !(*b)->stop_requested && !b_stop.stop_requested(),
+              "A cancellation must leave B token and pending work intact");
+        check(a_calls[0] == 1 && a_calls[1] == 0 && b_calls[6] == 1,
+              "independent batch work identities must not leak");
+    }
+    {
+        std::stop_source stop;
+        const auto callback_stop = BoundedWorkScheduler::run_with_admission_stop(
+            8, 1, stop.get_token(), [](std::size_t index) { return index != 2; });
+        check(callback_stop && callback_stop->started_count == 3
+                  && callback_stop->stop_requested && !callback_stop->admission_stop_observed,
+              "false callback is distinct from external admission cancellation");
+        const auto exception = BoundedWorkScheduler::run_with_admission_stop(
+            8, 1, stop.get_token(), [&](std::size_t) -> bool {
+                stop.request_stop(); throw std::runtime_error("retained failure");
+            });
+        check(!exception && exception.error().code == BoundedWorkErrorCode::callback_threw,
+              "cancellation cannot erase an admitted callback exception");
+    }
+    {
+        std::stop_source stop;
+        std::binary_semaphore entered{0}, release{0};
+        std::atomic<bool> returned{false}, finished{false};
+        std::optional<Result> result;
+        std::jthread schedule([&] {
+            result = BoundedWorkScheduler::run_with_admission_stop(
+                10, 2, stop.get_token(), [&](std::size_t index) -> bool {
+                    if (index == 0) {
+                        entered.release(); release.acquire(); finished.store(true);
+                        return true;
+                    }
+                    stop.request_stop();
+                    throw std::runtime_error("peer failure");
+                });
+            returned.store(true);
+        });
+        check(entered.try_acquire_for(10s), "first admitted callback must enter before failure drain");
+        // Whether the throwing peer has finished yet or not, a blocked admitted
+        // callback prevents both successful and erroneous scheduler return.
+        check(!returned.load(), "callback error must not detach a still-running peer");
+        release.release();
+        schedule.join();
+        check(result && !*result && result->error().code == BoundedWorkErrorCode::callback_threw
+                  && finished.load(), "callback exception returns only after peer completion");
+    }
+    {
+        std::stop_source stop;
+        const auto enormous = BoundedWorkScheduler::run_with_admission_stop(
+            std::numeric_limits<std::size_t>::max(), 1, stop.get_token(), [&](std::size_t index) {
+                stop.request_stop(); return index == 0;
+            });
+        check(enormous && enormous->started_count == 1 && enormous->admission_stop_observed,
+              "saturated admission must support SIZE_MAX item count without wrapping");
+        std::stop_source allocation_stop;
+        std::size_t calls = 0;
+        const auto impossible = BoundedWorkScheduler::run_with_admission_stop(
+            std::numeric_limits<std::size_t>::max(), std::numeric_limits<std::size_t>::max(),
+            allocation_stop.get_token(), [&](std::size_t) { ++calls; return true; });
+        check(!impossible && impossible.error().code == BoundedWorkErrorCode::worker_start_failed
+                  && calls == 0, "impossible worker storage is an error, not process termination");
+    }
+    {
+        std::stop_source stop;
+        const auto fixed = BoundedWorkScheduler::run_with_admission_stop(
+            6, ParallelismPolicy::fixed(2), ParallelismWorkload::dependency_scan,
+            stop.get_token(), no_work);
+        check(fixed && fixed->worker_count == 2 && fixed->started_count == 6,
+              "fixed policy keeps its existing worker ceiling");
+        const auto automatic = BoundedWorkScheduler::run_with_admission_stop(
+            2, ParallelismPolicy::automatic(), ParallelismWorkload::compilation,
+            stop.get_token(), no_work);
+        check(automatic && automatic->worker_count >= 1 && automatic->worker_count <= 2
+                  && automatic->started_count == 2,
+              "automatic policy remains bounded by ready work");
+    }
+    return failures;
+}
+
+} // namespace mqb::tests

--- a/cpp/tests/orchestration/scheduling/bounded_work_scheduler_tests.cpp
+++ b/cpp/tests/orchestration/scheduling/bounded_work_scheduler_tests.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "mqb/orchestration/BoundedWorkScheduler.hpp"
+#include "bounded_work_admission_cases.hpp"
 
 namespace {
 
@@ -350,6 +351,8 @@ int main() {
                    "inline callback exception should report callback_threw");
         }
     }
+
+    failures += mqb::tests::bounded_work_admission_cases();
 
     if (failures != 0) {
         std::cerr << failures << " test(s) failed\n";

--- a/tests/native/assert_cpp_layout.ps1
+++ b/tests/native/assert_cpp_layout.ps1
@@ -295,7 +295,7 @@ Assert-LeafLayout -Root (Join-Path $testsRoot 'orchestration') -LeafFiles ([orde
         'module_target_validation_tests.cpp'
     )
     'routing' = @('target_router_tests.cpp')
-    'scheduling' = @('bounded_work_scheduler_tests.cpp')
+    'scheduling' = @('bounded_work_scheduler_tests.cpp', 'bounded_work_admission_cases.hpp')
 })
 
 Write-Host 'C++ responsibility layout contract passed.'


### PR DESCRIPTION
## Accepted exact source

[Final updated-base source, execution and complete ABBA review](https://github.com/Iviesever/msvc-quick-build/pull/168#pullrequestreview-5141872386)

Continue #164 M1b with an **explicit opt-in bounded-scheduler primitive only**.

- Exact base: `361780d580b9be17548f3873f802b3df5deb7279` (#169).
- Reviewed head: `df2299cf7206dc50a0d83f2c0b34116ad7fd11eb`.
- Candidate and native test-merge tree: `ff277482bb55b3c4cb6e6665c75da1b849e620e9`.
- Native test-merge: `c7d6a7331218c96d490f5f1fddcfbce5bd226ce5`.
- Five files, 434 additions / 1 deletion. Merge-main update preserved the scheduler implementation while incorporating four disjoint #169 evidence files. History was not rewritten.
- **VERSION remains5.5.0. No tag/assets/Release change.**

## API and boundary

`BoundedWorkScheduler::run_with_admission_stop` closes callback admission when an explicitly supplied stop token is requested. A claim ordered before closure may enter later; admitted callbacks drain naturally. Outcomes distinguish external stop request/observation/incomplete admission, callback false, callback exception and startup error. The CAS admission limit saturates safely at SIZE_MAX. All owned workers join before summaries return.

Legacy `run` and existing product callers remain unchanged. A non-stoppable token delegates the legacy path. **No token is passed to ProcessSpec, no compiler Job is added, and CLI Ctrl+C is not enabled.** Detached work, external services, their writes and crash recovery are not covered by scheduler completion.

Native tests cover pre-stop, ordinary completion, callback-originated stop, bounded waves, competing/isolated batches, false/throw outcomes, no-token compatibility and oversized worker reservation. A reservation failure is not fault injection after some workers have already started; partial-start testing remains an explicit limit. The registered helper header preserves the existing79-executable test inventory.

## Completed updated-source gates

Native Debug #705/34226083352, complete Native Release/self-host/package #600/34226083357, Documentation #161/34226083407, Cross-Stage #185/34226083354, default endpoint #6/34226083362, private ownership #8/34226083372 and independent ABBA #547/34226083370 completed. Actual scheduler executable PASS was inspected in Debug job102063095038 and Release job102062680076, subshard3/8. `publish-release` was skipped.

Default56/private42 complete with all unmanaged controls and14 direct-drain controls passing.126 synthetic record-contract expectations,7 C++ helper checks and2 refusal guards pass. Preserve **2 default and1 private original B failures**, including C1001/C1090; all28 A-started managed endings still killed original MSPDBSRV. Recovery compiles do not replace original outcomes. The direct-drain fixture **does not yet call this new scheduler API**; actual API integration is the next separate topic.

Independent unchanged ABBA measured19x4 exact-base/head pairs, AB/BA/AB/BA.72 instrumented pairs have identical complete counters/breakdowns/compile-link-archive hit-miss;4 external timings-off pairs have unavailable counters. External no-op paired median−0.025ms/−0.11%, MAD1.105ms, maximum adverse+1.616ms. The predeclared median gate (worse by **both1ms and10%**) was not crossed. No speedup/zero-overhead claim. All19 rows, adverse cold4/4 and common-header no-op3/4 slower samples, raw ZIP hashes and observability limits are in the final review.

## Original failures and acceptance discipline

Initial head `6b7a775...` failed source-layout validation before compilation because the new helper header was not registered. Correction `82fe28d...` preserved that failure and its old-base runs. The later main merge generated `df2299...`; only this head's updated-base runs authorize the current decision. Old ABBA#543 and all adverse/historical cold-tail evidence are not overwritten or reused as new-head proof. No same-head repeat-until-green.

Original gates remain: full native/debug/release/selfhost/package, correct full diff/manifest/layout, real ownership regression, preserved complete diagnostics and unchanged independent ABBA with the declared external median threshold and all72 semantic identities. Green collection never proves a terminating ownership policy safe.

**Accept ordinary expected-head merge; do not mark M1b complete.** Next separately exercise this API in real-MSVC fixtures while retaining direct-drain controls. Project leases, owner-crash/uncertain cleanup, external writer authority, build/run separation and eventual release remain separate unproven boundaries. Title changed from temporary perf only after actual measurement#547 completed; later skipped perf jobs do not replace it.