### PR TITLE
test: investigate PCH PDB failure with fixed resource-query controls

### DIFF
--- a/.github/workflows/pdb-open-investigation.yml
+++ b/.github/workflows/pdb-open-investigation.yml
@@ -1,0 +1,139 @@
+name: PDB Open Investigation
+
+on:
+  pull_request:
+    paths:
+      - 'cpp/tests/platform/windows/msvc_service_ownership_probe.cpp'
+      - 'tests/native/collect_pdb_open_investigation.ps1'
+      - '.github/workflows/pdb-open-investigation.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: pdb-open-investigation-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+permissions:
+  contents: read
+jobs:
+  contract:
+    name: PDB identity record contracts
+    runs-on: windows-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - shell: pwsh
+        run: |
+          & ./tests/native/collect_pdb_open_investigation.ps1 -SelfTest `
+            -OutputRoot (Join-Path $PWD '.mqb/pdb-record-contracts')
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: pdb-record-contracts
+          path: .mqb/pdb-record-contracts/**
+          include-hidden-files: true
+          retention-days: 30
+  build:
+    name: Build exact ownership probe
+    runs-on: windows-latest
+    timeout-minutes: 30
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Build candidate and probe with MQB, without measuring ownership
+        shell: pwsh
+        run: |
+          $seed = & (Join-Path $PWD 'tests/native/acquire_seed.ps1') `
+            -RepoRoot $PWD -OutputRoot (Join-Path $PWD 'native-seed')
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $mqb = & (Join-Path $PWD 'tests/native/build_mqb.ps1') `
+            -BuilderMqbPath $seed -RepoRoot $PWD `
+            -Version ((Get-Content -LiteralPath 'VERSION' -Raw).Trim()) `
+            -Configuration Release -Clean -OutputPath (Join-Path $PWD 'native-out/endpoint/mqb.exe')
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          & (Join-Path $PWD 'tests/native/collect_msvc_service_ownership.ps1') `
+            -MqbPath $mqb -RepoRoot $PWD -BuildOnly `
+            -OutputRoot (Join-Path $PWD '.mqb/default-endpoint-build')
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          New-Item -ItemType Directory -Path 'native-out/endpoint-input' -Force | Out-Null
+          Copy-Item -LiteralPath $mqb -Destination 'native-out/endpoint-input/mqb.exe'
+          Copy-Item -LiteralPath '.mqb/bin/msvc_service_ownership_probe.exe' -Destination 'native-out/endpoint-input/'
+          Copy-Item -LiteralPath '.mqb/default-endpoint-build/probe.identity.json' -Destination 'native-out/endpoint-input/'
+      - uses: actions/upload-artifact@v7
+        with:
+          name: pdb-investigation-input
+          path: native-out/endpoint-input/*
+          if-no-files-found: error
+          retention-days: 30
+      - name: Retain probe build diagnostics
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: pdb-investigation-build-evidence
+          path: .mqb/default-endpoint-build/**
+          include-hidden-files: true
+          if-no-files-found: warn
+          retention-days: 30
+
+  observe:
+    name: Fixed eight-case PCH PDB query comparison
+    needs: [build, contract]
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - uses: actions/download-artifact@v8
+        with:
+          name: pdb-investigation-input
+          path: native-input
+      - name: Check physical file identity and sharing error contracts
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Path '.mqb/pdb-identity-tests' | Out-Null
+          $output = @(& ./native-input/msvc_service_ownership_probe.exe --pdb-identity-self-test `
+            (Join-Path $PWD '.mqb/pdb-identity-tests/files') 2>&1)
+          $code = $LASTEXITCODE
+          $output | Set-Content -LiteralPath '.mqb/pdb-identity-tests/output.txt' -Encoding utf8
+          if ($code -ne 0) { exit $code }
+      - name: Collect fixed PCH Release A-started drain query-on and query-off pairs
+        shell: pwsh
+        env:
+          MQB_OWNERSHIP_DISPOSABLE_HOST: '1'
+        run: |
+          & ./tests/native/collect_pdb_open_investigation.ps1 `
+            -MqbPath (Join-Path $PWD 'native-input/mqb.exe') `
+            -ProbePath (Join-Path $PWD 'native-input/msvc_service_ownership_probe.exe') `
+            -ProbeIdentityPath (Join-Path $PWD 'native-input/probe.identity.json') `
+            -RepoRoot $PWD -OutputRoot (Join-Path $PWD '.mqb/pdb-open-investigation')
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+      - name: Retain complete prefix and original failures
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: pdb-open-investigation-evidence
+          path: |
+            .mqb/pdb-identity-tests/**
+            .mqb/pdb-open-investigation/**
+            !.mqb/pdb-open-investigation/**/*.obj
+            !.mqb/pdb-open-investigation/**/*.pdb
+            !.mqb/pdb-open-investigation/**/*.pch
+            !.mqb/pdb-open-investigation/**/*.exe
+          include-hidden-files: true
+          if-no-files-found: warn
+          retention-days: 30
+      - name: Retain input binaries and post-cleanup failed PDB PCH bytes separately
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: pdb-open-investigation-binaries
+          path: |
+            .mqb/pdb-open-investigation/*.exe
+            .mqb/pdb-open-investigation/failure-files/**
+          include-hidden-files: true
+          if-no-files-found: warn
+          retention-days: 30

--- a/cpp/tests/platform/windows/msvc_service_ownership_probe.cpp
+++ b/cpp/tests/platform/windows/msvc_service_ownership_probe.cpp
@@ -13,6 +13,7 @@
 #include <fstream>
 #include <future>
 #include <iostream>
+#include <iterator>
 #include <optional>
 #include <sstream>
 #include <stdexcept>
@@ -248,6 +249,98 @@ std::vector<Process> new_servers(const std::vector<Process>& before, const fs::p
     return result;
 }
 
+
+// Metadata-only snapshots are observations, not locks or writer-quiescence
+// certificates. Share all access and close every handle before returning.
+struct FileIdentity {
+    Handle handle;
+    DWORD open_error{}, identity_error{};
+    FILE_ID_INFO id{};
+    fs::path path;
+    explicit FileIdentity(const fs::path& file) : path(file) {
+        handle = Handle{::CreateFileW(file.c_str(), FILE_READ_ATTRIBUTES,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, nullptr,
+            OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr)};
+        if (!handle) { open_error = ::GetLastError(); return; }
+        if (!::GetFileInformationByHandleEx(handle.value, FileIdInfo, &id, sizeof(id)))
+            identity_error = ::GetLastError();
+    }
+    bool known() const { return bool(handle) && identity_error == ERROR_SUCCESS; }
+    std::string json() const {
+        std::string file_id;
+        constexpr char hex[] = "0123456789abcdef";
+        for (const auto byte : id.FileId.Identifier) {
+            file_id += hex[byte >> 4]; file_id += hex[byte & 15];
+        }
+        return "{\"path\":" + (quoted)(path_text(path))
+            + ",\"open_error\":" + std::to_string(open_error)
+            + ",\"identity_error\":" + (handle ? std::to_string(identity_error) : "null")
+            + ",\"volume_serial\":" + (known() ? (quoted)(std::to_string(id.VolumeSerialNumber)) : "null")
+            + ",\"file_id\":" + (known() ? (quoted)(file_id) : "null") + "}";
+    }
+};
+bool same_file(const FileIdentity& a, const FileIdentity& b) {
+    return a.known() && b.known() && a.id.VolumeSerialNumber == b.id.VolumeSerialNumber
+        && std::equal(std::begin(a.id.FileId.Identifier), std::end(a.id.FileId.Identifier),
+                      std::begin(b.id.FileId.Identifier));
+}
+std::string identity_pair(const fs::path& a, const fs::path& b) {
+    const FileIdentity left{a}, right{b}; // Simultaneously open identities.
+    return "{\"A\":" + left.json() + ",\"B\":" + right.json()
+        + ",\"same_file\":" + (left.known() && right.known()
+            ? (same_file(left, right) ? "true" : "false") : "null") + "}";
+}
+void pdb_snapshot(const fs::path& dir, const std::string& phase) {
+    const auto started = std::chrono::steady_clock::now().time_since_epoch().count();
+    const auto pdb = identity_pair(dir / "A/compiler.pdb", dir / "B/compiler.pdb");
+    const auto pch_files = identity_pair(dir / "A/common.pch", dir / "B/common.pch");
+    write(dir / ("pdb-" + phase + ".json"), "{\"phase\":" + (quoted)(phase)
+        + ",\"started_tick\":" + std::to_string(started)
+        + ",\"ended_tick\":" + std::to_string(std::chrono::steady_clock::now().time_since_epoch().count())
+        + ",\"desired_access\":128,\"share_mode\":7,\"pdb\":" + pdb + ",\"pch\":" + pch_files
+        + ",\"handles_closed_before_return\":true,\"safe_to_transfer_write_lease\":false}\n");
+}
+int pdb_identity_self_test(const fs::path& dir) {
+    require(!fs::exists(dir), "refuse to overwrite metadata test evidence");
+    fs::create_directories(dir);
+    write(dir / "one", "original"); write(dir / "two", "other");
+    fs::create_hard_link(dir / "one", dir / "alias");
+    unsigned checks = 0;
+    {
+        FileIdentity one{dir / "one"}, alias{dir / "alias"}, two{dir / "two"};
+        require(one.known() && alias.known() && two.known(), "known file identities unavailable"); ++checks;
+        require(same_file(one, alias), "hard-link identity not recognized"); ++checks;
+        require(!same_file(one, two), "distinct files reported identical"); ++checks;
+        write(dir / "identities.json", "[" + one.json() + "," + alias.json() + "," + two.json() + "]\n");
+    }
+    {
+        FileIdentity missing{dir / "missing"};
+        require(missing.open_error == ERROR_FILE_NOT_FOUND && !missing.known(), "missing file must preserve error2"); ++checks;
+        write(dir / "missing.json", missing.json() + '\n');
+    }
+    {
+        Handle exclusive{::CreateFileW((dir / "one").c_str(), GENERIC_READ | GENERIC_WRITE,
+            0, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr)};
+        require(bool(exclusive), "exclusive control handle failed");
+        FileIdentity attributes{dir / "one"};
+        require(attributes.known(), "metadata snapshot conflicted with an exclusive data handle"); ++checks;
+        Handle denied{::CreateFileW((dir / "one").c_str(), GENERIC_READ,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, nullptr,
+            OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr)};
+        const DWORD error = denied ? ERROR_SUCCESS : ::GetLastError();
+        require(!denied && error == ERROR_SHARING_VIOLATION, "control data-read should preserve error32"); ++checks;
+        write(dir / "sharing.json", "{\"data_read_error\":" + std::to_string(error)
+            + ",\"metadata\":" + attributes.json() + "}\n");
+    }
+    std::ifstream input{dir / "one", std::ios::binary};
+    std::string contents{std::istreambuf_iterator<char>{input}, std::istreambuf_iterator<char>{}};
+    require(contents == "original", "metadata observation changed bytes"); ++checks;
+    write(dir / "contracts.json", "{\"checks\":" + std::to_string(checks)
+        + ",\"passed\":true,\"compiler_run\":false,\"historical_cause_resolved\":false}\n");
+    std::cout << "PDB_IDENTITY_CONTRACT " << checks << " checks passed (real files, no compiler)\n";
+    return 0;
+}
+
 struct Owners { DWORD error{}; bool includes_server{}; std::string identities{"[]"}; };
 Owners pdb_owners(const fs::path& pdb, const Process& server) {
     DWORD session{};
@@ -415,13 +508,19 @@ int root(int argc, wchar_t** argv, bool drain) {
     return stopped && exit_code(first) == 0 ? 0 : 1;
 }
 
-int measure(int argc, wchar_t** argv, bool default_endpoint) {
-    require(argc == 7, "measure arguments");
+int measure(int argc, wchar_t** argv, bool default_endpoint, bool pdb_study = false) {
+    require(argc == (pdb_study ? 8 : 7), "measure arguments");
     if (default_endpoint) require_default_host();
     const fs::path dir = fs::absolute(argv[2]);
     const std::string profile = utf8(argv[3]), origin = utf8(argv[4]), ending = utf8(argv[5]);
     const std::wstring fixture_id = argv[6];
     const bool drain = ending == "drain";
+    const bool query_enabled = !pdb_study || std::wstring{argv[7]} == L"rm-on";
+    if (pdb_study) {
+        require(default_endpoint && profile == "pch-release" && origin == "A-started" && drain,
+                "PDB study only supports the predeclared PCH Release A-started drain case");
+        require(std::wstring{argv[7]} == L"rm-on" || std::wstring{argv[7]} == L"rm-off", "unknown PDB query mode");
+    }
     require(profile == "zi-debug" || profile == "ZI-debug" || profile == "zi-release"
             || profile == "pch-debug" || profile == "pch-release"
             || profile == "modules-debug" || profile == "modules-release", "unknown profile");
@@ -490,7 +589,21 @@ int measure(int argc, wchar_t** argv, bool default_endpoint) {
     prepare(tc, dir / "B", profile);
     auto after_b = new_servers(before, tc.identity.compiler);
     require(after_b.size() == 1 && same(server, after_b[0]), "B did not retain the same observed endpoint service");
-    auto warm_owners = pdb_owners(dir / "B/compiler.pdb", server);
+    unsigned query_count = 0;
+    auto resource_owners = [&](const fs::path& file) {
+        if (!pdb_study) return pdb_owners(file, server);
+        const auto started = std::chrono::steady_clock::now().time_since_epoch().count();
+        const auto result = query_enabled ? pdb_owners(file, server) : Owners{ERROR_NOT_SUPPORTED, false, "[]"};
+        write(dir / ("rm-query-" + std::to_string(query_count++) + ".json"),
+            "{\"path\":" + (quoted)(path_text(file)) + ",\"attempted\":" + (query_enabled ? "true" : "false")
+            + ",\"started_tick\":" + std::to_string(started)
+            + ",\"ended_tick\":" + std::to_string(std::chrono::steady_clock::now().time_since_epoch().count())
+            + ",\"error\":" + (query_enabled ? std::to_string(result.error) : "null")
+            + ",\"owners\":" + (query_enabled ? result.identities : "null") + "}\n");
+        return result;
+    };
+    auto warm_owners = resource_owners(dir / "B/compiler.pdb");
+    if (pdb_study) pdb_snapshot(dir, "before-A");
     workload(dir / "B", profile);
     std::vector<Process> active_a;
     if (drain) {
@@ -520,8 +633,8 @@ int measure(int argc, wchar_t** argv, bool default_endpoint) {
     } while (std::chrono::steady_clock::now() < deadline);
     for (const auto& p : active)
         require(_wcsicmp(p.image.c_str(), tc.identity.compiler.c_str()) == 0, "B compiler image mismatch");
-    const auto active_owners = pdb_owners(dir / "B/compiler.pdb", server);
-    const auto a_owners_at_request = drain ? pdb_owners(dir / "A/compiler.pdb", server) : Owners{};
+    const auto active_owners = resource_owners(dir / "B/compiler.pdb");
+    const auto a_owners_at_request = drain ? resource_owners(dir / "A/compiler.pdb") : Owners{};
     const bool a_overlap = std::any_of(active_a.begin(), active_a.end(), [](const auto& p) { return alive(p.handle.value); });
     const bool overlap = std::any_of(active.begin(), active.end(), [](const auto& p) { return alive(p.handle.value); });
     // These are retained-handle observations, not proof of an in-flight PDB RPC.
@@ -531,13 +644,15 @@ int measure(int argc, wchar_t** argv, bool default_endpoint) {
     else require(::SetEvent(release.value) != FALSE, "release A failed");
     auto a_result = a_future.get();
     const auto settled = std::chrono::steady_clock::now();
+    if (pdb_study) pdb_snapshot(dir, "after-A");
     const bool service_survived = alive(server.handle.value);
     // The surviving service can still own PDB resources after the A client exits.
     // An empty snapshot is not a durable no-writer certificate either.
-    const auto a_owners_after = default_endpoint ? pdb_owners(dir / "A/compiler.pdb", server) : Owners{};
+    const auto a_owners_after = default_endpoint ? resource_owners(dir / "A/compiler.pdb") : Owners{};
     const bool a_handles_signaled = std::all_of(active_a.begin(), active_a.end(), [](const auto& p) { return !alive(p.handle.value); });
     const bool pending_dispatched = fs::exists(dir / "A/work1.argv.txt");
     auto b0_result = b0.get(), b1_result = b1.get();
+    if (pdb_study) pdb_snapshot(dir, "after-B");
     int linked = -2, executed = -2;
     if (exit_code(b0_result) == 0 && exit_code(b1_result) == 0) {
         std::vector<std::string> args{"/NOLOGO", "/DEBUG", "/INCREMENTAL:NO", "/OUT:" + path_text(dir / "B/result.exe"),
@@ -591,6 +706,9 @@ int measure(int argc, wchar_t** argv, bool default_endpoint) {
         + ",\"lifecycle_ok\":" + (lifecycle_ok ? "true" : "false")
         + ",\"unmanaged_control_ok\":" + (control_ok ? "true" : "false")
         + ",\"safe_to_integrate_cancellation\":false,\"safe_to_transfer_write_lease\":false\n}\n";
+    if (pdb_study) write(dir / "pdb-study.json", "{\"schema\":1,\"rm_queries_enabled\":"
+        + std::string{query_enabled ? "true" : "false"} + ",\"query_slots\":" + std::to_string(query_count)
+        + ",\"historical_cause_resolved\":false,\"safe_to_transfer_write_lease\":false}\n");
     write(dir / "observation.json", report);
     std::cout << report;
     return lifecycle_ok && control_ok && drain_ok ? 0 : 1;
@@ -601,11 +719,16 @@ int wmain(int argc, wchar_t** argv) {
     try {
         require(argc >= 2, "use --case/--default-case/--measure/--root");
         const std::wstring mode = argv[1];
+        if (mode == L"--pdb-identity-self-test") {
+            require(argc == 3, "identity test arguments"); return pdb_identity_self_test(fs::absolute(argv[2]));
+        }
         if (mode == L"--evidence-contract-self-test") return evidence_contract_self_test();
         if (mode == L"--root" || mode == L"--drain-root") return root(argc, argv, mode == L"--drain-root");
+        if (mode == L"--measure-pdb") return measure(argc, argv, true, true);
         if (mode == L"--measure" || mode == L"--measure-default") return measure(argc, argv, mode == L"--measure-default");
-        const bool default_endpoint = mode == L"--default-case";
-        require((mode == L"--case" || default_endpoint) && argc == 7, "case arguments");
+        const bool pdb_study = mode == L"--pdb-case";
+        const bool default_endpoint = mode == L"--default-case" || pdb_study;
+        require((mode == L"--case" || default_endpoint) && argc == (pdb_study ? 8 : 7), "case arguments");
         const fs::path dir = fs::absolute(argv[2]);
         fs::create_directories(dir);
         if (default_endpoint) {
@@ -620,7 +743,7 @@ int wmain(int argc, wchar_t** argv) {
         // No global service termination, PID-authorized kill, or product changes.
         ProcessSpec spec;
         spec.executable = self();
-        spec.arguments = {default_endpoint ? "--measure-default" : "--measure"};
+        spec.arguments = {pdb_study ? "--measure-pdb" : (default_endpoint ? "--measure-default" : "--measure")};
         for (int i = 2; i < argc; ++i) spec.arguments.push_back(utf8(argv[i]));
         std::stop_source lifetime;
         spec.cancellation = lifetime.get_token();

--- a/tests/native/collect_pdb_open_investigation.ps1
+++ b/tests/native/collect_pdb_open_investigation.ps1
@@ -1,0 +1,208 @@
+[CmdletBinding(DefaultParameterSetName = 'Study')]
+param(
+    [Parameter(Mandatory, ParameterSetName = 'Study')][string]$MqbPath,
+    [Parameter(Mandatory, ParameterSetName = 'Study')][string]$ProbePath,
+    [Parameter(Mandatory, ParameterSetName = 'Study')][string]$ProbeIdentityPath,
+    [Parameter(Mandatory, ParameterSetName = 'Contract')][switch]$SelfTest,
+    [Parameter(Mandatory)][string]$OutputRoot,
+    [string]$RepoRoot = (Join-Path $PSScriptRoot '../..')
+)
+$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+Set-StrictMode -Version 2.0
+$OutputRoot = [IO.Path]::GetFullPath($OutputRoot)
+$RepoRoot = [IO.Path]::GetFullPath($RepoRoot)
+if (Test-Path -LiteralPath $OutputRoot) { throw 'Refusing to overwrite an earlier investigation.' }
+New-Item -ItemType Directory -Path $OutputRoot -Force | Out-Null
+function Write-Json($Path, $Value) {
+    $Value | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $Path -Encoding utf8
+}
+function Assert-PdbQuery($Record, [bool]$Enabled) {
+    if ($Record.attempted -isnot [bool] -or $Record.attempted -ne $Enabled) { throw 'Wrong query mode.' }
+    if ($Enabled) {
+        if (($Record.error -isnot [long] -and $Record.error -isnot [int]) -or
+            $Record.error -lt 0 -or $Record.owners -isnot [array]) { throw 'Invalid query outcome.' }
+    } elseif ($null -ne $Record.error -or $null -ne $Record.owners) { throw 'Disabled query must remain unavailable.' }
+}
+function Assert-PdbPair($Pair) {
+    foreach ($side in @('A', 'B')) {
+        $r = $Pair.$side
+        if (($r.open_error -isnot [int] -and $r.open_error -isnot [long]) -or $r.open_error -lt 0) { throw 'Missing native open error.' }
+        if ($r.open_error -ne 0) {
+            if ($null -ne $r.identity_error -or $null -ne $r.file_id -or $null -ne $r.volume_serial) { throw 'Failed open cannot invent identity.' }
+        } else {
+            if (($r.identity_error -isnot [int] -and $r.identity_error -isnot [long]) -or $r.identity_error -lt 0) { throw 'Missing identity query error.' }
+            if ($r.identity_error -eq 0) {
+                if ($r.file_id -isnot [string] -or $r.file_id -cnotmatch '^[0-9a-f]{32}$' -or
+                    $r.volume_serial -isnot [string] -or $r.volume_serial -notmatch '^\d+$') { throw 'Malformed file identity.' }
+            } elseif ($null -ne $r.file_id -or $null -ne $r.volume_serial) { throw 'Failed query cannot invent identity.' }
+        }
+    }
+    $known = $Pair.A.open_error -eq 0 -and $Pair.B.open_error -eq 0 -and
+        $Pair.A.identity_error -eq 0 -and $Pair.B.identity_error -eq 0
+    if (-not $known) {
+        if ($null -ne $Pair.same_file) { throw 'Unavailable identity cannot prove distinctness.' }
+    } else {
+        $same = $Pair.A.volume_serial -ceq $Pair.B.volume_serial -and $Pair.A.file_id -ceq $Pair.B.file_id
+        if ($Pair.same_file -isnot [bool] -or $Pair.same_file -ne $same) { throw 'Identity comparison disagreement.' }
+    }
+}
+if ($SelfTest) {
+    $rows = @(foreach ($case in 0..9) {
+        $pair = [pscustomobject]@{
+            A = [pscustomobject]@{ open_error=0; identity_error=0; volume_serial='17'; file_id=('a'*32) }
+            B = [pscustomobject]@{ open_error=0; identity_error=0; volume_serial='17'; file_id=('b'*32) }
+            same_file=$false
+        }
+        $query = [pscustomobject]@{ attempted=$false; error=$null; owners=$null }
+        $expected = $case -in @(0,1,2)
+        switch ($case) {
+            1 { $pair.B.file_id=$pair.A.file_id; $pair.same_file=$true }
+            2 { $pair.A.open_error=2; $pair.A.identity_error=$null; $pair.A.file_id=$null; $pair.A.volume_serial=$null; $pair.same_file=$null }
+            3 { $pair.A.open_error='0' }
+            4 { $pair.B.file_id='bad' }
+            5 { $pair.same_file='false' }
+            6 { $pair.B.file_id=$pair.A.file_id }
+            7 { $pair.A.identity_error=5 }
+            8 { $query.error=0; $query.owners=@() }
+            9 { $query.attempted='false' }
+        }
+        $errorText=$null
+        try { Assert-PdbPair $pair; Assert-PdbQuery $query $false } catch { $errorText=$_.Exception.Message }
+        [pscustomobject]@{ case=$case; expected_accepted=$expected; accepted=($null -eq $errorText)
+            passed=($expected -eq ($null -eq $errorText)); error=$errorText }
+    })
+    Write-Json (Join-Path $OutputRoot 'contracts.json') @{ synthetic_only=$true; cases=$rows }
+    if (@($rows | Where-Object { -not $_.passed }).Count) { throw 'PDB evidence contract failed.' }
+    Write-Host 'PDB_RECORD_CONTRACT 10 checks passed (synthetic)'
+    return
+}
+if ($env:MQB_OWNERSHIP_DISPOSABLE_HOST -ne '1' -or $env:GITHUB_ACTIONS -ne 'true' -or
+    $env:RUNNER_ENVIRONMENT -ne 'github-hosted' -or (Test-Path Env:_MSPDBSRV_ENDPOINT_)) {
+    throw 'Requires an authorized pristine default endpoint on a disposable hosted VM.'
+}
+$ProbePath=[IO.Path]::GetFullPath($ProbePath); $MqbPath=[IO.Path]::GetFullPath($MqbPath)
+$head=(& git -C $RepoRoot rev-parse HEAD).Trim()
+if ($LASTEXITCODE -ne 0) { throw 'Unknown source head.' }
+if (@(& git -C $RepoRoot status --porcelain --untracked-files=no).Count -ne 0 -or $LASTEXITCODE -ne 0) { throw 'Dirty tracked source.' }
+if ((Get-Content (Join-Path $RepoRoot 'VERSION') -Raw).Trim() -cne '5.5.0') { throw 'VERSION changed.' }
+$origin=Get-Content -LiteralPath $ProbeIdentityPath -Raw | ConvertFrom-Json
+if ($origin.source_head -cne $head -or $origin.version -cne '5.5.0' -or $origin.configuration -cne 'Release' -or
+    $origin.probe_sha256 -cne (Get-FileHash -LiteralPath $ProbePath).Hash -or
+    $origin.candidate_sha256 -cne (Get-FileHash -LiteralPath $MqbPath).Hash) { throw 'Prebuilt identity mismatch.' }
+Copy-Item -LiteralPath $ProbePath -Destination (Join-Path $OutputRoot 'observed-probe.exe')
+Copy-Item -LiteralPath $MqbPath -Destination (Join-Path $OutputRoot 'builder-mqb.exe')
+Write-Json (Join-Path $OutputRoot 'identity.json') @{ head=$head; origin=$origin; os=[Environment]::OSVersion.VersionString
+    powershell=$PSVersionTable.PSVersion.ToString(); image=$env:ImageVersion; run_id=$env:GITHUB_RUN_ID
+    attempt=$env:GITHUB_RUN_ATTEMPT; historical_cause_resolved=$false }
+$plan=@(foreach ($pair in 1..4) {
+    $modes=if ($pair % 2) { @('rm-on','rm-off') } else { @('rm-off','rm-on') }
+    foreach ($mode in $modes) { [pscustomobject]@{ pair=$pair; mode=$mode; name=('{0:D2}-{1}' -f $pair,$mode) } }
+})
+Write-Json (Join-Path $OutputRoot 'plan.json') @{ cases=$plan; fixed_cases=8; repetitions_per_mode=4
+    profile='pch-release'; service_origin='A-started'; ending='drain'; adaptive_retries=$false }
+$rows=[Collections.Generic.List[object]]::new()
+$allTools=@{}
+foreach ($slot in $plan) {
+    $dir=Join-Path $OutputRoot $slot.name
+    New-Item -ItemType Directory -Path $dir | Out-Null
+    $arguments=@('--pdb-case',$dir,'pch-release','A-started','drain',('pdb-'+[guid]::NewGuid().ToString('N')),$slot.mode)
+    Write-Json (Join-Path $dir 'case-arguments.json') $arguments
+    $output=@(& $ProbePath @arguments 2>&1); $code=$LASTEXITCODE
+    $output | Set-Content -LiteralPath (Join-Path $dir 'outer-output.txt') -Encoding utf8
+    $errors=[Collections.Generic.List[string]]::new(); $cleanup=$false; $observation=$null; $aCode=$null
+    try {
+        $envelope=Get-Content -LiteralPath (Join-Path $dir 'default-envelope.json') -Raw | ConvertFrom-Json
+        $cleanup=$envelope.cleanup_verified -is [bool] -and $envelope.cleanup_verified -and
+            $envelope.outer_lifecycle_verified -is [bool] -and $envelope.outer_lifecycle_verified -and
+            $envelope.endpoint_override_absent -is [bool] -and $envelope.endpoint_override_absent -and
+            $envelope.remaining_servers -is [array] -and $envelope.remaining_servers.Count -eq 0
+        if (-not $cleanup) { throw 'Unproven outer cleanup.' }
+        $study=Get-Content -LiteralPath (Join-Path $dir 'pdb-study.json') -Raw | ConvertFrom-Json
+        $enabled=$slot.mode -eq 'rm-on'
+        if ($study.schema -ne 1 -or $study.query_slots -ne 4 -or $study.rm_queries_enabled -isnot [bool] -or
+            $study.rm_queries_enabled -ne $enabled -or $study.historical_cause_resolved -isnot [bool] -or
+            $study.historical_cause_resolved -or $study.safe_to_transfer_write_lease -isnot [bool] -or
+            $study.safe_to_transfer_write_lease) { throw 'Wrong study identity/safety record.' }
+        foreach ($i in 0..3) {
+            $record=Get-Content -LiteralPath (Join-Path $dir "rm-query-$i.json") -Raw | ConvertFrom-Json
+            Assert-PdbQuery $record $enabled
+        }
+        foreach ($phase in @('before-A','after-A','after-B')) {
+            $snapshot=Get-Content -LiteralPath (Join-Path $dir "pdb-$phase.json") -Raw | ConvertFrom-Json
+            if ($snapshot.phase -cne $phase -or $snapshot.desired_access -ne 128 -or $snapshot.share_mode -ne 7 -or
+                $snapshot.safe_to_transfer_write_lease -isnot [bool] -or $snapshot.safe_to_transfer_write_lease) { throw 'Wrong snapshot contract.' }
+            Assert-PdbPair $snapshot.pdb; Assert-PdbPair $snapshot.pch
+            if ($phase -eq 'before-A' -and ($snapshot.pdb.same_file -cne $false -or $snapshot.pch.same_file -cne $false)) {
+                throw 'A/B file identities not proven distinct before workload.'
+            }
+        }
+        $observation=Get-Content -LiteralPath (Join-Path $dir 'observation.json') -Raw | ConvertFrom-Json
+        if ($observation.profile -cne 'pch-release' -or $observation.origin -cne 'A-started' -or $observation.ending -cne 'drain' -or
+            $observation.endpoint_mode -cne 'default' -or $observation.safe_to_integrate_cancellation -isnot [bool] -or
+            $observation.safe_to_integrate_cancellation -or $observation.safe_to_transfer_write_lease -isnot [bool] -or
+            $observation.safe_to_transfer_write_lease) { throw 'Wrong original observation identity or safety flags.' }
+        $stems=@('A','A/prefix','A/warm','A/work0','B/prefix','B/warm','B/work0','B/work1','B/recovery')
+        if ($observation.B0_exit -eq 0 -and $observation.B1_exit -eq 0) {
+            $stems+='B/link'; if ($observation.B_link_exit -eq 0) { $stems+='B/run' }
+        }
+        $mapping=@{ A='A_exit'; 'B/work0'='B0_exit'; 'B/work1'='B1_exit'; 'B/link'='B_link_exit'; 'B/run'='B_run_exit'; 'B/recovery'='recovery_compile_exit' }
+        foreach ($stem in $stems) {
+            $r=Get-Content -LiteralPath (Join-Path $dir "$stem.result.json") -Raw | ConvertFrom-Json
+            if ($null -ne $r.PSObject.Properties['infrastructure_error'] -or
+                ($r.exit_code -isnot [int] -and $r.exit_code -isnot [long]) -or $r.cancelled -isnot [bool] -or $r.cancelled) { throw "Invalid tool result: $stem" }
+            if ($mapping.ContainsKey($stem) -and $r.exit_code -ne $observation.($mapping[$stem])) { throw "Original outcome mismatch: $stem" }
+            if ($stem -eq 'A/work0') { $aCode=$r.exit_code }
+            foreach ($suffix in @('stdout.txt','stderr.txt')) {
+                if (-not (Test-Path -LiteralPath (Join-Path $dir "$stem.$suffix") -PathType Leaf)) { throw "Missing diagnostic: $stem.$suffix" }
+            }
+            if ($stem -ne 'A' -and -not (Test-Path -LiteralPath (Join-Path $dir "$stem.argv.txt") -PathType Leaf)) { throw "Missing argv: $stem" }
+        }
+        $drain=Get-Content -LiteralPath (Join-Path $dir 'A/drain.json') -Raw | ConvertFrom-Json
+        if ($drain.first_compile_exit -ne $aCode -or $drain.work_compiles_dispatched -ne 1 -or $drain.pending_compile_exit -ne -2 -or
+            $drain.stop_observed -isnot [bool] -or -not $drain.stop_observed -or
+            $drain.safe_to_transfer_write_lease -isnot [bool] -or $drain.safe_to_transfer_write_lease -or
+            (Test-Path -LiteralPath (Join-Path $dir 'A/work1.argv.txt'))) { throw 'Original drain outcome mismatch.' }
+        if ($code -ne 0 -and $code -ne 1) { throw 'Unexpected outer exit.' }
+        //PLACEHOLDER
+        $compiler=(Get-Content -LiteralPath (Join-Path $dir 'toolchain.txt'))[0]
+        $toolDir=[IO.Path]::GetDirectoryName($compiler)
+        foreach ($name in @('cl.exe','c1xx.dll','c2.dll','mspdbcore.dll','mspdbsrv.exe','link.exe')) {
+            $path=Join-Path $toolDir $name
+            if (-not $allTools.ContainsKey($path)) {
+                $allTools[$path]=[ordered]@{ path=$path; available=(Test-Path -LiteralPath $path -PathType Leaf)
+                    phase='post-case tool-file inventory, not an in-flight module attestation' }
+                if ($allTools[$path].available) {
+                    $allTools[$path].sha256=(Get-FileHash -LiteralPath $path).Hash
+                    $allTools[$path].version=(Get-Item -LiteralPath $path).VersionInfo.FileVersion
+                }
+            }
+        }
+    } catch { $errors.Add($_.Exception.Message) }
+    $originalOk=$code -eq 0 -and $aCode -eq 0 -and $null -ne $observation -and
+        $observation.drain_control_ok -eq $true -and $observation.lifecycle_ok -eq $true
+    $rows.Add([pscustomobject]@{ name=$slot.name; mode=$slot.mode; exit_code=$code; cleanup_verified=$cleanup
+        evidence_complete=($errors.Count -eq 0); errors=@($errors.ToArray()); original_control_ok=$originalOk
+        original_A_compile_exit=$aCode; observation=$observation })
+    Write-Json (Join-Path $OutputRoot 'summary.json') @{ expected=8; completed=$rows.Count; cases=@($rows.ToArray())
+        original_failures=@($rows | Where-Object { -not $_.original_control_ok }).Count
+        historical_cause_resolved=$false; authorizes_held_pr_merge=$false
+        not_run=@($plan.name | Where-Object { $_ -notin $rows.name }) }
+    if (-not $cleanup -or $errors.Count) { throw 'Investigation stopped at incomplete evidence; no retry or further file inventory.' }
+    # Retain PDB/PCH bytes only for a failed case after confirmed outer cleanup.
+    # Successful case files and all source/argv/diagnostic files also remain local;
+    # the workflow upload excludes generated binaries except this failure snapshot.
+    if (-not $originalOk) {
+        $failure=Join-Path $OutputRoot ('failure-files/'+$slot.name)
+        foreach ($project in @('A','B')) {
+            New-Item -ItemType Directory -Path (Join-Path $failure $project) -Force | Out-Null
+            foreach ($name in @('compiler.pdb','common.pch')) {
+                $file=Join-Path $dir "$project/$name"
+                if (Test-Path -LiteralPath $file -PathType Leaf) { Copy-Item -LiteralPath $file -Destination (Join-Path $failure $project) }
+            }
+        }
+    }
+}
+Write-Json (Join-Path $OutputRoot 'tool-files.json') @($allTools.Values)
+if ($rows.Count -ne 8) { throw 'Incomplete fixed budget.' }
+Write-Host "PDB_OPEN_INVESTIGATION 8/8 records; $(@($rows | Where-Object { -not $_.original_control_ok }).Count) original control failures; historical cause unresolved."

--- a/tests/native/collect_pdb_open_investigation.ps1
+++ b/tests/native/collect_pdb_open_investigation.ps1
@@ -164,7 +164,8 @@ foreach ($slot in $plan) {
             $drain.safe_to_transfer_write_lease -isnot [bool] -or $drain.safe_to_transfer_write_lease -or
             (Test-Path -LiteralPath (Join-Path $dir 'A/work1.argv.txt'))) { throw 'Original drain outcome mismatch.' }
         if ($code -ne 0 -and $code -ne 1) { throw 'Unexpected outer exit.' }
-        //PLACEHOLDER
+        # A nonzero original compiler result remains a recorded failure, not a
+        # rejected record or a passing drain control. Never replace it by B recovery.
         $compiler=(Get-Content -LiteralPath (Join-Path $dir 'toolchain.txt'))[0]
         $toolDir=[IO.Path]::GetDirectoryName($compiler)
         foreach ($name in @('cl.exe','c1xx.dll','c2.dll','mspdbcore.dll','mspdbsrv.exe','link.exe')) {


### PR DESCRIPTION
## Final decision: accept investigation tooling; keep #170 and #172 on HOLD

[Final exact-source/execution/evidence review and decision](https://github.com/Iviesever/msvc-quick-build/pull/173#pullrequestreview-5150102232)

- **Base:** `c8c8c0172850ff11351b63d5bd1507a7f57ac01e` (merged #171).
- **Reviewed head:** `8b93235b534a37a188ca673b7612d8bdd5d34dc1`.
- **Candidate and native test-merge tree:** `26c21df19800de6eac2d1597fbfe3998dc1f617f`.
- Test-merge `2aae2c2022dc2dfb22463bb7e9320554fef389bd` has exactly those parents.
- Three test/CI files, **480 additions/9 deletions**. Product src/include, scheduler, original matrix collectors/workflows, native executable inventory, benchmark, CLI/freshness and VERSION are unchanged.
- **VERSION remains5.5.0; no historical tag/asset or formal Release changes.**

Continue #164 with one bounded PCH/PDB-open investigation. #172's original C1041 and #170's historical performance crossing are not explained or waived by this PR. Accepting a controlled observation tool is distinct from approving a held change.

## Delivered behavior

Explicit `--pdb-case` runs the unchanged PCH Release/A-started/direct-drain workload with its four Restart Manager queries enabled or disabled. Both modes take identical metadata-only A/B PDB/PCH snapshots before A, after A and after B. `FILE_READ_ATTRIBUTES`, read/write/delete sharing and OPEN_EXISTING obtain volume+128bit file IDs. A/B handles are simultaneous during a pair comparison, then closed. Native open/query errors and unknown identities remain explicit; disabled RM slots are attempted=false/error=null/owners=null, not successful empty queries. Compatibility observations use ERROR_NOT_SUPPORTED.

The collector preserves exact source/binary provenance, complete original argv/stdout/stderr/results, physical identities, query ticks and post-case tool-file hashes. Evidence completeness is separate from original build success. Unproven cleanup or incomplete evidence stops further slots; original compiler failures are never replaced by B's recovery. Failed-case PDB/PCH copying is only after verified outer cleanup, and is not a failure-instant snapshot.

Normal default56/private42 modes keep their original queries and receive no new investigation snapshots. Original direct-drain, fixed24kA/6kB input and /FS /Zi /O2 /MT /Yu with large-A-only /bigobj stay unchanged. No compiler gets a terminating token, no global service kill, no held scheduler fixture or link-cache instrumentation is imported.

API semantics are based on Microsoft CreateFileW, FILE_ID_INFO and RmGetList documentation. They do not establish a C1041 cause. Metadata-only observation and RM queries can perturb timing; finite file identities/empty resource sets do not prove continuous identity, RPC completion or writer quiescence.

## Completed evidence

[Source/record gate](https://github.com/Iviesever/msvc-quick-build/pull/173#issuecomment-5596194976)

[Fixed study, physical identities, original regressions and raw ZIP hashes](https://github.com/Iviesever/msvc-quick-build/pull/173#issuecomment-5596264627)

[Complete19-scenario independent ABBA with every adverse sample retained](https://github.com/Iviesever/msvc-quick-build/pull/173#issuecomment-5596223901)

| Gate | Exact-head run | Result |
|---|---|---|
| Native Debug/all shards and runtime/freshness checks | #713/34313621122 | Passed, actual build and tests rather than classifier skip |
| Complete Release/self-host/exact package | #606/34313621138 | Passed; publish-release skipped |
| Documentation/Cross-Stage | #167/34313621145; #190/34313621148 | Passed |
| PDB investigation | #1/34313621181 |10synthetic expected outcomes,7actual-file checks,8fixed cases complete |
| Original default endpoint | #10/34313621117 |56complete; all14unmanaged and14direct-drain controls pass |
| Original private endpoint | #12/34313621161 |42complete; all14unmanaged controls pass |
| Independent original observer-OFF ABBA | #558/34313621163 |76pairs;72instrumented semantic identities match |

The fixed budget was declared before measurement: **four query-on/off pairs/eight cases**, on-first for odd pairs, off-first for even pairs. No repeated slot or adaptive budget. **4/4original A+B controls pass in each mode**, original server survives, pending A suppressed, actual A/B compiler overlap observed. All88original tool results/176diagnostic files inspected.96metadata calls succeed, A/B PDB/PCH identities are distinct across24snapshots; no identity change observed at those finite points.16RM queries return error0 (15empty,oneA-at-requestserviceidentity);16disabled slots stay unknown/unattempted. Original A/B workload bytes and normalized argv match the historical failed fixture in all24comparisons.

**C1041 was not observed in these eight new cases; its historical cause remains unresolved.** This is not the historical #172 failing executable/host. Both modes contain new metadata observation. Native ticks express order within a process, not a documented portable duration unit. Tool hashes are post-case files, not loaded-module attestation. The post-cleanup failed-file-copy path was not exercised because no new study case failed.

Original regressions keep all28A-started managed-service deaths. Default happened to have all original B builds succeed despite14service deaths; private retains three original B failures(C1090/C1051) despite successful later recovery. Neither favorable results nor green collection authorizes service termination or lease transfer. Resource identity appears only5/56default and2/42private.

## Performance and unchanged acceptance discipline

Independent original19x4ABBA measured exact PR base/head with observer OFF.72instrumented pairs retain complete counters/breakdown/hit-miss; four external timings-off counter sets are unavailable. External no-op paired median **+0.8505ms/+7.1121%**, MAD0.35225ms,max+1.3756ms,**4/4slower**. The predeclared median gate (worse by **both1ms and10%**) is not crossed. No zero-cost/speedup claim: scale-single-TU is4/4slower,median+22.045ms/+16.82%; discovery-cold tail+550.034ms. All rows and unfavorable/favorable samples retained, no AA subtraction/noise-based deletion. Four-pair P95 is the maximum, not a population-tail estimate. #170's crossing and historical cold-tail debt remain open.

Original predeclared gates are unchanged: full exact-source native/selfhost/package and applicable docs/Cross-Stage;10synthetic plus7actual-file checks; eight complete fixed investigation records with typed missing evidence/original outcomes; original default56/private42 positive controls; independent19x4ABBA and all72semantic identities with the same median threshold. All applicable tooling gates passed. Study success never automatically approves #172/#170.

No post-PR source correction or same-head CI/benchmark rerun occurred. A pre-PR transfer placeholder correction remains in history. Local strict GCC checks used declaration-only Win32 shims, not MSVC runtime. All eight raw ZIPs, exact source trees, original samples and read-only audit scripts are separately retained; Actions retention30days. Investigation inputs are not the performance workflow's executable pair. Title changed only after actual#558 completed; later skipped perf jobs do not replace that measurement.

## Handoff

**Accept ordinary expected-head merge under protection. Keep #170 and #172 held, M1b incomplete and safety fields false.** Next focused work needs the actual file-open/RPC failure status with process/file identity at the event, trace-completeness checks and a separately labeled controlled positive failure—not another uninstrumented success-only rerun. Historical missing traces cannot be fabricated. Snapshot/event observers may themselves perturb behavior.

No CLI cancellation, project transaction, build/run/session/residency, owner-crash recovery, external writer authority or formal release is included. Final VERSION/release remains separate.