### PR TITLE
test: harden MSVC ownership evidence failure paths

### DIFF
--- a/.github/workflows/msvc-default-endpoint.yml
+++ b/.github/workflows/msvc-default-endpoint.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'cpp/**'
       - 'tests/native/collect_msvc_service_ownership.ps1'
+      - 'tests/native/verify_ownership_evidence_contract.ps1'
       - '.github/workflows/msvc-default-endpoint.yml'
   workflow_dispatch:
 
@@ -16,6 +17,29 @@ permissions:
   contents: read
 
 jobs:
+  contract:
+    name: Ownership evidence contract fault injection
+    runs-on: windows-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Parse and execute actual collector validation helpers
+        shell: pwsh
+        run: |
+          & ./tests/native/verify_ownership_evidence_contract.ps1
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+      - name: Retain synthetic contract evidence including failures
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ownership-collector-contract-evidence
+          path: .mqb/ownership-contract-tests/**
+          include-hidden-files: true
+          if-no-files-found: warn
+          retention-days: 30
+
   build:
     name: Build exact ownership probe
     runs-on: windows-latest
@@ -79,9 +103,16 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $false
           $probe = Join-Path $PWD 'native-input/msvc_service_ownership_probe.exe'
           $root = Join-Path $PWD '.mqb/default-endpoint-guards'
           New-Item -ItemType Directory -Path $root | Out-Null
+          $output = @(& $probe --evidence-contract-self-test 2>&1)
+          $code = $LASTEXITCODE
+          $output | Set-Content -LiteralPath (Join-Path $root 'evidence-contract.txt') -Encoding utf8
+          if ($code -ne 0 -or "$output" -notmatch 'EVIDENCE_CONTRACT_SELF_TEST 7 checks passed') {
+              throw 'Synthetic environment/diagnostic contract tests failed.'
+          }
           Remove-Item Env:MQB_OWNERSHIP_DISPOSABLE_HOST -ErrorAction SilentlyContinue
           $output = @(& $probe --default-case (Join-Path $root 'no-authorization') zi-debug A-started cancel guard 2>&1)
           $code = $LASTEXITCODE

--- a/cpp/tests/platform/windows/msvc_service_ownership_probe.cpp
+++ b/cpp/tests/platform/windows/msvc_service_ownership_probe.cpp
@@ -14,6 +14,7 @@
 #include <future>
 #include <iostream>
 #include <optional>
+#include <sstream>
 #include <stdexcept>
 #include <stop_token>
 #include <string>
@@ -152,6 +153,90 @@ void require_default_host() {
     require(size == 0 && ::GetLastError() == ERROR_ENVVAR_NOT_FOUND,
             "default endpoint experiment rejects an ambient endpoint override");
 }
+// The default experiment observes the discovered environment, not a repaired
+// version of it. Reject even an explicit removal/empty assignment before any
+// normalization; private endpoint replacement remains fixture-only behavior.
+void configure_fixture_environment(std::vector<mqb::process::EnvironmentVariable>& environment,
+                                   bool default_endpoint, const std::string& fixture_id) {
+    const auto is_endpoint = [](const auto& e) {
+        return _stricmp(e.name.c_str(), "_MSPDBSRV_ENDPOINT_") == 0;
+    };
+    if (default_endpoint) {
+        require(std::none_of(environment.begin(), environment.end(), is_endpoint),
+                "default endpoint experiment rejects a toolchain endpoint override");
+    } else {
+        std::erase_if(environment, is_endpoint);
+        environment.push_back({"_MSPDBSRV_ENDPOINT_", fixture_id, false});
+    }
+    for (const char* name : {"CL", "_CL_", "LINK", "_LINK_"}) {
+        std::erase_if(environment, [&](const auto& e) { return _stricmp(e.name.c_str(), name) == 0; });
+        environment.push_back({name, "", true});
+    }
+}
+void emit_outer_diagnostics(const RunResult& result, std::ostream& out, std::ostream& err) {
+    if (result) { out << result->stdout_text; err << result->stderr_text; }
+    else err << "OUTER_CLEANUP_ERROR " << result.error().message << " native=" << result.error().native_code << '\n';
+    // Postflight enumeration/writes can throw. Flush captured diagnostics first.
+    out.flush();
+    err.flush();
+}
+int evidence_contract_self_test() {
+    using Environment = std::vector<mqb::process::EnvironmentVariable>;
+    const auto equal = [](const Environment& a, const Environment& b) {
+        return a.size() == b.size() && std::equal(a.begin(), a.end(), b.begin(), [](const auto& x, const auto& y) {
+            return x.name == y.name && x.value == y.value && x.remove == y.remove;
+        });
+    };
+    unsigned checks = 0;
+    for (const auto& entry : Environment{{"_MSPDBSRV_ENDPOINT_", "polluted", false},
+                                        {"_mSpDbSrV_eNdPoInT_", "", false},
+                                        {"_mspdbsrv_endpoint_", "", true}}) {
+        Environment input{{"CL", "must-not-be-normalized", false}, entry};
+        const auto before = input;
+        bool rejected = false;
+        try { configure_fixture_environment(input, true, "unused"); }
+        catch (const std::runtime_error& e) {
+            rejected = std::string{e.what()}.find("toolchain endpoint override") != std::string::npos;
+        }
+        require(rejected && equal(input, before), "polluted default environment was reset instead of rejected");
+        ++checks;
+    }
+    Environment clean{{"PATH", "preserved", false}, {"_MSPDBSRV_ENDPOINT_X", "lookalike", false}};
+    configure_fixture_environment(clean, true, "must-not-be-used");
+    Environment expected{{"PATH", "preserved", false}, {"_MSPDBSRV_ENDPOINT_X", "lookalike", false},
+                         {"CL", "", true}, {"_CL_", "", true}, {"LINK", "", true}, {"_LINK_", "", true}};
+    require(equal(clean, expected), "clean default environment changed endpoint state");
+    ++checks;
+    Environment isolated{{"PATH", "preserved", false}, {"_MSPDBSRV_ENDPOINT_", "old", false},
+                         {"_mspdbsrv_endpoint_", "", true}, {"cl", "/unexpected", false}};
+    configure_fixture_environment(isolated, false, "fixture-only");
+    expected = {{"PATH", "preserved", false}, {"_MSPDBSRV_ENDPOINT_", "fixture-only", false},
+                {"CL", "", true}, {"_CL_", "", true}, {"LINK", "", true}, {"_LINK_", "", true}};
+    require(equal(isolated, expected), "private endpoint normalization changed");
+    ++checks;
+    std::ostringstream out, err;
+    ProcessResult captured;
+    captured.stdout_text = "original stdout\n";
+    captured.stderr_text = "original stderr\n";
+    try {
+        emit_outer_diagnostics(RunResult{captured}, out, err);
+        throw std::runtime_error("injected postflight failure");
+    } catch (const std::runtime_error& e) { err << e.what() << '\n'; }
+    require(out.str() == "original stdout\n" &&
+            err.str() == "original stderr\ninjected postflight failure\n", "postflight lost captured output");
+    ++checks;
+    std::ostringstream failed_out, failed_err;
+    mqb::process::ProcessError error;
+    error.message = "unproven cleanup";
+    error.native_code = 42;
+    emit_outer_diagnostics(std::unexpected(error), failed_out, failed_err);
+    require(failed_out.str().empty() && failed_err.str() == "OUTER_CLEANUP_ERROR unproven cleanup native=42\n",
+            "infrastructure diagnostic missing");
+    ++checks;
+    std::cout << "EVIDENCE_CONTRACT_SELF_TEST " << checks << " checks passed (synthetic; no MSVC run)\n";
+    return 0;
+}
+
 std::vector<Process> new_servers(const std::vector<Process>& before, const fs::path& compiler) {
     auto now = census(L"mspdbsrv.exe");
     std::vector<Process> result;
@@ -354,13 +439,8 @@ int measure(int argc, wchar_t** argv, bool default_endpoint) {
         throw std::runtime_error("MSVC discovery failed; see discovery.error.txt");
     }
     auto tc = std::move(*discovered);
-    // Private endpoints are still fixture isolation only. The default mode
-    // removes the override; fixture_id then names events, never the PDB endpoint.
-    for (const char* name : {"_MSPDBSRV_ENDPOINT_", "CL", "_CL_", "LINK", "_LINK_"}) {
-        std::erase_if(tc.environment, [&](const auto& e) { return _stricmp(e.name.c_str(), name) == 0; });
-        const bool private_endpoint = !default_endpoint && name == std::string{"_MSPDBSRV_ENDPOINT_"};
-        tc.environment.push_back({name, private_endpoint ? utf8(fixture_id) : "", !private_endpoint});
-    }
+    if (default_endpoint) require_default_host(); // Discovery may change the effective environment.
+    configure_fixture_environment(tc.environment, default_endpoint, utf8(fixture_id));
     write(dir / "toolchain.txt", path_text(tc.identity.compiler) + '\n' + tc.identity.version + '\n'
           + tc.identity.binary_stamp + "\nendpoint=" + (default_endpoint ? "<unset/default>" : utf8(fixture_id)) + '\n');
     auto before = census(L"mspdbsrv.exe");
@@ -521,6 +601,7 @@ int wmain(int argc, wchar_t** argv) {
     try {
         require(argc >= 2, "use --case/--default-case/--measure/--root");
         const std::wstring mode = argv[1];
+        if (mode == L"--evidence-contract-self-test") return evidence_contract_self_test();
         if (mode == L"--root" || mode == L"--drain-root") return root(argc, argv, mode == L"--drain-root");
         if (mode == L"--measure" || mode == L"--measure-default") return measure(argc, argv, mode == L"--measure-default");
         const bool default_endpoint = mode == L"--default-case";
@@ -545,6 +626,7 @@ int wmain(int argc, wchar_t** argv) {
         spec.cancellation = lifetime.get_token();
         WindowsProcessRunner runner;
         auto result = runner.run(spec);
+        emit_outer_diagnostics(result, std::cout, std::cerr);
         if (default_endpoint) {
             const auto remaining = census(L"mspdbsrv.exe");
             const bool clean = result.has_value() && remaining.empty();
@@ -552,15 +634,11 @@ int wmain(int argc, wchar_t** argv) {
                   + identities(remaining) + ",\"outer_lifecycle_verified\":" + (result ? "true" : "false")
                   + ",\"cleanup_verified\":" + (clean ? "true" : "false") + "}\n");
             if (!clean) {
-                if (result) { std::cout << result->stdout_text; std::cerr << result->stderr_text; }
-                else std::cerr << result.error().message << '\n';
                 std::cerr << "DEFAULT_ENDPOINT_CLEANUP_UNPROVEN: do not run another case\n";
                 return 1;
             }
         }
-        if (!result) { std::cerr << "OUTER_CLEANUP_ERROR " << result.error().message << '\n'; return 1; }
-        std::cout << result->stdout_text;
-        std::cerr << result->stderr_text;
+        if (!result) return 1;
         return result->exit_code;
     } catch (const std::exception& e) {
         std::cerr << "PROBE_INFRASTRUCTURE_FAILURE " << e.what() << '\n';

--- a/tests/native/collect_msvc_service_ownership.ps1
+++ b/tests/native/collect_msvc_service_ownership.ps1
@@ -11,6 +11,9 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
+# Nonzero native exits remain data until their diagnostics and case result are
+# persisted. Every native invocation below still checks its actual exit code.
+$PSNativeCommandUseErrorActionPreference = $false
 Set-StrictMode -Version 2.0
 $prebuilt = -not [string]::IsNullOrWhiteSpace($PrebuiltProbePath)
 if ($BuildOnly -and ($prebuilt -or $EndpointMode -eq 'default')) { throw 'BuildOnly requires a private build-only invocation.' }
@@ -34,6 +37,121 @@ $OutputRoot = [System.IO.Path]::GetFullPath($OutputRoot)
 # Never erase an earlier run, failure, or unfavorable observation.
 if (Test-Path -LiteralPath $OutputRoot) { throw "Evidence directory already exists: $OutputRoot" }
 New-Item -ItemType Directory -Path $OutputRoot -Force | Out-Null
+
+function Assert-OwnershipObservation {
+    param($Observation, [string]$EndpointMode, [string]$Profile, [string]$Origin, [string]$Ending)
+    if ($Observation -isnot [pscustomobject] -or
+        ($Observation.schema -isnot [int] -and $Observation.schema -isnot [long]) -or
+        $Observation.schema -ne 2) { throw 'Unexpected observation schema.' }
+    $identity = @{ endpoint_mode = $EndpointMode; profile = $Profile; origin = $Origin; ending = $Ending }
+    foreach ($field in $identity.Keys) {
+        if ($Observation.$field -isnot [string] -or $Observation.$field -cne $identity[$field]) {
+            throw "Unexpected observation identity: $field"
+        }
+    }
+    foreach ($field in @('A_exit', 'B0_exit', 'B1_exit', 'B_link_exit', 'B_run_exit', 'recovery_compile_exit')) {
+        if (($Observation.$field -isnot [int] -and $Observation.$field -isnot [long]) -or
+            $Observation.$field -lt [int]::MinValue -or $Observation.$field -gt [int]::MaxValue) {
+            throw "Missing or mistyped outcome: $field"
+        }
+    }
+    foreach ($field in @('safe_to_integrate_cancellation', 'safe_to_transfer_write_lease')) {
+        if ($Observation.$field -isnot [bool] -or $Observation.$field) { throw "Evidence must not authorize safety: $field" }
+    }
+    foreach ($field in @('lifecycle_ok', 'unmanaged_control_ok', 'drain_control_ok')) {
+        if ($Observation.$field -isnot [bool] -or -not $Observation.$field) { throw "Fixture control failed: $field" }
+    }
+    if ($Observation.server_survived_A -isnot [bool] -or $Observation.B_compiler_overlap_observed -isnot [bool]) {
+        throw 'Missing or mistyped liveness observation.'
+    }
+    if ($Ending -eq 'cancel') {
+        if ($Observation.A_exit -eq 0) { throw 'Cancelled A cannot report successful exit.' }
+    } elseif ($Observation.A_exit -ne 0) { throw 'Original A control failed.' }
+    if ($Observation.B0_exit -ne 0 -or $Observation.B1_exit -ne 0) {
+        if ($Observation.B_link_exit -ne -2 -or $Observation.B_run_exit -ne -2) { throw 'Unattempted link/run must remain unattempted.' }
+    } elseif ($Observation.B_link_exit -ne 0 -and $Observation.B_run_exit -ne -2) { throw 'Failed link cannot run an artifact.' }
+    if ($Ending -in @('unmanaged-normal', 'drain')) {
+        if (-not $Observation.server_survived_A -or $Observation.B0_exit -ne 0 -or $Observation.B1_exit -ne 0 -or
+            $Observation.B_link_exit -ne 0 -or $Observation.B_run_exit -ne 0) { throw 'Original B control failed.' }
+    }
+    if ($Ending -eq 'drain') {
+        foreach ($field in @('drain_requested', 'A_compiler_overlap_observed', 'B_compiler_overlap_observed', 'A_observed_compilers_signaled')) {
+            if ($Observation.$field -isnot [bool] -or -not $Observation.$field) { throw "Unproven drain boundary: $field" }
+        }
+        if ($Observation.A_pending_compile_dispatched -isnot [bool] -or $Observation.A_pending_compile_dispatched) {
+            throw 'Pending A work was not suppressed.'
+        }
+    }
+}
+
+function Test-OwnershipCleanupEnvelope {
+    param($Envelope)
+    try {
+        return $Envelope -is [pscustomobject] -and
+            $Envelope.cleanup_verified -is [bool] -and $Envelope.cleanup_verified -and
+            $Envelope.endpoint_override_absent -is [bool] -and $Envelope.endpoint_override_absent -and
+            $Envelope.outer_lifecycle_verified -is [bool] -and $Envelope.outer_lifecycle_verified -and
+            $Envelope.remaining_servers -is [array] -and $Envelope.remaining_servers.Count -eq 0
+    } catch { return $false }
+}
+
+function Get-OwnershipDiagnosticErrors {
+    param([string]$CaseRoot, [string]$Profile, [string]$Origin, [string]$Ending, $Observation)
+    # Check both expected and observed tools: a present-file inventory alone
+    # cannot detect an entirely missing invocation record.
+    $stems = @('A', 'A/warm', 'B/warm', 'B/work0', 'B/work1', 'B/recovery')
+    $prepared = @('A', 'B')
+    if ($Origin -eq 'preexisting') { $prepared += 'seed'; $stems += 'seed/warm' }
+    foreach ($directory in $prepared) {
+        if ($Profile.StartsWith('pch-')) { $stems += "$directory/prefix" }
+        if ($Profile.StartsWith('modules-')) { $stems += "$directory/provider" }
+    }
+    if ($Ending -eq 'drain') { $stems += 'A/work0' }
+    if ($null -ne $Observation -and $Observation.B0_exit -eq 0 -and $Observation.B1_exit -eq 0) {
+        $stems += 'B/link'
+        if ($Observation.B_link_exit -eq 0) { $stems += 'B/run' }
+    }
+    $stems += @(Get-ChildItem -LiteralPath $CaseRoot -Recurse -File |
+        Where-Object { $_.Name -match '\.(result\.json|argv\.txt)$' -and $_.Name -notin @('case.result.json', 'case.argv.txt') } |
+        ForEach-Object { [System.IO.Path]::GetRelativePath($CaseRoot, $_.FullName).Replace('\', '/') -replace '\.(result\.json|argv\.txt)$', '' })
+    foreach ($stem in @($stems | Sort-Object -Unique)) {
+        try {
+            $result = Get-Content -LiteralPath (Join-Path $CaseRoot "$stem.result.json") -Raw | ConvertFrom-Json
+            if ($result -isnot [pscustomobject] -or $null -ne $result.PSObject.Properties['infrastructure_error']) {
+                throw 'Process infrastructure error or invalid result schema.'
+            }
+            if (($result.exit_code -isnot [int] -and $result.exit_code -isnot [long]) -or
+                $result.cancelled -isnot [bool]) { throw 'Missing or mistyped tool outcome.' }
+            if ($result.cancelled -ne ($stem -eq 'A' -and $Ending -eq 'cancel')) { throw 'Unexpected cancellation outcome.' }
+            $outcomeFields = @{ A = 'A_exit'; 'B/work0' = 'B0_exit'; 'B/work1' = 'B1_exit';
+                'B/link' = 'B_link_exit'; 'B/run' = 'B_run_exit'; 'B/recovery' = 'recovery_compile_exit' }
+            if ($null -ne $Observation -and $outcomeFields.ContainsKey($stem)) {
+                $field = $outcomeFields[$stem]
+                if ($result.exit_code -ne $Observation.$field) { throw 'Original tool outcome disagrees with observation.' }
+            }
+            $suffixes = @('stdout.txt', 'stderr.txt')
+            if ($stem -ne 'A') { $suffixes += 'argv.txt' }
+            foreach ($suffix in $suffixes) {
+                if (-not (Test-Path -LiteralPath (Join-Path $CaseRoot "$stem.$suffix") -PathType Leaf)) {
+                    throw "Missing $suffix; original diagnostics are incomplete."
+                }
+            }
+            if ($stem -match '/(warm|prefix|provider)$' -and $result.exit_code -ne 0) { throw 'Preparation control failed.' }
+        } catch { "${stem}.result.json: $($_.Exception.Message)" }
+    }
+    if ($Ending -eq 'drain') {
+        try {
+            $drain = Get-Content -LiteralPath (Join-Path $CaseRoot 'A/drain.json') -Raw | ConvertFrom-Json
+            if ($drain.stop_observed -isnot [bool] -or -not $drain.stop_observed -or
+                $drain.safe_to_transfer_write_lease -isnot [bool] -or $drain.safe_to_transfer_write_lease) { throw 'Invalid drain flags.' }
+            foreach ($entry in @{ work_compiles_dispatched = 1; first_compile_exit = 0; pending_compile_exit = -2 }.GetEnumerator()) {
+                if (($drain.($entry.Key) -isnot [int] -and $drain.($entry.Key) -isnot [long]) -or
+                    $drain.($entry.Key) -ne $entry.Value) { throw 'Invalid original drain outcome.' }
+            }
+            if (Test-Path -LiteralPath (Join-Path $CaseRoot 'A/work1.argv.txt')) { throw 'Pending A work was dispatched.' }
+        } catch { "A/drain.json: $($_.Exception.Message)" }
+    }
+}
 
 Push-Location $RepoRoot
 try {
@@ -147,36 +265,29 @@ try {
                 $observation = $null
                 $parseError = $null
                 if (Test-Path -LiteralPath $observationPath -PathType Leaf) {
-                    try { $observation = Get-Content -LiteralPath $observationPath -Raw | ConvertFrom-Json }
-                    catch { $parseError = $_.Exception.Message }
+                    try {
+                        $observation = Get-Content -LiteralPath $observationPath -Raw | ConvertFrom-Json
+                        Assert-OwnershipObservation -Observation $observation -EndpointMode $EndpointMode `
+                            -Profile $profile -Origin $origin -Ending $ending
+                    } catch { $parseError = $_.Exception.Message }
                 }
                 # B failures are the result of the policy under test, not a reason
                 # to suppress their data. Missing evidence / failed unmanaged
                 # controls / process-infrastructure failures do fail collection.
-                $toolErrors = @(Get-ChildItem -LiteralPath $caseRoot -Recurse -File -Filter '*.result.json' |
-                    ForEach-Object {
-                        $result = Get-Content -LiteralPath $_.FullName -Raw | ConvertFrom-Json
-                        $property = $result.PSObject.Properties['infrastructure_error']
-                        if ($null -ne $property -and $property.Value -eq $true) {
-                            [System.IO.Path]::GetRelativePath($caseRoot, $_.FullName)
-                        }
-                    })
+                try {
+                    $toolErrors = @(Get-OwnershipDiagnosticErrors -CaseRoot $caseRoot -Profile $profile `
+                        -Origin $origin -Ending $ending -Observation $observation)
+                } catch { $toolErrors = @("Diagnostic inventory failed: $($_.Exception.Message)") }
                 $cleanupVerified = $null
                 $envelopeError = $null
                 if ($EndpointMode -eq 'default') {
                     try {
                         $envelope = Get-Content -LiteralPath (Join-Path $caseRoot 'default-envelope.json') -Raw | ConvertFrom-Json
-                        $cleanupVerified = $envelope.cleanup_verified -eq $true -and
-                            $envelope.endpoint_override_absent -eq $true -and
-                            $envelope.outer_lifecycle_verified -eq $true -and @($envelope.remaining_servers).Count -eq 0
+                        $cleanupVerified = Test-OwnershipCleanupEnvelope -Envelope $envelope
                     } catch { $envelopeError = $_.Exception.Message }
                 }
                 $collectionOk = $caseExit -eq 0 -and $null -ne $observation -and
                     $null -eq $parseError -and $toolErrors.Count -eq 0 -and ($EndpointMode -ne 'default' -or $cleanupVerified -eq $true)
-                if ($null -ne $observation -and ($observation.schema -ne 2 -or $observation.endpoint_mode -ne $EndpointMode)) {
-                    $collectionOk = $false
-                    $parseError = 'Unexpected observation schema or endpoint mode.'
-                }
                 if ($EndpointMode -eq 'default' -and $cleanupVerified -ne $true) { $aborted = $true }
                 if (-not $collectionOk) { $failed++ }
                 $row = [ordered]@{
@@ -198,6 +309,13 @@ try {
                 if ($aborted) { Write-Warning 'Default endpoint cleanup unproven; remaining cases not attempted.'; break caseMatrix }
             }
         }
+    }
+    if ($aborted) {
+        # Do not read/hash outputs possibly still being written after uncertain
+        # cleanup. Retain the captured prefix without inventing stable snapshots.
+        [ordered]@{ status = 'not_attempted'; reason = 'cleanup_unproven' } | ConvertTo-Json |
+            Set-Content -LiteralPath (Join-Path $OutputRoot 'binary-inventory-status.json') -Encoding utf8
+        exit 1
     }
     # Raw diagnostics/inputs are uploaded; large generated binaries are identified
     # by SHA-256 rather than being silently mistaken for retained artifact bytes.

--- a/tests/native/verify_ownership_evidence_contract.ps1
+++ b/tests/native/verify_ownership_evidence_contract.ps1
@@ -1,0 +1,150 @@
+[CmdletBinding()]
+param(
+    [string]$CollectorPath = (Join-Path $PSScriptRoot 'collect_msvc_service_ownership.ps1'),
+    [string]$OutputRoot = (Join-Path $PSScriptRoot '../../.mqb/ownership-contract-tests')
+)
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2.0
+$OutputRoot = [System.IO.Path]::GetFullPath($OutputRoot)
+if (Test-Path -LiteralPath $OutputRoot) { throw 'Refusing to overwrite earlier contract evidence.' }
+New-Item -ItemType Directory -Path $OutputRoot -Force | Out-Null
+# Import only the actual collector's validation functions. Never execute its
+# main body, discovery or compiler while testing damaged synthetic records.
+$tokens = $null; $parseErrors = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseFile($CollectorPath, [ref]$tokens, [ref]$parseErrors)
+if (@($parseErrors).Count -ne 0) { throw "Collector parse errors: $parseErrors" }
+foreach ($name in @('Assert-OwnershipObservation', 'Test-OwnershipCleanupEnvelope', 'Get-OwnershipDiagnosticErrors')) {
+    $definitions = @($ast.FindAll({ param($node)
+        $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -eq $name
+    }, $true))
+    if ($definitions.Count -ne 1) { throw "Expected exactly one collector function: $name" }
+    . ([scriptblock]::Create($definitions[0].Extent.Text))
+}
+$rows = [System.Collections.Generic.List[object]]::new()
+function Write-Json($Path, $Value) {
+    $Value | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $Path -Encoding utf8
+}
+function Write-Tool($Root, $Stem, [int]$Code = 0, [bool]$Cancelled = $false) {
+    $path = Join-Path $Root $Stem
+    New-Item -ItemType Directory -Path ([System.IO.Path]::GetDirectoryName($path)) -Force | Out-Null
+    Write-Json "$path.result.json" @{ exit_code = $Code; cancelled = $Cancelled }
+    [System.IO.File]::WriteAllText("$path.stdout.txt", '')
+    [System.IO.File]::WriteAllText("$path.stderr.txt", '')
+    if ($Stem -ne 'A') { [System.IO.File]::WriteAllText("$path.argv.txt", "synthetic-tool`n") }
+}
+function New-Fixture([string]$Name, [string]$Mode, [string]$Profile, [string]$Origin, [string]$Ending) {
+    $root = Join-Path $OutputRoot $Name
+    New-Item -ItemType Directory -Path $root | Out-Null
+    $observation = [pscustomobject]@{
+        schema = 2; endpoint_mode = $Mode; profile = $Profile; origin = $Origin; ending = $Ending
+        A_exit = $(if ($Ending -eq 'cancel') { 1223 } else { 0 })
+        B0_exit = 0; B1_exit = 0; B_link_exit = 0; B_run_exit = 0; recovery_compile_exit = 0
+        lifecycle_ok = $true; unmanaged_control_ok = $true; drain_control_ok = $true
+        safe_to_integrate_cancellation = $false; safe_to_transfer_write_lease = $false
+        server_survived_A = $true; B_compiler_overlap_observed = $true
+        drain_requested = ($Ending -eq 'drain'); A_compiler_overlap_observed = ($Ending -eq 'drain')
+        A_observed_compilers_signaled = $(if ($Ending -eq 'drain') { $true } else { $null })
+        A_pending_compile_dispatched = $(if ($Ending -eq 'drain') { $false } else { $null })
+    }
+    Write-Tool $root 'A' $observation.A_exit ($Ending -eq 'cancel')
+    foreach ($stem in @('A/warm', 'B/warm', 'B/work0', 'B/work1', 'B/link', 'B/run', 'B/recovery')) { Write-Tool $root $stem }
+    $prepared = @('A', 'B')
+    if ($Origin -eq 'preexisting') { $prepared += 'seed'; Write-Tool $root 'seed/warm' }
+    foreach ($directory in $prepared) {
+        if ($Profile.StartsWith('pch-')) { Write-Tool $root "$directory/prefix" }
+        if ($Profile.StartsWith('modules-')) { Write-Tool $root "$directory/provider" }
+    }
+    if ($Ending -eq 'drain') {
+        Write-Tool $root 'A/work0'
+        Write-Json (Join-Path $root 'A/drain.json') @{
+            stop_observed = $true; work_compiles_dispatched = 1; first_compile_exit = 0
+            pending_compile_exit = -2; safe_to_transfer_write_lease = $false
+        }
+    }
+    return [pscustomobject]@{
+        root = $root; observation = $observation
+        envelope = [pscustomobject]@{ cleanup_verified = $true; endpoint_override_absent = $true
+            outer_lifecycle_verified = $true; remaining_servers = @() }
+    }
+}
+function Run-Case {
+    param([string]$Name, [scriptblock]$Mutate = {}, [bool]$ExpectAccepted = $true,
+        [string]$Mode = 'default', [string]$Profile = 'zi-debug', [string]$Origin = 'A-started', [string]$Ending = 'normal')
+    $fixture = New-Fixture $Name $Mode $Profile $Origin $Ending
+    & $Mutate $fixture
+    Write-Json (Join-Path $fixture.root 'observation.json') $fixture.observation
+    Write-Json (Join-Path $fixture.root 'default-envelope.json') $fixture.envelope
+    # Use deserialized values, just as the collector does (including Int64 JSON numbers).
+    $observation = Get-Content -LiteralPath (Join-Path $fixture.root 'observation.json') -Raw | ConvertFrom-Json
+    $envelope = Get-Content -LiteralPath (Join-Path $fixture.root 'default-envelope.json') -Raw | ConvertFrom-Json
+    $errors = @()
+    try { Assert-OwnershipObservation $observation $Mode $Profile $Origin $Ending }
+    catch { $errors += $_.Exception.Message }
+    $errors += @(Get-OwnershipDiagnosticErrors $fixture.root $Profile $Origin $Ending $observation)
+    if ($Mode -eq 'default' -and -not (Test-OwnershipCleanupEnvelope $envelope)) { $errors += 'Cleanup unproven.' }
+    $accepted = $errors.Count -eq 0
+    $rows.Add([pscustomobject]@{ name = $Name; expected_accepted = $ExpectAccepted; accepted = $accepted
+        passed = ($accepted -eq $ExpectAccepted); errors = @($errors) })
+    Write-Json (Join-Path $OutputRoot 'summary.json') @{
+        schema = 1; synthetic_only = $true; collector_sha256 = (Get-FileHash $CollectorPath -Algorithm SHA256).Hash
+        powershell = $PSVersionTable.PSVersion.ToString(); cases = @($rows.ToArray())
+    }
+}
+# Each real matrix shape gets a synthetic intact-record control. This does not
+# claim any MSVC run, process termination or write-quiescence observation.
+foreach ($mode in @('private', 'default')) {
+    foreach ($profile in @('zi-debug', 'ZI-debug', 'zi-release', 'pch-debug', 'pch-release', 'modules-debug', 'modules-release')) {
+        foreach ($origin in @('preexisting', 'A-started')) {
+            $endings = @('unmanaged-normal', 'normal', 'cancel')
+            if ($mode -eq 'default') { $endings += 'drain' }
+            foreach ($ending in $endings) {
+                $label = if ($profile -ceq 'ZI-debug') { 'edit-continue-debug' } else { $profile }
+                Run-Case -Name "$mode-$label-$origin-$ending" -Mode $mode -Profile $profile -Origin $origin -Ending $ending
+            }
+        }
+    }
+}
+foreach ($suffix in @('result.json', 'stdout.txt', 'stderr.txt', 'argv.txt')) {
+    Run-Case -Name "missing-$suffix" -ExpectAccepted $false -Mutate {
+        param($f) Remove-Item -LiteralPath (Join-Path $f.root "B/work0.$suffix")
+    }
+}
+Run-Case 'malformed-result' { param($f) [IO.File]::WriteAllText((Join-Path $f.root 'B/work0.result.json'), '{broken') } $false
+Run-Case 'infrastructure-result' { param($f) Write-Json (Join-Path $f.root 'B/work0.result.json') @{ infrastructure_error = $true; native_code = 5 } } $false
+Run-Case 'string-result-code' { param($f) Write-Json (Join-Path $f.root 'B/work0.result.json') @{ exit_code = '0'; cancelled = $false } } $false
+Run-Case 'unexpected-tool-cancellation' { param($f) Write-Tool $f.root 'B/work0' 0 $true } $false
+Run-Case 'original-result-mismatch' { param($f) Write-Tool $f.root 'B/work0' 1 } $false
+Run-Case 'unlisted-attempt-without-result' { param($f) [IO.File]::WriteAllText((Join-Path $f.root 'B/extra.argv.txt'), 'attempted') } $false
+Run-Case 'wrong-profile-case' { param($f) $f.observation.profile = 'ZI-debug' } $false
+Run-Case 'wrong-mode' { param($f) $f.observation.endpoint_mode = 'private' } $false
+Run-Case 'missing-schema' { param($f) $f.observation.PSObject.Properties.Remove('schema') } $false
+Run-Case 'string-schema' { param($f) $f.observation.schema = '2' } $false
+Run-Case 'floating-exit' { param($f) $f.observation.A_exit = 0.25 } $false
+Run-Case 'out-of-range-exit' { param($f) $f.observation.A_exit = [long]4294967296 } $false
+Run-Case 'string-safety-flag' { param($f) $f.observation.safe_to_transfer_write_lease = 'false' } $false
+Run-Case 'authorized-safety-flag' { param($f) $f.observation.safe_to_integrate_cancellation = $true } $false
+Run-Case 'false-control' { param($f) $f.observation.lifecycle_ok = $false } $false
+Run-Case 'string-cleanup-flag' { param($f) $f.envelope.cleanup_verified = 'true' } $false
+Run-Case 'null-server-list' { param($f) $f.envelope.remaining_servers = $null } $false
+Run-Case 'remaining-server' { param($f) $f.envelope.remaining_servers = @(@{ pid = 42 }) } $false
+Run-Case 'missing-envelope-field' { param($f) $f.envelope.PSObject.Properties.Remove('outer_lifecycle_verified') } $false
+Run-Case -Name 'drain-no-overlap' -Ending drain -ExpectAccepted $false -Mutate { param($f) $f.observation.A_compiler_overlap_observed = $false }
+Run-Case -Name 'drain-record-missing' -Ending drain -ExpectAccepted $false -Mutate { param($f) Remove-Item -LiteralPath (Join-Path $f.root 'A/drain.json') }
+Run-Case -Name 'drain-pending-attempted' -Ending drain -ExpectAccepted $false -Mutate { param($f) Write-Tool $f.root 'A/work1' }
+Run-Case -Name 'preparation-failed' -Origin preexisting -Profile pch-debug -ExpectAccepted $false -Mutate { param($f) Write-Tool $f.root 'seed/prefix' 1 }
+# A failed managed B compile is valuable adverse evidence, not a failed collector;
+# the successful recovery MUST NOT replace the original nonzero tool result.
+Run-Case 'adverse-managed-compile-retained' {
+    param($f)
+    $f.observation.B0_exit = 1; $f.observation.B_link_exit = -2; $f.observation.B_run_exit = -2
+    $f.observation.server_survived_A = $false
+    Write-Tool $f.root 'B/work0' 1
+    foreach ($stem in @('B/link', 'B/run')) {
+        foreach ($suffix in @('result.json', 'stdout.txt', 'stderr.txt', 'argv.txt')) {
+            Remove-Item -LiteralPath (Join-Path $f.root "$stem.$suffix")
+        }
+    }
+} $true
+$failed = @($rows | Where-Object { -not $_.passed })
+Write-Host "OWNERSHIP_COLLECTOR_CONTRACT $($rows.Count) cases; $($failed.Count) failures (synthetic; no MSVC run)"
+if ($failed.Count -ne 0) { $failed | Format-List | Out-String | Write-Host; exit 1 }


### PR DESCRIPTION
## Final decision: accept evidence hardening; do not authorize cancellation or writer leases

[Final exact-source review and completed gates](https://github.com/Iviesever/msvc-quick-build/pull/169#pullrequestreview-5141407094)

- **Exact base:** `a9792704e0b2f040206974f717cc103d2a1e3c71` (#167).
- **Reviewed head:** `3d80ee34bb086f46e157098a350259767561787f`.
- **Candidate and native PR test-merge tree:** `c9cae9887556185805739ffb99211529e60082a6`.
- Native test-merge: `1da47599c2c0206176d30f07da530ff469b3ea6f`, with the declared base/head parents.
- Four test/CI files, **406 additions / 29 deletions**. No production source/header, manifest, native executable inventory (79), benchmark, scheduler, CLI/freshness or VERSION changes.
- **VERSION remains 5.5.0. No historical tag/asset change or formal release.**

This resumes the earlier unsubmitted guardrails patch with actual Windows validation and executable fault contracts. Scheduler #168 remains an independent topic, not duplicated or bundled here. This is not M1b completion.

## Delivered code

`msvc_service_ownership_probe.cpp` rejects captured toolchain endpoint overrides (including empty/removal entries) before normalization; private fixture normalization is unchanged. Captured output and infrastructure native errors are emitted/flushed before postflight operations can throw. The new seven-case self-test checks those helpers; its later-failure simulation is not an injected OS census failure.

`collect_msvc_service_ownership.ps1` validates required and observed tools, missing/corrupt diagnostics/results/argv, original outcome/report consistency, strict observation identity/outcome/safety types and typed cleanup evidence. A successful recovery cannot replace an original failure. Unproven default cleanup stops the matrix and suppresses subsequent binary reading/hashing.

`verify_ownership_evidence_contract.ps1` parses and executes the actual collector's three validation functions, without discovery/build: **98 intact matrix shapes + 27 damaged-record refusals + 1 retained adverse-result control**. The workflow adds an independent Windows contract job and executes the C++ self-test before the unchanged-size default56 matrix. The separate private42 workflow is byte-unchanged.

Compiler profiles, /Zi-/ZI-/FS, fixed 24k A / 6k B workloads and large-A-only /bigobj are unchanged. No process admission token, terminating compiler Job, global service kill or new CLI default is added.

## Completed evidence

| Gate | Exact-head run | Result |
|---|---|---|
| Native Debug and all subshards | #703 / 34221784609 | Passed, including freshness/runtime/parameter checks |
| Complete Native Release/self-host/package | #599 / 34221784665 | Passed; publish-release skipped |
| Documentation / Cross-Stage | #160 / 34221784659; #183 / 34221784662 | Passed |
| PowerShell contract and default endpoint | #5 / 34221784668 | 126/126 expected synthetic outcomes; 7 C++ self-tests; 2 refusal guards; default56 complete |
| Private endpoint | #7 / 34221784641 | private42 complete |
| Independent unchanged ABBA | #544 / 34221784661 | 76 pairs; 72 instrumented semantic identities match |

[126-case Windows artifact inspection and CRLF hash-audit correction](https://github.com/Iviesever/msvc-quick-build/pull/169#issuecomment-5584578850)

[Real default56/private42 results, executable provenance, failures and missing ownership evidence](https://github.com/Iviesever/msvc-quick-build/pull/169#issuecomment-5584737447)

[Complete 19-scenario ABBA table and unfavorable samples](https://github.com/Iviesever/msvc-quick-build/pull/169#issuecomment-5584681960)

**Negative evidence retained:** 3 default and 2 private original B builds fail with C1090; all 28 A-started managed endings kill the original service. Every later recovery compile succeeds but does not erase those failures. All 14 natural-drain controls pass; this fixture still does not call #168's new scheduler API. B resource identity is observed only 8/56 default, 3/42 private and 3/14 drain; empty post-A resource sets do not prove no remaining writers.

External timings-off no-op paired median **-0.723ms/-6.29%**, MAD0.867ms, maximum adverse +0.895ms. This is not a speedup/zero-overhead claim. Instrumented public-header and link-only are slower 4/4, medians +17.561ms/+14.74% and +32.838ms/+47.77%; modules-cold tail +582.944ms. No noise-based sample deletion; historical cold-tail debt remains open. Only the timings-disabled-no-op row uses external elapsed. Four-pair P95 is a maximum, not a population-tail estimate.

## Original predeclared gates — unchanged after measurement

Full final diff/exact-tree native Debug, all Release shards, self-host/package and documentation/relevant Cross-Stage must pass. All 126 synthetic expectations, seven C++ tests and refusal guards must pass, inspecting artifacts rather than status alone. Both fixed real matrices must complete without infrastructure/control/cleanup failure; all unmanaged and default drain controls pass while adverse managed results and missing resource identities are preserved. Independent ABBA remains 19 x 4, AB/BA/AB/BA, with all 72 instrumented counters/breakdowns/hit-miss fields identical and four timings-off counter sets unavailable. Paired-median external no-op worse by **both 1ms and 10%** blocks automatic acceptance; this gate was not crossed. No same-head repeat-until-green.

The temporary perf title was changed only after measurement #544 completed. Later title/ready-triggered skipped perf jobs are not substitutes for #544. All downloaded raw ZIPs and read-only recomputation are retained; Actions artifacts have a 30-day retention period. Diagnostic ZIPs omit generated fixture binaries, retaining post-case hashes; the separate exact-input ZIP contains its two prebuilt executables.

## Handoff

Accept ordinary expected-head merge under repository protection. Keep both safety-authorization fields false: no CLI cancellation, RPC completion, external-writer enumeration, durable quiescence or write-lease transfer is proven. Keep #164 as the roadmap entry point. Scheduler #168 must be reviewed against the current main/resulting tree; after its acceptance, exercise its actual API in the real-tool fixture before claiming production propagation. Project transactions, build/run separation, sessions/watchers/daemon and formal VERSION/release work are not bundled here.