### PR TITLE
feat: preserve typed work-batch results during admission stop

### DIFF
--- a/.github/workflows/msvc-work-batch.yml
+++ b/.github/workflows/msvc-work-batch.yml
@@ -1,0 +1,91 @@
+name: Typed MSVC Work Batch Evidence
+
+on:
+  pull_request:
+    paths:
+      - 'cpp/**'
+      - 'tests/native/collect_msvc_work_batch.ps1'
+      - '.github/workflows/msvc-work-batch.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: msvc-work-batch-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+permissions:
+  contents: read
+jobs:
+  build:
+    runs-on: windows-latest
+    timeout-minutes: 30
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Build exact candidate and typed batch fixture with MQB
+        shell: pwsh
+        run: |
+          $tokens=$null; $errors=$null
+          [void][Management.Automation.Language.Parser]::ParseFile(
+            (Join-Path $PWD 'tests/native/collect_msvc_work_batch.ps1'),[ref]$tokens,[ref]$errors)
+          if (@($errors).Count) { throw "$errors" }
+          $seed=& ./tests/native/acquire_seed.ps1 -RepoRoot $PWD -OutputRoot (Join-Path $PWD 'native-seed')
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $mqb=& ./tests/native/build_mqb.ps1 -BuilderMqbPath $seed -RepoRoot $PWD -Version '5.5.0' `
+            -Configuration Release -Clean -OutputPath (Join-Path $PWD 'native-out/work-batch/mqb.exe')
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          & ./tests/native/collect_msvc_work_batch.ps1 -MqbPath $mqb -RepoRoot $PWD -BuildOnly `
+            -OutputRoot (Join-Path $PWD '.mqb/work-batch-build')
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          New-Item -ItemType Directory -Path 'native-out/work-batch-input' -Force | Out-Null
+          Copy-Item .mqb/bin/msvc_work_batch_probe.exe,.mqb/work-batch-build/probe.identity.json native-out/work-batch-input/
+      - uses: actions/upload-artifact@v7
+        with:
+          name: exact-work-batch-input
+          path: native-out/work-batch-input/*
+          if-no-files-found: error
+          retention-days: 30
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: work-batch-build-evidence
+          path: .mqb/work-batch-build/**
+          include-hidden-files: true
+          if-no-files-found: warn
+          retention-days: 30
+  observe:
+    name: Six fixed real two-worker typed batches
+    needs: build
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - uses: actions/download-artifact@v8
+        with:
+          name: exact-work-batch-input
+          path: native-input
+      - shell: pwsh
+        env:
+          MQB_BATCH_DISPOSABLE_HOST: '1'
+        run: |
+          & ./tests/native/collect_msvc_work_batch.ps1 -RepoRoot $PWD `
+            -PrebuiltProbePath (Join-Path $PWD 'native-input/msvc_work_batch_probe.exe') `
+            -ProbeIdentityPath (Join-Path $PWD 'native-input/probe.identity.json') `
+            -OutputRoot (Join-Path $PWD '.mqb/msvc-work-batch-evidence')
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+      - name: Retain original results and failures without retry
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: msvc-work-batch-evidence
+          path: |
+            .mqb/msvc-work-batch-evidence/**
+            !.mqb/msvc-work-batch-evidence/**/*.obj
+            !.mqb/msvc-work-batch-evidence/**/*.pdb
+            !.mqb/msvc-work-batch-evidence/**/*.exe
+          include-hidden-files: true
+          if-no-files-found: warn
+          retention-days: 30

--- a/cpp/include/mqb/orchestration/BoundedWorkBatch.hpp
+++ b/cpp/include/mqb/orchestration/BoundedWorkBatch.hpp
@@ -1,0 +1,114 @@
+#pragma once
+
+#include <cstddef>
+#include <exception>
+#include <expected>
+#include <functional>
+#include <optional>
+#include <stop_token>
+#include <type_traits>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "mqb/orchestration/BoundedWorkScheduler.hpp"
+
+namespace mqb::orchestration {
+
+namespace detail {
+template<class> inline constexpr bool is_expected_work_result = false;
+template<class T, class E>
+inline constexpr bool is_expected_work_result<std::expected<T, E>> = true;
+} // namespace detail
+
+template<class Result>
+concept ExpectedWorkResult = detail::is_expected_work_result<Result>
+    && std::is_nothrow_move_constructible_v<Result>;
+
+enum class WorkBatchOutcome { succeeded, failed, cancelled };
+
+// monostate means NOT ENTERED, never a successful or cancelled tool execution.
+// Each admitted callback owns one preallocated slot. No slot is read while the
+// scheduler is running. Original error/result payloads and exception_ptr survive
+// cancellation, including when another callback or worker startup also fails.
+template<ExpectedWorkResult Result>
+struct WorkBatchReport {
+    using Attempt = std::variant<std::monostate, Result, std::exception_ptr>;
+    std::size_t requested_count{};
+    std::vector<Attempt> attempts;
+    std::optional<std::expected<BoundedWorkSummary, BoundedWorkError>> scheduling;
+    // Allocation/setup or a thrown scheduler invocation. Already saved attempts
+    // are retained. Absence of a scheduling summary is not successful drainage.
+    std::exception_ptr dispatch_exception;
+
+    [[nodiscard]] WorkBatchOutcome outcome() const noexcept {
+        if (dispatch_exception || !scheduling || !*scheduling
+            || attempts.size() != requested_count) return WorkBatchOutcome::failed;
+        std::size_t completed = 0;
+        for (const auto& attempt : attempts) {
+            if (std::holds_alternative<std::monostate>(attempt)) continue;
+            const auto* result = std::get_if<Result>(&attempt);
+            if (!result || !result->has_value()) return WorkBatchOutcome::failed;
+            ++completed;
+        }
+        const auto& summary = **scheduling;
+        if (completed != summary.started_count) return WorkBatchOutcome::failed;
+        // Failure above wins over external stop, even when stop was requested
+        // before the failed callback returned. A late stop after deregistration
+        // cannot mutate this report. Empty work follows the scheduler's no-op.
+        if (summary.admission_stop_observed) return WorkBatchOutcome::cancelled;
+        return completed == requested_count && !summary.stop_requested
+            && !summary.stopped_before_all_items
+            ? WorkBatchOutcome::succeeded : WorkBatchOutcome::failed;
+    }
+
+    // Necessary predecessor-result gate only. NOT freshness, transaction commit,
+    // process-tree quiescence, or permission to transfer a project write lease.
+    [[nodiscard]] bool all_succeeded() const noexcept {
+        return outcome() == WorkBatchOutcome::succeeded;
+    }
+};
+
+// Explicit opt-in result-preserving adapter, not a second scheduler. The work
+// callable must return std::expected<T,E> by value. Nothrow move preserves the
+// original payload without risking a second exception while storing it. Errors
+// are never interpreted as cancellation; only scheduler admission observation
+// produces the cancelled batch outcome. Admitted work owns its synchronous end.
+// This API launches no process, passes no token to work and publishes no cache.
+// Existing scheduler/CLI callers are unchanged. Work may run concurrently.
+template<class Work, class Result = std::invoke_result_t<Work&, std::size_t>>
+    requires ExpectedWorkResult<Result>
+[[nodiscard]] WorkBatchReport<Result> run_work_batch(
+    std::size_t item_count, std::size_t max_workers,
+    std::stop_token admission_stop, Work&& work) {
+    WorkBatchReport<Result> report;
+    report.requested_count = item_count;
+    try {
+        // Always use the owned-worker, natural-drain path, including when the
+        // caller supplies no token. The legacy non-stoppable path intentionally
+        // remains unchanged; it is not this adapter's exception-safety boundary.
+        std::stop_source private_lifetime;
+        const auto token = admission_stop.stop_possible()
+            ? admission_stop : private_lifetime.get_token();
+        if (max_workers != 0) report.attempts.resize(item_count);
+        report.scheduling.emplace(BoundedWorkScheduler::run_with_admission_stop(
+            item_count, max_workers, token, [&](std::size_t index) {
+                auto& slot = report.attempts[index];
+                try {
+                    slot.template emplace<1>(std::invoke(work, index));
+                    return std::get<1>(slot).has_value();
+                } catch (...) {
+                    slot.template emplace<2>(std::current_exception());
+                    throw; // Retain the scheduler's callback_threw error as well.
+                }
+            }));
+    } catch (...) {
+        // The chosen scheduler path owns and joins every started worker before
+        // throwing out of its invocation. This does not cover detached/external
+        // work, process errors or owner death, and implies no writer-lease safety.
+        report.dispatch_exception = std::current_exception();
+    }
+    return report;
+}
+
+} // namespace mqb::orchestration

