### PR TITLE
fix: preserve foreground stdin during vcvars bootstrap

### DIFF
--- a/cpp/src/msvc/toolchain/VisualStudioEnvironment.cpp
+++ b/cpp/src/msvc/toolchain/VisualStudioEnvironment.cpp
@@ -163,7 +163,9 @@ private:
     }
 
     script << "@echo off\r\n"
-           << "call \"%MQB_VCVARS%\" %MQB_VC_TARGET% >nul 2>&1\r\n"
+           // Environment bootstrap is noninteractive. Preserve foreground stdin
+           // for the eventual artifact, including non-seekable pipe input.
+           << "call \"%MQB_VCVARS%\" %MQB_VC_TARGET% <nul >nul 2>&1\r\n"
            << "if errorlevel 1 exit /b %errorlevel%\r\n"
            << "set\r\n";
     script.close();

--- a/cpp/tests/app/cli/mqb_native_msvc_cli_e2e_tests.cpp
+++ b/cpp/tests/app/cli/mqb_native_msvc_cli_e2e_tests.cpp
@@ -1,3 +1,8 @@
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+
 #include <chrono>
 #include <expected>
 #include <filesystem>
@@ -656,6 +661,106 @@ void verify_command_candidate_e2e(const fs::path& mqb_executable) {
     }
 }
 
