### PR TITLE
test: attribute link-cache save work to nested subspans

### DIFF
--- a/.github/workflows/link-cache-subspans.yml
+++ b/.github/workflows/link-cache-subspans.yml
@@ -1,0 +1,92 @@
+name: Link Cache Write Subspan Evidence
+
+on:
+  pull_request:
+    paths:
+      - 'cpp/include/mqb/core/PerformanceEvidence.hpp'
+      - 'cpp/src/core/cache/LinkCacheFile.cpp'
+      - 'cpp/src/app/diagnostics/PerformanceTimings.cpp'
+      - 'cpp/tests/core/cache/link_cache_file_tests.cpp'
+      - 'tests/native/collect_link_cache_subspans.ps1'
+      - '.github/workflows/link-cache-subspans.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: link-cache-subspans-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  contract:
+    name: Link cache subspan evidence contracts
+    runs-on: windows-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Validate positive and damaged subspan records
+        shell: pwsh
+        run: |
+          & ./tests/native/collect_link_cache_subspans.ps1 -SelfTest `
+            -OutputRoot (Join-Path $PWD '.mqb/link-cache-subspan-contracts')
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: link-cache-subspan-contracts
+          path: .mqb/link-cache-subspan-contracts/**
+          include-hidden-files: true
+          if-no-files-found: warn
+          retention-days: 30
+
+  study:
+    name: Fixed eight-report link cache subspan study
+    needs: contract
+    runs-on: windows-latest
+    timeout-minutes: 35
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+      - name: Preserve source and build exact candidate with MQB
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $root = Join-Path $PWD 'native-out/link-cache-subspans'
+          New-Item -ItemType Directory -Path $root -Force | Out-Null
+          & git archive --format=zip --output="$root/head-source.zip" HEAD
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          & git archive --format=zip --output="$root/base-source.zip" c8c8c0172850ff11351b63d5bd1507a7f57ac01e
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          Start-Transcript -LiteralPath (Join-Path $root 'build-transcript.txt') | Out-Null
+          try {
+              $seed = & ./tests/native/acquire_seed.ps1 -RepoRoot $PWD -OutputRoot (Join-Path $PWD 'native-seed')
+              if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+              $mqb = & ./tests/native/build_mqb.ps1 -BuilderMqbPath $seed -RepoRoot $PWD `
+                -Version '5.5.0' -Configuration Release -Clean -OutputPath (Join-Path $root 'mqb.exe')
+              if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+              @{ head = (& git rev-parse HEAD).Trim(); version = '5.5.0'; configuration = 'Release'
+                 binary_sha256 = (Get-FileHash -LiteralPath $mqb).Hash
+                 seed_sha256 = (Get-FileHash -LiteralPath $seed).Hash
+              } | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $root 'build-identity.json') -Encoding utf8
+          } finally { Stop-Transcript | Out-Null }
+      - name: Run declared four same-binary pairs without adaptive retries
+        shell: pwsh
+        run: |
+          & ./tests/native/collect_link_cache_subspans.ps1 `
+            -MqbPath (Join-Path $PWD 'native-out/link-cache-subspans/mqb.exe') -RepoRoot $PWD `
+            -OutputRoot (Join-Path $PWD 'native-out/link-cache-subspans/study')
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: link-cache-subspan-evidence
+          path: native-out/link-cache-subspans/**
+          include-hidden-files: true
+          if-no-files-found: warn
+          retention-days: 30

--- a/cpp/include/mqb/core/PerformanceEvidence.hpp
+++ b/cpp/include/mqb/core/PerformanceEvidence.hpp
@@ -54,6 +54,15 @@ enum class WorkKind : std::size_t {
     // Inclusive target preamble/result reporting, including formatting and
     // nested stream writes. Not additive with WallKind::reporting.
     target_reporting,
+    // Nested diagnostic work, not additional wall time. Serialize/prepare/
+    // stream/install are disjoint children of link_cache_write. Payload/flush
+    // are nested within stream, which also includes open, close and errors.
+    link_cache_serialize,
+    link_cache_prepare,
+    link_cache_stream,
+    link_cache_write_payload,
+    link_cache_flush,
+    link_cache_install,
     count,
 };
 

--- a/cpp/src/app/diagnostics/PerformanceTimings.cpp
+++ b/cpp/src/app/diagnostics/PerformanceTimings.cpp
@@ -51,7 +51,15 @@ constexpr std::array<std::string_view, mqb::performance::work_kind_count> work_n
     "filesystem_snapshot_module_scan",
     "filesystem_snapshot_other",
     "target_reporting",
+    "link_cache_serialize",
+    "link_cache_prepare",
+    "link_cache_stream",
+    "link_cache_write_payload",
+    "link_cache_flush",
+    "link_cache_install",
 };
+static_assert(std::all_of(work_names.begin(), work_names.end(),
+    [](const std::string_view name) { return !name.empty(); }));
 
 constexpr std::array<std::string_view, mqb::performance::cache_kind_count> cache_names{
     "compile",

--- a/cpp/src/core/cache/LinkCacheFile.cpp
+++ b/cpp/src/core/cache/LinkCacheFile.cpp
@@ -416,11 +416,17 @@ LinkCacheFile::load(const fs::path& file) {
 
 std::expected<void, LinkCacheFileError>
 LinkCacheFile::save(const fs::path& file, const LinkCacheEntry& entry) {
+    using mqb::performance::ScopedWork;
+    using mqb::performance::WorkKind;
     mqb::performance::ScopedCacheWrite evidence{
         mqb::performance::CacheKind::link};
-    auto bytes = serialize(file, entry);
+    auto bytes = [&] {
+        ScopedWork serialize_evidence{WorkKind::link_cache_serialize};
+        return serialize(file, entry);
+    }();
     if (!bytes) return std::unexpected(bytes.error());
 
+    ScopedWork prepare_evidence{WorkKind::link_cache_prepare};
     std::error_code error_code;
     if (!file.parent_path().empty()) {
         fs::create_directories(file.parent_path(), error_code);
@@ -431,7 +437,11 @@ LinkCacheFile::save(const fs::path& file, const LinkCacheEntry& entry) {
     }
 
     const fs::path temporary = temporary_path_for(file);
+    prepare_evidence.finish();
     {
+        // Declare before stream so this interval includes its implicit close.
+        // Payload and flush below are nested, not additional elapsed time.
+        ScopedWork stream_evidence{WorkKind::link_cache_stream};
         std::ofstream stream{temporary, std::ios::binary | std::ios::trunc};
         if (!stream) {
             return std::unexpected(make_error(
@@ -441,12 +451,19 @@ LinkCacheFile::save(const fs::path& file, const LinkCacheEntry& entry) {
                 "failed to open temporary link cache file"));
         }
         evidence.opened(static_cast<std::uint64_t>(bytes->size()));
-        if (!bytes->empty()) {
-            stream.write(
-                reinterpret_cast<const char*>(bytes->data()),
-                static_cast<std::streamsize>(bytes->size()));
+        {
+            ScopedWork payload_evidence{WorkKind::link_cache_write_payload};
+            if (!bytes->empty()) {
+                stream.write(
+                    reinterpret_cast<const char*>(bytes->data()),
+                    static_cast<std::streamsize>(bytes->size()));
+            }
         }
-        stream.flush();
+        {
+            // C++ stream flush is not a durable-storage or lease certificate.
+            ScopedWork flush_evidence{WorkKind::link_cache_flush};
+            stream.flush();
+        }
         if (!stream) {
             stream.close();
             fs::remove(temporary, error_code);
@@ -458,6 +475,8 @@ LinkCacheFile::save(const fs::path& file, const LinkCacheEntry& entry) {
         }
     }
 
+    // Includes the unchanged exists/remove/rename and failure cleanup paths.
+    ScopedWork install_evidence{WorkKind::link_cache_install};
     if (fs::exists(file, error_code) && !error_code) {
         fs::remove(file, error_code);
         if (error_code) {

--- a/cpp/tests/core/cache/link_cache_file_tests.cpp
+++ b/cpp/tests/core/cache/link_cache_file_tests.cpp
@@ -1,7 +1,9 @@
+#include <array>
 #include <chrono>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <iterator>
 #include <string>
 #include <string_view>
 #include <system_error>
@@ -12,6 +14,7 @@
 #include "mqb/core/LinkCacheFile.hpp"
 #include "mqb/core/LinkOptions.hpp"
 #include "mqb/core/LinkerIdentity.hpp"
+#include "mqb/core/PerformanceEvidence.hpp"
 
 namespace {
 
@@ -32,6 +35,126 @@ struct TempTree {
         fs::remove_all(root, ignored);
     }
 };
+
+using Work = mqb::performance::WorkKind;
+using Evidence = mqb::performance::EvidenceSnapshot;
+constexpr std::array children{
+    Work::link_cache_serialize, Work::link_cache_prepare,
+    Work::link_cache_stream, Work::link_cache_install};
+constexpr std::size_t link_index = static_cast<std::size_t>(mqb::performance::CacheKind::link);
+
+std::chrono::nanoseconds work(const Evidence& evidence, const Work kind) {
+    return evidence.work[static_cast<std::size_t>(kind)];
+}
+
+void check_subspans(const Evidence& evidence) {
+    std::chrono::nanoseconds disjoint{};
+    for (const auto child : children) {
+        expect(work(evidence, child).count() >= 0, "subspan duration cannot be negative");
+        disjoint += work(evidence, child);
+    }
+    expect(disjoint <= work(evidence, Work::link_cache_write),
+           "disjoint save children must fit inside the inclusive save interval");
+    expect(work(evidence, Work::link_cache_write_payload) + work(evidence, Work::link_cache_flush)
+               <= work(evidence, Work::link_cache_stream),
+           "payload and flush are nested in stream, not additive wall time");
+}
+
+std::string file_bytes(const fs::path& file) {
+    std::ifstream stream{file, std::ios::binary};
+    expect(bool(stream), "comparison file must be readable");
+    return {std::istreambuf_iterator<char>{stream}, std::istreambuf_iterator<char>{}};
+}
+
+void test_save_evidence(const fs::path& root, const mqb::LinkCacheEntry& entry) {
+    using mqb::performance::Activation;
+    using mqb::performance::Collector;
+    const auto plain_file = root / "plain.linkcache";
+    Collector inactive;
+    const auto plain = mqb::LinkCacheFile::save(plain_file, entry);
+    expect(plain.has_value(), "unobserved save succeeds");
+    const auto plain_bytes = file_bytes(plain_file);
+    expect(!plain_bytes.empty(), "comparison is not two absent files");
+    expect(inactive.snapshot().cache_files_written[link_index] == 0,
+           "inactive collector must not receive writes");
+    for (const auto child : children) {
+        expect(work(inactive.snapshot(), child).count() == 0, "inactive subspans stay zero");
+    }
+
+    Collector observed;
+    const auto observed_file = root / "observed.linkcache";
+    {
+        Activation activation{observed};
+        expect(mqb::LinkCacheFile::save(observed_file, entry).has_value(), "observed create succeeds");
+        expect(mqb::LinkCacheFile::save(observed_file, entry).has_value(), "observed replacement succeeds");
+    }
+    const auto snapshot = observed.snapshot();
+    check_subspans(snapshot);
+    expect(file_bytes(observed_file) == plain_bytes, "observation preserves exact cache format bytes");
+    expect(snapshot.cache_files_written[link_index] == 2, "nested scopes do not double count writes");
+    expect(snapshot.cache_bytes_written[link_index] == 2 * plain_bytes.size(),
+           "nested scopes do not double count payload bytes");
+    expect(work(snapshot, Work::link_cache_stream).count() > 0, "actual stream lifetime is observed");
+    const auto loaded = mqb::LinkCacheFile::load(observed_file);
+    expect(loaded && loaded->has_value(), "observed cache remains loadable");
+
+    auto oversized = entry;
+    oversized.linker.version.assign(4u * 1024u * 1024u + 1u, 'x');
+    Collector rejected;
+    const auto invalid_file = root / "invalid.linkcache";
+    {
+        Activation activation{rejected};
+        const auto result = mqb::LinkCacheFile::save(invalid_file, oversized);
+        expect(!result && result.error().code == mqb::LinkCacheFileErrorCode::file_write_failed,
+               "serialization retains its original error category");
+    }
+    check_subspans(rejected.snapshot());
+    expect(!fs::exists(invalid_file), "serialization failure must not install a cache");
+    for (const auto child : {Work::link_cache_prepare, Work::link_cache_stream,
+                             Work::link_cache_write_payload, Work::link_cache_flush, Work::link_cache_install}) {
+        expect(work(rejected.snapshot(), child).count() == 0, "unreached phases are not invented");
+    }
+    expect(rejected.snapshot().cache_files_written[link_index] == 0, "serialization failure writes nothing");
+
+    const auto blocker = root / "not-a-directory";
+    { std::ofstream stream{blocker}; stream << "keep"; }
+    Collector preparation;
+    {
+        Activation activation{preparation};
+        const auto result = mqb::LinkCacheFile::save(blocker / "cache", entry);
+        expect(!result && result.error().code == mqb::LinkCacheFileErrorCode::file_write_failed,
+               "directory failure retains its original error category");
+    }
+    check_subspans(preparation.snapshot());
+    expect(preparation.snapshot().cache_files_written[link_index] == 0, "directory failure writes nothing");
+    expect(work(preparation.snapshot(), Work::link_cache_stream).count() == 0 &&
+           work(preparation.snapshot(), Work::link_cache_install).count() == 0,
+           "directory failure never enters stream or install");
+    expect(file_bytes(blocker) == "keep", "directory failure does not damage blocking file");
+
+    const auto directory = root / "nonempty.linkcache";
+    fs::create_directories(directory);
+    { std::ofstream stream{directory / "keep.txt"}; stream << "untouched"; }
+    const auto unobserved_error = mqb::LinkCacheFile::save(directory, entry);
+    Collector installation;
+    {
+        Activation activation{installation};
+        const auto result = mqb::LinkCacheFile::save(directory, entry);
+        expect(!result && !unobserved_error &&
+               result.error().code == mqb::LinkCacheFileErrorCode::replace_failed &&
+               result.error().message == unobserved_error.error().message &&
+               result.error().file == unobserved_error.error().file,
+               "observed install failure preserves original diagnostics and identity");
+    }
+    check_subspans(installation.snapshot());
+    expect(installation.snapshot().cache_files_written[link_index] == 1,
+           "failed install still records the actual temporary write");
+    expect(file_bytes(directory / "keep.txt") == "untouched", "failed install preserves destination contents");
+    for (const auto& item : fs::directory_iterator(root)) {
+        expect(!item.path().filename().string().starts_with("nonempty.linkcache.tmp."),
+               "failed install retains original temporary-file cleanup");
+    }
+}
 
 } // namespace
 
@@ -68,6 +191,7 @@ int main() {
         .file_inputs = file_inputs,
         .side_outputs = side_outputs,
     };
+    test_save_evidence(tree.root, entry);
 
     const fs::path file = tree.root / "cache" / "plugin.linkcache";
     const auto missing = mqb::LinkCacheFile::load(file);

--- a/tests/native/collect_link_cache_subspans.ps1
+++ b/tests/native/collect_link_cache_subspans.ps1
@@ -23,7 +23,8 @@ function Assert-LinkCacheSubspans {
             -not [double]::IsFinite([double]$Work.$field) -or $Work.$field -lt 0) { throw "Invalid work interval: $field" }
         if ($NoSave -and $Work.$field -ne 0) { throw 'A no-save invocation cannot invent write work.' }
     }
-    //PLACEHOLDER
+    # Each public JSON duration is independently rounded to 0.001 ms. These are
+    # serialization tolerances, NOT performance acceptance/noise allowances.
     $disjoint = $Work.link_cache_serialize + $Work.link_cache_prepare + $Work.link_cache_stream + $Work.link_cache_install
     if ($disjoint -gt $Work.link_cache_write + 0.005) { throw 'Save children exceed inclusive save.' }
     if ($Work.link_cache_write_payload + $Work.link_cache_flush -gt $Work.link_cache_stream + 0.003) {

--- a/tests/native/collect_link_cache_subspans.ps1
+++ b/tests/native/collect_link_cache_subspans.ps1
@@ -1,0 +1,168 @@
+[CmdletBinding(DefaultParameterSetName = 'Study')]
+param(
+    [Parameter(Mandatory, ParameterSetName = 'Study')][string]$MqbPath,
+    [Parameter(Mandatory, ParameterSetName = 'Contract')][switch]$SelfTest,
+    [Parameter(Mandatory)][string]$OutputRoot,
+    [string]$RepoRoot = (Join-Path $PSScriptRoot '../..')
+)
+$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+Set-StrictMode -Version 2.0
+$OutputRoot = [IO.Path]::GetFullPath($OutputRoot)
+$RepoRoot = [IO.Path]::GetFullPath($RepoRoot)
+if (Test-Path -LiteralPath $OutputRoot) { throw 'Refusing to overwrite complete or partial evidence.' }
+New-Item -ItemType Directory -Path $OutputRoot -Force | Out-Null
+$names = @('link_cache_serialize', 'link_cache_prepare', 'link_cache_stream',
+    'link_cache_write_payload', 'link_cache_flush', 'link_cache_install')
+function Assert-LinkCacheSubspans {
+    param($Work, [bool]$NoSave)
+    $fields = @('link_cache_write', 'link_cache_serialize', 'link_cache_prepare', 'link_cache_stream',
+        'link_cache_write_payload', 'link_cache_flush', 'link_cache_install')
+    foreach ($field in $fields) {
+        if (($Work.$field -isnot [double] -and $Work.$field -isnot [int] -and $Work.$field -isnot [long]) -or
+            -not [double]::IsFinite([double]$Work.$field) -or $Work.$field -lt 0) { throw "Invalid work interval: $field" }
+        if ($NoSave -and $Work.$field -ne 0) { throw 'A no-save invocation cannot invent write work.' }
+    }
+    //PLACEHOLDER
+    $disjoint = $Work.link_cache_serialize + $Work.link_cache_prepare + $Work.link_cache_stream + $Work.link_cache_install
+    if ($disjoint -gt $Work.link_cache_write + 0.005) { throw 'Save children exceed inclusive save.' }
+    if ($Work.link_cache_write_payload + $Work.link_cache_flush -gt $Work.link_cache_stream + 0.003) {
+        throw 'Nested payload/flush exceed their stream parent.'
+    }
+}
+if ($SelfTest) {
+    $cases = @(
+        @{ name = 'valid-nested'; accept = $true; change = {} },
+        @{ name = 'valid-zero'; accept = $true; no_save = $true; change = { param($w) foreach($p in @($w.PSObject.Properties)){ $w.($p.Name) = 0 } } },
+        @{ name = 'missing-phase'; accept = $false; change = { param($w) $w.PSObject.Properties.Remove('link_cache_flush') } },
+        @{ name = 'negative'; accept = $false; change = { param($w) $w.link_cache_prepare = -1 } },
+        @{ name = 'string'; accept = $false; change = { param($w) $w.link_cache_flush = '4' } },
+        @{ name = 'nonfinite'; accept = $false; change = { param($w) $w.link_cache_flush = [double]::PositiveInfinity } },
+        @{ name = 'parent-too-small'; accept = $false; change = { param($w) $w.link_cache_write = 10 } },
+        @{ name = 'nested-too-large'; accept = $false; change = { param($w) $w.link_cache_flush = 11 } },
+        @{ name = 'no-save-with-work'; accept = $false; no_save = $true; change = {} }
+    )
+    $results = @(foreach ($case in $cases) {
+        $work = [pscustomobject]@{ link_cache_write = 20; link_cache_serialize = 1; link_cache_prepare = 2
+            link_cache_stream = 10; link_cache_write_payload = 3; link_cache_flush = 4; link_cache_install = 5 }
+        & $case.change $work
+        $errorText = $null
+        try { Assert-LinkCacheSubspans $work ($case.ContainsKey('no_save') -and $case.no_save) }
+        catch { $errorText = $_.Exception.Message }
+        [pscustomobject]@{ name = $case.name; expected_accepted = $case.accept; accepted = ($null -eq $errorText)
+            passed = (($null -eq $errorText) -eq $case.accept); error = $errorText }
+    })
+    @{ synthetic_only = $true; cases = $results } | ConvertTo-Json -Depth 6 |
+        Set-Content -LiteralPath (Join-Path $OutputRoot 'contracts.json') -Encoding utf8
+    if (@($results | Where-Object { -not $_.passed }).Count) { throw 'Subspan contract test failed.' }
+    Write-Host "LINK_CACHE_SUBSPAN_CONTRACT $($results.Count) checks passed (synthetic)"
+    return
+}
+# Reuse #171's actual clock and semantic validators, without executing its study.
+$collectorPath = Join-Path $PSScriptRoot 'collect_benchmark_attribution.ps1'
+$tokens = $null; $parseErrors = $null
+$ast = [Management.Automation.Language.Parser]::ParseFile($collectorPath, [ref]$tokens, [ref]$parseErrors)
+if (@($parseErrors).Count) { throw 'Attribution collector parse failure.' }
+foreach ($name in @('Assert-AttributionInvocation', 'Assert-AttributionSemantics', 'Get-AttributionMedian', 'Get-AttributionStatistics')) {
+    $defs = @($ast.FindAll({param($node) $node -is [Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -ceq $name}, $true))
+    if ($defs.Count -ne 1) { throw "Missing or duplicated existing validator: $name" }
+    . ([scriptblock]::Create($defs[0].Extent.Text))
+}
+$MqbPath = [IO.Path]::GetFullPath($MqbPath)
+$hash = (Get-FileHash -LiteralPath $MqbPath -Algorithm SHA256).Hash
+$head = (& git -C $RepoRoot rev-parse HEAD).Trim()
+if ($LASTEXITCODE -ne 0) { throw 'Source head unavailable.' }
+if ((Get-Content -LiteralPath (Join-Path $RepoRoot 'VERSION') -Raw).Trim() -cne '5.5.0') { throw 'VERSION changed.' }
+$benchmark = Join-Path $PSScriptRoot 'benchmark_mqb.ps1'
+Copy-Item -LiteralPath $MqbPath -Destination (Join-Path $OutputRoot 'measured-mqb.exe')
+Copy-Item -LiteralPath $benchmark -Destination (Join-Path $OutputRoot 'measured-harness.ps1')
+@{ schema = 1; head = $head; binary_sha256 = $hash; binary_path = $MqbPath
+    harness_sha256 = (Get-FileHash -LiteralPath $benchmark).Hash; version = '5.5.0'
+    runner_image = $env:ImageVersion; powershell = $PSVersionTable.PSVersion.ToString()
+    os = [Runtime.InteropServices.RuntimeInformation]::OSDescription; processors = [Environment]::ProcessorCount
+    github_run_id = $env:GITHUB_RUN_ID; run_attempt = $env:GITHUB_RUN_ATTEMPT
+} | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath (Join-Path $OutputRoot 'identity.json') -Encoding utf8
+$plan = @(foreach ($pair in 1..4) {
+    $sides = if ($pair % 2 -eq 1) { @('left', 'right') } else { @('right', 'left') }
+    foreach ($side in $sides) { [pscustomobject]@{ pair = $pair; side = $side; id = ('{0:D2}-{1}' -f $pair,$side) } }
+})
+@{ schema = 1; reports = 8; invocations = 168; runtime = 'same path and bytes on both AA sides'
+    plan = $plan; no_adaptive_retries = $true; historical_cause_resolved = $false; authorizes_merge = $false
+} | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath (Join-Path $OutputRoot 'plan.json') -Encoding utf8
+$required = @('cold','no-op','single-tu','public-header','build-run','link-only','target-scale-cold',
+    'target-scale-no-op','target-scale-no-op-auto','target-scale-no-op-j1','target-scale-common-header-no-op',
+    'target-scale-single-tu','discovery-cold','discovery-no-op','discovery-header','modules-cold','modules-no-op',
+    'timings-enabled-no-op','timings-disabled-no-op')
+$reports = @{}; $records = @{}; $completed = [Collections.Generic.List[string]]::new()
+$subspans = [Collections.Generic.List[object]]::new(); $current = $null
+try {
+    foreach ($slot in $plan) {
+        $current = $slot.id; $slotRoot = Join-Path $OutputRoot $slot.id
+        New-Item -ItemType Directory -Path $slotRoot | Out-Null
+        & $benchmark -MqbPath $MqbPath -Iterations 1 -OutputPath (Join-Path $slotRoot 'report.json') `
+            -InvocationEvidenceDirectory (Join-Path $slotRoot 'invocations') *> (Join-Path $slotRoot 'harness.log')
+        $report = Get-Content -LiteralPath (Join-Path $slotRoot 'report.json') -Raw | ConvertFrom-Json
+        if ($report.samples.Count -ne 19 -or $report.iterations -ne 1) { throw 'Incomplete fixture report.' }
+        $invocations = @(Get-ChildItem -LiteralPath (Join-Path $slotRoot 'invocations') -File -Filter '*.json' |
+            Where-Object { $_.Name -notlike '*.started.json' })
+        if ($invocations.Count -ne 21) { throw 'Expected 19 measurements and two primes.' }
+        foreach ($scenario in ($required + @('timings-prime','target-scale-common-header-prime'))) {
+            $record = Get-Content -LiteralPath (Join-Path $slotRoot "invocations/1-$scenario.json") -Raw | ConvertFrom-Json
+            Assert-AttributionInvocation $record $scenario $MqbPath
+            $records["$current/$scenario"] = $record
+        }
+        foreach ($scenario in $required) {
+            $sample = @($report.samples | Where-Object { $_.scenario -ceq $scenario })
+            if ($sample.Count -ne 1) { throw 'Missing or duplicate scenario.' }
+            $record = $records["$current/$scenario"]
+            if ($scenario -eq 'timings-disabled-no-op') {
+                if ($sample[0].total_ms -ne $record.external_ms -or '--timings=json' -in $record.argv) { throw 'External clock mismatch.' }
+                continue
+            }
+            $lines = @($record.output_lines | Where-Object { $_ -like '{"type":"mqb.timings"*' })
+            if ($lines.Count -ne 1 -or '--timings=json' -notin $record.argv) { throw 'Original timing record missing.' }
+            $timing = $lines[0] | ConvertFrom-Json
+            if ($timing.phases.total -ne $sample[0].total_ms) { throw 'Internal clock mismatch.' }
+            $work = $timing.attribution.work
+            Assert-LinkCacheSubspans $work ($sample[0].link_misses -eq 0)
+            foreach ($field in $names) {
+                if ($sample[0].attribution.work.$field -ne $work.$field) { throw 'Original subspan/report mismatch.' }
+            }
+            $subspans.Add([pscustomobject]@{ slot = $current; scenario = $scenario; work = $work
+                link_cache_writes = $timing.counter_breakdown.cache.link.files_written
+                external_ms = $record.external_ms; internal_ms = $timing.phases.total })
+        }
+        $reports[$current] = $report; $completed.Add($current)
+        @{ complete = $false; completed = @($completed.ToArray()); current = $null } | ConvertTo-Json -Depth 6 |
+            Set-Content -LiteralPath (Join-Path $OutputRoot 'progress.json') -Encoding utf8
+    }
+    $current = $null; $pairs = [Collections.Generic.List[object]]::new()
+    foreach ($pair in 1..4) {
+        $leftId = '{0:D2}-left' -f $pair; $rightId = '{0:D2}-right' -f $pair
+        foreach ($scenario in $required) {
+            $left = @($reports[$leftId].samples | Where-Object { $_.scenario -ceq $scenario })[0]
+            $right = @($reports[$rightId].samples | Where-Object { $_.scenario -ceq $scenario })[0]
+            Assert-AttributionSemantics $left $right ($scenario -ne 'timings-disabled-no-op')
+            $pairs.Add([pscustomobject]@{ pair = $pair; scenario = $scenario
+                left_external_ms = $records["$leftId/$scenario"].external_ms
+                right_external_ms = $records["$rightId/$scenario"].external_ms })
+        }
+    }
+    if ((Get-FileHash -LiteralPath $MqbPath).Hash -cne $hash) { throw 'Measured binary changed.' }
+    if ($subspans.Count -ne 144) { throw 'Incomplete instrumented subspan population.' }
+    $statistics = @(foreach ($scenario in $required) {
+        [pscustomobject]@{ scenario = $scenario; external = (Get-AttributionStatistics @($pairs | Where-Object { $_.scenario -ceq $scenario })) }
+    })
+    @{ complete = $true; subspans = @($subspans.ToArray()); pairs = @($pairs.ToArray()); statistics = $statistics
+        historical_cause_resolved = $false; authorizes_merge = $false
+        limitation = 'Nested cumulative work, not syscall/CPU/disk/ETW or durable-write evidence. The observer can perturb timings.'
+    } | ConvertTo-Json -Depth 12 | Set-Content -LiteralPath (Join-Path $OutputRoot 'comparison.json') -Encoding utf8
+    @{ complete = $true; completed = @($completed.ToArray()) } | ConvertTo-Json -Depth 6 |
+        Set-Content -LiteralPath (Join-Path $OutputRoot 'progress.json') -Encoding utf8
+    Write-Host 'Completed fixed 8 reports / 168 invocations / 144 instrumented subspan records.'
+} catch {
+    @{ complete = $false; completed = @($completed.ToArray()); failed_slot = $current; error = $_.ToString()
+        not_attempted = @($plan.id | Where-Object { $_ -notin $completed -and $_ -ne $current })
+    } | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath (Join-Path $OutputRoot 'progress.json') -Encoding utf8
+    throw
+}


### PR DESCRIPTION
## Decision: HOLD — real default-endpoint drain control failed

[Final exact-source, native execution, full19-rowABBA, raw-artifact review and HOLD decision](https://github.com/Iviesever/msvc-quick-build/pull/172#pullrequestreview-5149537042)

[Blocking C1041 failure with original compiler argv/results](https://github.com/Iviesever/msvc-quick-build/pull/172#issuecomment-5595470311)

**Keep this PR Draft and unmerged.** The new subspan diagnostic study, native tests and independent ABBA completed, but the predeclared requirement that every real default drain control pass is unmet. #170 remains independently Draft/HOLD. Neither PR is approved by this instrumentation.

## Exact source and scope

- Base **`c8c8c0172850ff11351b63d5bd1507a7f57ac01e`**, merged #171.
- Reviewed head **`6386cc2be1207c25692e96c1fe160755f6271edc`**.
- Candidate/native test-merge tree **`14ed3d293e64593e3b213cccb57067df59f6bc2b`**.
- Native test-merge **`fd769b90b9ad80c4af1f5978603486c47a55d062`**, with exactly those parents.
- Six files, **429 additions/8 deletions**. Product changes are diagnostic instrumentation in the existing collector, renderer and LinkCacheFile::save, not a test-only source diff.
- **VERSION5.5.0 unchanged. No historical tag/asset or formal Release changes.** No CLI, cache-format, file-operation ordering, manifest, native executable inventory or freshness change.

## Delivered diagnostic contract

Four disjoint child scopes within inclusive `link_cache_write`: serialization, directory/temporary-path preparation, complete stream lifetime, and installation/replacement. Payload write and flush are nested within stream. The stream interval includes implicit close and original failure cleanup; installation includes unchanged exists/remove/rename/error cleanup. Do not add nested work again as wall elapsed, label flush as durable storage, or infer a disk/antivirus/OS cause from these aggregate scopes.

The six enum/name entries append to existing fields. Existing cache counts, file format and errors are preserved; new JSON work fields are additive. Inactive scope guards take no new clock readings, but guard/collector overhead remains possible and was measured separately. No zero-overhead or optimization claim.

Existing native link-cache tests now check observed/unobserved create/replacement byte identity, round-trip and actual write counts, raw interval containment, oversize serialization rejection, directory obstruction and nonempty-destination replacement errors with unchanged diagnostics/cleanup. No new test executable is added.

The new collector reuses #171's original clock/statistics/semantic helpers, adds nine positive/negative subspan contracts and a predeclared **four AA pairs/eight reports/168 invocation records/144 instrumented subspan samples**. Same candidate path and bytes on both sides; fixed left/right order, complete plan before measurement, no overwrite/adaptive budget/retry. Original benchmark and ABBA scripts are byte-unchanged. Actual diagnostic executable and exact source archives are retained. JSON containment tolerances only cover independent0.001ms rounding, not performance noise.

## Completed gates and the failed gate

| Gate | Actual run | Result |
|---|---|---|
| Native Debug and all shards | #712/34307133464 | Passed; expanded cache test executed in job102327478334 |
| Complete Release/self-host/package | #605/34307133347 | Passed; cache test executed in job102327521691; publish-release skipped |
| Documentation/Cross-Stage/Reporting | #166/34307133248; #189/34307133346; #8/34307133247 | Passed |
| Incremental/PCH/module/build-plan evidence | Applicable six workflows | Passed |
| Subspan contracts and fixed study | #1/34307133260 | Nine expected contract outcomes;8reports/168invocations/144subspan records complete |
| Independent original ABBA | #556/34307133279 |76pairs measured/recomputed;72instrumented semantic identities match |
| Private endpoint | #11/34307133236 |42/42 collected; all unmanaged controls passed |
| **Default endpoint** | **#9/34307133230** | **56 records complete;1control failure;13/14drain controls passed** |

### Why the default failure blocks merge

`pch-release-A-started-drain` created its PCH and warmed successfully, then original A/work0 exited2 with **C1041 cannot open A/compiler.pdb**. Its argv already contains **/FS /Zi /O2 /MT /bigobj /Yucommon.hpp**. A and B use distinct PDB paths. A/drain.json records the failure; root exits1 and lifecycle/drain_control_ok are false. Pending A work is suppressed, B's original compile/link/run succeed and the original service survives, but those do not replace the failed A compile. The separate recovery compile is B, not A. Cleanup is verified, with no cause established for the failed PDB open.