--- a/cpp/tests/orchestration/scheduling/bounded_work_batch_cases.hpp
+++ b/cpp/tests/orchestration/scheduling/bounded_work_batch_cases.hpp
@@ -1,0 +1,161 @@
+#pragma once
+
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <expected>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <semaphore>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <variant>
+
+#include "mqb/orchestration/BoundedWorkBatch.hpp"
+
+namespace mqb::tests {
+inline int bounded_work_batch_cases() {
+    using namespace std::chrono_literals;
+    using namespace mqb::orchestration;
+    struct Error { int code; std::string stdout_text, stderr_text; };
+    using Result = std::expected<std::string, Error>;
+    using Report = WorkBatchReport<Result>;
+    int failures = 0;
+    unsigned checks = 0;
+    const auto check = [&](bool condition, const char* message) {
+        ++checks;
+        if (!condition) { ++failures; std::cerr << "FAIL: " << message << '\n'; }
+    };
+    const auto good = [](std::size_t i) -> Result { return "result-" + std::to_string(i); };
+    {
+        std::stop_source stop; stop.request_stop();
+        const auto empty = run_work_batch(0, 2, stop.get_token(), good);
+        check(empty.all_succeeded() && empty.attempts.empty(), "empty batch is an explicit no-op");
+        const auto invalid = run_work_batch(3, 0, stop.get_token(), good);
+        check(invalid.outcome() == WorkBatchOutcome::failed && invalid.scheduling && !*invalid.scheduling
+              && invalid.scheduling->error().code == BoundedWorkErrorCode::invalid_worker_count,
+              "pre-stop cannot erase invalid worker count");
+        const auto cancelled = run_work_batch(4, 2, stop.get_token(), good);
+        check(cancelled.outcome() == WorkBatchOutcome::cancelled && !cancelled.all_succeeded(), "pre-stop is cancellation");
+        check(cancelled.attempts.size() == 4 && std::holds_alternative<std::monostate>(cancelled.attempts[0])
+              && std::holds_alternative<std::monostate>(cancelled.attempts[3]), "unentered items remain explicit");
+    }
+    {
+        auto complete = run_work_batch(7, 3, {}, good);
+        check(complete.all_succeeded() && complete.attempts.size() == 7, "no-token typed work completes via owned scheduler");
+        for (std::size_t i = 0; i < 7; ++i) {
+            const auto* r = std::get_if<Result>(&complete.attempts[i]);
+            check(r && *r && **r == "result-" + std::to_string(i), "completed result remains in its source slot");
+        }
+        // Incomplete/contradictory records must never become an all-success gate.
+        complete.attempts[0].template emplace<0>();
+        check(!complete.all_succeeded(), "missing attempt is not a success");
+        Report unset;
+        check(!unset.all_succeeded(), "missing scheduler record is not an empty successful batch");
+    }
+    {
+        const auto failed = run_work_batch(6, 1, {}, [&](std::size_t i) -> Result {
+            if (i == 1) return std::unexpected(Error{42, "native stdout\n", "native stderr\n"});
+            return good(i);
+        });
+        const auto* original = std::get_if<Result>(&failed.attempts[1]);
+        check(failed.outcome() == WorkBatchOutcome::failed && !failed.all_succeeded(), "original returned error fails batch");
+        check(original && !*original && original->error().code == 42
+              && original->error().stdout_text == "native stdout\n" && original->error().stderr_text == "native stderr\n",
+              "original error and both diagnostics retained verbatim");
+        check(std::holds_alternative<std::monostate>(failed.attempts[2]), "failure suppresses unadmitted work");
+        check(failed.scheduling && *failed.scheduling && !(*failed.scheduling)->admission_stop_observed,
+              "callback error is not external cancellation");
+    }
+    for (int mode = 0; mode < 3; ++mode) {
+        // Two genuinely running callbacks; stop while both are admitted, then
+        // let the delayed original error/exception emerge. No timing sleeps.
+        std::stop_source stop;
+        std::counting_semaphore<2> entered{0}, release{0};
+        std::atomic<bool> returned{false};
+        std::optional<Report> report;
+        std::jthread caller([&] {
+            report = run_work_batch(5, 2, stop.get_token(), [&](std::size_t index) -> Result {
+                if (index < 2) { entered.release(); release.acquire(); }
+                if (index == 1 && mode == 1) return std::unexpected(Error{2, "compiler out", "original compiler failure"});
+                if (index == 1 && mode == 2) throw std::runtime_error("original callback exception");
+                return good(index);
+            });
+            returned.store(true);
+        });
+        const bool first = entered.try_acquire_for(10s), second = entered.try_acquire_for(10s);
+        check(first && second, "two callbacks reach fixed synchronization boundary");
+        stop.request_stop();
+        check(!returned.load(), "admission stop does not return before active callbacks drain");
+        release.release(2); caller.join();
+        check(report.has_value() && !report->all_succeeded(), "cancel/error prevents successor phase");
+        check(report && report->outcome() == (mode == 0 ? WorkBatchOutcome::cancelled : WorkBatchOutcome::failed),
+              "original errors/exceptions take precedence over simultaneous stop");
+        if (report) {
+            const auto* first_result = std::get_if<Result>(&report->attempts[0]);
+            check(first_result && *first_result && **first_result == "result-0", "successful sibling result survives failed batch");
+            check(std::holds_alternative<std::monostate>(report->attempts[2]), "pending index is never successful");
+            if (mode == 1) {
+                const auto* r = std::get_if<Result>(&report->attempts[1]);
+                check(r && !*r && r->error().stderr_text == "original compiler failure", "delayed compiler error retained after stop");
+            }
+            if (mode == 2) {
+                const auto* ptr = std::get_if<std::exception_ptr>(&report->attempts[1]);
+                std::string text;
+                if (ptr && *ptr) try { std::rethrow_exception(*ptr); } catch (const std::runtime_error& e) { text = e.what(); }
+                check(text == "original callback exception", "original exception remains rethrowable");
+                check(report->scheduling && !*report->scheduling
+                      && report->scheduling->error().code == BoundedWorkErrorCode::callback_threw,
+                      "scheduler exception metadata also retained");
+            }
+        }
+    }
+    {
+        std::stop_source stop;
+        const auto finished = run_work_batch(2, 1, stop.get_token(), good);
+        stop.request_stop();
+        check(finished.all_succeeded(), "stop after deregistration cannot mutate completed report");
+        std::stop_source last;
+        const auto cancelled = run_work_batch(1, 1, last.get_token(), [&](std::size_t i) -> Result { last.request_stop(); return good(i); });
+        check(cancelled.outcome() == WorkBatchOutcome::cancelled && std::get<Result>(cancelled.attempts[0]).has_value(),
+              "all admitted results can succeed while external stop remains a distinct batch outcome");
+    }
+    {
+        std::atomic<int> calls{0};
+        const auto allocation = run_work_batch(std::numeric_limits<std::size_t>::max(), 2, {}, [&](std::size_t i) -> Result {
+            ++calls; return good(i);
+        });
+        check(allocation.outcome() == WorkBatchOutcome::failed && allocation.dispatch_exception && calls.load() == 0,
+              "result allocation failure retains exception and launches no callback");
+    }
+    {
+        // Error/stop in A is not permission to stop independent batch B.
+        std::stop_source a_stop, b_stop;
+        std::counting_semaphore<2> entered{0}, release{0};
+        std::optional<Report> a, b;
+        const auto work = [&](std::size_t index) -> Result {
+            if (index == 0) { entered.release(); release.acquire(); }
+            return good(index);
+        };
+        std::jthread ta([&] { a = run_work_batch(3, 1, a_stop.get_token(), work); });
+        std::jthread tb([&] { b = run_work_batch(3, 1, b_stop.get_token(), work); });
+        const bool first = entered.try_acquire_for(10s), second = entered.try_acquire_for(10s);
+        check(first && second, "independent batches entered");
+        a_stop.request_stop(); release.release(2); ta.join(); tb.join();
+        check(a && a->outcome() == WorkBatchOutcome::cancelled && b && b->all_succeeded() && !b_stop.stop_requested(),
+              "independent result batches do not share cancellation");
+    }
+    {
+        const auto movable = run_work_batch(2, 2, {}, [](std::size_t i) -> std::expected<std::unique_ptr<int>, int> {
+            return std::make_unique<int>(static_cast<int>(i));
+        });
+        check(movable.all_succeeded(), "move-only expected payloads need no copy");
+        const auto void_result = run_work_batch(1, 1, {}, [](std::size_t) -> std::expected<void, int> { return {}; });
+        check(void_result.all_succeeded(), "void expected successes supported");
+    }
+    std::cout << "bounded_work_batch_cases " << checks << " checks " << (failures == 0 ? "passed" : "failed") << '\n';
+    return failures;
+}
+} // namespace mqb::tests