+void verify_foreground_handoff(const fs::path& mqb_executable) {
+    const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
+    TempTree tree{.root=fs::temp_directory_path() / ("mqb_foreground_" + std::to_string(unique))};
+    const auto root = tree.root / "foreground project";
+    const auto source = root / "main.cpp";
+    const auto input = root / "stdin.txt";
+    write_text(input, "foreground-input\n");
+    const std::string child = R"cpp(
+#define NOMINMAX
+#include <windows.h>
+#include <cstdio>
+#include <cwchar>
+#include <filesystem>
+#include <iostream>
+#include <string>
+int wmain(int argc, wchar_t** argv) {
+    if (argc != 6 || std::wcscmp(argv[1], L"") || std::wcscmp(argv[2], L"two words") ||
+        std::wcscmp(argv[3], L"quote\"inside") || std::wcscmp(argv[4], L"trailing\\") ||
+        std::wcscmp(argv[5], L"\u8fb9\u754c")) return 81;
+    if (std::filesystem::current_path().filename() != L"foreground project") return 82;
+    wchar_t value[80]{};
+    if (!GetEnvironmentVariableW(L"MQB_FOREGROUND_CONTRACT",value,80) || std::wcscmp(value,L"inherited-value")) return 83;
+    std::string line;
+    const bool read_ok = static_cast<bool>(std::getline(std::cin,line));
+    if (!read_ok || line != "foreground-input") {
+        std::fprintf(stderr,"FOREGROUND_INPUT_FAILURE read=%d state=%u bytes=%zu hex=",
+            read_ok,static_cast<unsigned>(std::cin.rdstate()),line.size());
+        for (const unsigned char byte : line) std::fprintf(stderr,"%02x",static_cast<unsigned>(byte));
+        std::fputc('\n',stderr);
+        return 84;
+    }
+    std::puts("FOREGROUND_STDOUT"); std::fputs("FOREGROUND_STDERR\n",stderr);
+    return 37;
+}
+)cpp";
+    write_text(source, child);
+    mqb::platform::windows::WindowsProcessRunner runner;
+    const auto launch = [&](std::vector<std::string> args) -> std::expected<mqb::process::ProcessResult, mqb::process::ProcessError> {
+        struct Input {
+            HANDLE old{::GetStdHandle(STD_INPUT_HANDLE)};
+            HANDLE file{INVALID_HANDLE_VALUE};
+            bool installed{};
+            explicit Input(const fs::path& path) {
+                file=::CreateFileW(path.c_str(),GENERIC_READ,FILE_SHARE_READ,nullptr,OPEN_EXISTING,FILE_ATTRIBUTE_NORMAL,nullptr);
+                installed=file!=INVALID_HANDLE_VALUE && ::SetStdHandle(STD_INPUT_HANDLE,file)!=FALSE;
+            }
+            ~Input() { if(installed) ::SetStdHandle(STD_INPUT_HANDLE,old); if(file!=INVALID_HANDLE_VALUE) ::CloseHandle(file); }
+        } redirected{input};
+        expect(redirected.installed, "real CLI foreground stdin setup must succeed");
+        if (!redirected.installed) return std::unexpected(mqb::process::ProcessError{
+            .code=mqb::process::ProcessErrorCode::io_failed, .message="stdin setup failed"});
+        mqb::process::ProcessSpec spec;
+        spec.executable=mqb_executable; spec.arguments=std::move(args); spec.working_directory=root;
+        spec.environment.push_back({"MQB_FOREGROUND_CONTRACT","inherited-value",false});
+        return runner.run(spec);
+    };
+    const std::vector<std::string> tail{"--", "", "two words", "quote\"inside", "trailing\\", "\xe8\xbe\xb9\xe7\x95\x8c"};
+    // This child uses the Debug standard library: keep its CRT selection in
+    // the same configuration instead of mixing the default _DEBUG with /MT.
+    std::vector<std::string> args{"run","main.cpp","--env","vs","--no-discover","--std","c++23","--debug","--runtime","MTd","-o","foreground"};
+    args.insert(args.end(),tail.begin(),tail.end());
+    auto cold=launch(args);
+    expect(cold.has_value(), "cold build/run foreground command should launch");
+    if(cold) {
+        std::cout << "FOREGROUND_EVIDENCE cold-run\n"; dump_failure(*cold);
+        expect(cold->exit_code==37 && cold->stdout_text.find("FOREGROUND_STDOUT")!=std::string::npos &&
+               cold->stderr_text.find("FOREGROUND_STDERR")!=std::string::npos,
+               "real child preserves stdin/environment/cwd/Unicode argv and nonzero exit after build");
+    }
+    args.erase(args.begin()); args.insert(args.begin()+1,"--run");
+    auto warm=launch(args);
+    expect(warm.has_value(), "source-first --run compatibility should launch");
+    if(warm) {
+        std::cout << "FOREGROUND_EVIDENCE warm-source-first\n"; dump_failure(*warm);
+        expect(warm->exit_code==37 && warm->stdout_text.find("[compile]")==std::string::npos &&
+               warm->stdout_text.find("[link]")==std::string::npos && warm->stdout_text.find("[run] foreground.exe")!=std::string::npos,
+               "warm foreground command runs without compiling or linking");
+    }
+    write_text(source,child+"\nstatic_assert(false, \"MQB_FOREGROUND_BUILD_FAILURE\");\n");
+    force_newer_timestamp(source);
+    auto failed=launch(args);
+    expect(failed.has_value(), "failing build should launch the compiler without launching old program");
+    if(failed) {
+        std::cout << "FOREGROUND_EVIDENCE compile-failure\n"; dump_failure(*failed);
+        expect(failed->exit_code==4 && failed->stdout_text.find("[run]")==std::string::npos &&
+               failed->stdout_text.find("FOREGROUND_STDOUT")==std::string::npos &&
+               (failed->stdout_text+failed->stderr_text).find("MQB_FOREGROUND_BUILD_FAILURE")!=std::string::npos,
+               "compile failure preserves original diagnostics and never runs prior successful artifact");
+    }
+    write_text(source,"extern int missing_foreground_symbol(); int main(){return missing_foreground_symbol();}\n");
+    force_newer_timestamp(source);
+    auto link_failed=launch(args);
+    expect(link_failed.has_value(), "link-failing foreground command should launch");
+    if(link_failed) {
+        std::cout << "FOREGROUND_EVIDENCE link-failure\n"; dump_failure(*link_failed);
+        expect(link_failed->exit_code==5 && link_failed->stdout_text.find("[run]")==std::string::npos,
+               "link failure must not launch the previous artifact");
+    }
+}
+
 } // namespace
 
 int main(const int argc, char* argv[]) {
@@ -667,6 +772,7 @@ int main(const int argc, char* argv[]) {
     verify_parser_contract();
     verify_native_candidate_e2e(fs::path{argv[1]});
     verify_command_candidate_e2e(fs::path{argv[1]});
+    verify_foreground_handoff(fs::path{argv[1]});
 
     if (failures != 0) {
         std::cerr << failures << " test(s) failed\n";

--- a/cpp/tests/msvc/toolchain/visual_studio_tests.cpp
+++ b/cpp/tests/msvc/toolchain/visual_studio_tests.cpp
@@ -1,7 +1,14 @@
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+
 #include <algorithm>
 #include <chrono>
 #include <cctype>
 #include <cstdlib>
+#include <cstdint>
+#include <stdexcept>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
@@ -12,6 +19,7 @@
 #include <utility>
 #include <vector>
 
+#include "../../../src/msvc/toolchain/VisualStudioEnvironment.hpp"
 #include "mqb/msvc/MsvcLinker.hpp"
 #include "mqb/msvc/MsvcToolchainEnvironmentIdentity.hpp"
 #include "mqb/msvc/MsvcToolchainLocator.hpp"
@@ -196,6 +204,155 @@ void restore_cache_text(const fs::path& cache_file, const std::string& cache_tex
     stream << cache_text;
 }
 
+// These tests use real cmd.exe, file/pipe handles and the product environment
+// capture. The unprotected script is the old call shape, not a second product
+// implementation. Never print the captured environment: it may contain secrets.
+void verify_environment_input(const fs::path& installed_vcvars) {
+    using mqb::msvc::detail::capture_visual_studio_environment;
+    using mqb::msvc::detail::default_command_processor;
+    const auto root = unique_cache_root();
+    struct Cleanup {
+        fs::path root;
+        ~Cleanup() { std::error_code ignored; fs::remove_all(root, ignored); }
+    } cleanup{root};
+    const auto require = [](bool ok, const char* message) {
+        if (!ok) throw std::runtime_error(message);
+    };
+    try {
+        fs::create_directories(root);
+        const auto save = [&](const fs::path& path, const std::string& bytes) {
+            std::ofstream out(path, std::ios::binary);
+            out << bytes;
+            out.close();
+            require(bool(out), "stdin test script/input write failed");
+        };
+        const auto reader = root / "reader.cmd";
+        const auto rejected = root / "reject.cmd";
+        const auto legacy = root / "unprotected.cmd";
+        save(reader, "@echo off\r\nset \"MQB_STDIN_READ=unread\"\r\n"
+                     "set /p MQB_STDIN_READ=\r\n"
+                     "set \"VCToolsInstallDir=C:\\mqb-stdin-test\\\"\r\nexit /b 0\r\n");
+        save(rejected, "@exit /b 17\r\n");
+        save(legacy, "@echo off\r\ncall \"%MQB_VCVARS%\" %MQB_VC_TARGET% >nul 2>&1\r\n"
+                     "if errorlevel 1 exit /b %errorlevel%\r\nset\r\n");
+        const std::string input = "foreground-input\nsecond-line\n";
+        const auto input_file = root / "stdin.txt";
+        save(input_file, input);
+        struct Input {
+            HANDLE previous{::GetStdHandle(STD_INPUT_HANDLE)};
+            HANDLE read{INVALID_HANDLE_VALUE};
+            bool pipe{}, installed{};
+            Input(const fs::path& file, const std::string& bytes, bool is_pipe) : pipe(is_pipe) {
+                if (pipe) {
+                    HANDLE writer{};
+                    if (!::CreatePipe(&read, &writer, nullptr, 0)) return;
+                    DWORD written{};
+                    const bool filled = ::WriteFile(writer, bytes.data(), static_cast<DWORD>(bytes.size()), &written, nullptr)
+                        && written == bytes.size();
+                    ::CloseHandle(writer); // No inherited writer can hold EOF open.
+                    if (!filled) return;
+                } else {
+                    read = ::CreateFileW(file.c_str(), GENERIC_READ, FILE_SHARE_READ,
+                        nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+                }
+                installed = read != INVALID_HANDLE_VALUE && ::SetStdHandle(STD_INPUT_HANDLE, read) != FALSE;
+            }
+            ~Input() {
+                if (installed) ::SetStdHandle(STD_INPUT_HANDLE, previous);
+                if (read && read != INVALID_HANDLE_VALUE) ::CloseHandle(read);
+            }
+            Input(const Input&) = delete;
+            Input& operator=(const Input&) = delete;
+            std::uint64_t remaining() const {
+                if (pipe) {
+                    DWORD available{};
+                    if (::PeekNamedPipe(read, nullptr, 0, nullptr, &available, nullptr)) return available;
+                    if (::GetLastError() == ERROR_BROKEN_PIPE) return 0;
+                    throw std::runtime_error("stdin pipe observation failed");
+                }
+                LARGE_INTEGER zero{}, position{}, size{};
+                if (!::GetFileSizeEx(read, &size) || !::SetFilePointerEx(read, zero, &position, FILE_CURRENT)
+                    || position.QuadPart < 0 || size.QuadPart < position.QuadPart)
+                    throw std::runtime_error("stdin file-position observation failed");
+                return static_cast<std::uint64_t>(size.QuadPart - position.QuadPart);
+            }
+            std::string consume(std::size_t size) const {
+                std::string bytes(size, '\0');
+                DWORD received{};
+                if (!::ReadFile(read, bytes.data(), static_cast<DWORD>(bytes.size()), &received, nullptr))
+                    throw std::runtime_error("preserved stdin read failed");
+                bytes.resize(received);
+                return bytes;
+            }
+        };
+        mqb::platform::windows::WindowsProcessRunner native;
+        const auto unprotected = [&](const fs::path& batch) {
+            mqb::process::ProcessSpec spec;
+            spec.executable = default_command_processor();
+            spec.arguments = {"/d", "/u", "/c", legacy.generic_string()};
+            spec.environment = {{"MQB_VCVARS", batch.generic_string()}, {"MQB_VC_TARGET", "x64"}};
+            return native.run(spec);
+        };
+        const auto protected_call = [&](const fs::path& batch) {
+            return capture_visual_studio_environment(native, default_command_processor(), batch, mqb::Architecture::x64);
+        };
+        for (const bool pipe : {false, true}) {
+            for (const bool protect : {false, true}) {
+                Input redirected{input_file, input, pipe};
+                require(redirected.installed && redirected.remaining() == input.size(), "fresh stdin setup failed");
+                if (protect) {
+                    const auto result = protected_call(reader);
+                    require(result.has_value(), "protected reader environment capture failed");
+                    const auto value = std::find_if(result->variables.begin(), result->variables.end(), [](const auto& item) {
+                        return item.name == "MQB_STDIN_READ";
+                    });
+                    require(value != result->variables.end() && value->value == "unread", "bootstrap received foreground bytes");
+                    require(redirected.remaining() == input.size(), "bootstrap advanced foreground input");
+                    require(redirected.consume(input.size()) == input, "protected stdin bytes changed");
+                } else {
+                    const auto result = unprotected(reader);
+                    require(result && result->exit_code == 0, "unprotected reader control failed to execute");
+                    require(redirected.remaining() < input.size(), "reader calibration did not consume stdin");
+                }
+                std::cout << "STDIN_EVIDENCE reader " << (pipe ? "pipe" : "file")
+                    << " protected=" << protect << " verified=1\n";
+            }
+        }
+        {
+            Input redirected{input_file, input, false};
+            require(redirected.installed, "failure control stdin setup failed");
+            const auto result = protected_call(rejected);
+            require(!result && result.error().code == mqb::msvc::ToolchainErrorCode::visual_studio_environment_failed
+                && result.error().message.find("17") != std::string::npos, "bootstrap error17 was hidden");
+            require(redirected.remaining() == input.size(), "failed bootstrap consumed foreground input");
+            std::cout << "STDIN_EVIDENCE bootstrap-error17 preserved=1 input_unchanged=1\n";
+        }
+        require(fs::is_regular_file(installed_vcvars), "installed vcvarsall absent for fixed real contrast");
+        for (const bool protect : {false, true}) {
+            Input redirected{input_file, input, false};
+            require(redirected.installed && redirected.remaining() == input.size(), "real vcvars stdin setup failed");
+            if (protect) {
+                const auto result = protected_call(installed_vcvars);
+                require(result && result->vc_tools_root.has_value(), "protected installed vcvars capture failed");
+            } else {
+                const auto result = unprotected(installed_vcvars);
+                require(result && result->exit_code == 0, "unprotected installed vcvars control failed");
+            }
+            const auto remaining = redirected.remaining();
+            std::cout << "STDIN_EVIDENCE installed-vcvars protected=" << protect
+                << " bytes_before=" << input.size() << " bytes_after=" << remaining << '\n';
+            if (protect) {
+                require(remaining == input.size(), "installed vcvars consumed foreground input");
+                require(redirected.consume(input.size()) == input, "installed vcvars changed input bytes");
+            }
+            // Unprotected consumption is retained, not required to reproduce on
+            // every vendor image; the deliberate reader above is the calibration.
+        }
+    } catch (const std::exception& error) {
+        expect(false, error.what());
+    }
+}
+
 } // namespace
 
 int main() {
@@ -221,6 +378,9 @@ int main() {
     const auto result = locator.discover(options);
     expect(result.has_value(), "Visual Studio toolchain should be discoverable on the Windows CI image");
     if (result) {
+        const auto* tools = find_environment_variable(*result, "VCToolsInstallDir");
+        expect(tools != nullptr, "installed tools root is required for stdin ownership tests");
+        if (tools) verify_environment_input(visual_studio_installation_from_tools_root(tools->value) / "VC/Auxiliary/Build/vcvarsall.bat");
         expect(result->source == mqb::msvc::ToolchainSource::visual_studio,
                "forced VS discovery should preserve toolchain provenance");
         expect(!result->reused,


### PR DESCRIPTION
## Accepted isolated correctness repair — #180 remains held

[Final exact-source review, native execution, artifact replay and acceptance decision](https://github.com/Iviesever/msvc-quick-build/pull/182#pullrequestreview-5166433266)

Accept ordinary expected-head merge of this three-file stdin fix. It does **not** authorize #180's build/run refactor, explain historical #599, complete M1b or grant transaction/lease/release authority.

## Exact source

- Base **`02f8fc9e03db789ebfea7a2462b1208a1be3ee45`**.
- Reviewed head **`0f20c10feca7060ac9c94ea7c720d17595eb441a`**.
- Candidate/native test-merge tree **`6ef8457242fa92bd076eefd396f23ac02602f540`**.
- Test-merge **`1eb1a707d62fc97a098e1f8f9b50dd041ad92444`**, exact base/head parents.
- Three existing files, **269 additions/1 deletion**;417of420files byte-identical. Exact source archives and patch replay verified.
- Selected blobs: VisualStudioEnvironment `13a855f51f8e23fc3b0ba0d0db25e8305d0ceb6b`; VS tests `ec38657c33487c95bcdaa2e0b9dd24d7c1fde11f`; CLI tests `3391f5e56072f565fe4fbca30eb695ba5e159738`.
- Reuses these reviewed file versions from #180 without its ancestry, BuildCompletion/Application/ModuleCliTarget changes or manifest/layout changes. **VERSION5.5.0; no tags/assets/formal release.**

## Fix

The noninteractive environment call reads NUL:

`call "%MQB_VCVARS%" %MQB_VC_TARGET% <nul >nul 2>&1`

The following errorlevel propagation and environment decoding stay unchanged. No input copying/rewinding, generic runner stdin change, compiler/link policy change, cancellation token or Job ownership change. Input remains available to the eventual foreground consumer.

## Current-head validation

| Gate | Actual first-attempt run | Result |
|---|---|---|
| Native Debug/all shards/freshness/runtime | #742/34468575640 | Passed; actual input and CLI execution inspected in job102845095770 |
| Full Release/self-host/exact package | #626/34468575666 | Passed; input/CLI execution in job102845117586; publish-release skipped |
| Original ownership and contracts | Default#29/34468575587;Private#31/34468575611 |70/70,42/42; all required positives and150record expectations pass |
| Original real batch/target studies | Batch#7/34468575617;Target#5/34468575600 |6/6 each; raw results/cache/provenance replayed;32target record expectations pass |
| Documentation/Cross-Stage | #187/34468575594;#217/34468575626 | Passed |
| Independent original observer-OFF ABBA | #608/34468575612 |76pairs;72complete instrumented semantic identities match |
| Five ancillary inspection/reporting workflows |14triggered workflows total |Completed successfully; not a full raw-artifact audit of every ancillary job |

[Native stdin and foreground inspection](https://github.com/Iviesever/msvc-quick-build/pull/182#issuecomment-5617730239)

Seven actual stdin records pass in BOTH Debug and Release: raw/protected deliberate reader on file/pipe, protected bootstrap error17, raw/protected installed vcvars. In both actual vendor-script observations unprotected input goes29to0bytes while protected input remains29bytes exactly. Raw installed behavior is observed, not assumed invariant across all vendor versions. Environment dumps are not printed.

Cold and warm foreground calls each return the original child37 with verified stdin/cwd/env/empty-spaced-quoted-trailing-backslash-Unicode argv and stdout/stderr. Cold compiles/links;warm does neither. Injected compile4/C2338 and link5/LNK2019/LNK1120 never launch the old artifact. The child uses Debug/MTd in both wrapper configurations. Native images differ, Debug20260907.229.1/Release20260824.214.3;C4996/D9025 warnings remain. Selected native log excerpts are retained, not described as full job logs.

Original default/private matrices retain two/one adverse managed-policy B first-build failures(C1090), separate recoveries and all28A-started managed-service deaths. No unsafe policy is authorized. Audited719/415results and1438/830diagnostics; sparse owner snapshots do not prove writer quiescence. The original batch failures and target-cache dirty-state checks remain intact. No post-submission source correction or same-head retry; untriggered observer research is not labeled current rerun evidence.

## Independent performance and unchanged historical limits

[Full19-scenario paired table and historical replay](https://github.com/Iviesever/msvc-quick-build/pull/182#issuecomment-5617776300)

Current external no-op paired median **−1.39135ms/−9.6286596%** does not cross the original **BOTH>1ms AND>10%** gate. Four external counter sets remain unavailable, not zero;72instrumented complete counters/breakdowns/hit-miss agree. Four-pairP95 is a maximum, not a population-tail estimate.

Keep cold+124.296ms/build-run+1.314ms/link-only+22.195ms medians and scale-cold+819.012ms/single-TU+539.134ms tails, with all favorable/adverse samples. No speedup/zero-overhead claim, noise deletion or AA subtraction. Original #599 still measures **+2.07175ms/+16.2700359633%, gate crossed** when replayed from its unmodified archive. Neither #601 nor this lower median resolves that incident. Current comparison JSON does not archive an actual performance binary pair or OS trace.

## Decision and next handoff

The original predeclared exact-source native/selfhost/package, seven input/four foreground controls in both configurations, applicable original positive regressions and independent19x4ABBA gates all pass; none was weakened or waived. **Accept this isolated fix; keep #180/#172 held and historic C1041/performance debts open.**

Next review the remaining #180 foreground build/run structural diff on the new main, removing these now-independent stdin files from its net scope, preserving original failures/#599 and declaring any risk/acceptance policy before fresh exact-base/head validation. This is not preauthorization of that PR. No new observer expansion, CLI cancellation, project leases/transactions or final release is included here.

Delivery includes10current core ZIPs+2historical ABBA ZIPs, exact source archives, patch, SHA256 manifest and completed portable offline replay. Not all workflow artifacts/full logs. Actions retention30days; diagnostic binary-body exclusions and finite snapshot limits remain explicit. Local source reconstruction/offline replay is not localMSVC/PowerShell execution. Temporaryperf title was removed only after actual#608finished; any title/ready-triggered skipped perf and post-merge push CI do not replace the completed evidence.