The unchanged positive artifact auditor rejects the matrix. A separate read-only failure audit verifies all56 records and retains that rejection; it does not turn this into an expected successful case. No same-head retry or removal of /FS/PCH/workload/case. This is distinct from the preserved **6 default+2 private original B failures** in the intentionally adverse managed-ending experiment. All28A-started managed endings still kill their original service. Both sets of evidence remain, and no service/writer-lease safety is authorized.

## Diagnostic findings, not historical root-cause resolution

The fixed study validates all72zero-save samples as zero,72actual saves and72instrumented AA semantic pairs. Maximum link-cache save is **3.039ms** (serialize0.289/prepare1.387/stream0.605/install0.757; nested payload0.122/flush0.047). No seconds-scale save tail reproduced; that does not disprove #171's earlier observation. Observed AA timings-off no-op median **+0.19685ms/+1.6587%**,4/4right sides slower, no gate crossing. Observer effects and unrecorded OS state remain.

Independent observer-OFF ABBA has external timings-off no-op paired median **+0.9536ms/+8.0065%**,MAD1.49965,max+3.2324ms,3/4slower. The unchanged BOTH>1ms AND>10% gate is not crossed, but this is near the boundary and not zero-cost proof. All18other scenarios remain instrumented; all favorable/adverse samples retained.