--- a/cpp/tests/orchestration/scheduling/bounded_work_scheduler_tests.cpp
+++ b/cpp/tests/orchestration/scheduling/bounded_work_scheduler_tests.cpp
@@ -9,6 +9,7 @@
 
 #include "mqb/orchestration/BoundedWorkScheduler.hpp"
 #include "bounded_work_admission_cases.hpp"
+#include "bounded_work_batch_cases.hpp"
 
 namespace {
 
@@ -353,6 +354,7 @@ int main() {
     }
 
     failures += mqb::tests::bounded_work_admission_cases();
+    failures += mqb::tests::bounded_work_batch_cases();
 
     if (failures != 0) {
         std::cerr << failures << " test(s) failed\n";

--- a/cpp/tests/platform/windows/msvc_work_batch_probe.cpp
+++ b/cpp/tests/platform/windows/msvc_work_batch_probe.cpp
@@ -1,0 +1,321 @@
+// Real-tool fixture for the opt-in typed batch, not a production CLI path.
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#include <tlhelp32.h>
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <future>
+#include <iostream>
+#include <semaphore>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "mqb/msvc/MsvcCompiler.hpp"
+#include "mqb/orchestration/BoundedWorkBatch.hpp"
+#include "mqb/platform/windows/CommandLine.hpp"
+#include "mqb/platform/windows/WindowsProcessRunner.hpp"
+
+namespace {
+namespace fs = std::filesystem;
+using namespace std::chrono_literals;
+using mqb::platform::windows::WindowsProcessRunner;
+using CompileResult = std::expected<mqb::process::ProcessResult, mqb::msvc::CompilerError>;
+using Batch = mqb::orchestration::WorkBatchReport<CompileResult>;
+void require(bool value, const std::string& text) { if (!value) throw std::runtime_error(text); }
+std::string text(const fs::path& path) {
+    auto converted = mqb::platform::windows::utf16_to_utf8(path.wstring());
+    require(converted.has_value(), "invalid path encoding"); return *converted;
+}
+std::string json_string(const std::string& value) {
+    std::string output = "\"";
+    constexpr char hex[] = "0123456789abcdef";
+    for (const unsigned char c : value) {
+        if (c == '"' || c == '\\') { output += '\\'; output += static_cast<char>(c); }
+        else if (c < 32) { output += "\\u00"; output += hex[c >> 4]; output += hex[c & 15]; }
+        else output += static_cast<char>(c);
+    }
+    return output + '"';
+}
+void write(const fs::path& path, const std::string& contents) {
+    std::ofstream file(path, std::ios::binary); file << contents; file.flush();
+    require(bool(file), "cannot preserve " + text(path));
+}
+struct Handle {
+    HANDLE value{};
+    explicit Handle(HANDLE h = nullptr) : value(h) {}
+    ~Handle() { if (value && value != INVALID_HANDLE_VALUE) ::CloseHandle(value); }
+    Handle(const Handle&) = delete;
+    Handle& operator=(const Handle&) = delete;
+    Handle(Handle&& h) noexcept : value(std::exchange(h.value, nullptr)) {}
+    explicit operator bool() const { return value && value != INVALID_HANDLE_VALUE; }
+};
+std::uint64_t ticks(FILETIME t) { return (std::uint64_t{t.dwHighDateTime} << 32) | t.dwLowDateTime; }
+struct Child { DWORD pid{}; std::uint64_t created{}; Handle process; };
+std::vector<Child> compilers(const fs::path& expected_image) {
+    Handle snapshot{::CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0)};
+    require(bool(snapshot), "process snapshot failed");
+    PROCESSENTRY32W entry{}; entry.dwSize = sizeof(entry);
+    std::vector<Child> result;
+    auto more = ::Process32FirstW(snapshot.value, &entry);
+    while (more) {
+        if (entry.th32ParentProcessID == ::GetCurrentProcessId() && _wcsicmp(entry.szExeFile, L"cl.exe") == 0) {
+            Handle process{::OpenProcess(SYNCHRONIZE | PROCESS_QUERY_LIMITED_INFORMATION, FALSE, entry.th32ProcessID)};
+            require(bool(process), "cannot retain observed compiler identity");
+            FILETIME created{}, exited{}, kernel{}, user{};
+            require(::GetProcessTimes(process.value, &created, &exited, &kernel, &user) != FALSE, "compiler creation time unavailable");
+            std::wstring image(32768, L'\0'); DWORD size = static_cast<DWORD>(image.size());
+            require(::QueryFullProcessImageNameW(process.value, 0, image.data(), &size) != FALSE, "compiler image unavailable");
+            image.resize(size);
+            require(_wcsicmp(image.c_str(), expected_image.c_str()) == 0, "unexpected compiler image");
+            result.push_back(Child{entry.th32ProcessID, ticks(created), std::move(process)});
+        }
+        more = ::Process32NextW(snapshot.value, &entry);
+    }
+    require(::GetLastError() == ERROR_NO_MORE_FILES, "incomplete process enumeration");
+    return result;
+}
+bool live(const Child& child) {
+    const auto status = ::WaitForSingleObject(child.process.value, 0);
+    require(status == WAIT_OBJECT_0 || status == WAIT_TIMEOUT, "retained process wait failed");
+    return status == WAIT_TIMEOUT;
+}
+struct CompilerRunner final : mqb::process::ProcessRunner {
+    WindowsProcessRunner native;
+    std::atomic<unsigned> invocations{0};
+    std::expected<mqb::process::ProcessResult, mqb::process::ProcessError>
+    run(const mqb::process::ProcessSpec& spec) override {
+        require(!spec.cancellation.stop_possible(), "compiler received a forbidden terminating token");
+        invocations.fetch_add(1);
+        return native.run(spec);
+    }
+};
+std::string state(mqb::orchestration::WorkBatchOutcome value) {
+    switch (value) {
+    case mqb::orchestration::WorkBatchOutcome::succeeded: return "succeeded";
+    case mqb::orchestration::WorkBatchOutcome::failed: return "failed";
+    case mqb::orchestration::WorkBatchOutcome::cancelled: return "cancelled";
+    }
+    throw std::runtime_error("unknown typed batch result");
+}
+void save_process(const fs::path& dir, const std::string& stem, const mqb::process::ProcessResult& result) {
+    write(dir / (stem + ".stdout.txt"), result.stdout_text);
+    write(dir / (stem + ".stderr.txt"), result.stderr_text);
+    write(dir / (stem + ".result.json"), "{\"exit_code\":" + std::to_string(result.exit_code)
+        + ",\"cancelled\":" + (result.termination == mqb::process::ProcessTermination::cancelled ? "true" : "false") + "}\n");
+}
+std::string save_attempts(const fs::path& dir, const Batch& report) {
+    std::string rows = "[";
+    for (std::size_t i = 0; i < report.attempts.size(); ++i) {
+        if (i) rows += ',';
+        const auto stem = "work" + std::to_string(i);
+        const auto* result = std::get_if<CompileResult>(&report.attempts[i]);
+        rows += "{\"index\":" + std::to_string(i) + ",\"state\":";
+        if (!result) {
+            if (std::holds_alternative<std::monostate>(report.attempts[i])) rows += "\"not_started\"}";
+            else {
+                rows += "\"exception\"}";
+                const auto& exception = std::get<std::exception_ptr>(report.attempts[i]);
+                try { if (exception) std::rethrow_exception(exception); }
+                catch (const std::exception& error) { write(dir / (stem + ".exception.txt"), error.what()); }
+                catch (...) { write(dir / (stem + ".exception.txt"), "non-standard exception"); }
+            }
+            continue;
+        }
+        if (*result) {
+            save_process(dir, stem, **result);
+            rows += "\"succeeded\",\"exit_code\":" + std::to_string((*result)->exit_code) + "}";
+        } else {
+            const auto& error = result->error();
+            write(dir / (stem + ".compiler-error.txt"), error.message);
+            rows += "\"failed\",\"compiler_error_code\":" + std::to_string(static_cast<int>(error.code));
+            if (error.process_result) {
+                save_process(dir, stem, *error.process_result);
+                rows += ",\"exit_code\":" + std::to_string(error.process_result->exit_code);
+            } else {
+                rows += ",\"exit_code\":null";
+                if (error.process_error) write(dir / (stem + ".process-error.txt"), error.process_error->message
+                    + " native=" + std::to_string(error.process_error->native_code));
+            }
+            rows += '}';
+        }
+    }
+    return rows + ']';
+}
+int run(int argc, wchar_t** argv) {
+    require(argc == 4, "use OUTPUT CONFIGURATION MODE");
+    wchar_t authorized[2]{};
+    require(::GetEnvironmentVariableW(L"MQB_BATCH_DISPOSABLE_HOST", authorized, 2) == 1 && authorized[0] == L'1',
+            "real batch fixture requires a disposable host");
+    const fs::path root = fs::absolute(argv[1]);
+    require(!fs::exists(root), "refusing to overwrite a previous case"); fs::create_directories(root);
+    const std::wstring config{argv[2]}, mode{argv[3]};
+    require(config == L"Debug" || config == L"Release", "unknown configuration");
+    require(mode == L"complete" || mode == L"cancel" || mode == L"failure-cancel", "unknown mode");
+    const bool cancel = mode != L"complete", fail = mode == L"failure-cancel";
+    WindowsProcessRunner discovery_runner;
+    mqb::msvc::DiscoveryOptions discovery;
+    discovery.preference = mqb::msvc::ToolchainPreference::visual_studio;
+    discovery.cache_file = fs::path{};
+    auto found = mqb::msvc::MsvcToolchainLocator{discovery_runner}.discover(discovery);
+    require(found.has_value(), found ? "" : found.error().message);
+    auto toolchain = std::move(*found);
+    for (const char* name : {"CL", "_CL_", "LINK", "_LINK_"}) {
+        std::erase_if(toolchain.environment, [&](const auto& e) { return _stricmp(e.name.c_str(), name) == 0; });
+        toolchain.environment.push_back({name, "", true});
+    }
+    write(root / "toolchain.txt", text(toolchain.identity.compiler) + '\n' + toolchain.identity.version + '\n'
+          + toolchain.identity.binary_stamp + '\n');
+    std::vector<mqb::msvc::MsvcCompileRecipe> recipes;
+    for (unsigned i = 0; i != 3; ++i) {
+        const auto stem = "work" + std::to_string(i);
+        std::string source;
+        if (i < 2) for (unsigned j = 0; j != 12000; ++j) {
+            const auto id = std::to_string(i) + "_" + std::to_string(j);
+            source += "struct T" + id + " { int a; int b; };\n__declspec(noinline) int f" + id
+                + "(int n) { T" + id + " t{n,n+1}; return t.a+t.b; }\n";
+        }
+        if (i == 0) source += "int batch_helper(); int main(){return batch_helper()==42?0:1;}\n";
+        if (i == 1) source += "int batch_helper(){return 42;}\n";
+        if (i == 2) source += "int pending_work(){return 1;}\n";
+        if (i == 1 && fail) source += "static_assert(false, \"MQB_BATCH_EXPECTED_COMPILER_FAILURE\");\n";
+        write(root / (stem + ".cpp"), source);
+        mqb::msvc::CompileInvocation invocation;
+        invocation.source = root / (stem + ".cpp"); invocation.object = root / (stem + ".obj");
+        invocation.working_directory = root;
+        invocation.options.configuration = config == L"Debug" ? mqb::BuildConfiguration::debug : mqb::BuildConfiguration::release;
+        invocation.options.runtime_library = config == L"Debug" ? mqb::RuntimeLibrary::mtd : mqb::RuntimeLibrary::mt;
+        invocation.options.additional_arguments = {"/Zi", "/FS", "/bigobj", "/Fd" + text(root / "compiler.pdb")};
+        auto recipe = mqb::msvc::MsvcCompiler::build_recipe(toolchain, invocation);
+        require(recipe.has_value(), recipe ? "" : recipe.error().message);
+        require(!recipe->process.cancellation.stop_possible(), "recipe introduced a process kill token");
+        std::string args = text(recipe->process.executable) + '\n';
+        for (const auto& arg : recipe->process.arguments) args += arg + '\n';
+        write(root / (stem + ".planned-argv.txt"), args);
+        recipes.push_back(std::move(*recipe));
+    }
+    CompilerRunner runner;
+    const mqb::msvc::MsvcCompiler compiler{toolchain, runner};
+    std::stop_source admission;
+    std::counting_semaphore<2> entered{0}, launch{0};
+    auto batch = std::async(std::launch::async, [&] {
+        return mqb::orchestration::run_work_batch(3, 2, admission.get_token(), [&](std::size_t i) -> CompileResult {
+            if (i < 2) { entered.release(); launch.acquire(); }
+            // Actual adapter -> scheduler -> existing compiler -> existing runner.
+            return compiler.execute_recipe(recipes[i]);
+        });
+    });
+    const bool first = entered.try_acquire_for(10s), second = entered.try_acquire_for(10s);
+    launch.release(2); // Also releases a failed fixture instead of deadlocking cleanup.
+    std::vector<Child> active;
+    std::string observation_error;
+    bool overlap = false;
+    try {
+        const auto deadline = std::chrono::steady_clock::now() + 15s;
+        do {
+            active = compilers(toolchain.identity.compiler);
+            if (active.size() == 2 && live(active[0]) && live(active[1])) { overlap = true; break; }
+            if (batch.wait_for(2ms) == std::future_status::ready) break;
+        } while (std::chrono::steady_clock::now() < deadline);
+    } catch (const std::exception& error) { observation_error = error.what(); }
+    if (cancel || !overlap || !first || !second || !observation_error.empty()) admission.request_stop();
+    auto result = batch.get(); // Does not return until both admitted callbacks drain.
+    const auto items = save_attempts(root, result);
+    bool retained_exited = true;
+    for (const auto& child : active) retained_exited = retained_exited && !live(child);
+    const auto expected = fail ? mqb::orchestration::WorkBatchOutcome::failed
+        : (cancel ? mqb::orchestration::WorkBatchOutcome::cancelled : mqb::orchestration::WorkBatchOutcome::succeeded);
+    const bool clean_observation = first && second && overlap && observation_error.empty() && retained_exited;
+    const bool schedule_ok = result.scheduling && *result.scheduling
+        && (*result.scheduling)->started_count == (cancel ? 2U : 3U)
+        && (*result.scheduling)->admission_stop_observed == cancel;
+    bool originals_ok = result.attempts.size() == 3;
+    if (originals_ok) {
+        for (std::size_t i = 0; i < (cancel ? 2U : 3U); ++i) {
+            const auto* original = std::get_if<CompileResult>(&result.attempts[i]);
+            if (i == 1 && fail) {
+                originals_ok = originals_ok && original && !*original
+                    && original->error().code == mqb::msvc::CompilerErrorCode::compilation_failed
+                    && original->error().process_result && original->error().process_result->exit_code != 0
+                    && (original->error().process_result->stdout_text + original->error().process_result->stderr_text)
+                        .find("MQB_BATCH_EXPECTED_COMPILER_FAILURE") != std::string::npos;
+            } else originals_ok = originals_ok && original && original->has_value() && (*original)->exit_code == 0;
+        }
+        if (cancel) originals_ok = originals_ok && std::holds_alternative<std::monostate>(result.attempts[2]);
+    }
+    unsigned link_calls = 0, run_calls = 0, commits = 0;
+    int link_exit = -2, run_exit = -2;
+    // This is the caller's predecessor-result gate, NOT a product transaction.
+    // No failure/stop path can link or write this fixture's commit sentinel.
+    if (clean_observation && result.all_succeeded()) {
+        mqb::process::ProcessSpec link;
+        link.executable = toolchain.linker; link.working_directory = root; link.environment = toolchain.environment;
+        link.arguments = {"/NOLOGO", "/DEBUG", "/INCREMENTAL:NO", "/OUT:" + text(root / "program.exe"),
+                          "/PDB:" + text(root / "linked.pdb")};
+        for (unsigned i = 0; i != 3; ++i) link.arguments.push_back(text(root / ("work" + std::to_string(i) + ".obj")));
+        std::string args = text(link.executable) + '\n'; for (const auto& arg : link.arguments) args += arg + '\n';
+        write(root / "link.argv.txt", args);
+        ++link_calls;
+        auto linked = discovery_runner.run(link);
+        if (linked) { save_process(root, "link", *linked); link_exit = linked->exit_code; }
+        else write(root / "link.error.txt", linked.error().message);
+        if (link_exit == 0) {
+            mqb::process::ProcessSpec program; program.executable = root / "program.exe"; program.working_directory = root;
+            ++run_calls; auto ran = discovery_runner.run(program);
+            if (ran) { save_process(root, "run", *ran); run_exit = ran->exit_code; }
+            else write(root / "run.error.txt", ran.error().message);
+            if (run_exit == 0) { write(root / "fixture-commit.json", "{\"fixture_only\":true}\n"); ++commits; }
+        }
+    }
+    const bool downstream_ok = cancel ? link_calls == 0 && run_calls == 0 && commits == 0
+        && !fs::exists(root / "program.exe") && !fs::exists(root / "fixture-commit.json")
+        : link_calls == 1 && run_calls == 1 && commits == 1 && link_exit == 0 && run_exit == 0;
+    std::string schedule = "null";
+    if (result.scheduling) {
+        if (*result.scheduling) {
+            const auto& summary = **result.scheduling;
+            schedule = "{\"worker_count\":" + std::to_string(summary.worker_count)
+                + ",\"started_count\":" + std::to_string(summary.started_count)
+                + ",\"stop_requested\":" + (summary.stop_requested ? "true" : "false")
+                + ",\"admission_stop_observed\":" + (summary.admission_stop_observed ? "true" : "false")
+                + ",\"stopped_before_all_items\":" + (summary.stopped_before_all_items ? "true" : "false") + "}";
+        } else schedule = "{\"error_code\":" + std::to_string(static_cast<int>(result.scheduling->error().code))
+            + ",\"message\":" + json_string(result.scheduling->error().message) + "}";
+    }
+    if (result.dispatch_exception) {
+        try { std::rethrow_exception(result.dispatch_exception); }
+        catch (const std::exception& error) { write(root / "dispatch-exception.txt", error.what()); }
+        catch (...) { write(root / "dispatch-exception.txt", "non-standard dispatch exception"); }
+    }
+    const bool pdb_created = fs::is_regular_file(root / "compiler.pdb");
+    const bool valid = pdb_created && clean_observation && schedule_ok && originals_ok && result.outcome() == expected
+        && runner.invocations.load() == (cancel ? 2U : 3U) && downstream_ok;
+    std::string observed = "[";
+    for (const auto& child : active) {
+        if (observed.size() != 1) observed += ',';
+        observed += "{\"pid\":" + std::to_string(child.pid) + ",\"created\":" + std::to_string(child.created) + "}";
+    }
+    observed += ']';
+    write(root / "observation.json", "{\"schema\":1,\"configuration\":" + json_string(text(config))
+        + ",\"mode\":" + json_string(text(mode)) + ",\"outcome\":" + json_string(state(result.outcome()))
+        + ",\"real_compiler_overlap\":" + (overlap ? "true" : "false") + ",\"retained_compilers_exited\":" + (retained_exited ? "true" : "false")
+        + ",\"observed_compilers\":" + observed + ",\"observation_error\":" + json_string(observation_error)
+        + ",\"compiler_pdb_created\":" + (pdb_created ? "true" : "false") + ",\"scheduling\":" + schedule + ",\"items\":" + items + ",\"compiler_invocations\":" + std::to_string(runner.invocations.load())
+        + ",\"link_calls\":" + std::to_string(link_calls) + ",\"run_calls\":" + std::to_string(run_calls)
+        + ",\"fixture_commits\":" + std::to_string(commits) + ",\"gate_passed\":" + (valid ? "true" : "false")
+        + ",\"production_pipeline_integrated\":false,\"safe_to_transfer_write_lease\":false}\n");
+    return valid ? 0 : 1;
+}
+} // namespace
+int wmain(int argc, wchar_t** argv) {
+    try { return run(argc, argv); }
+    catch (const std::exception& error) { std::cerr << "BATCH_FIXTURE_ERROR " << error.what() << '\n'; return 1; }
+}

--- a/tests/native/assert_cpp_layout.ps1
+++ b/tests/native/assert_cpp_layout.ps1
@@ -295,7 +295,7 @@ Assert-LeafLayout -Root (Join-Path $testsRoot 'orchestration') -LeafFiles ([orde
         'module_target_validation_tests.cpp'
     )
     'routing' = @('target_router_tests.cpp')
-    'scheduling' = @('bounded_work_scheduler_tests.cpp', 'bounded_work_admission_cases.hpp')
+    'scheduling' = @('bounded_work_scheduler_tests.cpp', 'bounded_work_admission_cases.hpp', 'bounded_work_batch_cases.hpp')
 })
 
 Write-Host 'C++ responsibility layout contract passed.'

