### PR TITLE
test: calibrate native PDB file events after recording readiness

### DIFF
--- a/.github/workflows/pdb-file-trace.yml
+++ b/.github/workflows/pdb-file-trace.yml
@@ -86,7 +86,7 @@ jobs:
           if-no-files-found: warn
           retention-days: 30
   observe:
-    name: Native failure calibration and four fixed traced MSVC cases
+    name: Recording readiness refusal and four fixed traced MSVC cases
     needs: [build, contract]
     # Different disposable VM; never compile tools on the observation host.
     runs-on: windows-latest

--- a/.github/workflows/pdb-file-trace.yml
+++ b/.github/workflows/pdb-file-trace.yml
@@ -1,0 +1,122 @@
+name: PDB File Event Evidence
+
+on:
+  pull_request:
+    paths:
+      - 'cpp/tests/platform/windows/pdb_file_event_probe.cpp'
+      - 'tests/native/collect_pdb_file_trace.ps1'
+      - 'tests/native/verify_pdb_file_trace.py'
+      - '.github/workflows/pdb-file-trace.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: pdb-file-trace-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+permissions:
+  contents: read
+jobs:
+  contract:
+    name: File-event correlation record contracts
+    runs-on: windows-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - shell: pwsh
+        run: |
+          python tests/native/verify_pdb_file_trace.py --self-test --output .mqb/file-trace-contracts.json
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $tokens=$null; $errors=$null
+          [void][Management.Automation.Language.Parser]::ParseFile(
+            (Join-Path $PWD 'tests/native/collect_pdb_file_trace.ps1'),[ref]$tokens,[ref]$errors)
+          if (@($errors).Count) { throw "$errors" }
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: file-trace-contracts
+          path: .mqb/file-trace-contracts.json
+          include-hidden-files: true
+          retention-days: 30
+  build:
+    name: Build exact file-event recorder and ownership probe
+    runs-on: windows-latest
+    timeout-minutes: 30
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - shell: pwsh
+        run: |
+          $seed=& ./tests/native/acquire_seed.ps1 -RepoRoot $PWD -OutputRoot (Join-Path $PWD 'native-seed')
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $mqb=& ./tests/native/build_mqb.ps1 -BuilderMqbPath $seed -RepoRoot $PWD -Version '5.5.0' `
+            -Configuration Release -Clean -OutputPath (Join-Path $PWD 'native-out/file-trace/mqb.exe')
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          & ./tests/native/collect_msvc_service_ownership.ps1 -MqbPath $mqb -RepoRoot $PWD -BuildOnly `
+            -OutputRoot (Join-Path $PWD '.mqb/file-trace-build')
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $output=@(& $mqb cpp/tests/platform/windows/pdb_file_event_probe.cpp cpp/src/platform/windows/CommandLine.cpp `
+            --env vs --no-discover --std c++23 --release --runtime MT -I cpp/include `
+            --compiler-arg /W4 --compiler-arg /permissive- --lib advapi32.lib --lib tdh.lib -o pdb_file_event_probe 2>&1)
+          $code=$LASTEXITCODE
+          $output | Set-Content .mqb/file-trace-build/recorder-build.txt -Encoding utf8
+          $output | ForEach-Object { Write-Host $_ }
+          if ($code -ne 0) { exit $code }
+          New-Item -ItemType Directory -Path 'native-out/file-trace-input' -Force | Out-Null
+          Copy-Item $mqb native-out/file-trace-input/mqb.exe
+          Copy-Item .mqb/bin/msvc_service_ownership_probe.exe,.mqb/bin/pdb_file_event_probe.exe,`
+            .mqb/file-trace-build/probe.identity.json native-out/file-trace-input/
+          @{ source_head=(& git rev-parse HEAD).Trim(); trace_sha256=(Get-FileHash .mqb/bin/pdb_file_event_probe.exe).Hash } |
+            ConvertTo-Json | Set-Content native-out/file-trace-input/file-trace.identity.json -Encoding utf8
+      - uses: actions/upload-artifact@v7
+        with:
+          name: file-trace-input
+          path: native-out/file-trace-input/*
+          if-no-files-found: error
+          retention-days: 30
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: file-trace-build
+          path: .mqb/file-trace-build/**
+          include-hidden-files: true
+          if-no-files-found: warn
+          retention-days: 30
+  observe:
+    name: Native failure calibration and four fixed traced MSVC cases
+    needs: [build, contract]
+    # Different disposable VM; never compile tools on the observation host.
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - uses: actions/download-artifact@v8
+        with:
+          name: file-trace-input
+          path: native-input
+      - shell: pwsh
+        env:
+          MQB_OWNERSHIP_DISPOSABLE_HOST: '1'
+        run: |
+          & ./tests/native/collect_pdb_file_trace.ps1 -InputRoot (Join-Path $PWD 'native-input') `
+            -OutputRoot (Join-Path $PWD '.mqb/pdb-file-trace') -RepoRoot $PWD
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+      - name: Preserve raw ETL, decoded events and original diagnostics on every outcome
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: pdb-file-trace-evidence
+          path: |
+            .mqb/pdb-file-trace/**
+            !.mqb/pdb-file-trace/**/*.obj
+            !.mqb/pdb-file-trace/**/*.pdb
+            !.mqb/pdb-file-trace/**/*.pch
+            !.mqb/pdb-file-trace/**/*.exe
+          include-hidden-files: true
+          if-no-files-found: warn
+          retention-days: 30

--- a/cpp/tests/platform/windows/pdb_file_event_probe.cpp
+++ b/cpp/tests/platform/windows/pdb_file_event_probe.cpp
@@ -9,6 +9,12 @@
 
 #include <algorithm>
 #include <array>
+#include <chrono>
+#include <condition_variable>
+#include <map>
+#include <mutex>
+#include <optional>
+#include <thread>
 #include <cstdint>
 #include <climits>
 #include <utility>
