### PR TITLE
test: verify real target admission preserves cache barriers

### DIFF
--- a/.github/workflows/msvc-target-admission.yml
+++ b/.github/workflows/msvc-target-admission.yml
@@ -1,0 +1,111 @@
+name: Real MSVC Target Admission Evidence
+
+on:
+  pull_request:
+    paths:
+      - 'cpp/**'
+      - 'tests/native/collect_msvc_target_admission.ps1'
+      - 'tests/native/verify_msvc_target_admission.py'
+      - '.github/workflows/msvc-target-admission.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: msvc-target-admission-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+permissions:
+  contents: read
+jobs:
+  contract:
+    name: Target evidence record contracts
+    runs-on: windows-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - shell: pwsh
+        run: |
+          python tests/native/verify_msvc_target_admission.py --self-test --output .mqb/target-admission-contracts.json
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: target-admission-contracts
+          path: .mqb/target-admission-contracts.json
+          include-hidden-files: true
+          retention-days: 30
+  build:
+    runs-on: windows-latest
+    timeout-minutes: 30
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Build exact candidate and target admission fixture with MQB
+        shell: pwsh
+        run: |
+          $tokens=$null; $errors=$null
+          [void][Management.Automation.Language.Parser]::ParseFile(
+            (Join-Path $PWD 'tests/native/collect_msvc_target_admission.ps1'),[ref]$tokens,[ref]$errors)
+          if (@($errors).Count) { throw "$errors" }
+          $seed=& ./tests/native/acquire_seed.ps1 -RepoRoot $PWD -OutputRoot (Join-Path $PWD 'native-seed')
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          $mqb=& ./tests/native/build_mqb.ps1 -BuilderMqbPath $seed -RepoRoot $PWD -Version '5.5.0' `
+            -Configuration Release -Clean -OutputPath (Join-Path $PWD 'native-out/target-admission/mqb.exe')
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          & ./tests/native/collect_msvc_target_admission.ps1 -MqbPath $mqb -RepoRoot $PWD -BuildOnly `
+            -OutputRoot (Join-Path $PWD '.mqb/target-admission-build')
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          New-Item -ItemType Directory -Path 'native-out/target-admission-input' -Force | Out-Null
+          Copy-Item .mqb/bin/msvc_target_admission_probe.exe,.mqb/target-admission-build/probe.identity.json native-out/target-admission-input/
+      - uses: actions/upload-artifact@v7
+        with:
+          name: exact-target-admission-input
+          path: native-out/target-admission-input/*
+          if-no-files-found: error
+          retention-days: 30
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: target-admission-build-evidence
+          path: .mqb/target-admission-build/**
+          include-hidden-files: true
+          if-no-files-found: warn
+          retention-days: 30
+  observe:
+    name: Six fixed real two-worker target builds
+    needs: [build, contract]
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - uses: actions/download-artifact@v8
+        with:
+          name: exact-target-admission-input
+          path: native-input
+      - shell: pwsh
+        env:
+          MQB_TARGET_DISPOSABLE_HOST: '1'
+        run: |
+          & ./tests/native/collect_msvc_target_admission.ps1 -RepoRoot $PWD `
+            -PrebuiltProbePath (Join-Path $PWD 'native-input/msvc_target_admission_probe.exe') `
+            -ProbeIdentityPath (Join-Path $PWD 'native-input/probe.identity.json') `
+            -OutputRoot (Join-Path $PWD '.mqb/msvc-target-admission-evidence')
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+      - name: Retain original results and failures without retry
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: msvc-target-admission-evidence
+          path: |
+            .mqb/msvc-target-admission-evidence/**
+            !.mqb/msvc-target-admission-evidence/**/*.obj
+            !.mqb/msvc-target-admission-evidence/**/*.pdb
+            !.mqb/msvc-target-admission-evidence/**/*.exe
+          include-hidden-files: true
+          if-no-files-found: warn
+          retention-days: 30