The worst new paired tail, discovery-header pair2, totals182.412→3721.849ms. **link_execution111.929→3651.657ms**, while **link_cache_write1.762→1.842ms**. This narrows THIS tail to the existing process-launch/wait/capture/cleanup envelope, not link-cache save, but it does not isolate link.exe CPU or an OS cause. The full table preserves cold4/4slower, discovery-header4/4slower and all remaining tails. No outlier deletion, AA subtraction, speedup or historical-cause claim.

## Original acceptance gates remain unchanged

Full final diff/exact trees; complete native Debug/Release/selfhost/package and relevant documentation/Cross-Stage/ownership gates; actual cache-test execution; nine contract expectations; fixed8reports/168records/144samples with original correspondence/containment/zero-save checks;72AA semantic identities. Independent original19x4ABBA with all72counter/breakdown/hit-miss identities and the original external no-op BOTH>1ms AND>10% median gate. Missing instrumentation is unavailable, not fabricated zero. All real default drain controls must pass: **this gate did not pass, so no merge**.

No post-PR source correction or same-head rerun. The pre-PR placeholder correction and initial local CRLF-vs-LF audit mismatch are recorded, not erased. Complete source-tree reconstruction resolves the latter without changing raw archives. No local MSVC/PowerShell execution is claimed.

## Handoff

First investigate the real A/PCH/PDB-open failure with a bounded predeclared plan and preserved exact tools, A/B PDB identity and underlying failure diagnostics. A successful rerun alone is insufficient; unavailable historical lock/RPC/OS traces cannot be fabricated. Reconsider this PR only after its unmet correctness gate is addressed. The performance follow-on can then target the newly localized link/process envelope with credible subspans/tool/OS evidence, not a blind median rerun.

#170 remains held. No M1b completion, CLI cancellation, durable quiescence, single-writer lease, transaction/build-run/session/daemon or release authorization. Five original ZIPs with verified hashes and read-only reproducible audits are retained in the delivery; Actions retention30days. Ownership generated binaries are post-case hashes, not failure-time snapshots; the separate diagnostic study archives its actual executable, not the independent ABBA executable pair. Title was changed only after actual#556 completed; later title-triggered skipped perf jobs are not replacement measurements.