@@ -133,7 +139,7 @@ struct Session {
         p->Wnode.BufferSize = static_cast<ULONG>(buffer.words.size() * sizeof(std::uint64_t));
         p->Wnode.Flags = WNODE_FLAG_TRACED_GUID; p->Wnode.ClientContext = 1; // QPC timestamps.
         p->BufferSize = 256; p->MinimumBuffers = 32; p->MaximumBuffers = 128;
-        p->LogFileMode = EVENT_TRACE_FILE_MODE_SEQUENTIAL; p->MaximumFileSize = 256; p->FlushTimer = 1;
+        p->LogFileMode = EVENT_TRACE_FILE_MODE_SEQUENTIAL | EVENT_TRACE_REAL_TIME_MODE; p->MaximumFileSize = 256; p->FlushTimer = 1;
         p->LoggerNameOffset = sizeof(EVENT_TRACE_PROPERTIES);
         p->LogFileNameOffset = p->LoggerNameOffset + static_cast<ULONG>((name.size() + 1) * sizeof(wchar_t));
         auto* base = reinterpret_cast<char*>(p);
@@ -161,7 +167,11 @@ std::string process_identity() {
     return "{\"pid\":" + std::to_string(::GetCurrentProcessId()) + ",\"tid\":" + std::to_string(::GetCurrentThreadId())
         + ",\"created_filetime\":" + std::to_string(filetime(created)) + "}";
 }
-std::string calibration(const fs::path& path) {
+struct CalibrationWindow {
+    std::uint64_t start{}, denied_before{}, denied_after{};
+    DWORD pid{}, tid{};
+};
+std::string calibration(const fs::path& path, CalibrationWindow* window = nullptr) {
     const auto start = qpc();
     Handle owner{::CreateFileW(path.c_str(), GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ,
                               nullptr, CREATE_NEW, FILE_ATTRIBUTE_NORMAL, nullptr)};
@@ -174,6 +184,7 @@ std::string calibration(const fs::path& path) {
     const DWORD error = denied ? ERROR_SUCCESS : ::GetLastError();
     const auto after = qpc();
     require(!denied && error == ERROR_SHARING_VIOLATION, "controlled sharing conflict missing native=" + std::to_string(error));
+    if (window) *window = {start, before, after, ::GetCurrentProcessId(), ::GetCurrentThreadId()};
     return "{\"path\":" + js(utf8(path.wstring())) + ",\"owner\":" + process_identity()
         + ",\"start_qpc\":" + std::to_string(start) + ",\"denied_before_qpc\":" + std::to_string(before)
         + ",\"denied_after_qpc\":" + std::to_string(after) + ",\"win32_error\":" + std::to_string(error)
@@ -182,7 +193,11 @@ std::string calibration(const fs::path& path) {
 }
 // TDH decodes selected named properties from the host's actual event schema.
 // Raw payload/version/flags are retained; no guessed hard-coded byte offsets.
-std::string event_data(EVENT_RECORD* event, std::string* schema) {
+struct FileFields {
+    std::optional<std::uint64_t> irp, status, issuing_tid;
+    std::wstring path;
+};
+std::string event_data(EVENT_RECORD* event, std::string* schema, FileFields* fields = nullptr) {
     ULONG bytes{};
     auto status = ::TdhGetEventInformation(event, 0, nullptr, nullptr, &bytes);
     require(status == ERROR_INSUFFICIENT_BUFFER && bytes <= 1024 * 1024, "TDH event metadata unavailable");
@@ -217,7 +232,9 @@ std::string event_data(EVENT_RECORD* event, std::string* schema) {
         std::string encoded;
         const auto type = property.nonStructType.InType;
         if (type == TDH_INTYPE_UNICODESTRING) {
-            encoded = js(utf8(bounded_string(data, size, 0)));
+            const auto text = bounded_string(data, size, 0);
+            encoded = js(utf8(text));
+            if (fields && name == L"FileName") fields->path = text;
         } else if (type == TDH_INTYPE_ANSISTRING) {
             // ProcessStop v2 ImageName is ANSI; retain exact bytes rather than
             // guessing an encoding or replacing the Unicode ProcessStart identity.
@@ -226,6 +243,11 @@ std::string event_data(EVENT_RECORD* event, std::string* schema) {
         } else if ((type == TDH_INTYPE_UINT32 || type == TDH_INTYPE_HEXINT32 || type == TDH_INTYPE_UINT64 ||
                     type == TDH_INTYPE_HEXINT64 || type == TDH_INTYPE_POINTER || type == TDH_INTYPE_FILETIME) && (size == 4 || size == 8)) {
             std::uint64_t number{}; std::memcpy(&number, data, size); encoded = std::to_string(number);
+            if (fields) {
+                if (name == L"Irp") fields->irp = number;
+                if (name == L"Status") fields->status = number;
+                if (name == L"IssuingThreadId" || name == L"ThreadId") fields->issuing_tid = number;
+            }
         } else { throw std::runtime_error("unsupported selected field " + utf8(name) + " type=" + std::to_string(type)); }
         if (!first) out += ','; first = false;
         out += js(utf8(name)) + ':' + encoded;
@@ -260,15 +282,183 @@ struct Decoder {
         } catch (...) { ++self.errors; }
     }
 };
+// Consume the SAME file+real-time session. No sleep, readiness-marker retry, or
+// discarded calibration. The ETL remains authoritative: offline audit must find
+// these exact live-observed payloads again, plus both original boundary controls.
+struct LiveReadiness {
+    struct Event {
+        std::uint64_t stamp{}, irp{}, status{}, issuing_tid{};
+        DWORD pid{}, tid{};
+        std::wstring path;
+        std::string json;
+    };
+    struct Pair {
+        Event begin, end;
+        std::string json() const { return "{\"begin\":" + begin.json + ",\"end\":" + end.json + "}"; }
+    };
+    std::mutex mutex;
+    std::condition_variable changed;
+    std::map<std::uint64_t, Event> pending;
+    std::optional<Pair> provider_pair;
+    std::vector<Pair> opening_pairs;
+    std::wstring name, device, drive, target;
+    EVENT_TRACE_LOGFILEW log{};
+    TRACEHANDLE trace{INVALID_PROCESSTRACE_HANDLE};
+    std::jthread consumer;
+    std::chrono::steady_clock::time_point deadline;
+    std::uint64_t frequency{}, started_qpc{}, expires_qpc{}, provider_ack{}, opening_ack{}, decision_qpc{};
+    std::uint64_t errors{};
+    ULONG process_status{ERROR_INVALID_STATE}, close_status{ERROR_INVALID_STATE};
+    DWORD wait_status{ERROR_INVALID_STATE};
+    bool active{}, admitted{}, done{};
+    std::string phase{"not-started"}, error;
+
+    LiveReadiness(std::wstring session, std::wstring device_root, std::wstring dos_root, std::uint64_t hz)
+        : name(std::move(session)), device(std::move(device_root)), drive(std::move(dos_root)), frequency(hz) {
+        log.LoggerName = name.data();
+        log.ProcessTraceMode = PROCESS_TRACE_MODE_REAL_TIME | PROCESS_TRACE_MODE_EVENT_RECORD | PROCESS_TRACE_MODE_RAW_TIMESTAMP;
+        log.EventRecordCallback = callback; log.Context = this;
+        trace = ::OpenTraceW(&log);
+        require(trace != INVALID_PROCESSTRACE_HANDLE, "OpenTrace live readiness failed native=" + std::to_string(::GetLastError()));
+        try {
+            consumer = std::jthread([this] {
+                const auto result = ::ProcessTrace(&trace, 1, nullptr, nullptr);
+                std::lock_guard lock{mutex}; process_status = result; done = true; changed.notify_all();
+            });
+        } catch (...) { ::CloseTrace(trace); trace = INVALID_PROCESSTRACE_HANDLE; throw; }
+    }
+    ~LiveReadiness() { finish(); }
+    void finish() {
+        if (trace == INVALID_PROCESSTRACE_HANDLE) return;
+        // ERROR_CTX_CLOSE_PENDING is a documented successful real-time close.
+        // Joining can wait for ETW's queued buffers; this is not a hard deadline.
+        close_status = ::CloseTrace(trace);
+        if (consumer.joinable()) consumer.join();
+        trace = INVALID_PROCESSTRACE_HANDLE;
+    }
+    void start() {
+        std::lock_guard lock{mutex};
+        require(!active, "readiness may only start once");
+        active = true; started_qpc = qpc(); expires_qpc = started_qpc + frequency * 10;
+        deadline = std::chrono::steady_clock::now() + std::chrono::seconds{10};
+        phase = "waiting-provider";
+    }
+    std::wstring canonical(std::wstring path) const {
+        std::replace(path.begin(), path.end(), L'/', L'\\');
+        if (path.size() > device.size() && path[device.size()] == L'\\' &&
+            ::CompareStringOrdinal(path.data(), static_cast<int>(device.size()), device.data(), static_cast<int>(device.size()), TRUE) == CSTR_EQUAL)
+            path = drive + path.substr(device.size());
+        if (path.starts_with(L"\\??\\") || path.starts_with(L"\\\\?\\")) path.erase(0, 4);
+        return path;
+    }
+    static void WINAPI callback(EVENT_RECORD* record) noexcept {
+        auto& self = *static_cast<LiveReadiness*>(record->UserContext);
+        try {
+            std::lock_guard lock{self.mutex};
+            if (!self.active || self.admitted || self.errors || self.wait_status == WAIT_TIMEOUT) return;
+            const auto id = record->EventHeader.EventDescriptor.Id;
+            if (!::IsEqualGUID(record->EventHeader.ProviderId, file_provider) || (id != 12 && id != 24)) return;
+            FileFields fields;
+            const auto data = event_data(record, nullptr, &fields);
+            require(fields.irp.has_value(), "live event missing IRP");
+            Event event;
+            event.stamp = static_cast<std::uint64_t>(record->EventHeader.TimeStamp.QuadPart);
+            event.irp = *fields.irp; event.pid = record->EventHeader.ProcessId; event.tid = record->EventHeader.ThreadId;
+            event.issuing_tid = fields.issuing_tid.value_or(event.tid);
+            event.path = self.canonical(fields.path);
+            event.json = "{\"provider\":\"file\",\"id\":" + std::to_string(id)
+                + ",\"version\":" + std::to_string(record->EventHeader.EventDescriptor.Version)
+                + ",\"pid\":" + std::to_string(event.pid) + ",\"tid\":" + std::to_string(event.tid)
+                + ",\"qpc\":" + std::to_string(event.stamp)
+                + ",\"raw_payload\":" + js(hex(record->UserData, record->UserDataLength)) + ",\"data\":" + data + "}";
+            if (event.stamp < self.started_qpc) return;
+            if (id == 12) {
+                require(!event.path.empty(), "live Create missing file name");
+                require(self.pending.size() < 8192 && !self.pending.contains(event.irp), "live pending IRP ambiguity/cap");
+                self.pending.emplace(event.irp, std::move(event));
+            } else {
+                require(fields.status.has_value() && *fields.status <= 0xffffffffULL, "live end missing native Status");
+                event.status = *fields.status;
+                const auto it = self.pending.find(event.irp);
+                if (it == self.pending.end()) return; // Other operations also emit OperationEnd.
+                Pair pair{std::move(it->second), std::move(event)}; self.pending.erase(it);
+                require(pair.begin.stamp <= pair.end.stamp, "live completion precedes Create");
+                if (!self.provider_pair && pair.end.status == ERROR_SUCCESS) {
+                    self.provider_pair = pair; self.provider_ack = qpc();
+                }
+                if (!self.target.empty() && _wcsicmp(pair.begin.path.c_str(), self.target.c_str()) == 0) {
+                    require(self.opening_pairs.size() < 2, "duplicate opening calibration pair");
+                    self.opening_pairs.push_back(std::move(pair));
+                }
+                self.changed.notify_all();
+            }
+        } catch (const std::exception& e) {
+            std::lock_guard lock{self.mutex}; ++self.errors; self.error = e.what(); self.changed.notify_all();
+        } catch (...) {
+            std::lock_guard lock{self.mutex}; ++self.errors; self.changed.notify_all();
+        }
+    }
+    template<class Predicate> void wait(std::unique_lock<std::mutex>& lock, Predicate satisfied) {
+        if (!changed.wait_until(lock, deadline, [&] { return errors || done || satisfied(); }) || qpc() > expires_qpc) {
+            wait_status = WAIT_TIMEOUT; decision_qpc = qpc();
+            throw std::runtime_error("recording readiness timeout; compiler not admitted");
+        }
+        require(errors == 0 && !done && satisfied(), "recording readiness unavailable: " + error);
+    }
+    void wait_provider() {
+        std::unique_lock lock{mutex}; wait(lock, [&] { return provider_pair.has_value(); });
+    }
+    void arm(const fs::path& marker) {
+        std::lock_guard lock{mutex};
+        require(provider_pair.has_value() && target.empty(), "invalid opening calibration admission");
+        target = canonical(marker.wstring()); phase = "waiting-opening-calibration";
+    }
+    void wait_calibration(const CalibrationWindow& window) {
+        std::unique_lock lock{mutex}; wait(lock, [&] { return opening_pairs.size() == 2; });
+        unsigned good{}, denied{};
+        for (const auto& pair : opening_pairs) {
+            require(pair.begin.pid == window.pid && pair.begin.issuing_tid == window.tid, "live marker process/thread mismatch");
+            if (pair.end.status == 0 && window.start <= pair.begin.stamp && pair.end.stamp <= window.denied_before) ++good;
+            if (pair.end.status == 0xc0000043ULL && window.denied_before <= pair.begin.stamp && pair.end.stamp <= window.denied_after) ++denied;
+        }
+        require(good == 1 && denied == 1, "live opening calibration status/order mismatch");
+        opening_ack = qpc();
+        require(opening_ack <= expires_qpc, "opening acknowledgement exceeded readiness deadline");
+        wait_status = WAIT_OBJECT_0; decision_qpc = opening_ack; admitted = true; phase = "admitted";
+        pending.clear(); // No further live decoding; offline ETL audit checks the entire trace.
+    }
+    bool healthy() const {
+        return admitted && errors == 0 && process_status == ERROR_SUCCESS &&
+            (close_status == ERROR_SUCCESS || close_status == ERROR_CTX_CLOSE_PENDING);
+    }
+    std::string report(bool withheld) const {
+        std::string pairs = "[";
+        for (const auto& pair : opening_pairs) { if (pairs.size() > 1) pairs += ','; pairs += pair.json(); }
+        return "{\"schema\":1,\"mode\":\"same-session-real-time\",\"wait_limit_ms\":10000,\"pending_irp_limit\":8192"
+            ",\"file_provider_withheld\":" + std::string{withheld ? "true" : "false"}
+            + ",\"accepted\":" + (admitted ? "true" : "false") + ",\"phase\":" + js(phase)
+            + ",\"start_qpc\":" + std::to_string(started_qpc) + ",\"deadline_qpc\":" + std::to_string(expires_qpc)
+            + ",\"provider_ack_qpc\":" + (provider_pair ? std::to_string(provider_ack) : "null")
+            + ",\"opening_ack_qpc\":" + (admitted ? std::to_string(opening_ack) : "null")
+            + ",\"decision_qpc\":" + std::to_string(decision_qpc)
+            + ",\"wait_status\":" + std::to_string(wait_status) + ",\"decode_errors\":" + std::to_string(errors)
+            + ",\"error\":" + (error.empty() ? "null" : js(error))
+            + ",\"process_trace_status\":" + std::to_string(process_status) + ",\"close_trace_status\":" + std::to_string(close_status)
+            + ",\"provider_pair\":" + (provider_pair ? provider_pair->json() : "null")
+            + ",\"opening_pairs\":" + pairs + "]}";
+    }
+};
 int record(int argc, wchar_t** argv) {
-    require(argc >= 4, "use pdb_file_event_probe OUTPUT-DIRECTORY EXECUTABLE [ARGV...]");
+    const bool withhold_file = argc > 1 && std::wstring_view{argv[1]} == L"--test-withhold-file-provider";
+    const int offset = withhold_file ? 1 : 0;
+    require(argc >= 4 + offset, "use pdb_file_event_probe OUTPUT-DIRECTORY EXECUTABLE [ARGV...]");
     for (const auto& expected : std::array<std::pair<const wchar_t*, const wchar_t*>, 3>{{
         {L"MQB_OWNERSHIP_DISPOSABLE_HOST", L"1"}, {L"GITHUB_ACTIONS", L"true"}, {L"RUNNER_ENVIRONMENT", L"github-hosted"}}}) {
         wchar_t value[128]{};
         require(::GetEnvironmentVariableW(expected.first, value, 128) > 0 && std::wstring_view{value} == expected.second,
                 "event recording requires an explicitly disposable hosted VM");
     }
-    const fs::path dir = fs::absolute(argv[1]);
+    const fs::path dir = fs::absolute(argv[1 + offset]);
     require(!fs::exists(dir), "refusing to overwrite an earlier trace"); fs::create_directories(dir);
     wchar_t device[32768]{};
     require(::QueryDosDeviceW(dir.root_name().c_str(), device, 32768) != 0, "QueryDosDevice failed");
@@ -279,13 +469,22 @@ int record(int argc, wchar_t** argv) {
     const auto etl = dir / "events.etl";
     const auto session_name = L"MQB-PdbFileTrace-" + std::to_wstring(::GetCurrentProcessId()) + L"-" + std::to_wstring(qpc());
     Session session{etl, session_name};
+    LiveReadiness live{session_name, device, dir.root_name().wstring(), frequency.QuadPart};
     std::string failure, before = "null", after = "null", child = "null";
     try {
-        session.enable(file_provider, file_mask); session.enable(process_provider, process_mask);
-        before = calibration(dir / "calibration-before.pdb");
-        const fs::path executable = fs::absolute(argv[2]);
+        // Provider registration/configuration is not recording readiness. Observe
+        // a complete real event pair, then acknowledge the single opening marker.
+        live.start();
+        if (!withhold_file) session.enable(file_provider, file_mask);
+        session.enable(process_provider, process_mask);
+        live.wait_provider();
+        live.arm(dir / "calibration-before.pdb");
+        CalibrationWindow opening{};
+        before = calibration(dir / "calibration-before.pdb", &opening);
+        live.wait_calibration(opening);
+        const fs::path executable = fs::absolute(argv[2 + offset]);
         std::vector<std::wstring> arguments;
-        for (int i = 3; i < argc; ++i) arguments.emplace_back(argv[i]);
+        for (int i = 3 + offset; i < argc; ++i) arguments.emplace_back(argv[i]);
         auto command = mqb::platform::windows::build_command_line(executable.wstring(), arguments);
         STARTUPINFOW startup{}; startup.cb = sizeof(startup); PROCESS_INFORMATION information{};
         // This test launcher owns only the root HANDLE. The existing ownership
@@ -305,15 +504,18 @@ int record(int argc, wchar_t** argv) {
         after = calibration(dir / "calibration-after.pdb");
     } catch (const std::exception& e) { failure = e.what(); }
     session.stop();
+    live.finish(); // CloseTrace targets the consumer, not the controller session.
+    const auto readiness = live.report(withhold_file);
+    save(dir / "readiness.json", readiness + "\n");
     auto* health = session.properties();
     // Stop result/loss counters survive even if TDH decoding subsequently fails.
-    save(dir / "capture.json", "{\"schema\":1,\"session\":" + js(utf8(session_name))
+    save(dir / "capture.json", "{\"schema\":2,\"session\":" + js(utf8(session_name))
         + ",\"dos_root\":" + js(utf8(dir.root_name().wstring())) + ",\"device_root\":" + js(utf8(device))
         + ",\"qpc_frequency\":" + std::to_string(frequency.QuadPart)
         + ",\"clock\":\"QPC\",\"file_mask\":" + std::to_string(file_mask) + ",\"process_mask\":" + std::to_string(process_mask)
         + ",\"stop_status\":" + std::to_string(session.stop_status) + ",\"events_lost\":" + std::to_string(health->EventsLost)
         + ",\"log_buffers_lost\":" + std::to_string(health->LogBuffersLost) + ",\"realtime_buffers_lost\":" + std::to_string(health->RealTimeBuffersLost)
-        + ",\"maximum_file_mb\":256,\"child\":" + child + ",\"before\":" + before + ",\"after\":" + after
+        + ",\"readiness\":" + readiness + ",\"maximum_file_mb\":256,\"child\":" + child + ",\"before\":" + before + ",\"after\":" + after
         + ",\"failure\":" + (failure.empty() ? "null" : js(failure))
         + ",\"historical_cause_resolved\":false,\"safe_to_transfer_write_lease\":false}\n");
     checked(session.stop_status, "ControlTrace stop");
@@ -328,13 +530,19 @@ int record(int argc, wchar_t** argv) {
         + ",\"total_events\":" + std::to_string(decoder.total) + ",\"selected_events\":" + std::to_string(decoder.selected)
         + ",\"decode_errors\":" + std::to_string(decoder.errors) + ",\"capped_events\":" + std::to_string(decoder.capped)
         + ",\"etl_bytes\":" + std::to_string(fs::file_size(etl)) + ",\"log_header_events_lost\":" + std::to_string(log.LogfileHeader.EventsLost) + "}\n");
-    require(failure.empty() && result == ERROR_SUCCESS && closed == ERROR_SUCCESS && decoder.errors == 0 && decoder.capped == 0 &&
+    require(failure.empty() && live.healthy() && result == ERROR_SUCCESS && closed == ERROR_SUCCESS && decoder.errors == 0 && decoder.capped == 0 &&
         bool(decoder.output) && health->EventsLost == 0 && health->LogBuffersLost == 0 && health->RealTimeBuffersLost == 0 &&
         log.LogfileHeader.EventsLost == 0 && fs::file_size(etl) < 256ULL * 1024 * 1024, "capture incomplete; retain diagnostics, do not interpret missing events");
     return 0; // Collection only. Original child success is evaluated separately.
 }
 }
 int wmain(int argc, wchar_t** argv) {
-    try { return record(argc, argv); }
+    try {
+        if (argc == 3 && std::wstring_view{argv[1]} == L"--test-child-sentinel") {
+            save(fs::path{argv[2]}, "CHILD_WAS_ADMITTED\n");
+            return 0;
+        }
+        return record(argc, argv);
+    }
     catch (const std::exception& e) { std::cerr << "FILE_TRACE_INFRASTRUCTURE_FAILURE " << e.what() << '\n'; return 1; }
 }

--- a/cpp/tests/platform/windows/pdb_file_event_probe.cpp
+++ b/cpp/tests/platform/windows/pdb_file_event_probe.cpp
@@ -17,6 +17,8 @@
 #include <fstream>
 #include <iostream>
 #include <stdexcept>
+#include <set>
+#include <tuple>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -180,14 +182,25 @@ std::string calibration(const fs::path& path) {
 }
 // TDH decodes selected named properties from the host's actual event schema.
 // Raw payload/version/flags are retained; no guessed hard-coded byte offsets.
-std::string event_data(EVENT_RECORD* event) {
+std::string event_data(EVENT_RECORD* event, std::string* schema) {
     ULONG bytes{};
     auto status = ::TdhGetEventInformation(event, 0, nullptr, nullptr, &bytes);
     require(status == ERROR_INSUFFICIENT_BUFFER && bytes <= 1024 * 1024, "TDH event metadata unavailable");
     Buffer storage(bytes); auto* info = storage.as<TRACE_EVENT_INFO>();
     checked(::TdhGetEventInformation(event, 0, nullptr, info, &bytes), "TdhGetEventInformation");
-    const std::vector<std::wstring> selected{L"Irp", L"FileObject", L"FileName", L"NtStatus", L"IssuingThreadId", L"ThreadId",
+    const std::vector<std::wstring> selected{L"Irp", L"FileObject", L"FileName", L"Status", L"NtStatus", L"IssuingThreadId", L"ThreadId",
         L"CreateOptions", L"CreateAttributes", L"ShareAccess", L"ProcessID", L"ThreadID", L"CreateTime", L"ImageName", L"ParentProcessID"};
+    if (schema) {
+        *schema = "[";
+        for (ULONG i = 0; i < info->TopLevelPropertyCount; ++i) {
+            const auto& p = info->EventPropertyInfoArray[i];
+            if (i) *schema += ',';
+            *schema += "{\"name\":" + js(utf8(bounded_string(info, bytes, p.NameOffset)))
+                + ",\"flags\":" + std::to_string(p.Flags)
+                + ",\"in_type\":" + ((p.Flags & PropertyStruct) ? "null" : std::to_string(p.nonStructType.InType)) + "}";
+        }
+        *schema += ']';
+    }
     std::string out = "{"; bool first = true;
     for (ULONG i = 0; i < info->TopLevelPropertyCount; ++i) {
         const auto& property = info->EventPropertyInfoArray[i];
@@ -205,6 +218,11 @@ std::string event_data(EVENT_RECORD* event) {
         const auto type = property.nonStructType.InType;
         if (type == TDH_INTYPE_UNICODESTRING) {
             encoded = js(utf8(bounded_string(data, size, 0)));
+        } else if (type == TDH_INTYPE_ANSISTRING) {
+            // ProcessStop v2 ImageName is ANSI; retain exact bytes rather than
+            // guessing an encoding or replacing the Unicode ProcessStart identity.
+            require(data[size - 1] == 0, "unterminated ANSI event property");
+            encoded = "{\"encoding\":\"opaque-ansi\",\"bytes\":" + js(hex(data, size - 1)) + "}";
         } else if ((type == TDH_INTYPE_UINT32 || type == TDH_INTYPE_HEXINT32 || type == TDH_INTYPE_UINT64 ||
                     type == TDH_INTYPE_HEXINT64 || type == TDH_INTYPE_POINTER || type == TDH_INTYPE_FILETIME) && (size == 4 || size == 8)) {
             std::uint64_t number{}; std::memcpy(&number, data, size); encoded = std::to_string(number);
@@ -217,6 +235,7 @@ std::string event_data(EVENT_RECORD* event) {
 struct Decoder {
     std::ofstream output;
     std::uint64_t total{}, selected{}, errors{}, capped{};
+    std::set<std::tuple<bool, USHORT, UCHAR>> schemas;
     explicit Decoder(const fs::path& file) : output(file, std::ios::binary) { require(bool(output), "cannot open events output"); }
     static void WINAPI callback(EVENT_RECORD* event) noexcept {
         auto& self = *static_cast<Decoder*>(event->UserContext);
@@ -227,13 +246,15 @@ struct Decoder {
         if (!(is_file && (id == 12 || id == 24)) && !(is_process && id >= 1 && id <= 4)) return;
         if (++self.selected > 500000) { ++self.capped; return; }
         try {
-            std::string decoded, error;
-            try { decoded = event_data(event); } catch (const std::exception& e) { error = e.what(); ++self.errors; decoded = "null"; }
+            std::string decoded, error, schema = "null";
+            const bool first_schema = self.schemas.emplace(is_file, id, event->EventHeader.EventDescriptor.Version).second;
+            try { decoded = event_data(event, first_schema ? &schema : nullptr); } catch (const std::exception& e) { error = e.what(); ++self.errors; decoded = "null"; }
             self.output << "{\"sequence\":" << self.total << ",\"provider\":" << js(is_file ? "file" : "process")
                 << ",\"id\":" << id << ",\"version\":" << unsigned(event->EventHeader.EventDescriptor.Version)
                 << ",\"flags\":" << event->EventHeader.Flags << ",\"pid\":" << event->EventHeader.ProcessId
                 << ",\"tid\":" << event->EventHeader.ThreadId << ",\"qpc\":" << event->EventHeader.TimeStamp.QuadPart
                 << ",\"raw_payload\":" << js(hex(event->UserData, event->UserDataLength))
+                << ",\"property_schema\":" << schema
                 << ",\"decode_error\":" << (error.empty() ? "null" : js(error)) << ",\"data\":" << decoded << "}\n";
             if (!self.output) ++self.errors;
         } catch (...) { ++self.errors; }

--- a/cpp/tests/platform/windows/pdb_file_event_probe.cpp
+++ b/cpp/tests/platform/windows/pdb_file_event_probe.cpp
@@ -1,0 +1,319 @@
+// Diagnostic fixture only. Never called by the production CLI.
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#include <evntrace.h>
+#include <evntcons.h>
+#include <tdh.h>
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <climits>
+#include <utility>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+#include "mqb/platform/windows/CommandLine.hpp"
+
+namespace {
+namespace fs = std::filesystem;
+constexpr GUID file_provider{0xedd08927,0x9cc4,0x4e65,{0xb9,0x70,0xc2,0x56,0x0f,0xb5,0xc2,0x89}};
+constexpr GUID process_provider{0x22fb2cd6,0x0e7b,0x422b,{0xa0,0xc7,0x2f,0xad,0x1f,0xd0,0xe7,0x16}};
+void require(bool ok, const std::string& text) { if (!ok) throw std::runtime_error(text); }
+void checked(ULONG code, const char* call) {
+    require(code == ERROR_SUCCESS, std::string{call} + " native=" + std::to_string(code));
+}
+std::string utf8(std::wstring_view text) {
+    auto result = mqb::platform::windows::utf16_to_utf8(text);
+    require(result.has_value(), "invalid UTF-16 in trace metadata");
+    return *result;
+}
+std::string js(std::string_view text) {
+    std::string out = "\"";
+    constexpr char h[] = "0123456789abcdef";
+    for (unsigned char c : text) {
+        if (c == '"' || c == '\\') { out += '\\'; out += static_cast<char>(c); }
+        else if (c < 32) { out += "\\u00"; out += h[c >> 4]; out += h[c & 15]; }
+        else out += static_cast<char>(c);
+    }
+    return out + '"';
+}
+std::string hex(const void* memory, std::size_t size) {
+    const auto* bytes = static_cast<const unsigned char*>(memory);
+    constexpr char h[] = "0123456789abcdef";
+    std::string out; out.reserve(size * 2);
+    for (std::size_t i = 0; i < size; ++i) { out += h[bytes[i] >> 4]; out += h[bytes[i] & 15]; }
+    return out;
+}
+void save(const fs::path& path, const std::string& text) {
+    std::ofstream out(path, std::ios::binary); out << text; out.flush();
+    require(bool(out), "cannot save " + utf8(path.wstring()));
+}
+std::uint64_t qpc() { LARGE_INTEGER n{}; require(::QueryPerformanceCounter(&n), "QPC failed"); return n.QuadPart; }
+std::uint64_t filetime(FILETIME t) { return (std::uint64_t{t.dwHighDateTime} << 32) | t.dwLowDateTime; }
+struct Handle {
+    HANDLE value{};
+    explicit Handle(HANDLE h = nullptr) : value(h) {}
+    ~Handle() { if (value && value != INVALID_HANDLE_VALUE) ::CloseHandle(value); }
+    Handle(const Handle&) = delete;
+    Handle& operator=(const Handle&) = delete;
+    explicit operator bool() const { return value && value != INVALID_HANDLE_VALUE; }
+};
+struct Buffer {
+    std::vector<std::uint64_t> words;
+    explicit Buffer(ULONG bytes) : words((bytes + 7ULL) / 8) {}
+    template<class T> T* as() { return reinterpret_cast<T*>(words.data()); }
+};
+std::wstring bounded_string(void* data, ULONG bytes, ULONG offset) {
+    require(offset < bytes && offset % 2 == 0, "bad metadata string offset");
+    const auto* start = reinterpret_cast<const wchar_t*>(static_cast<char*>(data) + offset);
+    auto count = (bytes - offset) / sizeof(wchar_t);
+    auto end = std::find(start, start + count, L'\0');
+    require(end != start + count, "unterminated metadata string");
+    return std::wstring{start, end};
+}
+// Restore the previous token privilege state, even on a failed capture.
+struct ProfilePrivilege {
+    Handle token;
+    TOKEN_PRIVILEGES previous{};
+    bool changed{};
+    ProfilePrivilege() : token([] { HANDLE h{}; require(::OpenProcessToken(::GetCurrentProcess(),
+        TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY, &h), "OpenProcessToken failed"); return h; }()) {
+        TOKEN_PRIVILEGES request{}; request.PrivilegeCount = 1;
+        require(::LookupPrivilegeValueW(nullptr, L"SeSystemProfilePrivilege", &request.Privileges[0].Luid), "privilege lookup failed");
+        request.Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
+        DWORD bytes = sizeof(previous); ::SetLastError(ERROR_SUCCESS);
+        require(::AdjustTokenPrivileges(token.value, FALSE, &request, sizeof(previous), &previous, &bytes), "privilege adjustment failed");
+        changed = true; checked(::GetLastError(), "AdjustTokenPrivileges");
+    }
+    ~ProfilePrivilege() { if (changed) ::AdjustTokenPrivileges(token.value, FALSE, &previous, 0, nullptr, nullptr); }
+};
+ULONGLONG keyword_mask(const GUID& provider, const fs::path& output,
+                       const std::vector<std::wstring>& required_names) {
+    ULONG bytes{}; auto guid = provider;
+    checked(::TdhEnumerateProviderFieldInformation(&guid, EventKeywordInformation, nullptr, &bytes) == ERROR_INSUFFICIENT_BUFFER
+        ? ERROR_SUCCESS : ERROR_INVALID_DATA, "TDH keyword size");
+    require(bytes && bytes <= 1024 * 1024, "unexpected keyword metadata size");
+    Buffer storage(bytes); auto* list = storage.as<PROVIDER_FIELD_INFOARRAY>();
+    checked(::TdhEnumerateProviderFieldInformation(&guid, EventKeywordInformation, list, &bytes), "TDH keywords");
+    ULONGLONG mask{}; std::vector<bool> found(required_names.size());
+    std::string report = "[";
+    for (ULONG i = 0; i < list->NumberOfElements; ++i) {
+        const auto& field = list->FieldInfoArray[i];
+        auto name = bounded_string(list, bytes, field.NameOffset);
+        if (i) report += ',';
+        report += "{\"name\":" + js(utf8(name)) + ",\"value\":" + std::to_string(field.Value) + "}";
+        for (std::size_t j = 0; j < required_names.size(); ++j) {
+            if (name.ends_with(required_names[j])) { mask |= field.Value; found[j] = true; }
+        }
+    }
+    save(output, report + "]\n");
+    require(std::all_of(found.begin(), found.end(), [](bool value) { return value; }), "required ETW keyword unavailable; see metadata");
+    return mask;
+}
+struct Session {
+    TRACEHANDLE handle{};
+    Buffer buffer;
+    std::wstring name;
+    bool started{};
+    ULONG stop_status{ERROR_INVALID_STATE};
+    Session(const fs::path& file, std::wstring session_name)
+        : buffer(static_cast<ULONG>(sizeof(EVENT_TRACE_PROPERTIES) + (file.wstring().size() + session_name.size() + 2) * sizeof(wchar_t))),
+          name(std::move(session_name)) {
+        auto* p = properties();
+        p->Wnode.BufferSize = static_cast<ULONG>(buffer.words.size() * sizeof(std::uint64_t));
+        p->Wnode.Flags = WNODE_FLAG_TRACED_GUID; p->Wnode.ClientContext = 1; // QPC timestamps.
+        p->BufferSize = 256; p->MinimumBuffers = 32; p->MaximumBuffers = 128;
+        p->LogFileMode = EVENT_TRACE_FILE_MODE_SEQUENTIAL; p->MaximumFileSize = 256; p->FlushTimer = 1;
+        p->LoggerNameOffset = sizeof(EVENT_TRACE_PROPERTIES);
+        p->LogFileNameOffset = p->LoggerNameOffset + static_cast<ULONG>((name.size() + 1) * sizeof(wchar_t));
+        auto* base = reinterpret_cast<char*>(p);
+        std::memcpy(base + p->LoggerNameOffset, name.c_str(), (name.size() + 1) * sizeof(wchar_t));
+        const auto path = file.wstring(); std::memcpy(base + p->LogFileNameOffset, path.c_str(), (path.size() + 1) * sizeof(wchar_t));
+        checked(::StartTraceW(&handle, name.c_str(), p), "StartTraceW");
+        started = true; // A name collision is refused, never stopped or reused.
+    }
+    EVENT_TRACE_PROPERTIES* properties() { return buffer.as<EVENT_TRACE_PROPERTIES>(); }
+    void enable(const GUID& guid, ULONGLONG mask) {
+        ENABLE_TRACE_PARAMETERS parameters{}; parameters.Version = ENABLE_TRACE_PARAMETERS_VERSION_2;
+        checked(::EnableTraceEx2(handle, &guid, EVENT_CONTROL_CODE_ENABLE_PROVIDER, TRACE_LEVEL_VERBOSE,
+                                mask, 0, 10000, &parameters), "EnableTraceEx2");
+    }
+    void stop() {
+        if (!started) return;
+        stop_status = ::ControlTraceW(handle, name.c_str(), properties(), EVENT_TRACE_CONTROL_STOP);
+        if (stop_status == ERROR_SUCCESS) started = false;
+    }
+    ~Session() { if (started) stop(); }
+};
+std::string process_identity() {
+    FILETIME created{}, end{}, kernel{}, user{};
+    require(::GetProcessTimes(::GetCurrentProcess(), &created, &end, &kernel, &user), "process identity failed");
+    return "{\"pid\":" + std::to_string(::GetCurrentProcessId()) + ",\"tid\":" + std::to_string(::GetCurrentThreadId())
+        + ",\"created_filetime\":" + std::to_string(filetime(created)) + "}";
+}
+std::string calibration(const fs::path& path) {
+    const auto start = qpc();
+    Handle owner{::CreateFileW(path.c_str(), GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ,
+                              nullptr, CREATE_NEW, FILE_ATTRIBUTE_NORMAL, nullptr)};
+    require(bool(owner), "cannot create unique calibration file native=" + std::to_string(::GetLastError()));
+    FILE_ID_INFO id{};
+    require(::GetFileInformationByHandleEx(owner.value, FileIdInfo, &id, sizeof(id)), "calibration file identity failed");
+    const auto before = qpc();
+    Handle denied{::CreateFileW(path.c_str(), GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                               nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr)};
+    const DWORD error = denied ? ERROR_SUCCESS : ::GetLastError();
+    const auto after = qpc();
+    require(!denied && error == ERROR_SHARING_VIOLATION, "controlled sharing conflict missing native=" + std::to_string(error));
+    return "{\"path\":" + js(utf8(path.wstring())) + ",\"owner\":" + process_identity()
+        + ",\"start_qpc\":" + std::to_string(start) + ",\"denied_before_qpc\":" + std::to_string(before)
+        + ",\"denied_after_qpc\":" + std::to_string(after) + ",\"win32_error\":" + std::to_string(error)
+        + ",\"expected_ntstatus\":3221225539,\"volume\":" + std::to_string(id.VolumeSerialNumber)
+        + ",\"file_id\":" + js(hex(id.FileId.Identifier, sizeof(id.FileId.Identifier))) + "}";
+}
+// TDH decodes selected named properties from the host's actual event schema.
+// Raw payload/version/flags are retained; no guessed hard-coded byte offsets.
+std::string event_data(EVENT_RECORD* event) {
+    ULONG bytes{};
+    auto status = ::TdhGetEventInformation(event, 0, nullptr, nullptr, &bytes);
+    require(status == ERROR_INSUFFICIENT_BUFFER && bytes <= 1024 * 1024, "TDH event metadata unavailable");
+    Buffer storage(bytes); auto* info = storage.as<TRACE_EVENT_INFO>();
+    checked(::TdhGetEventInformation(event, 0, nullptr, info, &bytes), "TdhGetEventInformation");
+    const std::vector<std::wstring> selected{L"Irp", L"FileObject", L"FileName", L"NtStatus", L"IssuingThreadId", L"ThreadId",
+        L"CreateOptions", L"CreateAttributes", L"ShareAccess", L"ProcessID", L"ThreadID", L"CreateTime", L"ImageName", L"ParentProcessID"};
+    std::string out = "{"; bool first = true;
+    for (ULONG i = 0; i < info->TopLevelPropertyCount; ++i) {
+        const auto& property = info->EventPropertyInfoArray[i];
+        auto name = bounded_string(info, bytes, property.NameOffset);
+        if (std::find(selected.begin(), selected.end(), name) == selected.end()) continue;
+        require(!(property.Flags & PropertyStruct), "selected ETW property is structured");
+        PROPERTY_DATA_DESCRIPTOR descriptor{};
+        descriptor.PropertyName = reinterpret_cast<ULONGLONG>(name.c_str()); descriptor.ArrayIndex = ULONG_MAX;
+        ULONG size{};
+        checked(::TdhGetPropertySize(event, 0, nullptr, 1, &descriptor, &size), "TdhGetPropertySize");
+        require(size && size <= 65536, "unexpected ETW property size");
+        Buffer value(size); auto* data = value.as<BYTE>();
+        checked(::TdhGetProperty(event, 0, nullptr, 1, &descriptor, size, data), "TdhGetProperty");
+        std::string encoded;
+        const auto type = property.nonStructType.InType;
+        if (type == TDH_INTYPE_UNICODESTRING) {
+            encoded = js(utf8(bounded_string(data, size, 0)));
+        } else if ((type == TDH_INTYPE_UINT32 || type == TDH_INTYPE_HEXINT32 || type == TDH_INTYPE_UINT64 ||
+                    type == TDH_INTYPE_HEXINT64 || type == TDH_INTYPE_POINTER || type == TDH_INTYPE_FILETIME) && (size == 4 || size == 8)) {
+            std::uint64_t number{}; std::memcpy(&number, data, size); encoded = std::to_string(number);
+        } else { throw std::runtime_error("unsupported selected field " + utf8(name) + " type=" + std::to_string(type)); }
+        if (!first) out += ','; first = false;
+        out += js(utf8(name)) + ':' + encoded;
+    }
+    return out + '}';
+}
+struct Decoder {
+    std::ofstream output;
+    std::uint64_t total{}, selected{}, errors{}, capped{};
+    explicit Decoder(const fs::path& file) : output(file, std::ios::binary) { require(bool(output), "cannot open events output"); }
+    static void WINAPI callback(EVENT_RECORD* event) noexcept {
+        auto& self = *static_cast<Decoder*>(event->UserContext);
+        ++self.total;
+        const auto id = event->EventHeader.EventDescriptor.Id;
+        const bool is_file = ::IsEqualGUID(event->EventHeader.ProviderId, file_provider);
+        const bool is_process = ::IsEqualGUID(event->EventHeader.ProviderId, process_provider);
+        if (!(is_file && (id == 12 || id == 24)) && !(is_process && id >= 1 && id <= 4)) return;
+        if (++self.selected > 500000) { ++self.capped; return; }
+        try {
+            std::string decoded, error;
+            try { decoded = event_data(event); } catch (const std::exception& e) { error = e.what(); ++self.errors; decoded = "null"; }
+            self.output << "{\"sequence\":" << self.total << ",\"provider\":" << js(is_file ? "file" : "process")
+                << ",\"id\":" << id << ",\"version\":" << unsigned(event->EventHeader.EventDescriptor.Version)
+                << ",\"flags\":" << event->EventHeader.Flags << ",\"pid\":" << event->EventHeader.ProcessId
+                << ",\"tid\":" << event->EventHeader.ThreadId << ",\"qpc\":" << event->EventHeader.TimeStamp.QuadPart
+                << ",\"raw_payload\":" << js(hex(event->UserData, event->UserDataLength))
+                << ",\"decode_error\":" << (error.empty() ? "null" : js(error)) << ",\"data\":" << decoded << "}\n";
+            if (!self.output) ++self.errors;
+        } catch (...) { ++self.errors; }
+    }
+};
+int record(int argc, wchar_t** argv) {
+    require(argc >= 4, "use pdb_file_event_probe OUTPUT-DIRECTORY EXECUTABLE [ARGV...]");
+    for (const auto& expected : std::array<std::pair<const wchar_t*, const wchar_t*>, 3>{{
+        {L"MQB_OWNERSHIP_DISPOSABLE_HOST", L"1"}, {L"GITHUB_ACTIONS", L"true"}, {L"RUNNER_ENVIRONMENT", L"github-hosted"}}}) {
+        wchar_t value[128]{};
+        require(::GetEnvironmentVariableW(expected.first, value, 128) > 0 && std::wstring_view{value} == expected.second,
+                "event recording requires an explicitly disposable hosted VM");
+    }
+    const fs::path dir = fs::absolute(argv[1]);
+    require(!fs::exists(dir), "refusing to overwrite an earlier trace"); fs::create_directories(dir);
+    wchar_t device[32768]{};
+    require(::QueryDosDeviceW(dir.root_name().c_str(), device, 32768) != 0, "QueryDosDevice failed");
+    LARGE_INTEGER frequency{}; require(::QueryPerformanceFrequency(&frequency), "QPC frequency unavailable");
+    ProfilePrivilege privilege;
+    const auto file_mask = keyword_mask(file_provider, dir / "file-keywords.json", {L"KERNEL_FILE_KEYWORD_CREATE", L"KERNEL_FILE_KEYWORD_OP_END"});
+    const auto process_mask = keyword_mask(process_provider, dir / "process-keywords.json", {L"WINEVENT_KEYWORD_PROCESS", L"WINEVENT_KEYWORD_THREAD"});
+    const auto etl = dir / "events.etl";
+    const auto session_name = L"MQB-PdbFileTrace-" + std::to_wstring(::GetCurrentProcessId()) + L"-" + std::to_wstring(qpc());
+    Session session{etl, session_name};
+    std::string failure, before = "null", after = "null", child = "null";
+    try {
+        session.enable(file_provider, file_mask); session.enable(process_provider, process_mask);
+        before = calibration(dir / "calibration-before.pdb");
+        const fs::path executable = fs::absolute(argv[2]);
+        std::vector<std::wstring> arguments;
+        for (int i = 3; i < argc; ++i) arguments.emplace_back(argv[i]);
+        auto command = mqb::platform::windows::build_command_line(executable.wstring(), arguments);
+        STARTUPINFOW startup{}; startup.cb = sizeof(startup); PROCESS_INFORMATION information{};
+        // This test launcher owns only the root HANDLE. The existing ownership
+        // probe owns its fixture-wide Job. No new compiler/service kill policy.
+        const auto child_start = qpc();
+        const BOOL launched = ::CreateProcessW(executable.c_str(), command.data(), nullptr, nullptr, TRUE, 0, nullptr, nullptr, &startup, &information);
+        const DWORD launch_error = launched ? ERROR_SUCCESS : ::GetLastError();
+        checked(launch_error, "CreateProcessW trace child");
+        Handle process{information.hProcess}, thread{information.hThread};
+        FILETIME created{}, exited{}, kernel{}, user{};
+        require(::GetProcessTimes(process.value, &created, &exited, &kernel, &user), "child identity failed");
+        require(::WaitForSingleObject(process.value, INFINITE) == WAIT_OBJECT_0, "child wait failed; cleanup unproven");
+        DWORD code{}; require(::GetExitCodeProcess(process.value, &code), "child exit query failed");
+        child = "{\"pid\":" + std::to_string(information.dwProcessId) + ",\"created_filetime\":" + std::to_string(filetime(created))
+            + ",\"before_launch_qpc\":" + std::to_string(child_start) + ",\"after_wait_qpc\":" + std::to_string(qpc())
+            + ",\"exit_code\":" + std::to_string(code) + "}";
+        after = calibration(dir / "calibration-after.pdb");
+    } catch (const std::exception& e) { failure = e.what(); }
+    session.stop();
+    auto* health = session.properties();
+    // Stop result/loss counters survive even if TDH decoding subsequently fails.
+    save(dir / "capture.json", "{\"schema\":1,\"session\":" + js(utf8(session_name))
+        + ",\"dos_root\":" + js(utf8(dir.root_name().wstring())) + ",\"device_root\":" + js(utf8(device))
+        + ",\"qpc_frequency\":" + std::to_string(frequency.QuadPart)
+        + ",\"clock\":\"QPC\",\"file_mask\":" + std::to_string(file_mask) + ",\"process_mask\":" + std::to_string(process_mask)
+        + ",\"stop_status\":" + std::to_string(session.stop_status) + ",\"events_lost\":" + std::to_string(health->EventsLost)
+        + ",\"log_buffers_lost\":" + std::to_string(health->LogBuffersLost) + ",\"realtime_buffers_lost\":" + std::to_string(health->RealTimeBuffersLost)
+        + ",\"maximum_file_mb\":256,\"child\":" + child + ",\"before\":" + before + ",\"after\":" + after
+        + ",\"failure\":" + (failure.empty() ? "null" : js(failure))
+        + ",\"historical_cause_resolved\":false,\"safe_to_transfer_write_lease\":false}\n");
+    checked(session.stop_status, "ControlTrace stop");
+    Decoder decoder{dir / "events.jsonl"};
+    auto etl_path = etl.wstring(); EVENT_TRACE_LOGFILEW log{}; log.LogFileName = etl_path.data();
+    log.ProcessTraceMode = PROCESS_TRACE_MODE_EVENT_RECORD | PROCESS_TRACE_MODE_RAW_TIMESTAMP;
+    log.EventRecordCallback = Decoder::callback; log.Context = &decoder;
+    auto trace = ::OpenTraceW(&log); require(trace != INVALID_PROCESSTRACE_HANDLE, "OpenTrace failed");
+    const auto result = ::ProcessTrace(&trace, 1, nullptr, nullptr);
+    const auto closed = ::CloseTrace(trace); decoder.output.flush();
+    save(dir / "decode.json", "{\"process_trace_status\":" + std::to_string(result) + ",\"close_trace_status\":" + std::to_string(closed)
+        + ",\"total_events\":" + std::to_string(decoder.total) + ",\"selected_events\":" + std::to_string(decoder.selected)
+        + ",\"decode_errors\":" + std::to_string(decoder.errors) + ",\"capped_events\":" + std::to_string(decoder.capped)
+        + ",\"etl_bytes\":" + std::to_string(fs::file_size(etl)) + ",\"log_header_events_lost\":" + std::to_string(log.LogfileHeader.EventsLost) + "}\n");
+    require(failure.empty() && result == ERROR_SUCCESS && closed == ERROR_SUCCESS && decoder.errors == 0 && decoder.capped == 0 &&
+        bool(decoder.output) && health->EventsLost == 0 && health->LogBuffersLost == 0 && health->RealTimeBuffersLost == 0 &&
+        log.LogfileHeader.EventsLost == 0 && fs::file_size(etl) < 256ULL * 1024 * 1024, "capture incomplete; retain diagnostics, do not interpret missing events");
+    return 0; // Collection only. Original child success is evaluated separately.
+}
+}
+int wmain(int argc, wchar_t** argv) {
+    try { return record(argc, argv); }
+    catch (const std::exception& e) { std::cerr << "FILE_TRACE_INFRASTRUCTURE_FAILURE " << e.what() << '\n'; return 1; }
+}

--- a/cpp/tests/platform/windows/pdb_file_event_probe.cpp
+++ b/cpp/tests/platform/windows/pdb_file_event_probe.cpp
@@ -469,7 +469,7 @@ int record(int argc, wchar_t** argv) {
     const auto etl = dir / "events.etl";
     const auto session_name = L"MQB-PdbFileTrace-" + std::to_wstring(::GetCurrentProcessId()) + L"-" + std::to_wstring(qpc());
     Session session{etl, session_name};
-    LiveReadiness live{session_name, device, dir.root_name().wstring(), frequency.QuadPart};
+    LiveReadiness live{session_name, device, dir.root_name().wstring(), static_cast<std::uint64_t>(frequency.QuadPart)};
     std::string failure, before = "null", after = "null", child = "null";
     try {
         // Provider registration/configuration is not recording readiness. Observe

--- a/tests/native/collect_pdb_file_trace.ps1
+++ b/tests/native/collect_pdb_file_trace.ps1
@@ -1,0 +1,114 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string]$InputRoot,
+    [Parameter(Mandatory)][string]$OutputRoot,
+    [string]$RepoRoot = (Join-Path $PSScriptRoot '../..')
+)
+$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+Set-StrictMode -Version 2.0
+$InputRoot = [IO.Path]::GetFullPath($InputRoot)
+$OutputRoot = [IO.Path]::GetFullPath($OutputRoot)
+$RepoRoot = [IO.Path]::GetFullPath($RepoRoot)
+if ($env:MQB_OWNERSHIP_DISPOSABLE_HOST -ne '1' -or $env:GITHUB_ACTIONS -ne 'true' -or
+    $env:RUNNER_ENVIRONMENT -ne 'github-hosted' -or (Test-Path Env:_MSPDBSRV_ENDPOINT_)) {
+    throw 'File-event tracing requires an authorized pristine disposable hosted VM.'
+}
+if (Test-Path -LiteralPath $OutputRoot) { throw 'Refusing to overwrite earlier trace evidence.' }
+New-Item -ItemType Directory -Path $OutputRoot -Force | Out-Null
+function Write-Json($Path, $Value) {
+    $Value | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $Path -Encoding utf8
+}
+$head = (& git -C $RepoRoot rev-parse HEAD).Trim()
+if ($LASTEXITCODE -ne 0) { throw 'Cannot identify source.' }
+if (@(& git -C $RepoRoot status --porcelain --untracked-files=no).Count -ne 0 -or $LASTEXITCODE -ne 0) { throw 'Tracked source is not clean.' }
+if ((Get-Content -LiteralPath (Join-Path $RepoRoot 'VERSION') -Raw).Trim() -cne '5.5.0') { throw 'VERSION changed.' }
+$origin = Get-Content -LiteralPath (Join-Path $InputRoot 'probe.identity.json') -Raw | ConvertFrom-Json
+$traceOrigin = Get-Content -LiteralPath (Join-Path $InputRoot 'file-trace.identity.json') -Raw | ConvertFrom-Json
+if ($origin.source_head -cne $head -or $traceOrigin.source_head -cne $head -or
+    $origin.version -cne '5.5.0' -or $origin.configuration -cne 'Release') { throw 'Prebuilt source identity mismatch.' }
+$probe = Join-Path $InputRoot 'msvc_service_ownership_probe.exe'
+$tracer = Join-Path $InputRoot 'pdb_file_event_probe.exe'
+if ($origin.probe_sha256 -cne (Get-FileHash -LiteralPath $probe).Hash -or
+    $origin.candidate_sha256 -cne (Get-FileHash -LiteralPath (Join-Path $InputRoot 'mqb.exe')).Hash -or
+    $traceOrigin.trace_sha256 -cne (Get-FileHash -LiteralPath $tracer).Hash) { throw 'Prebuilt binary identity mismatch.' }
+Write-Json (Join-Path $OutputRoot 'identity.json') @{
+    source_head=$head; probe=$origin; tracer=$traceOrigin; image=$env:ImageVersion
+    os=[Environment]::OSVersion.VersionString; powershell=$PSVersionTable.PSVersion.ToString()
+    run=$env:GITHUB_RUN_ID; attempt=$env:GITHUB_RUN_ATTEMPT
+    historical_cause_resolved=$false; all_writer_coverage_proven=$false
+}
+# Complete plan before the first native capture. Neither outcomes nor runtime
+# affect this budget. Boundary calibration files are not compiler PDB failures.
+$plan = @('rm-on','rm-off','rm-off','rm-on')
+Write-Json (Join-Path $OutputRoot 'plan.json') @{
+    modes=$plan; cases=4; pairs=2; controlled_conflicts_per_trace=2; adaptive_retries=$false
+    note='Positive native sharing conflicts are separate from original MSVC outcomes; no forced C1041.'
+}
+# Reuse actual prior validators without executing their discovery/build bodies.
+foreach ($definition in @(
+    @{ file='collect_msvc_service_ownership.ps1'; names=@('Get-OwnershipDiagnosticErrors','Test-OwnershipCleanupEnvelope') },
+    @{ file='collect_pdb_open_investigation.ps1'; names=@('Assert-PdbQuery','Assert-PdbPair') }
+)) {
+    $tokens=$null; $errors=$null
+    $ast=[Management.Automation.Language.Parser]::ParseFile((Join-Path $PSScriptRoot $definition.file),[ref]$tokens,[ref]$errors)
+    if (@($errors).Count) { throw 'Existing validator parse failed.' }
+    foreach ($name in $definition.names) {
+        $functions=@($ast.FindAll({ param($node)
+            $node -is [Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -eq $name
+        }, $true))
+        if ($functions.Count -ne 1) { throw "Ambiguous validation helper: $name" }
+        . ([scriptblock]::Create($functions[0].Extent.Text))
+    }
+}
+$rows = [Collections.Generic.List[object]]::new()
+foreach ($index in 0..3) {
+    $mode = $plan[$index]; $name = ('{0:D2}-{1}' -f ($index+1),$mode)
+    $slot = Join-Path $OutputRoot $name
+    $fixture = Join-Path $slot 'fixture'; $trace = Join-Path $slot 'trace'
+    New-Item -ItemType Directory -Path $slot | Out-Null
+    $arguments = @($trace,$probe,'--pdb-case',$fixture,'pch-release','A-started','drain',('trace-'+[guid]::NewGuid().ToString('N')),$mode)
+    Write-Json (Join-Path $slot 'arguments.json') $arguments
+    $output = @(& $tracer @arguments 2>&1); $code = $LASTEXITCODE
+    $output | Set-Content -LiteralPath (Join-Path $slot 'output.txt') -Encoding utf8
+    $errors = [Collections.Generic.List[string]]::new(); $originalOk=$null; $cleanup=$null
+    try {
+        if ($code -ne 0) { throw "Native trace capture failed with $code; no retry." }
+        & python (Join-Path $PSScriptRoot 'verify_pdb_file_trace.py') --trace $trace --case-root $fixture --output (Join-Path $slot 'trace-audit.json')
+        if ($LASTEXITCODE -ne 0) { throw 'Trace integrity/calibration gate failed.' }
+        $envelope=Get-Content -LiteralPath (Join-Path $fixture 'default-envelope.json') -Raw | ConvertFrom-Json
+        $cleanup=Test-OwnershipCleanupEnvelope $envelope
+        if (-not $cleanup) { throw 'Original fixture cleanup unproven.' }
+        $observation=Get-Content -LiteralPath (Join-Path $fixture 'observation.json') -Raw | ConvertFrom-Json
+        if ($observation.profile -cne 'pch-release' -or $observation.origin -cne 'A-started' -or $observation.ending -cne 'drain' -or
+            $observation.endpoint_mode -cne 'default' -or $observation.safe_to_transfer_write_lease -isnot [bool] -or
+            $observation.safe_to_transfer_write_lease -or $observation.safe_to_integrate_cancellation -isnot [bool] -or
+            $observation.safe_to_integrate_cancellation) { throw 'Wrong original fixture identity/safety fields.' }
+        $diagnostics=@(Get-OwnershipDiagnosticErrors $fixture 'pch-release' 'A-started' 'drain' $observation)
+        # This prior helper is strict about successful drain controls. Preserve
+        # failures as failures; do not relabel an A compiler failure as calibration.
+        if ($diagnostics.Count) { throw ($diagnostics -join '; ') }
+        foreach ($i in 0..3) {
+            $query=Get-Content -LiteralPath (Join-Path $fixture "rm-query-$i.json") -Raw | ConvertFrom-Json
+            Assert-PdbQuery $query ($mode -eq 'rm-on')
+        }
+        foreach ($phase in @('before-A','after-A','after-B')) {
+            $snapshot=Get-Content -LiteralPath (Join-Path $fixture "pdb-$phase.json") -Raw | ConvertFrom-Json
+            Assert-PdbPair $snapshot.pdb; Assert-PdbPair $snapshot.pch
+        }
+        $capture=Get-Content -LiteralPath (Join-Path $trace 'capture.json') -Raw | ConvertFrom-Json
+        $originalOk=$capture.child.exit_code -eq 0 -and $observation.lifecycle_ok -eq $true -and $observation.drain_control_ok -eq $true
+        if (-not $originalOk) { throw 'Original natural-drain control failed; traced failure is not a passing control.' }
+    } catch { $errors.Add($_.Exception.Message) }
+    $rows.Add([pscustomobject]@{ name=$name; mode=$mode; capture_exit=$code; cleanup_verified=$cleanup
+        original_control_ok=$originalOk; accepted=($errors.Count -eq 0); errors=@($errors.ToArray()) })
+    Write-Json (Join-Path $OutputRoot 'summary.json') @{
+        expected=4; completed=$rows.Count; cases=@($rows.ToArray()); not_run=(4-$rows.Count)
+        historical_cause_resolved=$false; authorizes_held_pr_merge=$false; safe_to_transfer_write_lease=$false
+    }
+    if ($errors.Count) { throw 'Stopped at failed evidence/control gate; remaining slots not attempted, no adaptive retry.' }
+}
+# This executable inventory is kept outside every timed/native capture and is
+# not an attestation of in-flight loaded modules or the separate ABBA pair.
+Get-ChildItem -LiteralPath $InputRoot -File | Get-FileHash | ConvertTo-Json |
+    Set-Content -LiteralPath (Join-Path $OutputRoot 'input-hashes.json') -Encoding utf8

--- a/tests/native/collect_pdb_file_trace.ps1
+++ b/tests/native/collect_pdb_file_trace.ps1
@@ -43,8 +43,33 @@ Write-Json (Join-Path $OutputRoot 'identity.json') @{
 $plan = @('rm-on','rm-off','rm-off','rm-on')
 Write-Json (Join-Path $OutputRoot 'plan.json') @{
     modes=$plan; cases=4; pairs=2; controlled_conflicts_per_trace=2; adaptive_retries=$false
+    readiness_wait_limit_ms=10000; negative_readiness_cases=1
     note='Positive native sharing conflicts are separate from original MSVC outcomes; no forced C1041.'
 }
+# One separately labeled refusal control: omit the file-provider enable request.
+# It must wait to its fixed deadline without issuing calibration or launching the
+# child. An accidentally admitted child writes a sentinel and fails this control.
+$negative = Join-Path $OutputRoot 'negative-readiness'
+New-Item -ItemType Directory -Path $negative | Out-Null
+$negativeTrace = Join-Path $negative 'trace'
+$sentinel = Join-Path $negative 'child-was-admitted.txt'
+Write-Json (Join-Path $OutputRoot 'summary.json') @{
+    expected=4; completed=0; cases=@(); not_run=4; negative_readiness_verified=$false
+    historical_cause_resolved=$false; authorizes_held_pr_merge=$false; safe_to_transfer_write_lease=$false
+}
+$negativeArguments = @('--test-withhold-file-provider',$negativeTrace,$tracer,'--test-child-sentinel',$sentinel)
+Write-Json (Join-Path $negative 'arguments.json') $negativeArguments
+$negativeOutput = @(& $tracer @negativeArguments 2>&1); $negativeExit = $LASTEXITCODE
+$negativeOutput | Set-Content -LiteralPath (Join-Path $negative 'output.txt') -Encoding utf8
+& python (Join-Path $PSScriptRoot 'verify_pdb_file_trace.py') --trace $negativeTrace --case-root $negative `
+    --expect-no-readiness --sentinel $sentinel --output (Join-Path $negative 'audit.json')
+$negativeAuditExit = $LASTEXITCODE
+$negativeOk = $negativeExit -eq 1 -and $negativeAuditExit -eq 0 -and -not (Test-Path -LiteralPath $sentinel)
+Write-Json (Join-Path $negative 'result.json') @{
+    expected_native_exit=1; actual_native_exit=$negativeExit; auditor_exit=$negativeAuditExit
+    sentinel_exists=(Test-Path -LiteralPath $sentinel); negative_readiness_verified=$negativeOk
+}
+if (-not $negativeOk) { throw 'Missing-readiness refusal control failed; no compiler cases attempted.' }
 # Reuse actual prior validators without executing their discovery/build bodies.
 foreach ($definition in @(
     @{ file='collect_msvc_service_ownership.ps1'; names=@('Get-OwnershipDiagnosticErrors','Test-OwnershipCleanupEnvelope') },
@@ -74,7 +99,7 @@ foreach ($index in 0..3) {
     $errors = [Collections.Generic.List[string]]::new(); $originalOk=$null; $cleanup=$null
     try {
         if ($code -ne 0) { throw "Native trace capture failed with $code; no retry." }
-        & python (Join-Path $PSScriptRoot 'verify_pdb_file_trace.py') --trace $trace --case-root $fixture --output (Join-Path $slot 'trace-audit.json')
+        & python (Join-Path $PSScriptRoot 'verify_pdb_file_trace.py') --trace $trace --case-root $fixture --require-readiness --output (Join-Path $slot 'trace-audit.json')
         if ($LASTEXITCODE -ne 0) { throw 'Trace integrity/calibration gate failed.' }
         $envelope=Get-Content -LiteralPath (Join-Path $fixture 'default-envelope.json') -Raw | ConvertFrom-Json
         $cleanup=Test-OwnershipCleanupEnvelope $envelope
@@ -104,6 +129,7 @@ foreach ($index in 0..3) {
         original_control_ok=$originalOk; accepted=($errors.Count -eq 0); errors=@($errors.ToArray()) })
     Write-Json (Join-Path $OutputRoot 'summary.json') @{
         expected=4; completed=$rows.Count; cases=@($rows.ToArray()); not_run=(4-$rows.Count)
+        negative_readiness_verified=$negativeOk
         historical_cause_resolved=$false; authorizes_held_pr_merge=$false; safe_to_transfer_write_lease=$false
     }
     if ($errors.Count) { throw 'Stopped at failed evidence/control gate; remaining slots not attempted, no adaptive retry.' }

--- a/tests/native/verify_pdb_file_trace.py
+++ b/tests/native/verify_pdb_file_trace.py
@@ -1,0 +1,267 @@
+"""Read-only ETW Create/OperationEnd audit. No Windows calls or third-party packages.
+
+An IRP/FileObject value is a transient kernel identifier, NOT a durable file ID.
+Zero reported loss and boundary controls do not prove coverage of every writer.
+"""
+from __future__ import annotations
+import argparse
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+
+class EvidenceError(ValueError):
+    pass
+
+
+def need(condition: bool, message: str) -> None:
+    if not condition:
+        raise EvidenceError(message)
+
+
+def integer(value: Any, field: str) -> int:
+    need(type(value) is int and value >= 0, f"missing/invalid unsigned {field}")
+    return value
+
+
+def load(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8-sig"))
+
+
+def canonical(path: str, capture: dict) -> str:
+    need(isinstance(path, str) and bool(path), "missing event path")
+    value = path.replace("/", "\\").casefold()
+    device = capture["device_root"].casefold()
+    if value.startswith(device + "\\"):
+        return capture["dos_root"].casefold() + value[len(device):]
+    for prefix in ("\\??\\", "\\\\?\\"):
+        if value.startswith(prefix):
+            value = value[len(prefix):]
+    return value
+
+
+def audit(capture: dict, decode: dict, events: list[dict], case_root: str) -> dict:
+    need(type(capture.get("schema")) is int and capture["schema"] == 1 and capture.get("clock") == "QPC", "unknown capture schema/clock")
+    integer(capture.get("qpc_frequency"), "qpc_frequency")
+    need(capture["qpc_frequency"] > 0, "zero QPC frequency")
+    for field in ("stop_status", "events_lost", "log_buffers_lost", "realtime_buffers_lost"):
+        need(integer(capture.get(field), field) == 0, f"incomplete capture: {field}")
+    for field in ("process_trace_status", "close_trace_status", "decode_errors", "capped_events", "log_header_events_lost"):
+        need(integer(decode.get(field), field) == 0, f"incomplete decode: {field}")
+    need(0 < integer(decode.get("etl_bytes"), "etl_bytes") < 256 * 1024 * 1024, "missing/capped ETL")
+    need(capture.get("failure") is None, "native capture failure")
+    need(capture.get("historical_cause_resolved") is False and capture.get("safe_to_transfer_write_lease") is False,
+         "trace must not authorize historical cause or writer lease")
+    need(integer(decode.get("selected_events"), "selected_events") == len(events), "selected-event count mismatch")
+    need(integer(decode.get("total_events"), "total_events") >= len(events), "total-event count mismatch")
+    sequences: set[int] = set()
+    for event in events:
+        sequence = integer(event.get("sequence"), "sequence")
+        need(sequence not in sequences, "duplicate event record")
+        sequences.add(sequence)
+        integer(event.get("qpc"), "qpc")
+        need(event.get("decode_error") is None and type(event.get("data")) is dict, "undecoded selected event")
+    events = sorted(events, key=lambda e: (e["qpc"], e["sequence"]))
+    markers = [capture.get("before"), capture.get("after")]
+    need(all(type(m) is dict for m in markers), "missing boundary calibration")
+    child = capture.get("child")
+    need(type(child) is dict, "child not launched or outcome unavailable")
+    for field in ("pid", "created_filetime", "before_launch_qpc", "after_wait_qpc", "exit_code"):
+        integer(child.get(field), field)
+    need(markers[0]["denied_after_qpc"] < child["before_launch_qpc"] <= child["after_wait_qpc"] < markers[1]["start_qpc"],
+         "calibrations do not bracket the child")
+    marker_paths = {canonical(m["path"], capture): m for m in markers}
+    need(len(marker_paths) == 2, "boundary markers reused")
+    root = canonical(case_root, capture).rstrip("\\") + "\\"
+    def relevant(event: dict) -> bool:
+        path = canonical(event["data"]["FileName"], capture)
+        return path in marker_paths or (path.startswith(root) and path.endswith((".pdb", ".pch")))
+
+    # Process and thread lifetime intervals prevent a bare/reused PID from
+    # silently acquiring identity. No PID is ever used to authorize termination.
+    processes: list[dict] = []
+    threads: list[dict] = []
+    for event in events:
+        if event["provider"] != "process":
+            continue
+        data = event["data"]; event_id = event["id"]
+        if event_id == 1:
+            processes.append({"pid": integer(data.get("ProcessID"), "ProcessID"),
+                              "created_filetime": integer(data.get("CreateTime"), "CreateTime"),
+                              "image": data.get("ImageName"), "start": event["qpc"], "end": None})
+        elif event_id == 2:
+            candidates = [p for p in processes if p["pid"] == data.get("ProcessID") and p["end"] is None]
+            if data.get("CreateTime") is not None:
+                candidates = [p for p in candidates if p["created_filetime"] == data["CreateTime"]]
+            if len(candidates) == 1:
+                candidates[0]["end"] = event["qpc"]
+        elif event_id == 3:
+            threads.append({"pid": data.get("ProcessID"), "tid": data.get("ThreadID"), "start": event["qpc"], "end": None})
+        elif event_id == 4:
+            candidates = [t for t in threads if t["pid"] == data.get("ProcessID") and t["tid"] == data.get("ThreadID") and t["end"] is None]
+            if len(candidates) == 1:
+                candidates[0]["end"] = event["qpc"]
+    matches = [p for p in processes if p["pid"] == child["pid"] and p["created_filetime"] == child["created_filetime"]
+               and child["before_launch_qpc"] <= p["start"] <= child["after_wait_qpc"]]
+    need(len(matches) == 1, "retained child HANDLE identity not matched by process-start event")
+
+    def identity(begin: dict) -> dict | None:
+        stamp = begin["qpc"]
+        issuing = begin["data"].get("IssuingThreadId", begin["data"].get("ThreadId", begin["tid"]))
+        path = canonical(begin["data"]["FileName"], capture)
+        if path in marker_paths:
+            owner = marker_paths[path]["owner"]
+            need(begin["pid"] == owner["pid"] and issuing == owner["tid"], "calibration process/thread mismatch")
+            return dict(owner, basis="native retained current-process identity")
+        owners = [t["pid"] for t in threads if t["tid"] == issuing and t["start"] <= stamp and (t["end"] is None or stamp <= t["end"])]
+        if len(set(owners)) > 1:
+            return None
+        pid = owners[0] if owners else begin["pid"]
+        candidates = [p for p in processes if p["pid"] == pid and p["start"] <= stamp and (p["end"] is None or stamp <= p["end"])]
+        if len(candidates) != 1 or not candidates[0]["created_filetime"] or not isinstance(candidates[0]["image"], str):
+            return None
+        return dict(candidates[0], basis="issuing-thread lifetime" if owners else "event-header process lifetime",
+                    header_pid=begin["pid"], issuing_tid=issuing)
+
+    pending: dict[int, dict] = {}
+    completed: list[dict] = []
+    errors: list[str] = []
+    unmatched_ends = 0
+    for event in events:
+        if event["provider"] != "file":
+            continue
+        data = event["data"]
+        irp = integer(data.get("Irp"), "Irp")
+        if event["id"] == 12:
+            integer(data.get("FileObject"), "FileObject")
+            need(isinstance(data.get("FileName"), str), "Create missing filename")
+            if irp in pending and (relevant(pending[irp]) or relevant(event)):
+                errors.append("ambiguous outstanding Create IRP")
+            pending[irp] = event
+        elif event["id"] == 24:
+            status = integer(data.get("NtStatus"), "NtStatus")
+            need(status <= 0xFFFFFFFF, "invalid NTSTATUS width")
+            begin = pending.pop(irp, None)
+            if begin is None:
+                unmatched_ends += 1  # Other operations also have OpEnd; not invented Create matches.
+            elif relevant(begin):
+                completed.append({"path": canonical(begin["data"]["FileName"], capture),
+                                  "begin_sequence": begin["sequence"], "end_sequence": event["sequence"],
+                                  "begin_qpc": begin["qpc"], "end_qpc": event["qpc"],
+                                  "irp": irp, "file_object": begin["data"]["FileObject"],
+                                  "ntstatus": status, "ntstatus_hex": f"0x{status:08x}",
+                                  "create_options": begin["data"].get("CreateOptions"),
+                                  "share_access": begin["data"].get("ShareAccess"), "process_identity": identity(begin)})
+    for begin in pending.values():
+        if relevant(begin):
+            errors.append("target Create has no matching OperationEnd")
+    need(not errors, "; ".join(errors))
+    for marker in markers:
+        need(integer(marker.get("win32_error"), "calibration Win32 status") == 32 and
+             integer(marker.get("expected_ntstatus"), "calibration NTSTATUS") == 0xC0000043, "wrong controlled failure")
+        need(isinstance(marker.get("file_id"), str) and len(marker["file_id"]) == 32 and all(c in "0123456789abcdef" for c in marker["file_id"]),
+             "missing held calibration file identity")
+        path = canonical(marker["path"], capture)
+        failed = [p for p in completed if p["path"] == path and p["ntstatus"] == 0xC0000043 and
+                  marker["denied_before_qpc"] <= p["begin_qpc"] <= p["end_qpc"] <= marker["denied_after_qpc"]]
+        good = [p for p in completed if p["path"] == path and p["ntstatus"] == 0 and p["end_qpc"] <= marker["denied_before_qpc"]]
+        need(len(failed) == 1 and len(good) == 1, "missing/ambiguous positive sharing-failure or successful-open calibration")
+    real = [p for p in completed if p["path"].startswith(root)]
+    for side in ("a", "b"):
+        opens = [p for p in real if p["path"] == root + side + "\\compiler.pdb" and p["process_identity"] is not None
+                 and p["process_identity"]["image"].replace("/", "\\").rsplit("\\", 1)[-1].casefold() in ("cl.exe", "mspdbsrv.exe")]
+        need(bool(opens), f"no event-time compiler/service process identity for {side.upper()} PDB opens")
+    return {"schema": 1, "integrity_checks_passed": True, "calibrated_conflicts": 2, "calibrated_successes": 2,
+            "target_open_pairs": completed, "real_open_pairs": len(real),
+            "real_failed_opens": [p for p in real if p["ntstatus"] & 0x80000000],
+            "unattributed_real_opens": sum(p["process_identity"] is None for p in real),
+            "unmatched_other_operation_ends": unmatched_ends,
+            "historical_cause_resolved": False, "all_writer_coverage_proven": False, "safe_to_transfer_write_lease": False}
+
+
+def self_test() -> dict:
+    capture = {"schema": 1, "clock": "QPC", "qpc_frequency": 10_000_000, "stop_status": 0, "events_lost": 0,
+               "log_buffers_lost": 0, "realtime_buffers_lost": 0, "failure": None, "historical_cause_resolved": False,
+               "safe_to_transfer_write_lease": False, "dos_root": "C:", "device_root": "\\Device\\Volume1",
+               "child": {"pid": 10, "created_filetime": 1000, "before_launch_qpc": 40, "after_wait_qpc": 90, "exit_code": 0}}
+    for name, start in (("before", 10), ("after", 100)):
+        capture[name] = {"path": f"C:\\trace\\{name}.pdb", "owner": {"pid": 1, "tid": 2, "created_filetime": 1},
+                         "start_qpc": start, "denied_before_qpc": start + 5, "denied_after_qpc": start + 9,
+                         "win32_error": 32, "expected_ntstatus": 0xC0000043, "volume": 1, "file_id": "a" * 32}
+    events = []
+    def event(provider, event_id, time, data, pid=1, tid=2):
+        events.append(dict(sequence=len(events) + 1, provider=provider, id=event_id, version=1, pid=pid, tid=tid,
+                           qpc=time, decode_error=None, data=data, raw_payload=""))
+    def pair(path, time, status, irp, pid=1, tid=2):
+        event("file", 12, time, dict(Irp=irp, FileObject=irp + 100, FileName=path, IssuingThreadId=tid), pid, tid)
+        event("file", 24, time + 1, dict(Irp=irp, NtStatus=status), pid, tid)
+    for name, start in (("before", 10), ("after", 100)):
+        pair(capture[name]["path"], start + 1, 0, start)
+        pair(capture[name]["path"], start + 6, 0xC0000043, start)  # Legitimate completed IRP reuse.
+    event("process", 1, 45, dict(ProcessID=10, CreateTime=1000, ImageName="probe.exe"))
+    event("process", 1, 50, dict(ProcessID=20, CreateTime=2000, ImageName="C:\\tools\\cl.exe"))
+    event("process", 3, 51, dict(ProcessID=20, ThreadID=21))
+    pair("C:\\case\\A\\compiler.pdb", 60, 0, 60, 20, 21)
+    pair("C:\\case\\B\\compiler.pdb", 70, 0, 70, 20, 21)
+    decode = dict(process_trace_status=0, close_trace_status=0, decode_errors=0, capped_events=0,
+                  log_header_events_lost=0, etl_bytes=1024, selected_events=len(events), total_events=len(events))
+    mutations = [
+        ("intact-controlled-native-status-shapes", True, lambda c, d, e: None),
+        ("event-loss", False, lambda c, d, e: c.update(events_lost=1)),
+        ("stop-error", False, lambda c, d, e: c.update(stop_status=5)),
+        ("decode-error", False, lambda c, d, e: d.update(decode_errors=1)),
+        ("capped-file", False, lambda c, d, e: d.update(etl_bytes=256 * 1024 * 1024)),
+        ("missing-status", False, lambda c, d, e: e[3]["data"].pop("NtStatus")),
+        ("fabricated-zero-status", False, lambda c, d, e: e[3]["data"].update(NtStatus=0)),
+        ("string-status", False, lambda c, d, e: e[3]["data"].update(NtStatus="3221225539")),
+        ("wrong-IRP", False, lambda c, d, e: e[3]["data"].update(Irp=999)),
+        ("wrong-marker-process", False, lambda c, d, e: e[2].update(pid=99)),
+        ("wrong-child-creation", False, lambda c, d, e: c["child"].update(created_filetime=42)),
+        ("no-process-identity", False, lambda c, d, e: e[9]["data"].update(CreateTime=0)),
+        ("duplicate-event", False, lambda c, d, e: e[1].update(sequence=e[0]["sequence"])),
+        ("missing-end-marker", False, lambda c, d, e: c.update(after=None)),
+        ("safety-authorized", False, lambda c, d, e: c.update(safe_to_transfer_write_lease=True)),
+        ("original-child-failure-is-not-collection-failure", True, lambda c, d, e: c["child"].update(exit_code=1)),
+    ]
+    rows = []
+    for name, expected, change in mutations:
+        c, d, e = copy.deepcopy((capture, decode, events)); change(c, d, e)
+        failure = None
+        try:
+            audit(c, d, e, "C:\\case")
+        except (EvidenceError, KeyError, TypeError) as exc:
+            failure = str(exc)
+        rows.append(dict(name=name, expected_accepted=expected, accepted=failure is None,
+                         passed=(failure is None) == expected, error=failure))
+    return {"synthetic_only": True, "cases": rows, "passed": all(r["passed"] for r in rows)}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--self-test", action="store_true")
+    parser.add_argument("--trace", type=Path)
+    parser.add_argument("--case-root")
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+    need(not args.output.exists(), "refusing to overwrite prior audit")
+    try:
+        if args.self_test:
+            result = self_test(); accepted = result["passed"]
+        else:
+            need(args.trace is not None and args.case_root is not None, "trace and case-root required")
+            capture, decode = load(args.trace / "capture.json"), load(args.trace / "decode.json")
+            need((args.trace / "events.etl").stat().st_size == decode["etl_bytes"], "ETL size mismatch")
+            with (args.trace / "events.jsonl").open(encoding="utf-8-sig") as source:
+                events = [json.loads(line) for line in source]
+            result = audit(capture, decode, events, args.case_root); accepted = True
+    except (EvidenceError, KeyError, TypeError, ValueError, OSError) as exc:
+        result = {"integrity_checks_passed": False, "error": str(exc), "historical_cause_resolved": False}; accepted = False
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    print(json.dumps({"accepted": accepted, "output": str(args.output)}, ensure_ascii=False))
+    return 0 if accepted else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/native/verify_pdb_file_trace.py
+++ b/tests/native/verify_pdb_file_trace.py
@@ -140,7 +140,9 @@ def audit(capture: dict, decode: dict, events: list[dict], case_root: str) -> di
                 errors.append("ambiguous outstanding Create IRP")
             pending[irp] = event
         elif event["id"] == 24:
-            status = integer(data.get("NtStatus"), "NtStatus")
+            # The selected manifest provider names this field Status. Do not
+            # confuse its schema with classic FileIo_OpEnd's NtStatus spelling.
+            status = integer(data.get("Status"), "native Status")
             need(status <= 0xFFFFFFFF, "invalid NTSTATUS width")
             begin = pending.pop(irp, None)
             if begin is None:
@@ -195,7 +197,7 @@ def self_test() -> dict:
                            qpc=time, decode_error=None, data=data, raw_payload=""))
     def pair(path, time, status, irp, pid=1, tid=2):
         event("file", 12, time, dict(Irp=irp, FileObject=irp + 100, FileName=path, IssuingThreadId=tid), pid, tid)
-        event("file", 24, time + 1, dict(Irp=irp, NtStatus=status), pid, tid)
+        event("file", 24, time + 1, dict(Irp=irp, Status=status), pid, tid)
     for name, start in (("before", 10), ("after", 100)):
         pair(capture[name]["path"], start + 1, 0, start)
         pair(capture[name]["path"], start + 6, 0xC0000043, start)  # Legitimate completed IRP reuse.
@@ -212,9 +214,9 @@ def self_test() -> dict:
         ("stop-error", False, lambda c, d, e: c.update(stop_status=5)),
         ("decode-error", False, lambda c, d, e: d.update(decode_errors=1)),
         ("capped-file", False, lambda c, d, e: d.update(etl_bytes=256 * 1024 * 1024)),
-        ("missing-status", False, lambda c, d, e: e[3]["data"].pop("NtStatus")),
-        ("fabricated-zero-status", False, lambda c, d, e: e[3]["data"].update(NtStatus=0)),
-        ("string-status", False, lambda c, d, e: e[3]["data"].update(NtStatus="3221225539")),
+        ("missing-status", False, lambda c, d, e: e[3]["data"].pop("Status")),
+        ("fabricated-zero-status", False, lambda c, d, e: e[3]["data"].update(Status=0)),
+        ("string-status", False, lambda c, d, e: e[3]["data"].update(Status="3221225539")),
         ("wrong-IRP", False, lambda c, d, e: e[3]["data"].update(Irp=999)),
         ("wrong-marker-process", False, lambda c, d, e: e[2].update(pid=99)),
         ("wrong-child-creation", False, lambda c, d, e: c["child"].update(created_filetime=42)),

--- a/tests/native/verify_pdb_file_trace.py
+++ b/tests/native/verify_pdb_file_trace.py
@@ -41,8 +41,8 @@ def canonical(path: str, capture: dict) -> str:
     return value
 
 
-def audit(capture: dict, decode: dict, events: list[dict], case_root: str) -> dict:
-    need(type(capture.get("schema")) is int and capture["schema"] == 1 and capture.get("clock") == "QPC", "unknown capture schema/clock")
+def checked_events(capture: dict, decode: dict, events: list[dict], *, failed_capture: bool = False) -> list[dict]:
+    need(type(capture.get("schema")) is int and capture["schema"] in (1, 2) and capture.get("clock") == "QPC", "unknown capture schema/clock")
     integer(capture.get("qpc_frequency"), "qpc_frequency")
     need(capture["qpc_frequency"] > 0, "zero QPC frequency")
     for field in ("stop_status", "events_lost", "log_buffers_lost", "realtime_buffers_lost"):
@@ -50,7 +50,8 @@ def audit(capture: dict, decode: dict, events: list[dict], case_root: str) -> di
     for field in ("process_trace_status", "close_trace_status", "decode_errors", "capped_events", "log_header_events_lost"):
         need(integer(decode.get(field), field) == 0, f"incomplete decode: {field}")
     need(0 < integer(decode.get("etl_bytes"), "etl_bytes") < 256 * 1024 * 1024, "missing/capped ETL")
-    need(capture.get("failure") is None, "native capture failure")
+    if not failed_capture:
+        need(capture.get("failure") is None, "native capture failure")
     need(capture.get("historical_cause_resolved") is False and capture.get("safe_to_transfer_write_lease") is False,
          "trace must not authorize historical cause or writer lease")
     need(integer(decode.get("selected_events"), "selected_events") == len(events), "selected-event count mismatch")
@@ -62,7 +63,96 @@ def audit(capture: dict, decode: dict, events: list[dict], case_root: str) -> di
         sequences.add(sequence)
         integer(event.get("qpc"), "qpc")
         need(event.get("decode_error") is None and type(event.get("data")) is dict, "undecoded selected event")
-    events = sorted(events, key=lambda e: (e["qpc"], e["sequence"]))
+    return sorted(events, key=lambda e: (e["qpc"], e["sequence"]))
+
+
+def readiness_state(capture: dict) -> dict:
+    need(capture.get("schema") == 2, "capture has no recording-readiness contract")
+    state = capture.get("readiness")
+    need(type(state) is dict and type(state.get("schema")) is int and state["schema"] == 1 and
+         state.get("mode") == "same-session-real-time", "missing/invalid readiness state")
+    for field, expected in (("wait_limit_ms", 10000), ("pending_irp_limit", 8192),
+                            ("decode_errors", 0), ("process_trace_status", 0)):
+        need(integer(state.get(field), field) == expected, f"readiness limit/health mismatch: {field}")
+    # CloseTrace can successfully initiate an asynchronous real-time close.
+    need(integer(state.get("close_trace_status"), "live close status") in (0, 7007), "live close failed")
+    need(state.get("error") is None, "live readiness decoding failed")
+    start = integer(state.get("start_qpc"), "readiness start")
+    deadline = integer(state.get("deadline_qpc"), "readiness deadline")
+    need(start > 0 and deadline == start + capture["qpc_frequency"] * 10, "readiness budget changed")
+    integer(state.get("decision_qpc"), "readiness decision")
+    return state
+
+
+def validate_readiness(capture: dict, events: list[dict]) -> None:
+    state = readiness_state(capture)
+    need(state.get("accepted") is True and state.get("file_provider_withheld") is False and
+         state.get("phase") == "admitted" and integer(state.get("wait_status"), "wait status") == 0,
+         "recording not ready for child admission")
+    begin = capture["before"]
+    ack = integer(state.get("opening_ack_qpc"), "opening acknowledgement")
+    provider_ack = integer(state.get("provider_ack_qpc"), "provider acknowledgement")
+    need(state["start_qpc"] <= provider_ack < begin["start_qpc"] <= begin["denied_after_qpc"] <= ack
+         <= state["deadline_qpc"] and ack < capture["child"]["before_launch_qpc"] and
+         state["decision_qpc"] == ack, "child admitted before event-backed readiness or after deadline")
+    keys = ("provider", "id", "version", "pid", "tid", "qpc", "raw_payload")
+    indexed: dict[tuple, list[dict]] = {}
+    for event in events:
+        indexed.setdefault(tuple(event.get(k) for k in keys), []).append(event)
+    def pair_evidence(pair: dict) -> tuple[dict, dict]:
+        need(type(pair) is dict, "readiness pair missing")
+        matched = []
+        for member in ("begin", "end"):
+            e = pair.get(member)
+            need(type(e) is dict and all(k in e for k in keys), "readiness event identity missing")
+            candidates = indexed.get(tuple(e[k] for k in keys), [])
+            need(len(candidates) == 1 and candidates[0]["data"] == e.get("data"),
+                 "live readiness evidence absent/ambiguous/different in authoritative ETL")
+            matched.append(candidates[0])
+        a, b = matched
+        need(a["provider"] == b["provider"] == "file" and a["id"] == 12 and b["id"] == 24 and
+             integer(a["data"].get("Irp"), "readiness IRP") == integer(b["data"].get("Irp"), "readiness end IRP") and
+             a["qpc"] <= b["qpc"], "invalid readiness Create/OperationEnd correlation")
+        need(integer(b["data"].get("Status"), "readiness Status") <= 0xffffffff, "bad readiness status width")
+        return a, b
+    a, b = pair_evidence(state.get("provider_pair"))
+    need(b["data"]["Status"] == 0 and state["start_qpc"] <= a["qpc"] <= b["qpc"] <= provider_ack,
+         "provider readiness is not backed by a successful real event pair")
+    pairs = state.get("opening_pairs")
+    need(type(pairs) is list and len(pairs) == 2, "opening readiness pairs missing")
+    statuses = []
+    for pair in pairs:
+        a, b = pair_evidence(pair)
+        need(canonical(a["data"]["FileName"], capture) == canonical(begin["path"], capture) and
+             a["pid"] == begin["owner"]["pid"] and
+             a["data"].get("IssuingThreadId", a["data"].get("ThreadId", a["tid"])) == begin["owner"]["tid"],
+             "opening readiness path/process/thread mismatch")
+        status = b["data"]["Status"]; statuses.append(status)
+        low, high = ((begin["start_qpc"], begin["denied_before_qpc"]) if status == 0
+                     else (begin["denied_before_qpc"], begin["denied_after_qpc"]))
+        need(low <= a["qpc"] <= b["qpc"] <= high <= ack, "opening live evidence outside native interval")
+    need(sorted(statuses) == [0, 0xc0000043], "opening readiness lacks one success and one controlled failure")
+
+
+def audit_no_readiness(capture: dict, decode: dict, events: list[dict], *, sentinel_exists: bool) -> dict:
+    events = checked_events(capture, decode, events, failed_capture=True)
+    state = readiness_state(capture)
+    need(state.get("file_provider_withheld") is True and state.get("accepted") is False and
+         state.get("phase") == "waiting-provider" and integer(state.get("wait_status"), "wait status") == 258,
+         "negative run did not time out at withheld-provider readiness gate")
+    need(state["decision_qpc"] >= state["deadline_qpc"], "negative test did not exercise the bounded wait")
+    need(state.get("provider_pair") is None and state.get("provider_ack_qpc") is None and
+         state.get("opening_ack_qpc") is None and state.get("opening_pairs") == [], "negative run fabricated readiness")
+    need(capture.get("failure") == "recording readiness timeout; compiler not admitted" and
+         capture.get("child") is None and capture.get("before") is None and capture.get("after") is None and
+         not sentinel_exists, "child/calibration admitted without recording readiness")
+    need(not any(e["provider"] == "file" for e in events), "withheld provider unexpectedly delivered file events")
+    return {"negative_readiness_passed": True, "child_not_admitted": True, "calibration_not_attempted": True,
+            "historical_cause_resolved": False, "safe_to_transfer_write_lease": False}
+
+
+def audit(capture: dict, decode: dict, events: list[dict], case_root: str, *, require_readiness: bool = False) -> dict:
+    events = checked_events(capture, decode, events)
     markers = [capture.get("before"), capture.get("after")]
     need(all(type(m) is dict for m in markers), "missing boundary calibration")
     child = capture.get("child")
@@ -71,6 +161,8 @@ def audit(capture: dict, decode: dict, events: list[dict], case_root: str) -> di
         integer(child.get(field), field)
     need(markers[0]["denied_after_qpc"] < child["before_launch_qpc"] <= child["after_wait_qpc"] < markers[1]["start_qpc"],
          "calibrations do not bracket the child")
+    if require_readiness or capture["schema"] == 2:
+        validate_readiness(capture, events)
     marker_paths = {canonical(m["path"], capture): m for m in markers}
     need(len(marker_paths) == 2, "boundary markers reused")
     root = canonical(case_root, capture).rstrip("\\") + "\\"
@@ -174,7 +266,7 @@ def audit(capture: dict, decode: dict, events: list[dict], case_root: str) -> di
         opens = [p for p in real if p["path"] == root + side + "\\compiler.pdb" and p["process_identity"] is not None
                  and p["process_identity"]["image"].replace("/", "\\").rsplit("\\", 1)[-1].casefold() in ("cl.exe", "mspdbsrv.exe")]
         need(bool(opens), f"no event-time compiler/service process identity for {side.upper()} PDB opens")
-    return {"schema": 1, "integrity_checks_passed": True, "calibrated_conflicts": 2, "calibrated_successes": 2,
+    return {"schema": 1, "readiness_verified": capture["schema"] == 2, "integrity_checks_passed": True, "calibrated_conflicts": 2, "calibrated_successes": 2,
             "target_open_pairs": completed, "real_open_pairs": len(real),
             "real_failed_opens": [p for p in real if p["ntstatus"] & 0x80000000],
             "unattributed_real_opens": sum(p["process_identity"] is None for p in real),
@@ -236,6 +328,59 @@ def self_test() -> dict:
             failure = str(exc)
         rows.append(dict(name=name, expected_accepted=expected, accepted=failure is None,
                          passed=(failure is None) == expected, error=failure))
+    # Old schemas remain usable for OFFLINE historical audit, not new captures.
+    live_capture, live_decode, live_events = copy.deepcopy((capture, decode, events))
+    event("file", 12, 3, dict(Irp=999, FileObject=1999, FileName="C:\\provider-ready", IssuingThreadId=2))
+    event("file", 24, 4, dict(Irp=999, Status=0))
+    live_events.extend(copy.deepcopy(events[-2:]))
+    live_decode.update(selected_events=len(live_events), total_events=len(live_events))
+    live_capture["schema"] = 2
+    live_capture["readiness"] = dict(schema=1, mode="same-session-real-time", wait_limit_ms=10000, pending_irp_limit=8192,
+        file_provider_withheld=False, accepted=True, phase="admitted", start_qpc=1, deadline_qpc=100000001,
+        provider_ack_qpc=5, opening_ack_qpc=30, decision_qpc=30, wait_status=0, decode_errors=0, error=None,
+        process_trace_status=0, close_trace_status=7007,
+        provider_pair=dict(begin=copy.deepcopy(live_events[-2]), end=copy.deepcopy(live_events[-1])),
+        opening_pairs=[dict(begin=copy.deepcopy(live_events[i]), end=copy.deepcopy(live_events[i+1])) for i in (0, 2)])
+    tests = [
+        ("event-backed-readiness", True, lambda c, d, e: None),
+        ("readiness-not-acknowledged", False, lambda c, d, e: c["readiness"].update(accepted=False)),
+        ("readiness-missing-live-pair", False, lambda c, d, e: c["readiness"].update(provider_pair=None)),
+        ("readiness-pair-not-in-ETL", False, lambda c, d, e: c["readiness"]["provider_pair"]["begin"].update(qpc=2)),
+        ("readiness-decoder-disagrees", False, lambda c, d, e: c["readiness"]["opening_pairs"][1]["end"]["data"].update(Status=0)),
+        ("readiness-after-child-launch", False, lambda c, d, e: c["readiness"].update(opening_ack_qpc=41, decision_qpc=41)),
+        ("readiness-native-timeout", False, lambda c, d, e: c["readiness"].update(wait_status=258)),
+        ("readiness-live-close-error", False, lambda c, d, e: c["readiness"].update(close_trace_status=6)),
+        ("readiness-live-process-error", False, lambda c, d, e: c["readiness"].update(process_trace_status=5)),
+        ("readiness-live-decode-error", False, lambda c, d, e: c["readiness"].update(decode_errors=1)),
+        ("readiness-before-provider-event", False, lambda c, d, e: c["readiness"].update(provider_ack_qpc=2)),
+        ("readiness-wrong-budget", False, lambda c, d, e: c["readiness"].update(wait_limit_ms=1)),
+        ("readiness-duplicate-calibration", False, lambda c, d, e: c["readiness"]["opening_pairs"].__setitem__(1, copy.deepcopy(c["readiness"]["opening_pairs"][0]))),
+        ("readiness-capture-downgraded", False, lambda c, d, e: c.update(schema=1)),
+    ]
+    for name, expected, change in tests:
+        c, d, e = copy.deepcopy((live_capture, live_decode, live_events)); change(c, d, e)
+        failure = None
+        try: audit(c, d, e, "C:\\case", require_readiness=True)
+        except (EvidenceError, KeyError, TypeError) as exc: failure = str(exc)
+        rows.append(dict(name=name, expected_accepted=expected, accepted=failure is None, passed=(failure is None)==expected, error=failure))
+    negative = copy.deepcopy(live_capture)
+    negative.update(child=None, before=None, after=None, failure="recording readiness timeout; compiler not admitted")
+    negative["readiness"].update(accepted=False, file_provider_withheld=True, phase="waiting-provider", wait_status=258,
+        decision_qpc=100000002, provider_pair=None, provider_ack_qpc=None, opening_ack_qpc=None, opening_pairs=[])
+    negative_events = [e for e in live_events if e["provider"] != "file"]
+    negative_decode = dict(live_decode, selected_events=len(negative_events), total_events=len(negative_events))
+    for name, expected, change, sentinel in [
+        ("negative-withheld-provider-no-child", True, lambda c: None, False),
+        ("negative-sentinel-created", False, lambda c: None, True),
+        ("negative-child-launched", False, lambda c: c.update(child={"pid": 10}), False),
+        ("negative-calibration-issued", False, lambda c: c.update(before={"path": "bad"}), False),
+        ("negative-wait-not-exercised", False, lambda c: c["readiness"].update(decision_qpc=2), False),
+        ("negative-provider-not-withheld", False, lambda c: c["readiness"].update(file_provider_withheld=False), False),
+    ]:
+        c = copy.deepcopy(negative); change(c); failure = None
+        try: audit_no_readiness(c, negative_decode, negative_events, sentinel_exists=sentinel)
+        except (EvidenceError, KeyError, TypeError) as exc: failure = str(exc)
+        rows.append(dict(name=name, expected_accepted=expected, accepted=failure is None, passed=(failure is None)==expected, error=failure))
     return {"synthetic_only": True, "cases": rows, "passed": all(r["passed"] for r in rows)}
 
 
@@ -244,6 +389,9 @@ def main() -> int:
     parser.add_argument("--self-test", action="store_true")
     parser.add_argument("--trace", type=Path)
     parser.add_argument("--case-root")
+    parser.add_argument("--require-readiness", action="store_true")
+    parser.add_argument("--expect-no-readiness", action="store_true")
+    parser.add_argument("--sentinel", type=Path)
     parser.add_argument("--output", required=True, type=Path)
     args = parser.parse_args()
     need(not args.output.exists(), "refusing to overwrite prior audit")
@@ -256,7 +404,14 @@ def main() -> int:
             need((args.trace / "events.etl").stat().st_size == decode["etl_bytes"], "ETL size mismatch")
             with (args.trace / "events.jsonl").open(encoding="utf-8-sig") as source:
                 events = [json.loads(line) for line in source]
-            result = audit(capture, decode, events, args.case_root); accepted = True
+            if capture.get("schema") == 2:
+                need(load(args.trace / "readiness.json") == capture.get("readiness"), "readiness record mismatch")
+            if args.expect_no_readiness:
+                need(args.sentinel is not None, "negative readiness sentinel path required")
+                result = audit_no_readiness(capture, decode, events, sentinel_exists=args.sentinel.exists())
+            else:
+                result = audit(capture, decode, events, args.case_root, require_readiness=args.require_readiness)
+            accepted = True
     except (EvidenceError, KeyError, TypeError, ValueError, OSError) as exc:
         result = {"integrity_checks_passed": False, "error": str(exc), "historical_cause_resolved": False}; accepted = False
     args.output.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Final decision: accept calibrated event tooling; keep #170 and #172 held

[Final exact-source, full execution, raw evidence and acceptance review](https://github.com/Iviesever/msvc-quick-build/pull/174#pullrequestreview-5151416473)

The missing recording-readiness boundary is now implemented and verified with actual Windows events. **Accept this investigation tool, not historical-cause resolution, CLI cancellation or writer-lease authority.** #170/#172 retain their independent HOLD decisions; M1b remains incomplete.

## Exact accepted source

- **Base:** `792fa39d3c2489ad520d25139709d6b0144ea29a` (#173).
- **Reviewed head:** `18f212865df52ea86431489adf80ff96a8c8a019`.
- **Candidate and native test-merge tree:** `7580fe467e0c7053c43a79aebb69c07ce4f9c8a9`.
- Test-merge `959eaac8fb13626d6d84911eeaad46aeb3fbe143`, exactly those base/head parents.
- Four new test/CI files, **1234 additions/0deletions**. All402existing main files remain byte-identical. Full canonical source-tree reconstruction and patch replay match the accepted tree.
- **VERSION5.5.0 unchanged. No historical tag/asset or formal Release change.**

## Delivered behavior

The native recorder owns a uniquely named file+real-time ETW session on an explicitly authorized disposable Windows VM. The authoritative ETL retains Kernel-File Create/OperationEnd and process/thread events, actual TDH property definitions, selected raw payload/decoded records, native QPC boundaries and stop/loss/decode/cap status. Session/evidence reuse is refused. No compiler/service termination policy or production caller changes.

A same-session live consumer must first receive a real successful Create/OperationEnd pair. The original opening calibration is then issued **once**; its successful open and controlled sharing failure must both arrive with matching native PID/TID/QPC before the compiler fixture may start. Both waits share a fixed10-second admission budget. No sleep, repeated marker or adaptive budget. A quiet host may be refused if no event witness arrives. The wait does not make provider APIs, queued-buffer drainage, teardown or compilation hard-time-bounded.

Offline audit independently rematches live selected header/QPC/raw-payload/TDH-data to the ETL-decoded stream. It retains original IRP lifetime, process identity, before/after calibration, loss/cap/status and original compiler outcome checks. Live readiness alone is insufficient. The Python verifier does not implement a separate binary ETL decoder. FileObject/IRP are transient identifiers, not durable file IDs; physical calibration identity is read separately from its held HANDLE.

One separately labeled negative invocation withholds file-provider enable and must time out without any calibration, child record or child-execution sentinel. It is a refusal test, not a manufactured MSVC C1041 reproduction. The real fixed study remains four fresh PCH Release/A-started/direct-drain cases, rm-on/off,off/on, unchanged24kA/6kB inputs and /FS /Zi /O2 /MT /Yu with large-A-only /bigobj. Existing default56/private42 probes and collectors are unchanged.

## Completed current-head gates

| Gate | Actual first-attempt run | Result |
|---|---|---|
| Native Debug/all shards and runtime/freshness/parameter checks | #718/34324815386 | Passed, actual execution |
| Complete Release/self-host/exact runtime-only package | #610/34324815289 | Passed; publish-release skipped |
| Documentation/Cross-Stage | #171/34324815504; #195/34324815191 | Passed |
| File-event contracts and native build | Event#4/34324815389 |36/36synthetic expectations(4accepted/32rejected), PowerShell parsing, actual recorder compilation passed |
| Native missing-readiness control | Event#4/34324815389 |10-second refusal, no calibration/child/sentinel |
| Fixed real traced compiler study | Event#4/34324815389 |4/4complete traces,8native sharing failures+8successes, all original A/B controls pass |
| Original default/private matrices | #14/34324815411; #16/34324815273 |56/56 and42/42complete; required positive controls pass |
| Independent original observer-OFF ABBA | #566/34324815334 |76pairs measured/recomputed;72instrumented semantic identities match |

[Full native readiness, negative control, four raw traces and executable provenance](https://github.com/Iviesever/msvc-quick-build/pull/174#issuecomment-5598228982)

[Full19-rowABBA, original ownership regressions and unfavorable evidence](https://github.com/Iviesever/msvc-quick-build/pull/174#issuecomment-5598292203)

The negative control reached10.000539seconds, wait258, child/calibration=null and sentinel absent; its ETL has no file events. All four positive traces match both live opening witnesses to offline records and have complete before/after native Status0 and0xc0000043(Win32error32) calibration, exact child creation identity and no reported loss/decode/cap failure. Actual observed admission acknowledgements were2.102–4.214seconds, not a general latency guarantee.44original tool results/88stdout-stderr files were inspected.300selected PDB/PCH completion pairs have attributed lifetimes in this scope, while24nonzero0xc0000034statuses remain despite successful original builds. Those statuses are not deleted or called C1041. No C1041 occurred in this new four-case fixture, and historical C1041 is not explained.

## Performance and unfavorable evidence retained

External timings-off no-op paired median **−1.2531ms/−8.0433%**, maximum adverse+3.622ms,2/4slower; original gate (worse by **both1ms and10%**) not crossed. No speedup/zero-overhead claim. Instrumented scale-no-op/auto are slower4/4, and scale-cold+980.648ms/discovery-header+829.318ms tails remain. Four-pair P95 is a maximum, not a population estimate. Only the external row uses timings-off elapsed; four counter sets are unavailable, not zeros. Original72instrumented complete counters/breakdowns/compile-link-archive hit-miss identities match. No noise-based deletion, AA subtraction, same-head remeasurement or historical cold-tail closure.

Original default/private retain **6+2managed B failures**(C1090/C1001) and all28A-started managed-service deaths. Failed link/run are unattempted; recovery compiles never replace originals. Default B owner identity15/56/private1/42 does not prove complete writer ownership. These adverse termination experiments are separate from successful new readiness/PCH controls.

## Original failures and gates are not rewritten

Older cfa/b6 traces still fail offline for original schema errors/missing opening calibration; their absent events are not fabricated. The independently failed Modules Debug C1041 positive control remains failed and untraced. New successful controls cannot explain or erase it.

First readiness head `b2498eca...` failed actual MSVC C2398. The correction only adds an explicit conversion at the QPC-frequency constructor call. That head has no native readiness observations; its Debug#717,Release#609/default#13 ended cancelled by the genuine source change. Preserve its35/56default prefix, completed private42 and separate ABBA#565 including its+1962.480ms tail. No same-head retry. LocalPython/GCC syntax tests are not local MSVC or ETW execution.

The originally required four complete traces/eight calibrated failures/eight successes, process/loss/decode/cap checks, original positive controls, full exact-source native/selfhost/package and independent19x4ABBA were not relaxed. The readiness amendment adds36synthetic expectations and an actual negative admission gate. All current applicable gates now pass. The temporary perf title was removed only after actual#566 finished; title/ready-triggered skipped perf jobs do not replace it.

## Decision and handoff

**Accept ordinary expected-head merge under unchanged branch protection. Keep #170/#172 held, safety fields false and VERSION5.5.0.** This resolves the tool's specified readiness/calibration acceptance gap for the tested scope, not historical OS causes, RPC completion, all-writer enumeration, durable quiescence, crash recovery or writer-lease transfer.

Next use the accepted calibrated recorder for a bounded investigation of the unresolved actual PDB-open/compiler failures, rather than creating another competing observer or relying on success-only reruns. Any future #170/#172 re-review must validate the then-current combined source and explicitly retain their original failures. M1b, CLI/transaction/build-run/session/residency and formal VERSION/release remain separate.

Raw current and previous ZIPs, canonical source archives, patches and offline reproduction are retained separately in delivery. Actions artifacts retain30days. Generated compiler binaries are omitted by the diagnostic artifact contract; separate input ZIPs contain the actual recorder/probe/MQB bytes, not the independent performance executable pair. Post-case binary inventories are not failure-instant snapshots. Post-merge push CI is not claimed already completed by these PR results.