### PR TITLE
feat: gate ordinary target links on typed compile admission outcomes

### DIFF
--- a/cpp/include/mqb/orchestration/BoundedWorkBatch.hpp
+++ b/cpp/include/mqb/orchestration/BoundedWorkBatch.hpp
@@ -69,18 +69,13 @@ struct WorkBatchReport {
     }
 };
 
-// Explicit opt-in result-preserving adapter, not a second scheduler. The work
-// callable must return std::expected<T,E> by value. Nothrow move preserves the
-// original payload without risking a second exception while storing it. Errors
-// are never interpreted as cancellation; only scheduler admission observation
-// produces the cancelled batch outcome. Admitted work owns its synchronous end.
-// This API launches no process, passes no token to work and publishes no cache.
-// Existing scheduler/CLI callers are unchanged. Work may run concurrently.
-template<class Work, class Result = std::invoke_result_t<Work&, std::size_t>>
-    requires ExpectedWorkResult<Result>
-[[nodiscard]] WorkBatchReport<Result> run_work_batch(
-    std::size_t item_count, std::size_t max_workers,
-    std::stop_token admission_stop, Work&& work) {
+namespace detail {
+// Share payload ownership across numeric and policy overloads. The scheduler
+// remains the sole owner of parallelism resolution and platform resource policy.
+template<ExpectedWorkResult Result, class Work, class Schedule>
+[[nodiscard]] WorkBatchReport<Result> collect_work_batch(
+    std::size_t item_count, bool valid_limit, std::stop_token admission_stop,
+    Work&& work, Schedule&& schedule) {
     WorkBatchReport<Result> report;
     report.requested_count = item_count;
     try {
@@ -90,9 +85,8 @@ template<class Work, class Result = std::invoke_result_t<Work&, std::size_t>>
         std::stop_source private_lifetime;
         const auto token = admission_stop.stop_possible()
             ? admission_stop : private_lifetime.get_token();
-        if (max_workers != 0) report.attempts.resize(item_count);
-        report.scheduling.emplace(BoundedWorkScheduler::run_with_admission_stop(
-            item_count, max_workers, token, [&](std::size_t index) {
+        if (valid_limit) report.attempts.resize(item_count);
+        report.scheduling.emplace(schedule(token, [&](std::size_t index) {
                 auto& slot = report.attempts[index];
                 try {
                     slot.template emplace<1>(std::invoke(work, index));
@@ -109,6 +103,33 @@ template<class Work, class Result = std::invoke_result_t<Work&, std::size_t>>
         report.dispatch_exception = std::current_exception();
     }
     return report;
+}
+} // namespace detail
+
+// Explicit opt-in adapter, not a second scheduler. Work returns expected by
+// value; only admission is cancelled, never an admitted process/callback.
+template<class Work, class Result = std::invoke_result_t<Work&, std::size_t>>
+    requires ExpectedWorkResult<Result>
+[[nodiscard]] WorkBatchReport<Result> run_work_batch(
+    std::size_t item_count, std::size_t max_workers,
+    std::stop_token admission_stop, Work&& work) {
+    return detail::collect_work_batch<Result>(item_count, max_workers != 0,
+        admission_stop, std::forward<Work>(work), [&](auto token, auto&& callback) {
+            return BoundedWorkScheduler::run_with_admission_stop(
+                item_count, max_workers, token, callback);
+        });
+}
+
+template<class Work, class Result = std::invoke_result_t<Work&, std::size_t>>
+    requires ExpectedWorkResult<Result>
+[[nodiscard]] WorkBatchReport<Result> run_work_batch(
+    std::size_t item_count, ParallelismPolicy policy, ParallelismWorkload workload,
+    std::stop_token admission_stop, Work&& work) {
+    return detail::collect_work_batch<Result>(item_count, policy.valid(),
+        admission_stop, std::forward<Work>(work), [&](auto token, auto&& callback) {
+            return BoundedWorkScheduler::run_with_admission_stop(
+                item_count, policy, workload, token, callback);
+        });
 }
 
 } // namespace mqb::orchestration

--- a/cpp/include/mqb/orchestration/MsvcIncrementalTargetCoordinator.hpp
+++ b/cpp/include/mqb/orchestration/MsvcIncrementalTargetCoordinator.hpp
@@ -3,6 +3,8 @@
 #include <cstddef>
 #include <expected>
 #include <filesystem>
+#include <memory>
+#include <stop_token>
 #include <optional>
 #include <string>
 #include <vector>
@@ -10,6 +12,7 @@
 #include "mqb/core/CompilerOptions.hpp"
 #include "mqb/core/LinkOptions.hpp"
 #include "mqb/core/ProjectArtifactLayout.hpp"
+#include "mqb/orchestration/BoundedWorkBatch.hpp"
 #include "mqb/orchestration/MsvcIncrementalCompileCoordinator.hpp"
 #include "mqb/orchestration/MsvcIncrementalLinkCoordinator.hpp"
 #include "mqb/orchestration/ParallelismPolicy.hpp"
@@ -41,6 +44,28 @@ struct TargetCompileResult {
     IncrementalCompileResult result;
 };
 
+// Opt-in failure/cancellation evidence. Each false phase result refers to the
+// exact source slot below; callback/setup exceptions remain in the typed batch.
+// Execution slots map through execution_sources (inspection uses source order).
+// A successful TU may save its own valid cache before a sibling stops the wave.
+// This is not rollback, external-writer completion, or a write-lease certificate.
+struct TargetCompileFailure {
+    std::size_t source_index{};
+};
+using TargetCompilePhase = WorkBatchReport<std::expected<void, TargetCompileFailure>>;
+struct TargetCompileWaveEvidence {
+    std::vector<std::optional<std::expected<IncrementalCompileResult, IncrementalCompileError>>> attempts;
+    std::optional<TargetCompilePhase> inspection;
+    std::optional<TargetCompilePhase> execution;
+    std::vector<std::size_t> execution_sources;
+    std::exception_ptr setup_exception;
+};
+struct TargetAdmissionEvidence {
+    // A second wave is the existing conservative freshness retry, not a retry
+    // after a compile failure. Keep both passes when the second is interrupted.
+    std::vector<TargetCompileWaveEvidence> waves;
+};
+
 enum class IncrementalTargetErrorCode {
     no_sources,
     invalid_parallelism,
@@ -51,6 +76,7 @@ enum class IncrementalTargetErrorCode {
     scheduling_failed,
     compile_failed,
     link_failed,
+    cancelled,
 };
 
 struct IncrementalTargetError {
@@ -59,6 +85,7 @@ struct IncrementalTargetError {
     std::filesystem::path source;
     std::optional<IncrementalCompileError> compile_error;
     std::optional<IncrementalLinkError> link_error;
+    std::shared_ptr<const TargetAdmissionEvidence> admission;
 };
 
 struct IncrementalTargetResult {
@@ -79,7 +106,21 @@ public:
     [[nodiscard]] std::expected<IncrementalTargetResult, IncrementalTargetError>
     run(const IncrementalTargetRequest& request) const;
 
+    // Validation still precedes cancellation. Reuses the normal inspect/miss
+    // execution and post-execution freshness barrier. A non-stoppable token
+    // delegates run(). Failure wins over concurrent stop, with original records.
+    // After a final stop check the terminal link stage is admitted as a whole;
+    // later stop does not terminate that link or roll back its valid cache save.
+    // No CLI caller opts in and no token is passed to ProcessSpec.
+    [[nodiscard]] std::expected<IncrementalTargetResult, IncrementalTargetError>
+    run_with_compile_admission_stop(
+        const IncrementalTargetRequest& request, std::stop_token admission_stop) const;
+
 private:
+    template<bool WithAdmissionStop>
+    [[nodiscard]] std::expected<IncrementalTargetResult, IncrementalTargetError>
+    run_impl(const IncrementalTargetRequest& request, std::stop_token admission_stop) const;
+
     MsvcIncrementalCompileCoordinator& compile_coordinator_;
     MsvcIncrementalLinkCoordinator& link_coordinator_;
 };

--- a/cpp/src/orchestration/incremental/MsvcIncrementalTargetCoordinator.cpp
+++ b/cpp/src/orchestration/incremental/MsvcIncrementalTargetCoordinator.cpp
@@ -6,6 +6,7 @@
 #include <optional>
 #include <string>
 #include <unordered_set>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -65,6 +66,20 @@ using CompileAttempt = detail::TargetCompileAttempt;
 
 std::expected<IncrementalTargetResult, IncrementalTargetError>
 MsvcIncrementalTargetCoordinator::run(const IncrementalTargetRequest& request) const {
+    return run_impl<false>(request, {});
+}
+
+std::expected<IncrementalTargetResult, IncrementalTargetError>
+MsvcIncrementalTargetCoordinator::run_with_compile_admission_stop(
+    const IncrementalTargetRequest& request, std::stop_token admission_stop) const {
+    if (!admission_stop.stop_possible()) return run(request);
+    return run_impl<true>(request, admission_stop);
+}
+
+template<bool WithAdmissionStop>
+std::expected<IncrementalTargetResult, IncrementalTargetError>
+MsvcIncrementalTargetCoordinator::run_impl(
+    const IncrementalTargetRequest& request, std::stop_token admission_stop) const {
     mqb::performance::ScopedWall validation_evidence{
         mqb::performance::WallKind::target_validation};
     if (request.sources.empty()) {
@@ -148,41 +163,85 @@ MsvcIncrementalTargetCoordinator::run(const IncrementalTargetRequest& request) c
     detail::FilesystemEvidenceTable* shared_evidence =
         filesystem_evidence ? &*filesystem_evidence : nullptr;
 
-    auto scheduled = detail::TargetCompileWave::run(
-        request,
-        compile_coordinator_,
-        request.force_downstream_rebuild,
-        shared_evidence,
-        attempts);
-    if (!scheduled) {
-        return std::unexpected(failure(
-            IncrementalTargetErrorCode::scheduling_failed,
-            "target compile scheduler failed: " + scheduled.error().message));
-    }
-    if (auto error = first_compile_error(request, attempts)) {
-        return std::unexpected(std::move(*error));
-    }
+    struct NoAdmissionEvidence {};
+    std::conditional_t<WithAdmissionStop, TargetAdmissionEvidence, NoAdmissionEvidence> admission;
+    const auto run_wave = [&](bool force, detail::FilesystemEvidenceTable* table)
+        -> std::expected<detail::TargetCompileWaveSummary, BoundedWorkError> {
+        if constexpr (!WithAdmissionStop) {
+            return detail::TargetCompileWave::run(
+                request, compile_coordinator_, force, table, attempts);
+        } else {
+            auto& wave = admission.waves.emplace_back();
+            try {
+                return detail::TargetCompileWave::run<true>(
+                    request, compile_coordinator_, force, table, attempts, admission_stop, &wave);
+            } catch (...) {
+                wave.setup_exception = std::current_exception();
+                return std::unexpected(BoundedWorkError{
+                    .code = BoundedWorkErrorCode::worker_start_failed,
+                    .message = "target compile wave setup failed",
+                });
+            }
+        }
+    };
+    auto scheduled = run_wave(request.force_downstream_rebuild, shared_evidence);
+    const auto wave_error = [&]() -> std::optional<IncrementalTargetError> {
+        if constexpr (!WithAdmissionStop) {
+            if (!scheduled) return failure(IncrementalTargetErrorCode::scheduling_failed,
+                "target compile scheduler failed: " + scheduled.error().message);
+            return first_compile_error(request, attempts);
+        } else {
+            // Prefer an actual compile failure to concurrent cancellation AND a
+            // scheduling error; all additional exceptions remain in the report.
+            auto error = first_compile_error(request, attempts);
+            const auto& wave = admission.waves.back();
+            const auto failed = [](const auto& phase) {
+                return phase && phase->outcome() == WorkBatchOutcome::failed;
+            };
+            const auto cancelled = [](const auto& phase) {
+                return phase && phase->outcome() == WorkBatchOutcome::cancelled;
+            };
+            if (!error && (!scheduled || wave.setup_exception
+                || failed(wave.inspection) || failed(wave.execution))) {
+                error = failure(IncrementalTargetErrorCode::scheduling_failed,
+                    scheduled ? "typed target compile wave failed"
+                              : "target compile scheduler failed: " + scheduled.error().message);
+            }
+            if (!error && (cancelled(wave.inspection) || cancelled(wave.execution)
+                || admission_stop.stop_requested())) {
+                error = failure(IncrementalTargetErrorCode::cancelled,
+                    "target compile admission stopped; terminal link was not admitted");
+            }
+            if (error) {
+                admission.waves.back().attempts = std::move(attempts);
+                error->admission = std::make_shared<TargetAdmissionEvidence>(std::move(admission));
+            }
+            return error;
+        }
+    };
+    if (auto error = wave_error()) return std::unexpected(std::move(*error));
 
     if (shared_evidence != nullptr
         && !shared_evidence->revalidate_shared()) {
         // This barrier remains AFTER miss execution. A dependency can change
         // while a compiler is running, not just during parallel inspection.
         // Rebuild the complete target without reusing any earlier decision.
-        scheduled = detail::TargetCompileWave::run(
-            request,
-            compile_coordinator_,
-            true,
-            nullptr,
-            attempts);
-        if (!scheduled) {
-            return std::unexpected(failure(
+        if constexpr (WithAdmissionStop) {
+            admission.waves.back().attempts = std::move(attempts);
+        }
+        scheduled = run_wave(true, nullptr);
+        if constexpr (!WithAdmissionStop) {
+            if (!scheduled) return std::unexpected(failure(
                 IncrementalTargetErrorCode::scheduling_failed,
-                "target conservative rebuild scheduler failed: "
-                    + scheduled.error().message));
+                "target conservative rebuild scheduler failed: " + scheduled.error().message));
         }
-        if (auto error = first_compile_error(request, attempts)) {
-            return std::unexpected(std::move(*error));
-        }
+        if (auto error = wave_error()) return std::unexpected(std::move(*error));
+    }
+
+    if constexpr (WithAdmissionStop) {
+        // This is the terminal-stage admission decision. Once it passes, a late
+        // stop does not terminate link or pretend its valid cache save rolled back.
+        if (auto error = wave_error()) return std::unexpected(std::move(*error));
     }
 
     timings.compile = std::chrono::duration_cast<std::chrono::nanoseconds>(

--- a/cpp/src/orchestration/incremental/TargetCompileWave.hpp
+++ b/cpp/src/orchestration/incremental/TargetCompileWave.hpp
@@ -4,6 +4,8 @@
 #include <expected>
 #include <memory>
 #include <optional>
+#include <numeric>
+#include <stop_token>
 #include <utility>
 #include <vector>
 
@@ -33,21 +35,52 @@ struct TargetCompileWaveSummary {
 // and conservative whole-target retry, including mutations during execution.
 class TargetCompileWave {
 public:
-    template <typename TargetRequest>
+    template <bool WithAdmissionStop = false, typename TargetRequest>
     [[nodiscard]] static std::expected<TargetCompileWaveSummary, BoundedWorkError>
     run(
         const TargetRequest& request,
         MsvcIncrementalCompileCoordinator& coordinator,
         const bool force_rebuild,
         FilesystemEvidenceTable* evidence_table,
-        std::vector<std::optional<TargetCompileAttempt>>& attempts) {
+        std::vector<std::optional<TargetCompileAttempt>>& attempts,
+        std::stop_token admission_stop = {},
+        TargetCompileWaveEvidence* typed = nullptr) {
         attempts.clear();
         attempts.resize(request.sources.size());
 
+        // Both paths below retain identical TLS/inspection/execution authority.
+        // The false specialization contains only the original scheduler call.
+        const auto dispatch = [&](std::size_t count, bool inspection, const auto& work)
+            -> std::expected<BoundedWorkSummary, BoundedWorkError> {
+            if constexpr (!WithAdmissionStop) {
+                return BoundedWorkScheduler::run(count, request.max_parallel_compiles, work);
+            } else {
+                auto& saved = inspection ? typed->inspection : typed->execution;
+                saved.emplace(run_work_batch(count, request.max_parallel_compiles,
+                    ParallelismWorkload::compilation, admission_stop,
+                    [&](std::size_t index) -> std::expected<void, TargetCompileFailure> {
+                        if (work(index)) return {};
+                        return std::unexpected(TargetCompileFailure{
+                            inspection ? index : typed->execution_sources[index]});
+                    }));
+                if (!saved->scheduling) {
+                    return std::unexpected(BoundedWorkError{
+                        .code = BoundedWorkErrorCode::worker_start_failed,
+                        .message = "typed compile batch did not produce a scheduler result",
+                    });
+                }
+                return *saved->scheduling;
+            }
+        };
+
         if (evidence_table == nullptr || force_rebuild) {
+            if constexpr (WithAdmissionStop) {
+                typed->execution_sources.resize(request.sources.size());
+                std::iota(typed->execution_sources.begin(), typed->execution_sources.end(), std::size_t{0});
+            }
             const auto direct = [&] {
-                return BoundedWorkScheduler::run(
-                    request.sources.size(), request.max_parallel_compiles,
+                return dispatch(
+                    request.sources.size(), false,
                     [&](const std::size_t index) {
                         auto compile_request = make_request(
                             request.sources[index], request.compiler_options,
@@ -101,11 +134,10 @@ public:
         const auto inspected = [&] {
             if (request.max_parallel_compiles == 1) {
                 ScopedFilesystemEvidenceActivation active{evidence_table};
-                return BoundedWorkScheduler::run(
-                    request.sources.size(), request.max_parallel_compiles, inspect_one);
+                return dispatch(request.sources.size(), true, inspect_one);
             }
-            return BoundedWorkScheduler::run(
-                request.sources.size(), request.max_parallel_compiles,
+            return dispatch(
+                request.sources.size(), true,
                 [&](const std::size_t index) {
                     ScopedFilesystemEvidenceActivation active{evidence_table};
                     return inspect_one(index);
@@ -124,6 +156,7 @@ public:
             if (pending[index]) misses.push_back(index);
         }
         if (misses.empty()) return summary;
+        if constexpr (WithAdmissionStop) typed->execution_sources = misses;
 
         const auto execute_one = [&](const std::size_t miss_index) {
             const std::size_t source_index = misses[miss_index];
@@ -136,11 +169,10 @@ public:
             // Execution and cache sealing must not consume inspection snapshots.
             if (request.max_parallel_compiles == 1 || misses.size() == 1) {
                 ScopedFilesystemEvidenceActivation suspended{nullptr};
-                return BoundedWorkScheduler::run(
-                    misses.size(), request.max_parallel_compiles, execute_one);
+                return dispatch(misses.size(), false, execute_one);
             }
-            return BoundedWorkScheduler::run(
-                misses.size(), request.max_parallel_compiles,
+            return dispatch(
+                misses.size(), false,
                 [&](const std::size_t index) {
                     ScopedFilesystemEvidenceActivation suspended{nullptr};
                     return execute_one(index);

--- a/cpp/tests/orchestration/incremental/incremental_target_coordinator_tests.cpp
+++ b/cpp/tests/orchestration/incremental/incremental_target_coordinator_tests.cpp
@@ -7,6 +7,10 @@
 #include <filesystem>
 #include <fstream>
 #include <functional>
+#include <future>
+#include <semaphore>
+#include <stop_token>
+#include <iterator>
 #include <iostream>
 #include <mutex>
 #include <set>
@@ -279,6 +283,271 @@ private:
                 root / ".mqb" / "cache" / "compile" / (name + ".cache"),
         },
     };
+}
+
+
+// These tests execute the PRODUCT target/compile/link/cache coordinators and
+// real filesystem cache persistence. Only the process boundary is deterministic;
+// this is not a claim of actual cl.exe execution or project-transaction rollback.
+class AdmissionToolRunner final : public mqb::process::ProcessRunner {
+public:
+    TargetToolRunner tools;
+    fs::path compiler;
+    std::function<void(const mqb::process::ProcessSpec&)> before_compile, before_link;
+    std::string throws_on, process_error_on;
+    std::atomic<bool> saw_process_token{false}, saw_execution_snapshot{false};
+    AdmissionToolRunner(const fs::path& cl, const fs::path& link, const fs::path& header)
+        : tools(cl, link, 1, header), compiler(cl) {}
+    std::expected<mqb::process::ProcessResult, mqb::process::ProcessError>
+    run(const mqb::process::ProcessSpec& spec) override {
+        if (spec.cancellation.stop_possible()) saw_process_token.store(true);
+        if (spec.executable == compiler) {
+            if (mqb::orchestration::detail::active_filesystem_evidence_table != nullptr)
+                saw_execution_snapshot.store(true);
+            if (before_compile) before_compile(spec);
+            const auto source = utf8_path(spec.arguments.back()).filename().string();
+            if (source == throws_on) throw std::runtime_error("original target callback exception");
+            if (source == process_error_on) return std::unexpected(mqb::process::ProcessError{
+                .code = mqb::process::ProcessErrorCode::launch_failed,
+                .native_code = 123, .message = "original target process failure",
+            });
+        } else if (before_link) before_link(spec);
+        return tools.run(spec);
+    }
+};
+
+struct AdmissionFixture {
+    TemporaryDirectory dir;
+    fs::path cl{dir.path() / "tools/cl.exe"}, link{dir.path() / "tools/link.exe"};
+    fs::path header{dir.path() / "src/common.hpp"};
+    mqb::msvc::MsvcToolchain toolchain{
+        .identity = {.compiler=cl, .version="target-admission-test", .binary_stamp="stable-test-tool"},
+        .linker=link, .vc_tools_root=dir.path() / "tools",
+    };
+    AdmissionToolRunner runner{cl, link, header};
+    mqb::msvc::MsvcCompileExecutor executor{toolchain, runner};
+    mqb::orchestration::MsvcIncrementalCompileCoordinator compile{toolchain, executor};
+    mqb::msvc::MsvcLinker linker{toolchain, runner};
+    mqb::orchestration::MsvcIncrementalLinkCoordinator linking{toolchain, linker};
+    mqb::orchestration::MsvcIncrementalTargetCoordinator target{compile, linking};
+    mqb::orchestration::IncrementalTargetRequest request;
+    explicit AdmissionFixture(std::size_t count=4) {
+        write_text(cl, "fake compiler identity"); write_text(link, "fake linker identity");
+        write_text(header, "#pragma once\n");
+        const std::array<const char*,4> names{"a.cpp","b.cpp","c.cpp","d.cpp"};
+        for (std::size_t i=0; i<count; ++i) request.sources.push_back(make_source(dir.path(),names[i]));
+        request.target = {.executable=dir.path()/".mqb/bin/target.exe", .link_cache=dir.path()/".mqb/cache/link/target.cache"};
+        request.working_directory=dir.path(); request.max_parallel_compiles=2;
+    }
+};
+std::string read_bytes(const fs::path& path) {
+    std::ifstream stream{path,std::ios::binary};
+    return std::string{std::istreambuf_iterator<char>{stream},std::istreambuf_iterator<char>{}};
+}
+void target_admission_cases() {
+    using namespace mqb::orchestration;
+    using namespace std::chrono_literals;
+    unsigned checks=0;
+    const auto check=[&](bool value,const char* message) { ++checks; expect(value,message); };
+    {
+        AdmissionFixture f;
+        std::stop_source stopped; stopped.request_stop();
+        auto invalid=f.request; invalid.max_parallel_compiles=0;
+        const auto rejected=f.target.run_with_compile_admission_stop(invalid,stopped.get_token());
+        check(!rejected && rejected.error().code==IncrementalTargetErrorCode::invalid_parallelism,
+              "validation error precedes pre-stop");
+        const auto result=f.target.run_with_compile_admission_stop(f.request,stopped.get_token());
+        check(!result && result.error().code==IncrementalTargetErrorCode::cancelled && result.error().admission,
+              "pre-stopped target returns typed cancellation with evidence");
+        check(f.runner.tools.compile_calls()==0 && f.runner.tools.link_calls()==0 && !fs::exists(f.dir.path()/".mqb"),
+              "pre-stop must publish neither compile nor link cache");
+        if (!result && result.error().admission) {
+            const auto& w=result.error().admission->waves.back();
+            check(w.inspection && w.inspection->outcome()==WorkBatchOutcome::cancelled && !w.execution,
+                  "pre-stop cannot execute previously uninspected items");
+            check(std::all_of(w.attempts.begin(),w.attempts.end(),[](const auto& a){return !a;}),
+                  "pre-stopped original attempts remain unentered");
+        }
+    }
+    // Missing object, corrupted/missing cache and final output repair continue to
+    // use the existing freshness authority, including shared-hit revalidation.
+    {
+        AdmissionFixture f;
+        std::stop_source stop;
+        const auto cold=f.target.run_with_compile_admission_stop(f.request,stop.get_token());
+        check(cold && cold->any_compiled && cold->link.linked && fs::exists(f.request.target.link_cache),
+              "opt-in success really links and saves the product link cache");
+        const int calls=f.runner.tools.compile_calls(), links=f.runner.tools.link_calls();
+        const auto warm=f.target.run_with_compile_admission_stop(f.request,stop.get_token());
+        check(warm && !warm->any_compiled && !warm->link.linked && f.runner.tools.compile_calls()==calls && f.runner.tools.link_calls()==links,
+              "opt-in all-hit target still skips compile and link execution");
+        fs::remove(f.request.sources[1].artifacts.object);
+        const auto miss=f.target.run_with_compile_admission_stop(f.request,stop.get_token());
+        check(miss && f.runner.tools.compile_calls()==calls+1 && miss->compiles[1].result.compiled && !miss->compiles[0].result.compiled,
+              "opt-in split wave executes only the original missing-object source index");
+        fs::remove(f.request.target.executable);
+        const auto output=f.target.run_with_compile_admission_stop(f.request,stop.get_token());
+        check(output && !output->any_compiled && output->link.linked,
+              "opt-in late output freshness still repairs missing executable");
+        const auto fallback=f.target.run_with_compile_admission_stop(f.request,{});
+        check(fallback && !fallback->any_compiled && !fallback->link.linked,
+              "non-stoppable explicit token delegates the legacy no-op path");
+        check(!f.runner.saw_process_token && !f.runner.saw_execution_snapshot,
+              "neither process kill tokens nor inspection snapshots enter compiler execution");
+    }
+    for (int mode=0; mode<5; ++mode) {
+        AdmissionFixture f;
+        check(f.target.run(f.request).has_value(),"prepare real warm product cache for stop/error test");
+        const auto old_link=read_bytes(f.request.target.link_cache);
+        const auto old_link_time=fs::last_write_time(f.request.target.link_cache);
+        const auto old_failed_cache=read_bytes(f.request.sources[1].artifacts.compile_cache);
+        for (std::size_t i=0;i<3;++i) fs::remove(f.request.sources[i].artifacts.object);
+        if (mode==1) f.runner.tools.fail_sources({"b.cpp"});
+        if (mode==2 || mode==3) f.runner.throws_on="b.cpp";
+        if (mode==3) f.runner.tools.fail_sources({"a.cpp"});
+        if (mode==4) f.runner.process_error_on="b.cpp";
+        std::stop_source stop;
+        std::counting_semaphore<2> entered{0},release{0};
+        std::atomic<unsigned> calls{0};
+        f.runner.before_compile=[&](const auto&) {
+            if (calls.fetch_add(1)<2) {entered.release();release.acquire();}
+        };
+        auto future=std::async(std::launch::async,[&]{return f.target.run_with_compile_admission_stop(f.request,stop.get_token());});
+        const bool one=entered.try_acquire_for(10s),two=entered.try_acquire_for(10s);
+        stop.request_stop(); release.release(2);
+        const auto result=future.get();
+        check(one&&two,"both product compile callbacks reach deterministic in-flight boundary");
+        const auto code=mode==0?IncrementalTargetErrorCode::cancelled:
+            (mode==2?IncrementalTargetErrorCode::scheduling_failed:IncrementalTargetErrorCode::compile_failed);
+        check(!result && result.error().code==code,"original target failure outranks concurrent cancellation");
+        check(f.runner.tools.link_calls()==1 && read_bytes(f.request.target.link_cache)==old_link
+              && fs::last_write_time(f.request.target.link_cache)==old_link_time,
+              "failed/cancelled target does not enter real linker or rewrite its existing link cache");
+        check(calls.load()==2 && !fs::exists(f.request.sources[2].artifacts.object),
+              "pending missing source never executes or satisfies target prerequisites");
+        check(!f.runner.saw_process_token && !f.runner.saw_execution_snapshot,
+              "stopped compilation still uses nonterminating, uncached execution evidence");
+        if (!result && result.error().admission) {
+            const auto& w=result.error().admission->waves.back();
+            check(w.execution_sources==std::vector<std::size_t>({0,1,2}) && w.inspection && w.inspection->all_succeeded(),
+                  "typed execution retains compact-miss to original-source mapping");
+            check(!w.attempts[2] && w.attempts[3] && w.attempts[3]->has_value() && !w.attempts[3]->value().compiled,
+                  "pending source and successful inspected cache hit remain distinct");
+            check(w.execution && w.execution->outcome()==(mode==0?WorkBatchOutcome::cancelled:WorkBatchOutcome::failed),
+                  "typed phase keeps original failure even when stop is also observed");
+            if (mode==1) {
+                const auto& original=w.attempts[1]->error().compile_error->compiler_error->process_result;
+                check(original && original->exit_code==2 && original->stderr_text=="simulated parallel compile failure: b.cpp",
+                      "target error preserves exact original compiler result and diagnostic");
+                check(read_bytes(f.request.sources[1].artifacts.compile_cache)==old_failed_cache,
+                      "failed compiler cannot publish a new source cache entry");
+            }
+            if (mode==2 || mode==3) {
+                const auto* exception=std::get_if<std::exception_ptr>(&w.execution->attempts[1]);
+                std::string message;
+                if (exception && *exception) try { std::rethrow_exception(*exception); }
+                catch(const std::runtime_error& e){message=e.what();}
+                check(message=="original target callback exception","original callback exception remains rethrowable at target boundary");
+                if(mode==3)check(result.error().source==f.request.sources[0].source,
+                                "real compile failure is primary even with a sibling exception and stop");
+            }
+            if(mode==4) {
+                const auto& native=w.attempts[1]->error().compile_error->compiler_error->process_error;
+                check(native && native->native_code==123 && native->message=="original target process failure",
+                      "process infrastructure failure is not converted into target cancellation");
+            }
+        } else check(false,"all interrupted opt-in waves retain their original evidence");
+    }
+    {
+        AdmissionFixture f;
+        f.request.max_parallel_compiles=1;
+        f.request.sources.back().artifacts.object.clear();
+        std::stop_source stop;
+        const auto result=f.target.run_with_compile_admission_stop(f.request,stop.get_token());
+        check(!result && result.error().code==IncrementalTargetErrorCode::compile_failed
+              && result.error().compile_error->code==IncrementalCompileErrorCode::planning_failed,
+              "inspection failure is preserved before any planned miss executes");
+        check(f.runner.tools.compile_calls()==0 && f.runner.tools.link_calls()==0 && !fs::exists(f.dir.path()/".mqb"),
+              "failed inspection prevents all compile/cache/link writes");
+        check(!result && result.error().admission && result.error().admission->waves[0].inspection
+              && !result.error().admission->waves[0].execution,"inspection-only failure has no invented execution batch");
+    }
+    {
+        AdmissionFixture f;
+        check(f.target.run(f.request).has_value(), "prepare sparse miss mapping");
+        f.request.max_parallel_compiles=1;
+        fs::remove(f.request.sources[1].artifacts.object);
+        fs::remove(f.request.sources[3].artifacts.object);
+        f.runner.tools.fail_sources({"d.cpp"});
+        std::stop_source stop;
+        const auto result=f.target.run_with_compile_admission_stop(f.request,stop.get_token());
+        check(!result && result.error().code==IncrementalTargetErrorCode::compile_failed
+              && result.error().source==f.request.sources[3].source,
+              "sparse miss failure retains original source rather than compact slot index");
+        if (!result && result.error().admission) {
+            const auto& wave=result.error().admission->waves.back();
+            check(wave.execution_sources==std::vector<std::size_t>({1,3}), "execution map retains noncontiguous sources");
+            const auto* failed=std::get_if<std::expected<void,TargetCompileFailure>>(&wave.execution->attempts[1]);
+            check(failed && !*failed && failed->error().source_index==3, "typed failure index resolves to original source payload");
+            check(wave.attempts[0] && !wave.attempts[0]->value().compiled && wave.attempts[1]->value().compiled,
+                  "original cache hit and completed miss remain separate evidence");
+        } else check(false,"sparse failure evidence retained");
+        check(f.runner.tools.link_calls()==1,"sparse partial success cannot publish target link state");
+    }
+    for (bool cancel_retry : {false,true}) {
+        AdmissionFixture f;
+        check(f.target.run(f.request).has_value(),"prepare shared dependency cache for conservative retry");
+        f.request.max_parallel_compiles=1;
+        fs::remove(f.request.sources[0].artifacts.object);
+        const auto old_time=fs::last_write_time(f.header);
+        const auto old_link=read_bytes(f.request.target.link_cache);
+        std::stop_source stop;
+        unsigned entered=0;
+        f.runner.before_compile=[&](const auto&) {
+            if(entered++==0) fs::last_write_time(f.header,old_time+2s);
+            else if(cancel_retry)stop.request_stop();
+        };
+        const auto result=f.target.run_with_compile_admission_stop(f.request,stop.get_token());
+        if(cancel_retry) {
+            check(!result && result.error().code==IncrementalTargetErrorCode::cancelled,
+                  "stop during conservative retry still blocks the target successor");
+            check(entered==2 && f.runner.tools.link_calls()==1 && read_bytes(f.request.target.link_cache)==old_link,
+                  "conservative retry does not publish old hits or rewrite link cache after stop");
+            if(!result && result.error().admission) {
+                const auto& waves=result.error().admission->waves;
+                check(waves.size()==2 && waves[0].attempts[3] && !waves[0].attempts[3]->value().compiled
+                      && waves[1].attempts[0] && !waves[1].attempts[1],
+                      "failed second pass retains the first completed wave and current not-entered slots");
+            } else check(false,"conservative retry evidence retained");
+        } else {
+            check(result && entered==5 && f.runner.tools.link_calls()==2,
+                  "post-execution freshness barrier still reruns one miss then all four sources");
+            check(result && std::all_of(result->compiles.begin(),result->compiles.end(),[](const auto& c){return c.result.compiled;}),
+                  "stale inspected hits never reach final link after mutation");
+        }
+        check(detail::active_filesystem_evidence_table==nullptr,"opt-in retry restores caller evidence TLS");
+    }
+    {
+        AdmissionFixture f(2);
+        f.request.force_downstream_rebuild=true;
+        std::stop_source stop;
+        f.runner.before_compile=[&](const auto&){stop.request_stop();};
+        const auto result=f.target.run_with_compile_admission_stop(f.request,stop.get_token());
+        check(!result && result.error().code==IncrementalTargetErrorCode::cancelled && f.runner.tools.link_calls()==0
+              && !fs::exists(f.request.target.link_cache),"small/forced direct path also blocks real link-cache publication");
+        check(!result && result.error().admission && !result.error().admission->waves[0].inspection
+              && result.error().admission->waves[0].execution,"direct path records execution only");
+    }
+    {
+        AdmissionFixture f;
+        std::stop_source stop;
+        f.runner.before_link=[&](const auto&){stop.request_stop();};
+        const auto result=f.target.run_with_compile_admission_stop(f.request,stop.get_token());
+        check(result && result->link.linked && fs::exists(f.request.target.link_cache) && stop.stop_requested(),
+              "late stop does not terminate or roll back an already-admitted terminal link");
+        check(!f.runner.saw_process_token,"even admitted terminal link receives no terminating token");
+    }
+    std::cout<<"target_compile_admission_cases "<<checks<<" checks completed\n";
 }
 
 template <typename Coordinator>
@@ -727,8 +996,7 @@ int main() {
         common_header};
     failing_runner.fail_sources({"b.cpp", "c.cpp"});
     mqb::msvc::MsvcCompileExecutor failing_executor{
-        toolchain,
-        failing_runner};
+        toolchain, failing_runner};
     mqb::orchestration::MsvcIncrementalCompileCoordinator
         failing_compile_coordinator{toolchain, failing_executor};
     mqb::msvc::MsvcLinker failing_linker{toolchain, failing_runner};
@@ -755,6 +1023,8 @@ int main() {
            "failure wave should still prove three concurrent in-flight compiles");
     expect(failing_runner.link_calls() == 0,
            "target must not link when any parallel compile fails");
+
+    target_admission_cases();
 
     if (failures != 0) {
         std::cerr << failures << " test(s) failed\n";

--- a/cpp/tests/orchestration/scheduling/bounded_work_batch_cases.hpp
+++ b/cpp/tests/orchestration/scheduling/bounded_work_batch_cases.hpp
@@ -155,6 +155,24 @@ inline int bounded_work_batch_cases() {
         const auto void_result = run_work_batch(1, 1, {}, [](std::size_t) -> std::expected<void, int> { return {}; });
         check(void_result.all_succeeded(), "void expected successes supported");
     }
+    {
+        const auto complete = run_work_batch(3, ParallelismPolicy::fixed(2),
+            ParallelismWorkload::compilation, {}, good);
+        check(complete.all_succeeded() && (*complete.scheduling)->worker_count == 2,
+              "typed policy adapter uses the existing scheduler's fixed worker limit");
+        std::stop_source stop; stop.request_stop();
+        const auto cancelled = run_work_batch(3, ParallelismPolicy::automatic(),
+            ParallelismWorkload::compilation, stop.get_token(), good);
+        check(cancelled.outcome() == WorkBatchOutcome::cancelled && (*cancelled.scheduling)->worker_count == 0,
+              "pre-stopped automatic policy does not start workers");
+        const auto invalid = run_work_batch(3, ParallelismPolicy::fixed(0),
+            ParallelismWorkload::compilation, stop.get_token(), good);
+        check(invalid.outcome() == WorkBatchOutcome::failed && invalid.scheduling && !*invalid.scheduling,
+              "invalid policy cannot be reported as external cancellation");
+        const auto empty = run_work_batch(0, ParallelismPolicy::automatic(),
+            ParallelismWorkload::compilation, stop.get_token(), good);
+        check(empty.all_succeeded(), "typed policy adapter preserves valid empty no-op");
+    }
     std::cout << "bounded_work_batch_cases " << checks << " checks " << (failures == 0 ? "passed" : "failed") << '\n';
     return failures;
 }


### PR DESCRIPTION
## Final decision: accept the explicit ordinary-target API

[Final exact-source review, native execution, complete ABBA table and scope-limited acceptance](https://github.com/Iviesever/msvc-quick-build/pull/178#pullrequestreview-5162401900)

Accept ordinary expected-head merge. This is product target/compile-wave integration, not a test-only diff, CLI Ctrl+C feature or write-lease authority. #172 remains independently held and historical C1041/performance debts remain open.

## Exact source

- Base: **`57fb087a036e513552555257a6d37ae7126e1108`**.
- Reviewed head: **`dbb76bc88b173804dcc2711e499f806e2b8c9190`**.
- Candidate/native test-merge tree: **`81e15a7507f4b972df8535322a943d4ecf9b731a`**.
- Native test-merge: `3ccd1c0ec3715ed06a1ade98724ed3b0d4df0dce`, exactly those base/head parents.
- Six existing files, **497 additions/56 deletions**;408of414files byte-identical. Complete canonical source reconstruction and patch replay match the candidate tree.
- Scheduler/compiler/link-cache implementations, CLI/static/module callers, benchmark/ABBA, source manifest,79native-test inventory and observer tools unchanged. **VERSION5.5.0; no historical tag/asset or formal Release change.**

## Behavior and limits

`MsvcIncrementalTargetCoordinator::run_with_compile_admission_stop` is explicit opt-in; a non-stoppable token delegates the ordinary run. Validation keeps priority. A false compile-time specialization retains ordinary scheduling without typed evidence vectors; changed compiled code/public error layout are not claimed cost-free.

The wave retains small/forced direct execution, large-target inspection/only-miss execution, TLS evidence ownership and the **post-execution** shared-dependency revalidation with conservative full rebuild. Original compile errors win over simultaneous cancellation/sibling exceptions. Evidence keeps source-indexed original results, unentered items, phase summaries, exception pointers and both waves if conservative retry stops. Existing numeric and new policy batch overloads share one result collector and the existing scheduler/resource policy.

A failed or cancelled compile wave returns before target link/cache-save. Successful TUs may still save their own valid caches; this is not project rollback. After the final terminal-stage admission check, later stop does not terminate link or undo its cache save. No token reaches ProcessSpec. Static/modules/PCH-parent orchestration and CLI cancellation remain separate. Setup/evidence allocations outside caught wave operations may throw; partial native-worker-start failure is not fault-injected.

## Actual current-head validation

| Gate | Run | Result |
|---|---|---|
| Native Debug/all shards/freshness/runtime/parameters | #733/34431700798 | Passed; actual84target and50batch checks inspected in job102730455603 |
| Complete Release/self-host/exact runtime-only package | #620/34431700817 | Passed; actual84/50checks in job102730020368; publish-release skipped |
| Underlying real MSVC two-worker batch | #2/34431700821 | All6fixed Debug/Release success/cancel/failure-cancel cases passed |
| Original default/private/record contracts | #24/34431700813;#26/34431700826 |70/70,42/42,150/150expected record outcomes; required positive controls pass |
| Documentation/Cross-Stage/Build Plan | #181/34431700804;#210/34431700845;#81/34431700795 | Passed |
| Independent original observer-OFF ABBA | #593/34431700856 |76pairs measured/recomputed;72complete instrumented semantic identities match |

Accepted File Event/PDB Open investigations did not trigger and are not labeled new passes. No post-publication source revision or same-head CI/native/benchmark retry was requested. Native C4100 for unused `inspection` in the false wave specialization is retained as a nonblocking warning; builds are not described as warning-free.

### Product-boundary tests versus true compiler runs

The **84new tests execute the actual product target/compile/link/cache coordinators and real cache files**, but tool processes are deterministic substitutes. They check target link-cache bytes and mtime unchanged on cancellation/original failure/exception, successful source-cache preservation without fake rollback, sparse miss maps, inspection errors, TLS suspension, execution-time header changes, conservative retry and terminal-link late-stop semantics. Positive paths really enter product link/cache persistence; this is not the old fixture sentinel renamed as integration.

The separate existing true-MSVC six-case fixture exercises the underlying typed batch, **not this new target entry point**. Both failure-cancel cases retain C2338/exit2 and successful siblings while reporting failed, never cancelled-success. Four stopped cases suppress pending work and fixture successors; both positive cases link/run.18original results/36diagnostics and exact input executable provenance were independently checked. True-cl end-to-end verification of the new target API remains the next focused step.

Original default/private matrices retain nine/four adverse managed-ending B failures, original diagnostics, unattempted link/run and separate recoveries. All28A-started managed endings still kill original services; sparse owner identity is not writer quiescence.705/409tool results and1410/818diagnostics audited.150ownership record expectations match113accepted/37rejected;14scheduler/direct input pairs match56sources/70argv after directory normalization only.

## Performance and original gates

[Resumed artifact/native verification](https://github.com/Iviesever/msvc-quick-build/pull/178#issuecomment-5612425706)

External timings-off no-op paired median **+0.0983ms/+1.0498363%**, max+0.291ms,2/4slower, does not cross the original **BOTH>1ms AND>10%** gate. All72instrumented counters/breakdowns/compile-link-archive hit-miss values match; four external counter sets remain unavailable, not zero. Only the external row uses timings-off elapsed; four-pairP95 is a maximum.

Preserve cold/single-TU/link-only **4/4slower** with medians+239.579ms/+18.85%,+51.755ms/+56.07%,+17.678ms/+31.82%, plus scale-cold+2847.057ms tail. No cause has been isolated. No speedup/zero-overhead claim, offset against favorable scenarios, noise deletion, AA subtraction or historic debt closure. Comparison JSON does not archive the performance executable pair/OS trace.

Predeclared exact-source native/selfhost/package,84target+50batch tests, original70/42positive controls, six real underlying batch cases,150record contracts and original19x4ABBA/72semantic identities/unchanged threshold all pass. No required current failure was waived. Limited acceptance of the API is not a claim that historical C1041 or release performance requirements are solved.

## Handoff and evidence retention

Next separate small iteration: exercise **this target entry point with actual MSVC/link/cache files**, keeping fixed Debug/Release success/cancellation/failure-plus-cancellation controls and original diagnostics. Do not relabel the present process-substitute target tests or the old real batch fixture as that coverage. Keep no-token behavior, freshness and inspection/execution boundaries, and do not expand CLI/static/modules/PCH-parent cancellation or observers prematurely. M1b, external-writer authority, transactions/build-run/session/residency and formal VERSION/release remain gated.

Eight immutable core artifact ZIPs, exact base/head source archives, patch, manifests and executed portable read-only replay are retained; not all Actions artifacts. Retention30days. Actual input executables match their own provenance, not the independent ABBA pair. Generated compiler binary bodies are omitted by the diagnostic contract; finite hash inventories are post-case, not failure-time snapshots. Native logs in delivery are marked excerpts. Resumed local verification reconstructed exact source through the connector after container network failure; it does not claim another local48-TU or MSVC/PowerShell/ETW run. Temporaryperf title removed only after actual#593completed; title/ready skips and post-merge push CI do not replace that evidence.