--- a/cpp/tests/platform/windows/msvc_target_admission_probe.cpp
+++ b/cpp/tests/platform/windows/msvc_target_admission_probe.cpp
@@ -1,0 +1,450 @@
+// End-to-end fixture for the explicit target API; no product/CLI policy change.
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#include <tlhelp32.h>
+#include <bcrypt.h>
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <future>
+#include <iostream>
+#include <iterator>
+#include <optional>
+#include <semaphore>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "mqb/core/ProjectArtifactLayout.hpp"
+#include "mqb/msvc/MsvcCompileExecutor.hpp"
+#include "mqb/msvc/MsvcLinker.hpp"
+#include "mqb/orchestration/MsvcIncrementalTargetCoordinator.hpp"
+#include "mqb/platform/windows/CommandLine.hpp"
+#include "mqb/platform/windows/WindowsProcessRunner.hpp"
+
+namespace {
+namespace fs = std::filesystem;
+namespace orch = mqb::orchestration;
+using namespace std::chrono_literals;
+using mqb::platform::windows::WindowsProcessRunner;
+using NativeResult = std::expected<mqb::process::ProcessResult, mqb::process::ProcessError>;
+using TargetResult = std::expected<orch::IncrementalTargetResult, orch::IncrementalTargetError>;
+void require(bool value, const std::string& message) { if (!value) throw std::runtime_error(message); }
+std::string text(const fs::path& path) {
+    auto result = mqb::platform::windows::utf16_to_utf8(path.generic_wstring());
+    require(result.has_value(), "path encoding failed"); return *result;
+}
+std::string js(std::string_view value) {
+    std::string out = "\"";
+    constexpr char hex[] = "0123456789abcdef";
+    for (unsigned char c : value) {
+        if (c == '"' || c == '\\') { out += '\\'; out += static_cast<char>(c); }
+        else if (c < 32) { out += "\\u00"; out += hex[c >> 4]; out += hex[c & 15]; }
+        else out += static_cast<char>(c);
+    }
+    return out + '"';
+}
+std::string boolean(bool value) { return value ? "true" : "false"; }
+void write(const fs::path& path, const std::string& bytes) {
+    std::ofstream out(path, std::ios::binary); out.write(bytes.data(), static_cast<std::streamsize>(bytes.size())); out.flush();
+    require(bool(out), "cannot preserve " + text(path));
+}
+struct Handle {
+    HANDLE value{};
+    explicit Handle(HANDLE h = nullptr) : value(h) {}
+    ~Handle() { if (*this) ::CloseHandle(value); }
+    Handle(const Handle&) = delete;
+    Handle& operator=(const Handle&) = delete;
+    Handle(Handle&& other) noexcept : value(std::exchange(other.value, nullptr)) {}
+    explicit operator bool() const { return value && value != INVALID_HANDLE_VALUE; }
+};
+std::uint64_t ticks(FILETIME t) { return (std::uint64_t{t.dwHighDateTime} << 32) | t.dwLowDateTime; }
+std::string hash(std::string& bytes) {
+    BCRYPT_ALG_HANDLE algorithm{};
+    require(::BCryptOpenAlgorithmProvider(&algorithm, BCRYPT_SHA256_ALGORITHM, nullptr, 0) == 0, "SHA256 provider failed");
+    struct Close { BCRYPT_ALG_HANDLE h; ~Close() { ::BCryptCloseAlgorithmProvider(h, 0); } } close{algorithm};
+    std::array<unsigned char, 32> output{};
+    require(bytes.size() <= 64ULL * 1024 * 1024, "snapshot cap exceeded");
+    require(::BCryptHash(algorithm, nullptr, 0, reinterpret_cast<PUCHAR>(bytes.data()),
+            static_cast<ULONG>(bytes.size()), output.data(), static_cast<ULONG>(output.size())) == 0, "SHA256 failed");
+    constexpr char hex[] = "0123456789abcdef"; std::string result;
+    for (auto b : output) { result += hex[b >> 4]; result += hex[b & 15]; }
+    return result;
+}
+// All snapshot handles close before a target run. A finite observation of bytes,
+// mtime and file ID is NOT a lock, crash-recovery or all-writer certificate.
+struct Snapshot {
+    std::string bytes, digest;
+    std::uint64_t modified{}, identity{}, volume{};
+    bool operator==(const Snapshot& other) const {
+        return bytes == other.bytes && modified == other.modified && identity == other.identity && volume == other.volume;
+    }
+    std::string json() const {
+        return "{\"size\":" + std::to_string(bytes.size()) + ",\"sha256\":" + js(digest)
+            + ",\"mtime\":" + std::to_string(modified) + ",\"file_id\":" + std::to_string(identity)
+            + ",\"volume\":" + std::to_string(volume) + "}";
+    }
+};
+Snapshot snapshot(const fs::path& path) {
+    Handle file{::CreateFileW(path.c_str(), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+        nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr)};
+    require(bool(file), "snapshot open failed: " + text(path) + " native=" + std::to_string(::GetLastError()));
+    BY_HANDLE_FILE_INFORMATION before{}, after{};
+    require(::GetFileInformationByHandle(file.value, &before) != FALSE, "snapshot identity failed");
+    const auto size = (std::uint64_t{before.nFileSizeHigh} << 32) | before.nFileSizeLow;
+    require(size > 0 && size <= 64ULL * 1024 * 1024, "snapshot size invalid");
+    Snapshot result; result.bytes.resize(static_cast<std::size_t>(size));
+    std::size_t offset = 0;
+    while (offset < size) {
+        DWORD read{};
+        require(::ReadFile(file.value, result.bytes.data() + offset, static_cast<DWORD>(size - offset), &read, nullptr) && read != 0,
+                "snapshot read incomplete");
+        offset += read;
+    }
+    require(::GetFileInformationByHandle(file.value, &after) != FALSE && before.nFileSizeHigh == after.nFileSizeHigh
+        && before.nFileSizeLow == after.nFileSizeLow && ticks(before.ftLastWriteTime) == ticks(after.ftLastWriteTime)
+        && before.nFileIndexHigh == after.nFileIndexHigh && before.nFileIndexLow == after.nFileIndexLow,
+        "snapshot changed while reading");
+    result.modified = ticks(after.ftLastWriteTime);
+    result.identity = (std::uint64_t{after.nFileIndexHigh} << 32) | after.nFileIndexLow;
+    result.volume = after.dwVolumeSerialNumber; result.digest = hash(result.bytes);
+    return result;
+}
+struct Child { DWORD pid{}; std::uint64_t created{}; Handle process; };
+std::vector<Child> compilers(const fs::path& expected_image) {
+    Handle snapshot{::CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0)};
+    require(bool(snapshot), "process snapshot failed");
+    PROCESSENTRY32W entry{}; entry.dwSize = sizeof(entry);
+    std::vector<Child> result;
+    auto more = ::Process32FirstW(snapshot.value, &entry);
+    while (more) {
+        if (entry.th32ParentProcessID == ::GetCurrentProcessId() && _wcsicmp(entry.szExeFile, L"cl.exe") == 0) {
+            Handle process{::OpenProcess(SYNCHRONIZE | PROCESS_QUERY_LIMITED_INFORMATION, FALSE, entry.th32ProcessID)};
+            require(bool(process), "cannot retain observed compiler identity");
+            FILETIME created{}, exited{}, kernel{}, user{};
+            require(::GetProcessTimes(process.value, &created, &exited, &kernel, &user) != FALSE, "compiler creation time unavailable");
+            std::wstring image(32768, L'\0'); DWORD size = static_cast<DWORD>(image.size());
+            require(::QueryFullProcessImageNameW(process.value, 0, image.data(), &size) != FALSE, "compiler image unavailable");
+            image.resize(size);
+            require(_wcsicmp(image.c_str(), expected_image.wstring().c_str()) == 0, "unexpected compiler image");
+            result.push_back(Child{entry.th32ProcessID, ticks(created), std::move(process)});
+        }
+        more = ::Process32NextW(snapshot.value, &entry);
+    }
+    require(::GetLastError() == ERROR_NO_MORE_FILES, "incomplete process enumeration");
+    return result;
+}
+bool live(const Child& child) {
+    const auto status = ::WaitForSingleObject(child.process.value, 0);
+    require(status == WAIT_OBJECT_0 || status == WAIT_TIMEOUT, "retained process wait failed");
+    return status == WAIT_TIMEOUT;
+}
+
+void save_process(const fs::path& stem, const NativeResult& result) {
+    if (!result) {
+        write(stem.string() + ".result.json", "{\"infrastructure_error\":true,\"native_code\":"
+            + std::to_string(result.error().native_code) + ",\"message\":" + js(result.error().message) + "}\n");
+        return;
+    }
+    write(stem.string() + ".stdout.txt", result->stdout_text);
+    write(stem.string() + ".stderr.txt", result->stderr_text);
+    write(stem.string() + ".result.json", "{\"exit_code\":" + std::to_string(result->exit_code)
+        + ",\"cancelled\":" + boolean(result->termination == mqb::process::ProcessTermination::cancelled) + "}\n");
+}
+struct Runner final : mqb::process::ProcessRunner {
+    WindowsProcessRunner native;
+    fs::path compiler, linker, directory;
+    std::array<fs::path, 3> sources;
+    std::atomic<unsigned> compiles{0}, links{0}, runs{0};
+    std::atomic<bool> saw_token{false};
+    std::counting_semaphore<2> entered{0}, launch{0};
+    bool synchronize{}; // Set only between fully joined target invocations.
+    void phase(const fs::path& path, bool gated = false) {
+        directory = path; synchronize = gated; compiles = 0; links = 0; runs = 0;
+    }
+    NativeResult run(const mqb::process::ProcessSpec& spec) override {
+        if (spec.cancellation.stop_possible()) { saw_token = true; throw std::runtime_error("terminating process token rejected"); }
+        std::string label;
+        const bool compiling = _wcsicmp(spec.executable.c_str(), compiler.c_str()) == 0;
+        unsigned count = 0;
+        if (compiling) {
+            count = compiles.fetch_add(1);
+            for (unsigned i = 0; i != sources.size(); ++i) {
+                if (std::find(spec.arguments.begin(), spec.arguments.end(), text(sources[i])) != spec.arguments.end())
+                    label = "work" + std::to_string(i);
+            }
+            require(!label.empty(), "compiler source not in target request");
+        } else if (_wcsicmp(spec.executable.c_str(), linker.c_str()) == 0) {
+            label = "link"; require(links.fetch_add(1) == 0, "unexpected second target link");
+        } else { label = "run"; require(runs.fetch_add(1) == 0, "unexpected second program run"); }
+        const auto stem = directory / label;
+        require(!fs::exists(stem.string() + ".argv.json"), "duplicate invocation; refusing to erase diagnostics");
+        std::string argv = "[" + js(text(spec.executable));
+        for (const auto& arg : spec.arguments) argv += ',' + js(arg);
+        write(stem.string() + ".argv.json", argv + "]\n");
+        if (compiling && synchronize && count < 2) { entered.release(); launch.acquire(); }
+        auto result = native.run(spec); // Exactly the product ProcessSpec; no fabricated outcomes.
+        save_process(stem, result); // Native diagnostics survive subsequent product/fixture errors.
+        return result;
+    }
+};
+const mqb::process::ProcessResult* original(const orch::IncrementalCompileError& error) {
+    if (!error.compile_error || !error.compile_error->compiler_error
+        || !error.compile_error->compiler_error->process_result) return nullptr;
+    return &*error.compile_error->compiler_error->process_result;
+}
+std::string phase_json(const std::optional<orch::TargetCompilePhase>& phase) {
+    if (!phase) return "null";
+    const auto outcome = phase->outcome();
+    std::string out = "{\"outcome\":" + js(outcome == orch::WorkBatchOutcome::succeeded ? "succeeded"
+        : outcome == orch::WorkBatchOutcome::cancelled ? "cancelled" : "failed");
+    if (phase->scheduling && *phase->scheduling) {
+        const auto& s = **phase->scheduling;
+        out += ",\"worker_count\":" + std::to_string(s.worker_count) + ",\"started_count\":" + std::to_string(s.started_count)
+            + ",\"stop_requested\":" + boolean(s.stop_requested) + ",\"admission_stop_observed\":" + boolean(s.admission_stop_observed)
+            + ",\"stopped_before_all_items\":" + boolean(s.stopped_before_all_items);
+    }
+    return out + '}';
+}
+std::string report_json(const TargetResult& result) {
+    std::string out = "{\"succeeded\":" + boolean(result.has_value());
+    if (result) {
+        out += ",\"linked\":" + boolean(result->link.linked) + ",\"compiles\":[";
+        for (std::size_t i = 0; i < result->compiles.size(); ++i) {
+            if (i) out += ',';
+            const auto& r = result->compiles[i];
+            out += "{\"source\":" + js(text(r.source)) + ",\"compiled\":" + boolean(r.result.compiled)
+                + ",\"warnings\":" + std::to_string(r.result.warnings.size()) + '}';
+        }
+        return out + "]}";
+    }
+    const auto& e = result.error();
+    out += ",\"code\":" + std::to_string(static_cast<int>(e.code)) + ",\"message\":" + js(e.message)
+        + ",\"source\":" + js(text(e.source));
+    if (e.compile_error) {
+        const auto* r = original(*e.compile_error);
+        out += ",\"original_exit\":" + (r ? std::to_string(r->exit_code) : "null");
+        if (r) out += ",\"original_stdout\":" + js(r->stdout_text) + ",\"original_stderr\":" + js(r->stderr_text);
+    }
+    out += ",\"waves\":[";
+    if (e.admission) for (std::size_t w = 0; w < e.admission->waves.size(); ++w) {
+        if (w) out += ',';
+        const auto& wave = e.admission->waves[w];
+        out += "{\"inspection\":" + phase_json(wave.inspection) + ",\"execution\":" + phase_json(wave.execution)
+            + ",\"execution_sources\":[";
+        for (std::size_t i = 0; i < wave.execution_sources.size(); ++i) {
+            if (i) out += ',';
+            out += std::to_string(wave.execution_sources[i]);
+        }
+        out += "],\"attempts\":[";
+        for (std::size_t i = 0; i < wave.attempts.size(); ++i) {
+            if (i) out += ',';
+            const auto& attempt = wave.attempts[i];
+            if (!attempt) out += "{\"state\":\"not_started\"}";
+            else if (*attempt) out += "{\"state\":\"succeeded\",\"compiled\":" + boolean(attempt->value().compiled) + '}';
+            else {
+                const auto* r = original(attempt->error());
+                out += "{\"state\":\"failed\",\"exit_code\":" + (r ? std::to_string(r->exit_code) : "null") + '}';
+            }
+        }
+        out += "]}";
+    }
+    return out + "]}";
+}
+std::string source(unsigned index, bool revised, bool fail) {
+    std::string out = "#include \"shared.hpp\"\n";
+    if (index < 2) for (unsigned f = 0; f < 12000; ++f) {
+        const auto id = std::to_string(index) + "_" + std::to_string(f);
+        out += "struct T" + id + "{int a,b;};\n__declspec(noinline) int f" + id
+            + "(int x){T" + id + " t{x,x+1};return t.a+t.b;}\n";
+    }
+    if (index == 0) out += "int helper(); int pending(); int main(){return helper()==VALUE && pending()==1?0:1;}\n";
+    if (index == 1) out += "int helper(){return VALUE;}\n";
+    if (index == 2) out += "int pending(){return 1;}\n";
+    // Revision changes the source bytes/size, not compiler policy or shared inputs.
+    if (revised) out += "\n// fixed source revision for admission test\n";
+    if (index == 1 && fail) out += "static_assert(false, \"MQB_TARGET_EXPECTED_COMPILER_FAILURE\");\n";
+    return out;
+}
+int run(int argc, wchar_t** argv) {
+    require(argc == 4, "use ROOT Debug|Release complete|cancel|failure-cancel");
+    wchar_t authorization[2]{};
+    require(::GetEnvironmentVariableW(L"MQB_TARGET_DISPOSABLE_HOST", authorization, 2) == 1 && authorization[0] == L'1',
+        "target fixture requires an explicitly disposable host");
+    const fs::path root = fs::absolute(argv[1]);
+    require(!fs::exists(root), "refuse to overwrite previous evidence");
+    const std::wstring configuration = argv[2], mode = argv[3];
+    require(configuration == L"Debug" || configuration == L"Release", "unknown configuration");
+    require(mode == L"complete" || mode == L"cancel" || mode == L"failure-cancel", "unknown mode");
+    const bool stopping = mode != L"complete", failing = mode == L"failure-cancel";
+    fs::create_directories(root / "src");
+    for (const auto* phase : {"cold", "warm", "subject", "snapshots"}) fs::create_directories(root / "evidence" / phase);
+    WindowsProcessRunner discovery_runner;
+    mqb::msvc::DiscoveryOptions discovery; discovery.preference = mqb::msvc::ToolchainPreference::visual_studio;
+    discovery.cache_file = fs::path{};
+    auto found = mqb::msvc::MsvcToolchainLocator{discovery_runner}.discover(discovery);
+    require(found.has_value(), found ? "" : found.error().message);
+    auto tc = std::move(*found);
+    for (const char* name : {"CL", "_CL_", "LINK", "_LINK_"}) {
+        std::erase_if(tc.environment, [&](const auto& e) { return _stricmp(e.name.c_str(), name) == 0; });
+        tc.environment.push_back({name, "", true});
+    }
+    write(root / "toolchain.txt", text(tc.identity.compiler) + '\n' + tc.identity.version + '\n' + tc.identity.binary_stamp + '\n');
+    Runner runner; runner.compiler = tc.identity.compiler; runner.linker = tc.linker;
+    mqb::msvc::MsvcCompileExecutor executor{tc, runner};
+    orch::MsvcIncrementalCompileCoordinator compiling{tc, executor};
+    mqb::msvc::MsvcLinker linker{tc, runner};
+    orch::MsvcIncrementalLinkCoordinator linking{tc, linker};
+    orch::MsvcIncrementalTargetCoordinator target{compiling, linking};
+    auto layout = mqb::ProjectArtifactLayout::create(root); require(layout.has_value(), "artifact layout failed");
+    orch::IncrementalTargetRequest request;
+    request.working_directory = root; request.max_parallel_compiles = 2;
+    request.compiler_options.configuration = configuration == L"Debug" ? mqb::BuildConfiguration::debug : mqb::BuildConfiguration::release;
+    request.compiler_options.runtime_library = configuration == L"Debug" ? mqb::RuntimeLibrary::mtd : mqb::RuntimeLibrary::mt;
+    request.compiler_options.additional_arguments = {"/Zi", "/FS", "/bigobj", "/Fd" + text(root / ".mqb/compiler.pdb")};
+    request.link_options.configuration = request.compiler_options.configuration;
+    // Keep real Debug incremental-link defaults; no linker policy workaround.
+    auto artifacts = layout->for_target("target-admission"); require(artifacts.has_value(), "target layout failed");
+    request.target = *artifacts;
+    write(root / "src/shared.hpp", "#pragma once\n#define VALUE 42\n");
+    for (unsigned i = 0; i != 3; ++i) {
+        runner.sources[i] = root / "src" / ("work" + std::to_string(i) + ".cpp");
+        write(runner.sources[i], source(i, false, false));
+        write(root / "evidence/cold" / ("work" + std::to_string(i) + ".input.cpp"), source(i, false, false));
+        auto a = layout->for_source(runner.sources[i]); require(a.has_value(), "source layout failed");
+        request.sources.push_back({runner.sources[i], *a});
+    }
+    std::array<fs::path, 5> files{request.target.link_cache, request.target.executable,
+        request.sources[0].artifacts.compile_cache, request.sources[1].artifacts.compile_cache, request.sources[2].artifacts.compile_cache};
+    const std::array<const char*, 5> names{"link_cache", "executable", "source0_cache", "source1_cache", "source2_cache"};
+    const auto snapshots = [&](const std::string& phase) {
+        std::array<Snapshot, 5> values;
+        std::string json = "{";
+        for (std::size_t i = 0; i < files.size(); ++i) {
+            values[i] = snapshot(files[i]);
+            if (i) json += ',';
+            json += js(names[i]) + ':' + values[i].json();
+            if (i != 1) write(root / "evidence/snapshots" / (phase + "-" + names[i] + ".bytes"), values[i].bytes);
+        }
+        write(root / "evidence/snapshots" / (phase + ".json"), json + "}\n");
+        return values;
+    };
+    const auto run_program = [&] {
+        mqb::process::ProcessSpec program; program.executable = request.target.executable; program.working_directory = root;
+        auto result = runner.run(program);
+        require(result && result->exit_code == 0, "actual target program failed");
+    };
+    const auto run_phase = [&](const std::string& phase, std::stop_token stop) {
+        auto result = target.run_with_compile_admission_stop(request, stop);
+        write(root / "evidence" / phase / "target.json", report_json(result) + '\n');
+        return result;
+    };
+    std::stop_source cold_stop;
+    runner.phase(root / "evidence/cold");
+    auto cold = run_phase("cold", cold_stop.get_token());
+    require(cold && cold->any_compiled && cold->link.linked && runner.compiles == 3 && runner.links == 1, "cold target control failed");
+    run_program(); const auto initial = snapshots("cold");
+    runner.phase(root / "evidence/warm");
+    std::stop_source warm_stop; auto warm = run_phase("warm", warm_stop.get_token());
+    require(warm && !warm->any_compiled && !warm->link.linked && runner.compiles == 0 && runner.links == 0,
+        "warm target unexpectedly dispatched work");
+    const auto before = snapshots("before"); require(initial == before, "warm no-op changed cached artifacts");
+    for (unsigned i = 0; i != 3; ++i) {
+        write(runner.sources[i], source(i, true, failing));
+        write(root / "evidence/subject" / ("work" + std::to_string(i) + ".input.cpp"), source(i, true, failing));
+    }
+    runner.phase(root / "evidence/subject", true);
+    std::stop_source stop;
+    auto future = std::async(std::launch::async, [&] { return run_phase("subject", stop.get_token()); });
+    const bool first = runner.entered.try_acquire_for(10s), second = runner.entered.try_acquire_for(10s);
+    runner.launch.release(2); // Always release callbacks even when an observation fails.
+    bool overlap = false; std::string observation_error; std::vector<Child> active;
+    try {
+        const auto deadline = std::chrono::steady_clock::now() + 15s;
+        do {
+            active = compilers(tc.identity.compiler);
+            if (active.size() == 2 && live(active[0]) && live(active[1])) { overlap = true; break; }
+            if (future.wait_for(2ms) == std::future_status::ready) break;
+        } while (std::chrono::steady_clock::now() < deadline);
+    } catch (const std::exception& e) { observation_error = e.what(); }
+    if (stopping || !overlap || !first || !second || !observation_error.empty()) stop.request_stop();
+    auto result = future.get(); // Real target returns after its admitted compile callbacks join.
+    bool exited = true; for (const auto& p : active) exited = exited && !live(p);
+    const auto after = snapshots("after");
+    std::array<bool, 3> reusable{};
+    for (unsigned i = 0; i < 3; ++i) {
+        orch::IncrementalCompileRequest inspect;
+        inspect.unit.source = runner.sources[i]; inspect.unit.outputs.push_back({request.sources[i].artifacts.object, mqb::ArtifactKind::object});
+        inspect.options = request.compiler_options; inspect.cache_file = request.sources[i].artifacts.compile_cache;
+        inspect.source_dependencies_file = request.sources[i].artifacts.dependencies;
+        auto r = compiling.inspect(inspect);
+        require(r.has_value(), "post-target read-only source inspection failed");
+        reusable[i] = r->plan.empty();
+    }
+    orch::IncrementalLinkRequest link_inspection;
+    for (const auto& item : request.sources) link_inspection.objects.push_back(item.artifacts.object);
+    link_inspection.output = request.target.executable; link_inspection.options = request.link_options;
+    link_inspection.cache_file = request.target.link_cache; link_inspection.working_directory = root;
+    const auto link_plan = linking.inspect(link_inspection);
+    require(link_plan.has_value(), "post-target read-only link inspection failed");
+    const bool link_reusable = link_plan->plan.empty();
+    // Inspection above must not mutate the objects/caches it inspected.
+    const auto inspected = snapshots("inspected");
+    bool good = first && second && overlap && exited && observation_error.empty() && after == inspected && !runner.saw_token;
+    if (!stopping) {
+        good = good && result && result->link.linked && runner.compiles == 3 && runner.links == 1
+            && std::all_of(reusable.begin(), reusable.end(), [](bool v) { return v; })
+            && link_reusable && result->link.warnings.empty() && !(before[0] == after[0]);
+        if (result && result->link.linked) run_program();
+        good = good && runner.runs == 1;
+    } else {
+        good = good && !result && result.error().code == (failing ? orch::IncrementalTargetErrorCode::compile_failed : orch::IncrementalTargetErrorCode::cancelled)
+            && runner.compiles == 2 && runner.links == 0 && runner.runs == 0
+            && before[0] == after[0] && before[1] == after[1] && before[4] == after[4]
+            && reusable[0] && reusable[1] == !failing && !reusable[2] && !link_reusable;
+        if (failing) good = good && before[3] == after[3];
+        if (!result && result.error().admission && result.error().admission->waves.size() == 1) {
+            const auto& w = result.error().admission->waves[0];
+            good = good && w.inspection && w.inspection->all_succeeded() && w.execution
+                && w.execution->scheduling && *w.execution->scheduling
+                && (*w.execution->scheduling)->started_count == 2 && (*w.execution->scheduling)->admission_stop_observed
+                && w.execution_sources == std::vector<std::size_t>{0,1,2}
+                && w.attempts.size() == 3 && !w.attempts[2];
+            if (failing && result.error().compile_error) {
+                const auto* r = original(*result.error().compile_error);
+                good = good && r && r->exit_code != 0 && result.error().source == runner.sources[1]
+                    && (r->stdout_text + r->stderr_text).find("MQB_TARGET_EXPECTED_COMPILER_FAILURE") != std::string::npos;
+            }
+        } else good = false;
+    }
+    std::string children = "[";
+    for (const auto& child : active) {
+        if (children.size() > 1) children += ',';
+        children += "{\"pid\":" + std::to_string(child.pid) + ",\"created\":" + std::to_string(child.created) + '}';
+    }
+    children += ']';
+    write(root / "observation.json", "{\"schema\":1,\"configuration\":" + js(text(configuration)) + ",\"mode\":" + js(text(mode))
+        + ",\"gate_passed\":" + boolean(good) + ",\"compiler_invocations\":" + std::to_string(runner.compiles.load())
+        + ",\"link_invocations\":" + std::to_string(runner.links.load()) + ",\"run_invocations\":" + std::to_string(runner.runs.load())
+        + ",\"overlap\":" + boolean(overlap) + ",\"observed_compilers\":" + children + ",\"retained_exited\":" + boolean(exited)
+        + ",\"observation_error\":" + js(observation_error) + ",\"process_token_seen\":" + boolean(runner.saw_token)
+        + ",\"post_reusable\":[" + boolean(reusable[0]) + ',' + boolean(reusable[1]) + ',' + boolean(reusable[2]) + ']'
+        + ",\"post_link_reusable\":" + boolean(link_reusable)
+        + ",\"target_api\":\"run_with_compile_admission_stop\",\"real_processes\":true,\"cli_integrated\":false"
+          ",\"safe_to_transfer_write_lease\":false,\"historical_cause_resolved\":false}\n");
+    return good ? 0 : 1;
+}
+} // namespace
+int wmain(int argc, wchar_t** argv) {
+    try { return run(argc, argv); }
+    catch (const std::exception& error) { std::cerr << "TARGET_ADMISSION_FIXTURE_ERROR " << error.what() << '\n'; return 1; }
+}

