### PR TITLE
test: validate real scheduler drain on accepted PDB evidence baseline

### DIFF
--- a/.github/workflows/msvc-default-endpoint.yml
+++ b/.github/workflows/msvc-default-endpoint.yml
@@ -130,7 +130,7 @@ jobs:
             ConvertTo-Json | Set-Content -LiteralPath (Join-Path $root 'guards.json') -Encoding utf8
           # Both native failures above are expected and independently asserted.
           exit 0
-      - name: Observe fixed 56-case default endpoint matrix
+      - name: Observe fixed 70-case default endpoint matrix
         shell: pwsh
         env:
           MQB_OWNERSHIP_DISPOSABLE_HOST: '1'

--- a/cpp/tests/platform/windows/msvc_service_ownership_probe.cpp
+++ b/cpp/tests/platform/windows/msvc_service_ownership_probe.cpp
@@ -7,6 +7,8 @@
 #include <restartmanager.h>
 
 #include <algorithm>
+#include <array>
+#include <atomic>
 #include <chrono>
 #include <expected>
 #include <filesystem>
@@ -23,6 +25,7 @@
 #include <vector>
 
 #include "mqb/msvc/MsvcToolchainLocator.hpp"
+#include "mqb/orchestration/BoundedWorkScheduler.hpp"
 #include "mqb/platform/windows/CommandLine.hpp"
 #include "mqb/platform/windows/WindowsProcessRunner.hpp"
 
@@ -381,7 +384,89 @@ void workload(const fs::path& dir, const std::string& profile, unsigned function
     }
 }
 