--- a/tests/native/collect_msvc_work_batch.ps1
+++ b/tests/native/collect_msvc_work_batch.ps1
@@ -1,0 +1,131 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string]$RepoRoot,
+    [Parameter(Mandatory)][string]$OutputRoot,
+    [string]$MqbPath,
+    [switch]$BuildOnly,
+    [string]$PrebuiltProbePath,
+    [string]$ProbeIdentityPath
+)
+$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+Set-StrictMode -Version 2.0
+$RepoRoot = [IO.Path]::GetFullPath($RepoRoot)
+$OutputRoot = [IO.Path]::GetFullPath($OutputRoot)
+if (Test-Path -LiteralPath $OutputRoot) { throw 'Refuse to overwrite earlier batch evidence.' }
+New-Item -ItemType Directory -Path $OutputRoot -Force | Out-Null
+function Write-Json($Path, $Value) {
+    $Value | ConvertTo-Json -Depth 15 | Set-Content -LiteralPath $Path -Encoding utf8
+}
+Push-Location $RepoRoot
+try {
+    $head = (& git rev-parse HEAD).Trim()
+    if ($LASTEXITCODE -ne 0) { throw 'Cannot read source HEAD.' }
+    if (@(& git status --porcelain --untracked-files=no).Count -ne 0 -or $LASTEXITCODE -ne 0) { throw 'Tracked source must be clean.' }
+    if ((Get-Content VERSION -Raw).Trim() -cne '5.5.0') { throw 'VERSION must remain 5.5.0.' }
+    if ($BuildOnly) {
+        if ([string]::IsNullOrWhiteSpace($MqbPath) -or -not [string]::IsNullOrWhiteSpace($PrebuiltProbePath)) { throw 'Invalid build-only input.' }
+        $MqbPath = [IO.Path]::GetFullPath($MqbPath)
+        & ./tests/native/assert_cpp_layout.ps1 -CppRoot (Join-Path $RepoRoot 'cpp')
+        $config = Get-Content cpp/mqb.json -Raw | ConvertFrom-Json
+        $sources = @($config.discovery.extra_sources | ForEach-Object { $_.Replace('\','/') } | Sort-Object -Unique)
+        $actual = @(Get-ChildItem cpp/src -Recurse -File -Filter '*.cpp' | ForEach-Object {
+            [IO.Path]::GetRelativePath((Join-Path $RepoRoot 'cpp'), $_.FullName).Replace('\','/')
+        } | Where-Object { $_ -ne 'src/app/main.cpp' } | Sort-Object -Unique)
+        if (@(Compare-Object $actual $sources).Count) { throw 'Product source manifest drift.' }
+        $arguments = @('cpp/tests/platform/windows/msvc_work_batch_probe.cpp')
+        $arguments += @($sources | ForEach-Object { 'cpp/' + $_ })
+        $arguments += @('--env','vs','--no-discover','--std',[string]$config.build.standard,'--release','--runtime','MT')
+        foreach ($path in @($config.build.include_dirs)) { $arguments += @('-I',('cpp/' + $path)) }
+        foreach ($arg in @($config.build.compiler_args)) { $arguments += @('--compiler-arg',[string]$arg) }
+        $arguments += @('-D','MQB_VERSION="work-batch-probe"','--lib','shell32.lib','-o','msvc_work_batch_probe')
+        Write-Json (Join-Path $OutputRoot 'build.argv.json') $arguments
+        $output = @(& $MqbPath @arguments 2>&1); $code = $LASTEXITCODE
+        $output | Set-Content -LiteralPath (Join-Path $OutputRoot 'build.output.txt') -Encoding utf8
+        $output | ForEach-Object { Write-Host $_ }
+        if ($code -ne 0) { throw "Probe build failed: $code" }
+        $probe = Join-Path $RepoRoot '.mqb/bin/msvc_work_batch_probe.exe'
+        Write-Json (Join-Path $OutputRoot 'probe.identity.json') @{
+            schema=1; source_head=$head; version='5.5.0'; configuration='Release'
+            probe_sha256=(Get-FileHash -LiteralPath $probe).Hash
+            candidate_sha256=(Get-FileHash -LiteralPath $MqbPath).Hash
+            build_run_id=$env:GITHUB_RUN_ID; build_run_attempt=$env:GITHUB_RUN_ATTEMPT
+        }
+        return
+    }
+    if ($env:GITHUB_ACTIONS -ne 'true' -or $env:RUNNER_ENVIRONMENT -ne 'github-hosted' -or
+        $env:MQB_BATCH_DISPOSABLE_HOST -ne '1') { throw 'Native batch cases require a separate disposable hosted VM.' }
+    if ([string]::IsNullOrWhiteSpace($PrebuiltProbePath) -or [string]::IsNullOrWhiteSpace($ProbeIdentityPath)) { throw 'Prebuilt probe and identity required.' }
+    $probe = [IO.Path]::GetFullPath($PrebuiltProbePath)
+    $origin = Get-Content -LiteralPath $ProbeIdentityPath -Raw | ConvertFrom-Json
+    if ($origin.source_head -cne $head -or $origin.version -cne '5.5.0' -or $origin.configuration -cne 'Release' -or
+        $origin.probe_sha256 -cne (Get-FileHash -LiteralPath $probe).Hash) { throw 'Exact prebuilt source/binary identity mismatch.' }
+    Write-Json (Join-Path $OutputRoot 'identity.json') @{
+        source_head=$head; probe=$origin; image=$env:ImageVersion; run=$env:GITHUB_RUN_ID; attempt=$env:GITHUB_RUN_ATTEMPT
+        os=[Environment]::OSVersion.VersionString; powershell=$PSVersionTable.PSVersion.ToString()
+        production_pipeline_integrated=$false; safe_to_transfer_write_lease=$false
+    }
+    $plan = @()
+    foreach ($config in @('Debug','Release')) {
+        foreach ($mode in @('complete','cancel','failure-cancel')) { $plan += @{ configuration=$config; mode=$mode } }
+    }
+    Write-Json (Join-Path $OutputRoot 'plan.json') @{
+        cases=$plan; expected_cases=6; workers=2; items=3; functions_per_active_source=12000
+        compiler_failure='separately labelled static_assert, not historical PDB reproduction'; retries=0
+        successor_gate='actual fixture link/run and commit sentinel only; not product cache/lease publication'
+    }
+    $rows = [Collections.Generic.List[object]]::new()
+    foreach ($case in $plan) {
+        $name = $case.configuration + '-' + $case.mode
+        $root = Join-Path $OutputRoot $name
+        # The native probe owns creation of this fresh directory.
+        $arguments = @($root,$case.configuration,$case.mode)
+        $output = @(& $probe @arguments 2>&1); $code = $LASTEXITCODE
+        if (-not (Test-Path -LiteralPath $root)) { New-Item -ItemType Directory -Path $root | Out-Null }
+        $output | Set-Content -LiteralPath (Join-Path $root 'case.output.txt') -Encoding utf8
+        Write-Json (Join-Path $root 'case.argv.json') $arguments
+        $errors = @(); $report = $null
+        try {
+            $report = Get-Content -LiteralPath (Join-Path $root 'observation.json') -Raw | ConvertFrom-Json
+            if ($code -ne 0 -or $report.gate_passed -isnot [bool] -or -not $report.gate_passed) { throw 'Native batch contract failed.' }
+            if ($report.production_pipeline_integrated -isnot [bool] -or $report.production_pipeline_integrated -or
+                $report.safe_to_transfer_write_lease -isnot [bool] -or $report.safe_to_transfer_write_lease) { throw 'Invalid authority claim.' }
+            $expected = if ($case.mode -eq 'complete') { 'succeeded' } elseif ($case.mode -eq 'cancel') { 'cancelled' } else { 'failed' }
+            if ($report.configuration -cne $case.configuration -or $report.mode -cne $case.mode -or $report.outcome -cne $expected) { throw 'Result identity/outcome mismatch.' }
+            $count = if ($case.mode -eq 'complete') { 3 } else { 2 }
+            if ($report.items.Count -ne 3 -or $report.compiler_invocations -ne $count -or $report.scheduling.worker_count -ne 2 -or
+                $report.scheduling.started_count -ne $count -or $report.real_compiler_overlap -ne $true -or $report.retained_compilers_exited -ne $true) { throw 'Incomplete multiworker evidence.' }
+            foreach ($index in 0..($count-1)) {
+                $stem = 'work' + $index
+                $result = Get-Content -LiteralPath (Join-Path $root "$stem.result.json") -Raw | ConvertFrom-Json
+                $stdout = [IO.File]::ReadAllText((Join-Path $root "$stem.stdout.txt"))
+                $stderr = [IO.File]::ReadAllText((Join-Path $root "$stem.stderr.txt"))
+                if ($result.exit_code -ne $report.items[$index].exit_code -or $result.cancelled -ne $false) { throw 'Original result replaced or tool terminated.' }
+                if ($case.mode -eq 'failure-cancel' -and $index -eq 1) {
+                    if ($result.exit_code -eq 0 -or ($stdout+$stderr) -notmatch 'MQB_BATCH_EXPECTED_COMPILER_FAILURE') { throw 'Original injected compiler error missing.' }
+                } elseif ($result.exit_code -ne 0) { throw 'Original positive compiler failed.' }
+            }
+            if ($count -eq 2) {
+                if ($report.items[2].state -cne 'not_started' -or (Test-Path -LiteralPath (Join-Path $root 'work2.result.json')) -or
+                    $report.link_calls -ne 0 -or $report.run_calls -ne 0 -or $report.fixture_commits -ne 0 -or
+                    (Test-Path -LiteralPath (Join-Path $root 'fixture-commit.json')) -or (Test-Path -LiteralPath (Join-Path $root 'program.exe'))) {
+                    throw 'Failed/cancelled batch advanced to a successor or counted missing work successful.'
+                }
+            } else {
+                foreach ($stem in @('link','run')) {
+                    $result = Get-Content -LiteralPath (Join-Path $root "$stem.result.json") -Raw | ConvertFrom-Json
+                    if ($result.exit_code -ne 0) { throw 'Positive successor failed.' }
+                }
+                if ($report.link_calls -ne 1 -or $report.run_calls -ne 1 -or $report.fixture_commits -ne 1 -or
+                    -not (Test-Path -LiteralPath (Join-Path $root 'fixture-commit.json'))) { throw 'Positive successor gate untested.' }
+            }
+        } catch { $errors += $_.Exception.Message }
+        $rows.Add(@{ case=$name; native_exit=$code; accepted=($errors.Count -eq 0); errors=$errors; observation=$report })
+        Write-Json (Join-Path $OutputRoot 'summary.json') @{
+            expected_cases=6; completed_cases=$rows.Count; not_run_cases=(6-$rows.Count); cases=@($rows.ToArray())
+            production_pipeline_integrated=$false; safe_to_transfer_write_lease=$false
+        }
+        if ($errors.Count) { throw 'Stopped at first failed evidence/control; remaining fixed cases not attempted.' }
+    }
+}
+finally { Pop-Location }


### PR DESCRIPTION
## Final decision: accept opt-in typed batch outcomes; production integration stays separate

[Final exact-source review, real two-worker results, full19-rowABBA and acceptance decision](https://github.com/Iviesever/msvc-quick-build/pull/177#pullrequestreview-5161902436)

**Accept ordinary expected-head merge.** This is a new public product interface with actual native validation, not merely test-only code. Existing product callers and CLI behavior remain unchanged. Historical C1041/performance debts, #172 HOLD and M1b's remaining gates are not resolved by this decision.

## Exact source

- Base **`8e4c9eef2ab0479c43e0448421baea53ac699362`**.
- Reviewed head **`2088e6afe0e6473aa88b96b14ce2d0ccdc1f69de`**.
- Candidate/native test-merge tree **`8e84f920b1f3f57b64a651a34ffa5112a619f9bb`**.
- Test-merge **`5c466aff88d4ab1fdc478560665273a7ee03d61f`**, exactly those base/head parents.
- Seven files, **821 additions/1 deletion**;409base files,407unchanged,2modified+5new,414candidate files. Complete source archives/tree hashes and patch replay verified.
- No existing product .cpp, scheduler implementation, compiler, ProcessSpec, production caller, manifest/native79-executable inventory, benchmark, CLI/freshness or VERSION change. **VERSION5.5.0; no historical tag/asset or formal release change.**

## Product result contract

`run_work_batch` accepts callbacks returning nothrow-movable `std::expected<T,E>` by value, and composes the existing owned-worker scheduler. Preallocated per-index slots keep **not-entered/original expected/original exception_ptr**, plus separate scheduling result and setup/dispatch exception. Successful sibling payloads survive another callback's failure. Original returned errors and exceptions take precedence over concurrent external admission cancellation; pending work never becomes successful.

When no external stoppable token is supplied, a private stop source selects the existing RAII/owned-worker path; the unchanged legacy scheduler is not silently rewritten. No token is passed to work or ProcessSpec. Expected payload storage cannot introduce a throwing move; allocation can fail and is retained. The API is not a second scheduler and launches no process itself.

`all_succeeded()` is a necessary predecessor-result gate, **not** freshness, commit authority, process/service-writer quiescence or safe project write-lease transfer. No production pipeline calls it yet. Partially launched OS-worker startup failure has not been fault-injected; setup allocation failure/source RAII reasoning are not that runtime coverage.

## Completed current-head gates

|Gate|Actual run|Result|
|---|---|---|
|Native Debug/all shards/freshness/runtime/parameters|#731/34426468999|Passed; actual new46-check execution inspected in job102714136189|
|Complete Release/self-host/exact runtime-only package|#619/34426468958|Passed; actual46checks in job102714039788; publish-release skipped|
|New two-worker fixture|#1/34426468957|Actual PowerShell/native build; all6fixed Debug/Release cases pass|
|Original ownership/record regressions|Default#23/34426468875;Private#25/34426468949|70/70,42/42; all required positive controls and150record expectations pass|
|Independent original observer-OFF ABBA|#590/34426468972|76pairs measured/recomputed;72complete instrumented semantic identities match|
|Documentation/Cross-Stage and7inspection workflows|15total triggered workflows|All completed successfully; ancillary statuses are not a full raw-artifact audit|

The accepted File Event/PDB Open research workflows were **not triggered by this diff** and are not presented as rerun/passed this head. Their code/dependent product paths remain unchanged. No post-submission source revision or same-head native/CI/benchmark retry occurred.

### Actual multiworker success/failure/cancellation

[Six-case original-result and executable-provenance audit](https://github.com/Iviesever/msvc-quick-build/pull/177#issuecomment-5611463733)

Debug and Release each run the fixed complete/cancel/failure-cancel sequence. Complete returns succeeded with original exits0,0,0 and actual link/run/fixture-commit. Cancel returns cancelled with original exits0,0, two entered items and no successor. Failure-cancel returns **failed**, with original exits0,2/C2338 and the injected static_assert marker, even while admission_stop_observed=true; no successor is invoked. The third slot remains not_started for all four stopped cases. Original failure is not rewritten as cancellation or recovery success.

All6cases retain two real live cl.exe handles/image/creation identities before the stop decision and observe their completion before accepting the batch. The forwarding runner rejects terminating tokens and every native compiler result has cancelled=false. Two12000-function active inputs, one pending input, /FS/effective /Zi,/bigobj and /MTd or /MT remain fixed. The original recipe's /Z7 precedes /Zi; actual PDB creation is checked. Twelve input comparisons and twelve planned-argv comparisons normalize only case paths and the declared trailing failure marker. These are recipe-derived argv, not independent OS command telemetry.

All18original compile/link/run results and36stdout/stderr files inspected. Positive cases really link/run; stopped cases have no link/run call, output executable or sentinel. That sentinel is **fixture-only**, not production cache publication. `production_pipeline_integrated=false` and `safe_to_transfer_write_lease=false` remain explicit. The injected static_assert is not historical PDB/C1041 reproduction or an RPC-completion test.

### Existing errors and performance stay visible

Default70 preserves all14single-worker scheduler controls and14direct references;126source/argv comparisons across those pairs and actual helper/refusal outputs pass. Four intentionally adverse default B failures remain (Zi Release,PCH Release,Modules Debug,Modules Release under A-started normal), C1090/original exit2, unattempted link/run and separate recovery0. Private B happens to pass, but all28A-started managed endings still kill original services. Default715/private417toolresults and1430/834diagnostics checked. Resource identities16/70and0/42 are not writer-quiescence evidence.

Independent19x4ABBA preserves all72instrumented complete counters/breakdowns/compile-link-archive hit-miss identities; four external timings-off counter sets unavailable, not zeros. External no-op paired median **+0.3388ms/+3.1622469%**, maximum adverse+1.363ms,2/4slower; unchanged **BOTH>1ms AND>10%** median gate not crossed. Preserve link-only+283.626ms,scale-j1+1.926ms median and all other adverse/favorable samples. No speedup/zero-overhead claim, noise deletion, AA subtraction or historical debt closure. Only external row uses timings-off elapsed; four-pairP95 is a maximum, not a population-tail estimate. Comparison JSON does not archive the benchmark binary pair or OS trace.

## Original predeclared gates and next boundary

Full exact-source native Debug/all Release/selfhost/package,46checks in actual Debug/Release,six real two-worker outcome/successor controls,original70/42positive controls and150record expectations, plus unchanged19x4ABBA and its original conjunction were required before acceptance. Those gates now pass; none was waived or weakened. Untriggered historical research is not relabeled current validation. Temporaryperf title changed only after actual#590finished; later skippedperf jobs are not new measurements.

**Next separate small PR:** adopt typed outcomes at an explicit compile-wave/target boundary without changing the existing no-token hot path or weakening inspection/execution evidence and freshness semantics. Original failures must block downstream target link/cache publication and unentered tasks cannot satisfy prerequisites. Test real production-boundary behavior rather than claiming this fixture commit is production integration. No additional observer expansion, CLI cancel switch, shared-service termination policy, project lease/transaction/build-run/session/residency or formal release is introduced here.

Eight immutable coreZIPs, completebase/headsourcearchives,patch,manifests and executedread-onlyaudits are retained in delivery; not every Actionsartifact. Retention30days; generatedcompilerbinarybodies are excludedfromdiagnosticZIPs, separateinputs contain actual observer executables and are not the ABBApair. Finitepost-caseinventories are not failure-instantsnapshots. LocalGCC/ASan/UBSan with platformshims and declaration-onlyWin32syntaxchecks are not localMSVC/PowerShell/ETWexecution; original localsetupfailures remain logged. Native log excerpts are explicitly excerpts, not full archivedCIlogs. No current failed check or original failure was relabeled successful.