--- a/tests/native/collect_msvc_target_admission.ps1
+++ b/tests/native/collect_msvc_target_admission.ps1
@@ -1,0 +1,115 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string]$RepoRoot,
+    [Parameter(Mandatory)][string]$OutputRoot,
+    [string]$MqbPath,
+    [switch]$BuildOnly,
+    [string]$PrebuiltProbePath,
+    [string]$ProbeIdentityPath
+)
+$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $false
+Set-StrictMode -Version 2.0
+$RepoRoot = [IO.Path]::GetFullPath($RepoRoot)
+$OutputRoot = [IO.Path]::GetFullPath($OutputRoot)
+if (Test-Path -LiteralPath $OutputRoot) { throw 'Refuse to overwrite earlier batch evidence.' }
+New-Item -ItemType Directory -Path $OutputRoot -Force | Out-Null
+function Write-Json($Path, $Value) {
+    $Value | ConvertTo-Json -Depth 15 | Set-Content -LiteralPath $Path -Encoding utf8
+}
+Push-Location $RepoRoot
+try {
+    $head = (& git rev-parse HEAD).Trim()
+    if ($LASTEXITCODE -ne 0) { throw 'Cannot read source HEAD.' }
+    if (@(& git status --porcelain --untracked-files=no).Count -ne 0 -or $LASTEXITCODE -ne 0) { throw 'Tracked source must be clean.' }
+    if ((Get-Content VERSION -Raw).Trim() -cne '5.5.0') { throw 'VERSION must remain 5.5.0.' }
+    if ($BuildOnly) {
+        if ([string]::IsNullOrWhiteSpace($MqbPath) -or -not [string]::IsNullOrWhiteSpace($PrebuiltProbePath)) { throw 'Invalid build-only input.' }
+        $MqbPath = [IO.Path]::GetFullPath($MqbPath)
+        & ./tests/native/assert_cpp_layout.ps1 -CppRoot (Join-Path $RepoRoot 'cpp')
+        $config = Get-Content cpp/mqb.json -Raw | ConvertFrom-Json
+        $sources = @($config.discovery.extra_sources | ForEach-Object { $_.Replace('\','/') } | Sort-Object -Unique)
+        $actual = @(Get-ChildItem cpp/src -Recurse -File -Filter '*.cpp' | ForEach-Object {
+            [IO.Path]::GetRelativePath((Join-Path $RepoRoot 'cpp'), $_.FullName).Replace('\','/')
+        } | Where-Object { $_ -ne 'src/app/main.cpp' } | Sort-Object -Unique)
+        if (@(Compare-Object $actual $sources).Count) { throw 'Product source manifest drift.' }
+        $arguments = @('cpp/tests/platform/windows/msvc_target_admission_probe.cpp')
+        $arguments += @($sources | ForEach-Object { 'cpp/' + $_ })
+        $arguments += @('--env','vs','--no-discover','--std',[string]$config.build.standard,'--release','--runtime','MT')
+        foreach ($path in @($config.build.include_dirs)) { $arguments += @('-I',('cpp/' + $path)) }
+        foreach ($arg in @($config.build.compiler_args)) { $arguments += @('--compiler-arg',[string]$arg) }
+        $arguments += @('-D','MQB_VERSION="target-admission-probe"','--lib','shell32.lib','--lib','bcrypt.lib','-o','msvc_target_admission_probe')
+        Write-Json (Join-Path $OutputRoot 'build.argv.json') $arguments
+        $output = @(& $MqbPath @arguments 2>&1); $code = $LASTEXITCODE
+        $output | Set-Content -LiteralPath (Join-Path $OutputRoot 'build.output.txt') -Encoding utf8
+        $output | ForEach-Object { Write-Host $_ }
+        if ($code -ne 0) { throw "Probe build failed: $code" }
+        $probe = Join-Path $RepoRoot '.mqb/bin/msvc_target_admission_probe.exe'
+        Write-Json (Join-Path $OutputRoot 'probe.identity.json') @{
+            schema=1; source_head=$head; version='5.5.0'; configuration='Release'
+            probe_sha256=(Get-FileHash -LiteralPath $probe).Hash
+            candidate_sha256=(Get-FileHash -LiteralPath $MqbPath).Hash
+            build_run_id=$env:GITHUB_RUN_ID; build_run_attempt=$env:GITHUB_RUN_ATTEMPT
+        }
+        return
+    }
+    if ($env:GITHUB_ACTIONS -ne 'true' -or $env:RUNNER_ENVIRONMENT -ne 'github-hosted' -or
+        $env:MQB_TARGET_DISPOSABLE_HOST -ne '1') { throw 'Native batch cases require a separate disposable hosted VM.' }
+    if ([string]::IsNullOrWhiteSpace($PrebuiltProbePath) -or [string]::IsNullOrWhiteSpace($ProbeIdentityPath)) { throw 'Prebuilt probe and identity required.' }
+    $probe = [IO.Path]::GetFullPath($PrebuiltProbePath)
+    $origin = Get-Content -LiteralPath $ProbeIdentityPath -Raw | ConvertFrom-Json
+    if ($origin.source_head -cne $head -or $origin.version -cne '5.5.0' -or $origin.configuration -cne 'Release' -or
+        $origin.probe_sha256 -cne (Get-FileHash -LiteralPath $probe).Hash) { throw 'Exact prebuilt source/binary identity mismatch.' }
+    Write-Json (Join-Path $OutputRoot 'identity.json') @{
+        source_head=$head; probe=$origin; image=$env:ImageVersion; run=$env:GITHUB_RUN_ID; attempt=$env:GITHUB_RUN_ATTEMPT
+        os=[Environment]::OSVersion.VersionString; powershell=$PSVersionTable.PSVersion.ToString()
+        target_api_real_processes=$true; cli_integrated=$false; safe_to_transfer_write_lease=$false
+    }
+    $plan = @()
+    foreach ($config in @('Debug','Release')) {
+        foreach ($mode in @('complete','cancel','failure-cancel')) { $plan += @{ configuration=$config; mode=$mode } }
+    }
+    Write-Json (Join-Path $OutputRoot 'plan.json') @{
+        cases=$plan; expected_cases=6; workers=2; items=3; functions_per_active_source=12000
+        compiler_failure='separately labelled static_assert, not historical PDB reproduction'; retries=0
+        target_api='run_with_compile_admission_stop'; phases=@('cold','warm','subject');
+        cache_gate='actual product target link-cache/exe bytes, mtime and file identity; no project rollback'
+    }
+    $rows = [Collections.Generic.List[object]]::new()
+    Write-Json (Join-Path $OutputRoot 'summary.json') @{
+        expected_cases=6; completed_cases=0; not_run_cases=6; cases=@()
+        cli_integrated=$false; safe_to_transfer_write_lease=$false
+    }
+    foreach ($case in $plan) {
+        $name = $case.configuration + '-' + $case.mode
+        $root = Join-Path $OutputRoot $name
+        $arguments = @($root,$case.configuration,$case.mode)
+        $output = @(& $probe @arguments 2>&1); $code = $LASTEXITCODE
+        if (-not (Test-Path -LiteralPath $root)) { New-Item -ItemType Directory -Path $root | Out-Null }
+        $output | Set-Content -LiteralPath (Join-Path $root 'case.output.txt') -Encoding utf8
+        Write-Json (Join-Path $root 'case.argv.json') $arguments
+        # Run even after a native failure, preserving missing/partial evidence as
+        # rejection rather than inventing successful outcomes from the exit code.
+        & python (Join-Path $PSScriptRoot 'verify_msvc_target_admission.py') --case $root `
+            --output (Join-Path $root 'audit.json')
+        $auditCode = $LASTEXITCODE
+        $audit = Get-Content -LiteralPath (Join-Path $root 'audit.json') -Raw | ConvertFrom-Json
+        $ok = $code -eq 0 -and $auditCode -eq 0 -and $audit.accepted -eq $true
+        if ($ok -and ($audit.configuration -cne $case.configuration -or $audit.mode -cne $case.mode)) { $ok = $false }
+        $rows.Add(@{ case=$name; native_exit=$code; audit_exit=$auditCode; accepted=$ok; audit=$audit })
+        Write-Json (Join-Path $OutputRoot 'summary.json') @{
+            expected_cases=6; completed_cases=$rows.Count; not_run_cases=(6-$rows.Count); cases=@($rows.ToArray())
+            cli_integrated=$false; safe_to_transfer_write_lease=$false
+        }
+        if (-not $ok) { throw 'Original target/evidence control failed; stop fixed remaining slots without retry.' }
+    }
+    # Post-case inventories do not establish failure-time or all-writer identity.
+    $binaries = @(Get-ChildItem -LiteralPath $OutputRoot -Recurse -File | Where-Object {
+        $_.Extension -in @('.exe','.obj','.pdb')
+    } | ForEach-Object { @{
+        path=[IO.Path]::GetRelativePath($OutputRoot,$_.FullName); bytes=$_.Length
+        sha256=(Get-FileHash -LiteralPath $_.FullName -Algorithm SHA256).Hash
+    } })
+    Write-Json (Join-Path $OutputRoot 'generated-binary-hashes.json') $binaries
+}
+finally { Pop-Location }

--- a/tests/native/verify_msvc_target_admission.py
+++ b/tests/native/verify_msvc_target_admission.py
@@ -1,0 +1,257 @@
+"""Offline audit of actual target API/native process/cache evidence.
+
+The synthetic self-test tests record acceptance, not Windows execution. Finite
+cache snapshots and joined client processes do not authorize a writer lease.
+"""
+from __future__ import annotations
+import argparse
+import copy
+import hashlib
+import json
+import tempfile
+from pathlib import Path
+
+
+class EvidenceError(ValueError):
+    pass
+
+
+def need(condition, message):
+    if not condition:
+        raise EvidenceError(message)
+
+
+def uint(value, name):
+    need(type(value) is int and value >= 0, 'invalid unsigned field: ' + name)
+    return value
+
+
+def load(path):
+    return json.loads(path.read_text(encoding='utf-8-sig'))
+
+
+def dump(path, value):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2) + '\n', encoding='utf-8')
+
+
+def audit(root: Path) -> dict:
+    report = load(root / 'observation.json')
+    need(type(report.get('schema')) is int and report['schema'] == 1, 'unknown target report schema')
+    mode, config = report.get('mode'), report.get('configuration')
+    need(mode in ('complete', 'cancel', 'failure-cancel') and config in ('Debug', 'Release'), 'wrong case identity')
+    for field in ('gate_passed', 'overlap', 'retained_exited', 'real_processes'):
+        need(report.get(field) is True, 'unproven native control: ' + field)
+    for field in ('process_token_seen', 'cli_integrated', 'safe_to_transfer_write_lease', 'historical_cause_resolved'):
+        need(report.get(field) is False, 'incorrect authority/token: ' + field)
+    need(report.get('target_api') == 'run_with_compile_admission_stop' and report.get('observation_error') == '', 'wrong target entry/observation failure')
+    children = report.get('observed_compilers')
+    need(type(children) is list and len(children) == 2, 'two retained real compiler identities required')
+    need(len({(uint(p.get('pid'), 'pid'), uint(p.get('created'), 'created')) for p in children}) == 2,
+         'compiler identities duplicated')
+    need(all(p['pid'] > 0 and p['created'] > 0 for p in children), 'invalid compiler identity')
+    stopping, failing = mode != 'complete', mode == 'failure-cancel'
+    counts = (2, 0, 0) if stopping else (3, 1, 1)
+    for field, value in zip(('compiler_invocations', 'link_invocations', 'run_invocations'), counts):
+        need(uint(report.get(field), field) == value, 'unexpected successor/dispatch count: ' + field)
+    expected_reuse = [True, not failing, not stopping]
+    reuse = report.get('post_reusable')
+    need(type(reuse) is list and all(type(x) is bool for x in reuse) and reuse == expected_reuse,
+         'failed/pending source was reusable or completed cache invalid')
+    need(report.get('post_link_reusable') is (not stopping), 'target freshness falsely satisfied or completed target dirty')
+    evidence = root / 'evidence'
+    target = {phase: load(evidence / phase / 'target.json') for phase in ('cold', 'warm', 'subject')}
+    for phase in ('cold', 'warm'):
+        r = target[phase]
+        need(r.get('succeeded') is True and r.get('linked') is (phase == 'cold'), 'cold/warm target path failed')
+        cs = r.get('compiles')
+        need(type(cs) is list and len(cs) == 3 and all(c.get('compiled') is (phase == 'cold') for c in cs), 'cold/warm compile decisions invalid')
+        need([Path(c['source'].replace('\\', '/')).name for c in cs] == ['work0.cpp', 'work1.cpp', 'work2.cpp'], 'source result mapping invalid')
+    subject = target['subject']
+    if stopping:
+        need(subject.get('succeeded') is False and type(subject.get('code')) is int
+             and subject['code'] == (7 if failing else 9), 'original failure/cancellation classification wrong')
+        waves = subject.get('waves')
+        need(type(waves) is list and len(waves) == 1, 'unexpected/absent target wave evidence')
+        w = waves[0]
+        need(w.get('execution_sources') == [0, 1, 2], 'sparse execution source mapping changed')
+        need(w['inspection'].get('outcome') == 'succeeded' and uint(w['inspection'].get('started_count'), 'inspection count') == 3,
+             'inspection did not complete before execution')
+        execution = w['execution']
+        need(execution.get('outcome') == ('failed' if failing else 'cancelled'), 'phase hid original failure')
+        need(uint(execution.get('worker_count'), 'workers') == 2 and uint(execution.get('started_count'), 'started') == 2,
+             'wrong typed execution count')
+        for field in ('stop_requested', 'admission_stop_observed', 'stopped_before_all_items'):
+            need(execution.get(field) is True, 'missing stop boundary: ' + field)
+        attempts = w.get('attempts')
+        need(type(attempts) is list and len(attempts) == 3 and attempts[0].get('state') == 'succeeded'
+             and attempts[0].get('compiled') is True and attempts[2] == {'state': 'not_started'}, 'successful sibling or pending item lost')
+        need(attempts[1].get('state') == ('failed' if failing else 'succeeded'), 'wrong original item1 outcome')
+        if not failing:
+            need(attempts[1].get('compiled') is True, 'cancelled sibling result missing')
+    else:
+        need(subject.get('succeeded') is True and subject.get('linked') is True, 'complete target did not link')
+        need(len(subject.get('compiles', [])) == 3 and all(c.get('compiled') is True for c in subject['compiles']), 'complete target skipped dirty work')
+    result_count = 0
+    for phase in ('cold', 'warm', 'subject'):
+        expected = [] if phase == 'warm' else ['work0', 'work1']
+        if phase == 'cold' or (phase == 'subject' and not stopping):
+            expected += ['work2', 'link', 'run']
+        directory = evidence / phase
+        for suffix in ('result.json', 'stdout.txt', 'stderr.txt', 'argv.json'):
+            actual = {p.name[:-len('.' + suffix)] for p in directory.glob('*.' + suffix)}
+            need(actual == set(expected), f'{phase}: missing/unexpected {suffix}')
+        for stem in expected:
+            r = load(directory / (stem + '.result.json'))
+            need('infrastructure_error' not in r and type(r.get('exit_code')) is int and r.get('cancelled') is False, 'native process failed/terminated or invalid result')
+            out = (directory / (stem + '.stdout.txt')).read_bytes().decode('utf-8')
+            err = (directory / (stem + '.stderr.txt')).read_bytes().decode('utf-8')
+            args = load(directory / (stem + '.argv.json'))
+            need(type(args) is list and args and all(type(a) is str for a in args), 'missing native argv')
+            if stem.startswith('work'):
+                need(Path(args[0].replace('\\', '/')).name.lower() == 'cl.exe', 'noncompiler substituted')
+                need(all(option in args for option in ('/Zi', '/FS', '/bigobj', '/MTd' if config == 'Debug' else '/MT')),
+                     'compiler policy changed')
+                need(any(a.startswith('/Fd') and a.endswith('compiler.pdb') for a in args), 'PDB output not recorded')
+                need(any(a.replace('\\', '/').endswith('/' + stem + '.cpp') for a in args), 'argv/source index mismatch')
+            if phase == 'subject' and stem == 'work1' and failing:
+                need(r['exit_code'] != 0 and 'MQB_TARGET_EXPECTED_COMPILER_FAILURE' in out + err, 'original injected compiler failure absent')
+                need(subject.get('original_exit') == r['exit_code'] and subject.get('original_stdout') == out
+                     and subject.get('original_stderr') == err, 'target error lost original native diagnostics')
+                need(subject['waves'][0]['attempts'][1].get('exit_code') == r['exit_code'], 'per-source failure exit mismatch')
+                need(Path(subject['source'].replace('\\', '/')).name == 'work1.cpp', 'error attributed to wrong source')
+            else:
+                need(r['exit_code'] == 0, 'required positive native tool failed')
+            result_count += 1
+    snapshots = {}
+    keys = {'link_cache', 'executable', 'source0_cache', 'source1_cache', 'source2_cache'}
+    for phase in ('cold', 'before', 'after', 'inspected'):
+        record = load(evidence / 'snapshots' / (phase + '.json'))
+        need(set(record) == keys, 'incomplete artifact snapshot inventory')
+        for key, value in record.items():
+            for field in ('size', 'mtime', 'file_id', 'volume'):
+                need(uint(value.get(field), field) > 0, 'zero snapshot identity/size')
+            digest = value.get('sha256')
+            need(type(digest) is str and len(digest) == 64 and all(c in '0123456789abcdef' for c in digest), 'invalid SHA256')
+            if key != 'executable':
+                raw = (evidence / 'snapshots' / (phase + '-' + key + '.bytes')).read_bytes()
+                need(len(raw) == value['size'] and hashlib.sha256(raw).hexdigest() == digest, 'snapshot bytes/hash mismatch')
+        snapshots[phase] = record
+    need(snapshots['cold'] == snapshots['before'], 'warm no-op rewrote artifact')
+    need(snapshots['after'] == snapshots['inspected'], 'read-only inspect changed cache/artifact')
+    if stopping:
+        for key in ('link_cache', 'executable', 'source2_cache') + (('source1_cache',) if failing else ()):
+            need(snapshots['before'][key] == snapshots['after'][key], 'stopped target published/modified ' + key)
+    else:
+        need(snapshots['before']['link_cache'] != snapshots['after']['link_cache'], 'positive target never published its link cache')
+    return dict(accepted=True, configuration=config, mode=mode, original_results=result_count,
+                target_endpoint_real_tools=True, source_cache_policy='completed TUs may retain valid caches; no project rollback',
+                snapshots=snapshots, historical_cause_resolved=False, safe_to_transfer_write_lease=False)
+
+
+def fixture(root, config='Debug', mode='complete'):
+    stopping, failing = mode != 'complete', mode == 'failure-cancel'
+    dump(root / 'observation.json', dict(schema=1, mode=mode, configuration=config, gate_passed=True,
+        overlap=True, retained_exited=True, real_processes=True, process_token_seen=False, cli_integrated=False,
+        safe_to_transfer_write_lease=False, historical_cause_resolved=False, target_api='run_with_compile_admission_stop',
+        observation_error='', observed_compilers=[dict(pid=10, created=100), dict(pid=11, created=101)],
+        compiler_invocations=2 if stopping else 3, link_invocations=0 if stopping else 1, run_invocations=0 if stopping else 1,
+        post_reusable=[True, not failing, not stopping], post_link_reusable=not stopping))
+    for phase in ('cold', 'warm', 'subject'):
+        r = dict(succeeded=True, linked=phase != 'warm', compiles=[dict(source=f'C:/src/work{i}.cpp', compiled=phase != 'warm', warnings=0) for i in range(3)])
+        if phase == 'subject' and stopping:
+            r = dict(succeeded=False, code=7 if failing else 9, message='synthetic target error', source='C:/src/work1.cpp' if failing else '',
+                waves=[dict(inspection=dict(outcome='succeeded', started_count=3),
+                    execution=dict(outcome='failed' if failing else 'cancelled', worker_count=2, started_count=2,
+                        stop_requested=True, admission_stop_observed=True, stopped_before_all_items=True),
+                    execution_sources=[0,1,2], attempts=[dict(state='succeeded', compiled=True),
+                        dict(state='failed', exit_code=2) if failing else dict(state='succeeded', compiled=True), dict(state='not_started')])])
+            if failing:
+                r.update(original_exit=2, original_stdout='MQB_TARGET_EXPECTED_COMPILER_FAILURE\n', original_stderr='')
+        directory = root / 'evidence' / phase
+        dump(directory / 'target.json', r)
+        names = [] if phase == 'warm' else ['work0', 'work1']
+        if phase == 'cold' or (phase == 'subject' and not stopping): names += ['work2','link','run']
+        for name in names:
+            bad = phase == 'subject' and name == 'work1' and failing
+            dump(directory / (name + '.result.json'), dict(exit_code=2 if bad else 0, cancelled=False))
+            (directory / (name + '.stdout.txt')).write_bytes(('MQB_TARGET_EXPECTED_COMPILER_FAILURE\n' if bad else '').encode('utf-8'))
+            (directory / (name + '.stderr.txt')).write_bytes(b'')
+            args = ['C:/tools/cl.exe', '/Zi', '/FS', '/bigobj', '/MTd' if config == 'Debug' else '/MT', '/FdC:/compiler.pdb', f'C:/src/{name}.cpp'] if name.startswith('work') else [f'C:/tools/{name}.exe']
+            dump(directory / (name + '.argv.json'), args)
+    for phase in ('cold','before','after','inspected'):
+        record = {}
+        for key in ('link_cache','executable','source0_cache','source1_cache','source2_cache'):
+            raw=(key + '-synthetic-data').encode()
+            record[key]=dict(size=len(raw), sha256=hashlib.sha256(raw).hexdigest(), mtime=10, file_id=20, volume=30)
+            if key != 'executable':
+                dest=root/'evidence/snapshots'/f'{phase}-{key}.bytes';dest.parent.mkdir(parents=True,exist_ok=True);dest.write_bytes(raw)
+        if not stopping and phase in ('after','inspected'): record['link_cache']['mtime'] = 20
+        dump(root/'evidence/snapshots'/f'{phase}.json',record)
+
+
+def self_test():
+    rows=[]
+    def change(root, relative, mutate):
+        p=root/relative;r=load(p);mutate(r);dump(p,r)
+    mutations=[
+        ('stale-target-treated-fresh', lambda r: change(r,'observation.json',lambda d:d.update(post_link_reusable=True))),
+        ('wrong-outcome', lambda r: change(r,'evidence/subject/target.json',lambda d:d.update(code=9))),
+        ('error-lost', lambda r: change(r,'evidence/subject/target.json',lambda d:d.update(original_stdout=''))),
+        ('stop-lost', lambda r: change(r,'evidence/subject/target.json',lambda d:d['waves'][0]['execution'].update(admission_stop_observed=False))),
+        ('pending-counted', lambda r: change(r,'evidence/subject/target.json',lambda d:d['waves'][0]['attempts'][2].update(state='succeeded'))),
+        ('source-mapping', lambda r: change(r,'evidence/subject/target.json',lambda d:d['waves'][0].update(execution_sources=[1,0,2]))),
+        ('wrong-source', lambda r: change(r,'evidence/subject/target.json',lambda d:d.update(source='C:/src/work0.cpp'))),
+        ('zeroed-original', lambda r: change(r,'evidence/subject/work1.result.json',lambda d:d.update(exit_code=0))),
+        ('missing-diagnostic', lambda r:(r/'evidence/subject/work1.stderr.txt').unlink()),
+        ('extra-result', lambda r:dump(r/'evidence/subject/work2.result.json',dict(exit_code=0,cancelled=False))),
+        ('hidden-link', lambda r:dump(r/'evidence/subject/link.argv.json',['link.exe'])),
+        ('missing-argv', lambda r:(r/'evidence/subject/work0.argv.json').unlink()),
+        ('process-cancelled', lambda r:change(r,'evidence/subject/work1.result.json',lambda d:d.update(cancelled=True))),
+        ('wrong-flag', lambda r:change(r,'evidence/subject/work1.argv.json',lambda d:d.remove('/FS'))),
+        ('fake-warm-hit', lambda r:change(r,'evidence/warm/target.json',lambda d:d.update(linked=True))),
+        ('bad-cache-bytes', lambda r:(r/'evidence/snapshots/after-link_cache.bytes').write_bytes(b'wrong')),
+        ('changed-cache-time', lambda r:change(r,'evidence/snapshots/after.json',lambda d:d['link_cache'].update(mtime=11))),
+        ('missing-cache-copy', lambda r:(r/'evidence/snapshots/before-source1_cache.bytes').unlink()),
+        ('unobserved-overlap', lambda r:change(r,'observation.json',lambda d:d.update(overlap=False))),
+        ('token-passed', lambda r:change(r,'observation.json',lambda d:d.update(process_token_seen=True))),
+        ('failed-source-reused', lambda r:change(r,'observation.json',lambda d:d.update(post_reusable=[True,True,False]))),
+        ('lease-authorized', lambda r:change(r,'observation.json',lambda d:d.update(safe_to_transfer_write_lease=True))),
+        ('duplicate-handles', lambda r:change(r,'observation.json',lambda d:d.update(observed_compilers=[dict(pid=1,created=2)]*2))),
+        ('string-native-exit', lambda r:change(r,'evidence/subject/work1.result.json',lambda d:d.update(exit_code='2'))),
+        ('boolean-count', lambda r:change(r,'observation.json',lambda d:d.update(compiler_invocations=True))),
+    ]
+    with tempfile.TemporaryDirectory() as directory:
+        base=Path(directory)
+        tests=[(c+'-'+m,c,m,None) for c in ('Debug','Release') for m in ('complete','cancel','failure-cancel')]
+        def crlf(r):
+            value='MQB_TARGET_EXPECTED_COMPILER_FAILURE\r\n'
+            (r/'evidence/subject/work1.stdout.txt').write_bytes(value.encode())
+            change(r,'evidence/subject/target.json',lambda d:d.update(original_stdout=value))
+        tests += [('raw-crlf-preserved','Debug','failure-cancel',crlf)]
+        tests += [(name,'Debug','failure-cancel',mutate) for name,mutate in mutations]
+        for i,(name,config,mode,mutate) in enumerate(tests):
+            root=base/str(i);fixture(root,config,mode)
+            if mutate: mutate(root)
+            error=None
+            try: audit(root)
+            except (ValueError,KeyError,TypeError,OSError) as exc:error=str(exc)
+            expected = mutate is None or name == 'raw-crlf-preserved'
+            rows.append(dict(name=name,expected_accepted=expected,accepted=error is None,
+                passed=(error is None)==expected,error=error))
+    return dict(synthetic_only=True, cases=rows, passed=all(r['passed'] for r in rows))
+
+
+def main():
+    p=argparse.ArgumentParser(description=__doc__);p.add_argument('--self-test',action='store_true');p.add_argument('--case',type=Path)
+    p.add_argument('--output',required=True,type=Path);a=p.parse_args()
+    need(not a.output.exists(),'refuse to overwrite previous audit')
+    try:
+        result=self_test() if a.self_test else audit(a.case)
+        ok=result.get('passed',result.get('accepted',False))
+    except (ValueError,KeyError,TypeError,OSError) as e:
+        result=dict(accepted=False,error=str(e),safe_to_transfer_write_lease=False);ok=False
+    dump(a.output,result);print(json.dumps(dict(accepted=ok,output=str(a.output))));return 0 if ok else 1
+
+
+if __name__=='__main__':raise SystemExit(main())


### PR DESCRIPTION
## Final decision: accept actual MSVC/link/cache coverage of the target API

[Final exact-source review, all current gates and acceptance decision](https://github.com/Iviesever/msvc-quick-build/pull/179#pullrequestreview-5163283209)

Accept ordinary expected-head merge. This test iteration closes #178's real-tool target-endpoint coverage gap without modifying product behavior or enabling CLI cancellation. #172 remains independently held; M1b and historic C1041/performance requirements remain open.

## Exact source

- Base **`d863b1a5dbab2cc1d8b1c09ae9ced5953fa52d64`**.
- Reviewed head **`2b0b22b918a4ffc83a711288c6172c36cef85a0b`**.
- Candidate/native test-merge tree **`24346d15b7f245396c972dfd2478b2ef0ecaa3a4`**.
- Native test-merge **`342a4c75df929255f13bb1b51ab427fa2a95d66a`**, exactly those base/head parents.
- Four new test/CI files, **933 additions/0 deletions**; all414existing files unchanged,418candidate files. Complete canonical source reconstruction and patch replay match both trees.
- Product implementation,scheduler,CLI,manifest/native79inventory,benchmark/ABBA and accepted observer tools unchanged. **VERSION5.5.0; no historical tag/asset or formal release change.**

## What actually runs

The fixture uses the real product target,compile,link and cache coordinators. Its runner records and forwards the unchanged ProcessSpec to WindowsProcessRunner and rejects any stoppable process token. There are no simulated compiler outcomes or substitute cache implementations.

Six fixed ordinary executable targets: Debug/Release each complete,cancel,failure-cancel. Every target calls the explicit API for a cold build and actual program run, a zero-tool warm no-op, then a revised-source subject build. Two12000-function sources and one pending source,2workers,shared header,/FS/effective /Zi,/bigobj and correct MTd/MT are preserved. Actual Debug link keeps /INCREMENTAL;Release /INCREMENTAL:NO. Cancellation follows observation of two retained live cl.exe identities. Missing overlap fails the fixture instead of growing or repeating it.

## Completed current-head gates

| Gate | Actual run | Result |
|---|---|---|
| Native Debug/all shards/freshness/runtime/parameters | #735/34441769183 | Actual build and tests passed |
| Complete Release/self-host/exact runtime-only package | #621/34441769137 | Passed; publish-release skipped |
| New target record/native tests | #1/34441769199 |32/32expectations,PowerShell parsing,actual probe build and6/6real target cases passed |
| Original true-MSVC batch regression | #3/34441769275 | Six fixed cases passed independently |
| Original ownership/record regressions | #25/34441769205;#27/34441769115 |70/70,42/42;required positive controls and150record expectations passed |
| Documentation/Cross-Stage | #182/34441769153;#212/34441769122 | Passed |
| Independent original observer-OFF ABBA | #596/34441769135 |76pairs measured/recomputed;72instrumented complete semantic identities match |

All nine current-head workflows completed on their first attempt. Untriggered old File Event/PDB Open studies are not described as rerun. No post-publication source correction or same-head native/CI/benchmark retry. Existing C4100,C4996,D9025 build warnings remain in diagnostics; no warning-free claim.

### Actual failures, cancellation and real target cache barriers

[Full native target/cache and provenance inspection](https://github.com/Iviesever/msvc-quick-build/pull/179#issuecomment-5613813299)

Both complete subjects compile0,0,0,actually link/run and publish their target cache. Both cancelled subjects preserve original0,0 and unentered third item,report cancelled and invoke no link/run. Both failure-cancel subjects preserve original0,2/C2338,exact stdout/stderr/source1 and unentered third item,report **compile_failed**,not cancellation-success. These static_assert failures are explicitly injected,not historical C1041 reproduction.

All four stopped targets preserve actual old EXE/link-cache bytes,mtime,volume and fileID. Pending sourcecache remains unchanged;failed sourcecache also remains unchanged. Completed siblings may save valid source caches. Real product read-only inspection marks failed/pending sources and the stopped target dirty while completed sources remain reusable. **Unchanged old cache is not falsely accepted as fresh.** Inspection changes none of the snapshots. This is not project rollback or a writer-lease guarantee.

Independently replayed48native result files,96diagnostic files,96raw cache copies,120artifact snapshot records,24source comparisons and20executed-argv comparisons. Native executable bytes are compared in-process with digest/identity records but not archived as independent body snapshots. Exact input probe hashes match source/provenance;input binaries are not the ABBA executable pair. All six targets use real selected cl.exe handles and joined completion,no terminating token.

### Original negative evidence and performance retained

[Full19-rowABBA and original matrix audit](https://github.com/Iviesever/msvc-quick-build/pull/179#issuecomment-5613873650)

Default/private matrices retain nine/five original B failures in the intentionally adverse managed-ending policy,exact diagnostics,unattempted link/run and separate recoveries. All28A-started managed endings still kill original services.705/407original results and1410/814diagnostics checked. Sparse owner identity14/70 and4/42 is not complete-writer evidence. All14scheduler/direct input pairs and150typed record expectations match;these independent gates were not replaced by the new target study.

External timings-off no-op paired median **+0.22385ms/+1.9108219%**,2/4slower,does not cross the unchanged **BOTH>1ms AND>10%** gate. All72instrumented counters/breakdowns/compile-link-archive hit-miss match;four external counter sets unavailable,not zero. Only the final row is external elapsed;four-pairP95 is a maximum. Keep timings-enabled-no-op4/4slower,public-header/cold3/4slower and common-header+12.482ms tail. No speedup/zero-overhead claim,noise deletion,AA subtraction or historical debt closure. Comparison JSON is not an OS trace or actual ABBA binary-pair archive.

## Original acceptance criteria and handoff

The predeclared exact-source fullnative/selfhost/package,32record expectations,6real cold/warm/subject targets with original result/cache/freshness checks,original70/42positive controls,six true-MSVC batch cases and independent19x4ABBA/72semantic identities/unchanged threshold all passed. No current gate was waived. Successful new controls do not explain historic C1041 or performance incidents.

**Next separate small implementation: foreground build/run separation from #164.** Isolate build completion from launching the built program while preserving argv,cwd,environment,stdin/output and exit codes. Establish the future transaction boundary before foreground program execution without claiming that compiler exit proves external-writer quiescence. Do not add another observer,enable CLI cancellation or introduce leases through this test change. Current native coverage is three-source executables,not DLL/static/modules/PCH-parent,small/forced,late-link or partial-worker-start/owner-crash cases.

Eleven immutable coreZIPs,canonical base/head source archives,exact patch,metadata and executed portable replay are retained;not every Actions artifact. Retention30days. Generated target binary bodies are excluded from diagnostic ZIPs;cache bytes retained and finite post-case hashes do not represent incident-time state. Local32record tests and declaration-only Win32/BCrypt GCC syntax checks are not localMSVC/PowerShell/ETW execution. Prepublication path/newline/shim corrections are documented;only verified blobs entered the commit. Temporaryperf title changed only after actual#596completed;later skipped jobs or new post-merge push CI are not substituted for these completed results.