-int root(int argc, wchar_t** argv, bool drain) {
+// Fixture-only bridge from the parent's named event to the real scheduler API.
+// The 10ms wait is polling for bridge shutdown, NOT a cancellation deadline.
+// Only callback admission receives a token; compile() stays unmanaged.
+int scheduler_drain(const MsvcToolchain& tc, const fs::path& dir,
+                    const std::string& profile, HANDLE cancel) {
+    std::stop_source admission;
+    std::atomic<bool> callback_active{false};
+    bool event_observed = false;
+    bool forwarded_during_callback = false;
+    DWORD wait_error = ERROR_SUCCESS;
+    std::array<int, 2> codes{-2, -2};
+    std::size_t dispatched = 0;
+    std::string callback_exception;
+    std::jthread bridge([&](std::stop_token shutdown) {
+        while (!shutdown.stop_requested()) {
+            const auto status = ::WaitForSingleObject(cancel, 10);
+            if (status == WAIT_OBJECT_0) {
+                event_observed = true;
+                const bool active_before = callback_active.load(std::memory_order_acquire);
+                admission.request_stop();
+                forwarded_during_callback = active_before && callback_active.load(std::memory_order_acquire);
+                return;
+            }
+            if (status != WAIT_TIMEOUT) {
+                wait_error = status == WAIT_FAILED ? ::GetLastError() : ERROR_INVALID_FUNCTION;
+                if (wait_error == ERROR_SUCCESS) wait_error = ERROR_INVALID_FUNCTION;
+                admission.request_stop(); // Close admission but retain the bridge failure.
+                return;
+            }
+        }
+    });
+    const auto scheduled = mqb::orchestration::BoundedWorkScheduler::run_with_admission_stop(
+        2, 1, admission.get_token(), [&](std::size_t index) {
+            ++dispatched;
+            callback_active.store(true, std::memory_order_release);
+            struct Active {
+                std::atomic<bool>& flag;
+                ~Active() { flag.store(false, std::memory_order_release); }
+            } active{callback_active};
+            try {
+                codes.at(index) = exit_code(compile(tc, dir, profile, "work" + std::to_string(index), true));
+                return codes.at(index) == 0;
+            } catch (const std::exception& e) {
+                callback_exception = e.what();
+                throw; // Preserve callback_threw; never replace it with cancellation success.
+            } catch (...) {
+                callback_exception = "non-standard callback exception";
+                throw;
+            }
+        });
+    bridge.request_stop();
+    bridge.join(); // Synchronizes all bridge observations before serialization.
+    if (!callback_exception.empty()) std::cerr << "SCHEDULER_CALLBACK_ERROR " << callback_exception << '\n';
+    if (!scheduled) std::cerr << "SCHEDULER_ERROR " << scheduled.error().message << '\n';
+    if (wait_error != ERROR_SUCCESS) std::cerr << "SCHEDULER_BRIDGE_ERROR native=" << wait_error << '\n';
+    std::cerr.flush();
+    const std::string summary = "{\"schema\":1,\"api\":\"BoundedWorkScheduler::run_with_admission_stop\""
+        ",\"scheduler_succeeded\":" + std::string{scheduled ? "true" : "false"}
+        + ",\"worker_count\":" + (scheduled ? std::to_string(scheduled->worker_count) : "null")
+        + ",\"started_count\":" + (scheduled ? std::to_string(scheduled->started_count) : "null")
+        + ",\"stop_requested\":" + (scheduled ? (scheduled->stop_requested ? "true" : "false") : "null")
+        + ",\"admission_stop_observed\":" + (scheduled ? (scheduled->admission_stop_observed ? "true" : "false") : "null")
+        + ",\"stopped_before_all_items\":" + (scheduled ? (scheduled->stopped_before_all_items ? "true" : "false") : "null")
+        + ",\"event_observed\":" + (event_observed ? "true" : "false")
+        + ",\"forwarded_during_callback\":" + (forwarded_during_callback ? "true" : "false")
+        + ",\"bridge_wait_error\":" + std::to_string(wait_error)
+        + ",\"callback_exception\":" + quoted(callback_exception)
+        + ",\"scheduler_error_code\":" + (scheduled ? "null" : std::to_string(static_cast<int>(scheduled.error().code)))
+        + ",\"safe_to_transfer_write_lease\":false}\n";
+    write(dir / "scheduler.json", summary);
+    write(dir / "drain.json", "{\"stop_observed\":" + std::string{admission.stop_requested() ? "true" : "false"}
+          + ",\"work_compiles_dispatched\":" + std::to_string(dispatched)
+          + ",\"first_compile_exit\":" + std::to_string(codes[0])
+          + ",\"pending_compile_exit\":" + std::to_string(codes[1])
+          + ",\"safe_to_transfer_write_lease\":false}\n");
+    // callback_active covers compile/capture/diagnostics, not an in-flight RPC.
+    return scheduled && scheduled->worker_count == 1 && scheduled->started_count == 1
+        && scheduled->stop_requested && scheduled->admission_stop_observed && scheduled->stopped_before_all_items
+        && event_observed && forwarded_during_callback && wait_error == ERROR_SUCCESS
+        && callback_exception.empty() && dispatched == 1 && codes[0] == 0 && codes[1] == -2 ? 0 : 1;
+}
+
+int root(int argc, wchar_t** argv, bool drain, bool use_scheduler) {
     require(argc == (drain ? 8 : 7), "root arguments");
     MsvcToolchain tc;
     tc.identity.compiler = argv[2]; // Environment already supplied by the measured parent.
@@ -400,6 +485,7 @@ int root(int argc, wchar_t** argv, bool drain) {
     // Fixture watchdog only; not a product cancellation deadline.
     require(::WaitForSingleObject(release.value, 120000) == WAIT_OBJECT_0, "root fixture watchdog");
     if (!drain) return 0;
+    if (use_scheduler) return scheduler_drain(tc, dir, profile, cancel.value);
     const auto first = compile(tc, dir, profile, "work0", true);
     const auto status = ::WaitForSingleObject(cancel.value, 0);
     require(status == WAIT_TIMEOUT || status == WAIT_OBJECT_0, "admission cancellation wait failed");
@@ -421,7 +507,8 @@ int measure(int argc, wchar_t** argv, bool default_endpoint) {
     const fs::path dir = fs::absolute(argv[2]);
     const std::string profile = utf8(argv[3]), origin = utf8(argv[4]), ending = utf8(argv[5]);
     const std::wstring fixture_id = argv[6];
-    const bool drain = ending == "drain";
+    const bool use_scheduler = ending == "scheduler-drain";
+    const bool drain = ending == "drain" || use_scheduler;
     require(profile == "zi-debug" || profile == "ZI-debug" || profile == "zi-release"
             || profile == "pch-debug" || profile == "pch-release"
             || profile == "modules-debug" || profile == "modules-release", "unknown profile");
@@ -457,7 +544,7 @@ int measure(int argc, wchar_t** argv, bool default_endpoint) {
     std::stop_source stop;
     ProcessSpec a;
     a.executable = self();
-    a.arguments = {drain ? "--drain-root" : "--root", path_text(tc.identity.compiler), path_text(dir / "A"), profile,
+    a.arguments = {use_scheduler ? "--scheduler-drain-root" : (drain ? "--drain-root" : "--root"), path_text(tc.identity.compiler), path_text(dir / "A"), profile,
                    utf8(ready_name), utf8(release_name)};
     if (drain) a.arguments.push_back(utf8(cancel_name));
     a.environment = tc.environment;
@@ -568,6 +655,7 @@ int measure(int argc, wchar_t** argv, bool default_endpoint) {
         + ",\"B_observed_compilers\":" + identities(active)
         + ",\"endpoint_mode\":" + quoted(default_endpoint ? "default" : "private")
         + ",\"request_to_A_result_ms\":" + std::to_string(std::chrono::duration<double, std::milli>(settled - requested).count())
+        + ",\"scheduler_api_used\":" + (use_scheduler ? "true" : "false")
         + ",\"drain_requested\":" + (drain ? "true" : "false")
         + ",\"A_observed_compilers\":" + identities(active_a)
         + ",\"A_compiler_overlap_observed\":" + (a_overlap ? "true" : "false")
@@ -602,7 +690,8 @@ int wmain(int argc, wchar_t** argv) {
         require(argc >= 2, "use --case/--default-case/--measure/--root");
         const std::wstring mode = argv[1];
         if (mode == L"--evidence-contract-self-test") return evidence_contract_self_test();
-        if (mode == L"--root" || mode == L"--drain-root") return root(argc, argv, mode == L"--drain-root");
+        if (mode == L"--root" || mode == L"--drain-root" || mode == L"--scheduler-drain-root")
+            return root(argc, argv, mode != L"--root", mode == L"--scheduler-drain-root");
         if (mode == L"--measure" || mode == L"--measure-default") return measure(argc, argv, mode == L"--measure-default");
         const bool default_endpoint = mode == L"--default-case";
         require((mode == L"--case" || default_endpoint) && argc == 7, "case arguments");

--- a/cpp/tests/platform/windows/msvc_service_ownership_probe.cpp
+++ b/cpp/tests/platform/windows/msvc_service_ownership_probe.cpp
@@ -440,6 +440,7 @@ int scheduler_drain(const MsvcToolchain& tc, const fs::path& dir,
     if (!scheduled) std::cerr << "SCHEDULER_ERROR " << scheduled.error().message << '\n';
     if (wait_error != ERROR_SUCCESS) std::cerr << "SCHEDULER_BRIDGE_ERROR native=" << wait_error << '\n';
     std::cerr.flush();
+    // Suppress ADL: a mutable std::string would prefer std::quoted over this JSON helper.
     const std::string summary = "{\"schema\":1,\"api\":\"BoundedWorkScheduler::run_with_admission_stop\""
         ",\"scheduler_succeeded\":" + std::string{scheduled ? "true" : "false"}
         + ",\"worker_count\":" + (scheduled ? std::to_string(scheduled->worker_count) : "null")
@@ -450,7 +451,7 @@ int scheduler_drain(const MsvcToolchain& tc, const fs::path& dir,
         + ",\"event_observed\":" + (event_observed ? "true" : "false")
         + ",\"forwarded_during_callback\":" + (forwarded_during_callback ? "true" : "false")
         + ",\"bridge_wait_error\":" + std::to_string(wait_error)
-        + ",\"callback_exception\":" + quoted(callback_exception)
+        + ",\"callback_exception\":" + (quoted)(callback_exception)
         + ",\"scheduler_error_code\":" + (scheduled ? "null" : std::to_string(static_cast<int>(scheduled.error().code)))
         + ",\"safe_to_transfer_write_lease\":false}\n";
     write(dir / "scheduler.json", summary);

--- a/tests/native/collect_msvc_service_ownership.ps1
+++ b/tests/native/collect_msvc_service_ownership.ps1
@@ -64,17 +64,19 @@ function Assert-OwnershipObservation {
     if ($Observation.server_survived_A -isnot [bool] -or $Observation.B_compiler_overlap_observed -isnot [bool]) {
         throw 'Missing or mistyped liveness observation.'
     }
+    if ($Observation.scheduler_api_used -isnot [bool] -or
+        $Observation.scheduler_api_used -ne ($Ending -eq 'scheduler-drain')) { throw 'Wrong scheduler API identity.' }
     if ($Ending -eq 'cancel') {
         if ($Observation.A_exit -eq 0) { throw 'Cancelled A cannot report successful exit.' }
     } elseif ($Observation.A_exit -ne 0) { throw 'Original A control failed.' }
     if ($Observation.B0_exit -ne 0 -or $Observation.B1_exit -ne 0) {
         if ($Observation.B_link_exit -ne -2 -or $Observation.B_run_exit -ne -2) { throw 'Unattempted link/run must remain unattempted.' }
     } elseif ($Observation.B_link_exit -ne 0 -and $Observation.B_run_exit -ne -2) { throw 'Failed link cannot run an artifact.' }
-    if ($Ending -in @('unmanaged-normal', 'drain')) {
+    if ($Ending -in @('unmanaged-normal', 'drain', 'scheduler-drain')) {
         if (-not $Observation.server_survived_A -or $Observation.B0_exit -ne 0 -or $Observation.B1_exit -ne 0 -or
             $Observation.B_link_exit -ne 0 -or $Observation.B_run_exit -ne 0) { throw 'Original B control failed.' }
     }
-    if ($Ending -eq 'drain') {
+    if ($Ending -in @('drain', 'scheduler-drain')) {
         foreach ($field in @('drain_requested', 'A_compiler_overlap_observed', 'B_compiler_overlap_observed', 'A_observed_compilers_signaled')) {
             if ($Observation.$field -isnot [bool] -or -not $Observation.$field) { throw "Unproven drain boundary: $field" }
         }
@@ -106,7 +108,7 @@ function Get-OwnershipDiagnosticErrors {
         if ($Profile.StartsWith('pch-')) { $stems += "$directory/prefix" }
         if ($Profile.StartsWith('modules-')) { $stems += "$directory/provider" }
     }
-    if ($Ending -eq 'drain') { $stems += 'A/work0' }
+    if ($Ending -in @('drain', 'scheduler-drain')) { $stems += 'A/work0' }
     if ($null -ne $Observation -and $Observation.B0_exit -eq 0 -and $Observation.B1_exit -eq 0) {
         $stems += 'B/link'
         if ($Observation.B_link_exit -eq 0) { $stems += 'B/run' }
@@ -139,7 +141,7 @@ function Get-OwnershipDiagnosticErrors {
             if ($stem -match '/(warm|prefix|provider)$' -and $result.exit_code -ne 0) { throw 'Preparation control failed.' }
         } catch { "${stem}.result.json: $($_.Exception.Message)" }
     }
-    if ($Ending -eq 'drain') {
+    if ($Ending -in @('drain', 'scheduler-drain')) {
         try {
             $drain = Get-Content -LiteralPath (Join-Path $CaseRoot 'A/drain.json') -Raw | ConvertFrom-Json
             if ($drain.stop_observed -isnot [bool] -or -not $drain.stop_observed -or
@@ -148,8 +150,29 @@ function Get-OwnershipDiagnosticErrors {
                 if (($drain.($entry.Key) -isnot [int] -and $drain.($entry.Key) -isnot [long]) -or
                     $drain.($entry.Key) -ne $entry.Value) { throw 'Invalid original drain outcome.' }
             }
+            $first = Get-Content -LiteralPath (Join-Path $CaseRoot 'A/work0.result.json') -Raw | ConvertFrom-Json
+            if ($first.exit_code -ne $drain.first_compile_exit) { throw 'Original A compile disagrees with drain outcome.' }
             if (Test-Path -LiteralPath (Join-Path $CaseRoot 'A/work1.argv.txt')) { throw 'Pending A work was dispatched.' }
         } catch { "A/drain.json: $($_.Exception.Message)" }
+    }
+    if ($Ending -eq 'scheduler-drain') {
+        try {
+            $scheduler = Get-Content -LiteralPath (Join-Path $CaseRoot 'A/scheduler.json') -Raw | ConvertFrom-Json
+            if ($scheduler -isnot [pscustomobject] -or $scheduler.api -isnot [string] -or $scheduler.api -cne 'BoundedWorkScheduler::run_with_admission_stop') {
+                throw 'Wrong scheduler API record.'
+            }
+            foreach ($entry in @{ schema = 1; worker_count = 1; started_count = 1; bridge_wait_error = 0 }.GetEnumerator()) {
+                if (($scheduler.($entry.Key) -isnot [int] -and $scheduler.($entry.Key) -isnot [long]) -or
+                    $scheduler.($entry.Key) -ne $entry.Value) { throw 'Invalid scheduler or bridge outcome.' }
+            }
+            foreach ($field in @('scheduler_succeeded', 'stop_requested', 'admission_stop_observed',
+                'stopped_before_all_items', 'event_observed', 'forwarded_during_callback')) {
+                if ($scheduler.$field -isnot [bool] -or -not $scheduler.$field) { throw "Unproven scheduler boundary: $field" }
+            }
+            if ($scheduler.callback_exception -isnot [string] -or $scheduler.callback_exception.Length -ne 0 -or
+                $null -ne $scheduler.scheduler_error_code -or $scheduler.safe_to_transfer_write_lease -isnot [bool] -or
+                $scheduler.safe_to_transfer_write_lease) { throw 'Scheduler failure or invalid safety authorization.' }
+        } catch { "A/scheduler.json: $($_.Exception.Message)" }
     }
 }
 
@@ -236,7 +259,7 @@ try {
     $profiles = @('zi-debug', 'ZI-debug', 'zi-release', 'pch-debug', 'pch-release', 'modules-debug', 'modules-release')
     $origins = @('preexisting', 'A-started')
     $endings = @('unmanaged-normal', 'normal', 'cancel')
-    if ($EndpointMode -eq 'default') { $endings += 'drain' }
+    if ($EndpointMode -eq 'default') { $endings += @('drain', 'scheduler-drain') }
     $expectedCases = $profiles.Count * $origins.Count * $endings.Count
     $aborted = $false
     $rows = [System.Collections.Generic.List[object]]::new()

--- a/tests/native/verify_ownership_evidence_contract.ps1
+++ b/tests/native/verify_ownership_evidence_contract.ps1
@@ -35,6 +35,7 @@ function Write-Tool($Root, $Stem, [int]$Code = 0, [bool]$Cancelled = $false) {
 function New-Fixture([string]$Name, [string]$Mode, [string]$Profile, [string]$Origin, [string]$Ending) {
     $root = Join-Path $OutputRoot $Name
     New-Item -ItemType Directory -Path $root | Out-Null
+    $isDrain = $Ending -in @('drain', 'scheduler-drain')
     $observation = [pscustomobject]@{
         schema = 2; endpoint_mode = $Mode; profile = $Profile; origin = $Origin; ending = $Ending
         A_exit = $(if ($Ending -eq 'cancel') { 1223 } else { 0 })
@@ -42,9 +43,10 @@ function New-Fixture([string]$Name, [string]$Mode, [string]$Profile, [string]$Or
         lifecycle_ok = $true; unmanaged_control_ok = $true; drain_control_ok = $true
         safe_to_integrate_cancellation = $false; safe_to_transfer_write_lease = $false
         server_survived_A = $true; B_compiler_overlap_observed = $true
-        drain_requested = ($Ending -eq 'drain'); A_compiler_overlap_observed = ($Ending -eq 'drain')
-        A_observed_compilers_signaled = $(if ($Ending -eq 'drain') { $true } else { $null })
-        A_pending_compile_dispatched = $(if ($Ending -eq 'drain') { $false } else { $null })
+        scheduler_api_used = ($Ending -eq 'scheduler-drain')
+        drain_requested = $isDrain; A_compiler_overlap_observed = $isDrain
+        A_observed_compilers_signaled = $(if ($isDrain) { $true } else { $null })
+        A_pending_compile_dispatched = $(if ($isDrain) { $false } else { $null })
     }
     Write-Tool $root 'A' $observation.A_exit ($Ending -eq 'cancel')
     foreach ($stem in @('A/warm', 'B/warm', 'B/work0', 'B/work1', 'B/link', 'B/run', 'B/recovery')) { Write-Tool $root $stem }
@@ -54,11 +56,20 @@ function New-Fixture([string]$Name, [string]$Mode, [string]$Profile, [string]$Or
         if ($Profile.StartsWith('pch-')) { Write-Tool $root "$directory/prefix" }
         if ($Profile.StartsWith('modules-')) { Write-Tool $root "$directory/provider" }
     }
-    if ($Ending -eq 'drain') {
+    if ($isDrain) {
         Write-Tool $root 'A/work0'
         Write-Json (Join-Path $root 'A/drain.json') @{
             stop_observed = $true; work_compiles_dispatched = 1; first_compile_exit = 0
             pending_compile_exit = -2; safe_to_transfer_write_lease = $false
+        }
+    }
+    if ($Ending -eq 'scheduler-drain') {
+        Write-Json (Join-Path $root 'A/scheduler.json') @{
+            schema = 1; api = 'BoundedWorkScheduler::run_with_admission_stop'
+            scheduler_succeeded = $true; worker_count = 1; started_count = 1
+            stop_requested = $true; admission_stop_observed = $true; stopped_before_all_items = $true
+            event_observed = $true; forwarded_during_callback = $true; bridge_wait_error = 0
+            callback_exception = ''; scheduler_error_code = $null; safe_to_transfer_write_lease = $false
         }
     }
     return [pscustomobject]@{
@@ -96,7 +107,7 @@ foreach ($mode in @('private', 'default')) {
     foreach ($profile in @('zi-debug', 'ZI-debug', 'zi-release', 'pch-debug', 'pch-release', 'modules-debug', 'modules-release')) {
         foreach ($origin in @('preexisting', 'A-started')) {
             $endings = @('unmanaged-normal', 'normal', 'cancel')
-            if ($mode -eq 'default') { $endings += 'drain' }
+            if ($mode -eq 'default') { $endings += @('drain', 'scheduler-drain') }
             foreach ($ending in $endings) {
                 $label = if ($profile -ceq 'ZI-debug') { 'edit-continue-debug' } else { $profile }
                 Run-Case -Name "$mode-$label-$origin-$ending" -Mode $mode -Profile $profile -Origin $origin -Ending $ending
@@ -145,6 +156,24 @@ Run-Case 'adverse-managed-compile-retained' {
         }
     }
 } $true
+function Mutate-Scheduler($Fixture, [string]$Field, $Value) {
+    $path = Join-Path $Fixture.root 'A/scheduler.json'
+    $record = Get-Content -LiteralPath $path -Raw | ConvertFrom-Json
+    $record.$Field = $Value
+    Write-Json $path $record
+}
+Run-Case -Name 'scheduler-record-missing' -Ending scheduler-drain -ExpectAccepted $false -Mutate {
+    param($f) Remove-Item -LiteralPath (Join-Path $f.root 'A/scheduler.json')
+}
+Run-Case -Name 'scheduler-wrong-count' -Ending scheduler-drain -ExpectAccepted $false -Mutate { param($f) Mutate-Scheduler $f 'started_count' 2 }
+Run-Case -Name 'scheduler-wrong-api' -Ending scheduler-drain -ExpectAccepted $false -Mutate { param($f) Mutate-Scheduler $f 'api' 'direct-fixture' }
+Run-Case -Name 'scheduler-string-stop' -Ending scheduler-drain -ExpectAccepted $false -Mutate { param($f) Mutate-Scheduler $f 'admission_stop_observed' 'true' }
+Run-Case -Name 'scheduler-bridge-error' -Ending scheduler-drain -ExpectAccepted $false -Mutate { param($f) Mutate-Scheduler $f 'bridge_wait_error' 6 }
+Run-Case -Name 'scheduler-event-unseen' -Ending scheduler-drain -ExpectAccepted $false -Mutate { param($f) Mutate-Scheduler $f 'event_observed' $false }
+Run-Case -Name 'scheduler-stop-after-callback' -Ending scheduler-drain -ExpectAccepted $false -Mutate { param($f) Mutate-Scheduler $f 'forwarded_during_callback' $false }
+Run-Case -Name 'scheduler-callback-exception' -Ending scheduler-drain -ExpectAccepted $false -Mutate { param($f) Mutate-Scheduler $f 'callback_exception' 'retained original failure' }
+Run-Case -Name 'scheduler-failure' -Ending scheduler-drain -ExpectAccepted $false -Mutate { param($f) Mutate-Scheduler $f 'scheduler_succeeded' $false }
+Run-Case -Name 'scheduler-original-A-mismatch' -Ending scheduler-drain -ExpectAccepted $false -Mutate { param($f) Write-Tool $f.root 'A/work0' 1 }
 $failed = @($rows | Where-Object { -not $_.passed })
 Write-Host "OWNERSHIP_COLLECTOR_CONTRACT $($rows.Count) cases; $($failed.Count) failures (synthetic; no MSVC run)"
 if ($failed.Count -ne 0) { $failed | Format-List | Out-String | Write-Host; exit 1 }


### PR DESCRIPTION
## Final decision: accept test-only scheduler integration; retain historical runtime debts

[Final exact-source, complete execution, raw-artifact,19-rowABBA and limited-risk acceptance review](https://github.com/Iviesever/msvc-quick-build/pull/170#pullrequestreview-5161319605)

**Accept ordinary expected-head merge.** This explicitly revises #170's PR-level HOLD for the test integration only. The original +1.6946ms/+13.7988% performance crossing remains unexplained, and the historical C1041 is not fixed. All current mandatory gates pass; no current failed check is waived. #172 remains independently held, M1b incomplete, and production cancellation/lease/release acceptance remains separate.

## Exact source

- Base **`4fac6817748aabb77654e8ffad9c4f6ce206dcdd`** (#176).
- Reviewed head **`ffaa1a530a5a7766c5aeb443ca86fa034f2b8e93`**.
- Candidate/native test-merge tree **`e518e8b694df53cd45c72761f386f3b998ab3d2d`**.
- Test-merge **`21f2a4aa647009025d1e7ea7d025716aa0407f11`**, exact base/head parents.
- Head is an ordinary merge of previous #170 head283b507... and current main4fac681..., with explicit conflict resolution, not a history rewrite.
- Four test/CI files, **160 additions/14 deletions**.405of409main files remain byte-identical. Three nonconflicting files and the existing scheduler_drain helper are byte-identical to corrected old #170.
- Product src/include, scheduler implementation/callers, ProcessSpec, benchmark, manifest/native inventory, CLI/freshness and **VERSION5.5.0** unchanged. No historical tags/assets or formal release.

## Delivered integration and boundary

The actual `BoundedWorkScheduler::run_with_admission_stop(2,1,...)` fixture now coexists with all accepted #171–#176 evidence capabilities. Its bridge requests admission stop while the first callback is active; the already-started compiler naturally completes and the pending TU is not dispatched. B compiles/links/runs in its own output/PDB space against the same service. Neither compiler gets a terminating token. Callback/bridge/scheduler errors remain failures.

The default matrix keeps all original56cases and adds14scheduler-drain controls; private42 is unchanged. Existing observer/query/fault entry points stay direct-drain controls, with an explicit guard against mislabeling them as scheduler runs. No new observer or #172 code is introduced. Callback-active includes capture/diagnostics, not proof of RPC-in-flight; this remains one A worker/one active/one pending, not real multiworker or production CLI cancellation.

## Completed current combined-source validation

|Gate|Actual run|Result|
|---|---|---|
|Native Debug/all shards/freshness/runtime/parameters|#729/34418829397|Passed, actual execution|
|Complete Release/self-host/exact runtime-only package|#618/34418829374|Passed; publish-release skipped|
|Documentation/Cross-Stage/original PDB investigation|#179/34418829415;#206/34418829364;#9/34418829368|Passed|
|Ownership record contracts|Default#22/34418829373|150/150expectations:113accepted/37rejected; actual collector hash checked|
|Original and real scheduler matrix|Default#22/34418829373|70/70complete,14scheduler+14direct references and required unmanaged controls pass|
|Private matrix|#24/34418829380|42/42complete; required positive controls pass|
|Accepted trace/invocation/query/fault capabilities|Event#12/34418829379|187record expectations, all five retained studies and native refusal controls pass|
|Independent observer-OFF ABBA|#587/34418867045|76pairs measured/recomputed;72complete instrumented semantic identities match|

Each of14scheduler records was checked against the actual API summary, original A/work0 result, no pending dispatch, real A/B overlap, A retained-handle completion, service survival and original B compile/link/run0. The14reference pairs match56source files and70argv records after only directory normalization. Seven native helper checks and both refusal outputs are retained. Green summary alone was not used as proof.

The five accepted studies were replayed using the exact published auditors. They retain28calibrated traces+4untraced workloads, five native missing-readiness controls,308tool results/616diagnostics and23ambiguous invocation intervals. Two separately injected cold-B originals still produce C1041/exit2 with retained-service sharing failures; their recovery0 is not substituted for the first failure. These injections are not historical reproduction or scheduler failure-propagation evidence. Actual observer input binaries match all five provenance records, but are not the ABBA executable pair.

Original default/private matrices preserve two/zero adverse managed-policy B failures in this batch. Default /ZI A-started cancel(C1083/C2471) and PCH Release A-started normal(C1090) retain original exit2 and unattempted link/run; recovery does not replace them. All28A-started managed endings still kill the original service.719/417tool results and1438/834diagnostic files were checked. Sparse owner snapshots are not a no-writer certificate.

## Performance and historical-risk disposition

[Scope, original gates and risk policy declared before this measurement](https://github.com/Iviesever/msvc-quick-build/pull/170#issuecomment-5610284651)

Current external timings-off no-op paired median **+0.0995ms/+0.8877037%**, maximum adverse+2.512ms,2/4slower: unchanged gate **worse by BOTH>1ms AND>10%** not crossed. Preserve discovery-cold+3104.250ms,4/4slower scale-j1 and scale-single-TU, and every other favorable/adverse sample in the full review. No speedup/zero-overhead claim, noise deletion, AA subtraction or historical debt closure. Four external counter sets are unavailable, not zeros; only that row uses external elapsed; four-pairP95 is a maximum.

Both original #170 raw ABBA ZIPs were recomputed again: f52 still crosses the original gate,283b remains below it. The ADL compile correction and later smaller medians do not explain that crossing. #171's accepted fixedAA/AB study and archived runtime images are additional later evidence, not reconstruction of missing historical traces. #176's cold-file injection does not explain historical warm/concurrent C1041. All those debts remain open for production/release acceptance.

**This is limited acceptance of test-only integration, not fulfillment of historical root-cause requirements.** Current correctness/performance requirements were not lowered. Original positive controls remain enabled; future failures still block their relevant gates. No same-head native/CI/benchmark retry was requested. #586 was a skipped synchronize trigger, not another measured batch; actual#587 supplies this comparison.

## Handoff and retained evidence

Next separate iteration: typed original-failure/cancellation propagation and real multiworker scheduling. A failed compiler must not become cancellation success or permit downstream link/cache publication. This is not implemented or authorized by the present fixture. External-writer authority, single-writer project transactions, build/run separation, sessions/residency and final VERSION/release remain dependent gates. #172 is not approved here.

Delivery retains12current coreZIPs and4unmodified historicalABBA/build-failureZIPs, exact source archives, patch, manifests and replayable read-only audits. Not every Actions artifact is included. Retention30days; generated compiler binary bodies are excluded from diagnosticZIPs and finite hash inventories are post-case, not failure-time snapshots. The Python auditor checks the accepted decoded ETL stream, not a second binary ETL decoder. No local MSVC/PowerShell/ETW execution is claimed.

Local cross-platform audit development initially compared randomized temporary-path error strings too strictly; the two exact ENOENT cases retain both raw errors and require the same relative filename and all other fields. No source/native evidence/CI outcome changed. A bad unreferenced transcription blob was rejected before committing; only verified probe blob1ad20d94... entered the source tree. Title changed only after actual#587 completed; later skipped perf jobs and post-merge push CI are not substituted for completed exact-tree validation.